### PR TITLE
Fix handling of empty source sections

### DIFF
--- a/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/source/SourceSection.java
+++ b/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/source/SourceSection.java
@@ -172,6 +172,9 @@ public final class SourceSection {
      * @since 0.8 or earlier
      */
     public int getEndLine() {
+        if (source.getLength() == 0) {
+            return 1;
+        }
         return source.getLineNumber(charIndex + charLength - 1);
     }
 


### PR DESCRIPTION
This is work in progress. I'd like first to get feedback on the desired semantics.

Currently, `SourceSection.getEndLine()` does pass `-1` for an empty source section to `source.getLineNumber(offset)`, which causes an `IllegalArgumentException`. However, this does not seem to be intended.

Source.offsetToLine uses the following check:

`if (offset == 0 && textLength == 0) { return 1; }`

This seems to indicate that empty source sections should be supported.

If this is indeed the case, this should be further be tested. Other methods might not be correctly handling this either, for instance `getEndColumn()`.

/cc @chumer @jtulach @mlvdv 
