### PR TITLE
Make ProfilerInstrument.ID public

### DIFF
--- a/truffle/com.oracle.truffle.tools/src/com/oracle/truffle/tools/ProfilerInstrument.java
+++ b/truffle/com.oracle.truffle.tools/src/com/oracle/truffle/tools/ProfilerInstrument.java
@@ -30,7 +30,7 @@ import com.oracle.truffle.api.instrumentation.TruffleInstrument.Registration;
 
 @Registration(id = ProfilerInstrument.ID)
 public class ProfilerInstrument extends TruffleInstrument {
-    static final String ID = "profiler";
+    public static final String ID = "profiler";
 
     private Profiler profiler;
     private Instrumenter instrumenter;


### PR DESCRIPTION
Since we need to use strings to get instruments from the polyglot engine, this ID should be public to be usable and avoid stuff breaking inadvertently on change.

/cc @chumer @jtulach @mlvdv 
