### PR TITLE
Added SourceSectionFilter support for source section based on column and length

### DIFF
--- a/truffle/com.oracle.truffle.api.debug.test/src/com/oracle/truffle/api/debug/test/BreakpointTest.java
+++ b/truffle/com.oracle.truffle.api.debug.test/src/com/oracle/truffle/api/debug/test/BreakpointTest.java
@@ -38,6 +38,7 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import com.oracle.truffle.api.debug.Breakpoint;
+import com.oracle.truffle.api.debug.Breakpoint.Builder;
 import com.oracle.truffle.api.debug.DebuggerSession;
 import com.oracle.truffle.api.debug.SuspendedEvent;
 import com.oracle.truffle.api.source.Source;
@@ -324,6 +325,28 @@ public class BreakpointTest extends AbstractDebugTest {
 
             expectSuspended((SuspendedEvent event) -> {
                 checkState(event, 1, true, "STATEMENT");
+                Assert.assertEquals(sourceSection, event.getSourceSection());
+                assertSame(breakpoint, event.getBreakpoints().iterator().next());
+                event.prepareContinue();
+            });
+
+            expectDone();
+        }
+    }
+
+    @Test
+    public void testBreakSourceSectionFromCoordinates() throws Throwable {
+        final Source source = testSource("ROOT(STATEMENT,\nSTATEMENT,\nSTATEMENT)\n");
+        try (DebuggerSession session = startSession()) {
+            SourceSection sourceSection = source.createSection(16, 9);
+            Builder builder = Breakpoint.newBuilder(source.getURI());
+            builder.lineIs(2).columnIs(1).sectionLength(9);
+            Breakpoint breakpoint = session.install(builder.build());
+
+            startEval(source);
+
+            expectSuspended((SuspendedEvent event) -> {
+                checkState(event, 2, true, "STATEMENT");
                 Assert.assertEquals(sourceSection, event.getSourceSection());
                 assertSame(breakpoint, event.getBreakpoints().iterator().next());
                 event.prepareContinue();

--- a/truffle/com.oracle.truffle.api.debug/src/com/oracle/truffle/api/debug/Breakpoint.java
+++ b/truffle/com.oracle.truffle.api.debug/src/com/oracle/truffle/api/debug/Breakpoint.java
@@ -776,7 +776,7 @@ public final class Breakpoint {
             }
             if (column != -1) {
                 assert sectionLength != -1;
-                f.indexIn(column, sectionLength);
+                f.columnAndLength(column, sectionLength);
             }
             if (sourceSection != null) {
                 f.sourceSectionEquals(sourceSection);

--- a/truffle/com.oracle.truffle.api.debug/src/com/oracle/truffle/api/debug/Breakpoint.java
+++ b/truffle/com.oracle.truffle.api.debug/src/com/oracle/truffle/api/debug/Breakpoint.java
@@ -607,6 +607,8 @@ public final class Breakpoint {
         private final Object key;
 
         private int line = -1;
+        private int column = -1;
+        private int sectionLength = -1;
         private int ignoreCount;
         private boolean oneShot;
         private SourceSection sourceSection;
@@ -648,6 +650,60 @@ public final class Breakpoint {
         }
 
         /**
+         * Specifies the breakpoint's starting column.
+         *
+         * Requires {@link #sectionLength(int) section length} to be set as well.
+         *
+         * Can only be invoked once per builder. Cannot be used together with
+         * {@link Breakpoint#newBuilder(SourceSection)}.
+         *
+         * @param column 1-based start column
+         * @throws IllegalStateException if {@code column < 1}
+         *
+         * @since unreleased
+         */
+        public Builder columnIs(@SuppressWarnings("hiding") int column) {
+            if (column <= 0) {
+                throw new IllegalArgumentException("Column argument must be > 0.");
+            }
+            if (this.column != -1) {
+                throw new IllegalStateException("ColumnIs can only be called once per breakpoint builder.");
+            }
+            if (sourceSection != null) {
+                throw new IllegalArgumentException("ColumnIs cannot be used with source section based breakpoint. ");
+            }
+            this.column = column;
+            return this;
+        }
+
+        /**
+         * Specifies the breakpoint's section length.
+         *
+         * Requires {@link #columnIs(int) starting column} to be set as well.
+         *
+         * Can only be invoked once per builder. Cannot be used together with
+         * {@link Breakpoint#newBuilder(SourceSection)}.
+         *
+         * @param length number of characters in the source section
+         * @throws IllegalStateException if {@code length < 1}
+         *
+         * @since unreleased
+         */
+        public Builder sectionLength(int length) {
+            if (length <= 0) {
+                throw new IllegalArgumentException("Length argument must be > 0.");
+            }
+            if (this.sectionLength != -1) {
+                throw new IllegalStateException("SectionLength can only be called once per breakpoint builder.");
+            }
+            if (sourceSection != null) {
+                throw new IllegalArgumentException("SectionLength cannot be used with source section based breakpoint. ");
+            }
+            this.sectionLength = length;
+            return this;
+        }
+
+        /**
          * Specifies the number of times a breakpoint is ignored until it hits (i.e. suspends
          * execution}.
          *
@@ -683,6 +739,9 @@ public final class Breakpoint {
          * @since 0.17
          */
         public Breakpoint build() {
+            if (column != -1 ^ sectionLength != -1) {
+                throw new IllegalArgumentException("Column and sectionLength need to be set both to indicate a source section");
+            }
             SourceSectionFilter f = buildFilter();
             BreakpointLocation location = new BreakpointLocation(key, line);
             Breakpoint breakpoint = new Breakpoint(location, f, oneShot);
@@ -714,6 +773,10 @@ public final class Breakpoint {
             }
             if (line != -1) {
                 f.lineStartsIn(IndexRange.byLength(line, 1));
+            }
+            if (column != -1) {
+                assert sectionLength != -1;
+                f.indexIn(column, sectionLength);
             }
             if (sourceSection != null) {
                 f.sourceSectionEquals(sourceSection);

--- a/truffle/com.oracle.truffle.api.instrumentation/src/com/oracle/truffle/api/instrumentation/SourceSectionFilter.java
+++ b/truffle/com.oracle.truffle.api.instrumentation/src/com/oracle/truffle/api/instrumentation/SourceSectionFilter.java
@@ -361,6 +361,27 @@ public final class SourceSectionFilter {
         }
 
         /**
+         * Add a filter for a specific source section starting at a column and has a given length.
+         *
+         * Requires {@link #lineIs(int) line predicated} to be set as well.
+         *
+         * @param column start column (inclusive)
+         * @param length number of characters (exclusive)
+         * @return the builder to chain calls
+         * @since unreleased
+         */
+        public Builder columnAndLength(int column, int length) {
+            if (column < 1) {
+                throw new IllegalArgumentException("Column has to be >= 1");
+            }
+            if (length < 1) {
+                throw new IllegalArgumentException("Length has to be >= 1");
+            }
+            expressions.add(new EventFilterExpression.SourceCoordinateEquals(column, length));
+            return this;
+        }
+
+        /**
          * Add a filter for all sources sections end in one of the given index ranges. Line indices
          * must be greater or equal to <code>1</code>.
          *
@@ -1011,6 +1032,38 @@ public final class SourceSectionFilter {
                 appendRanges(builder, ranges);
                 builder.append(")");
                 return builder.toString();
+            }
+        }
+
+        private static final class SourceCoordinateEquals extends EventFilterExpression {
+            private final int column;
+            private final int length;
+
+            SourceCoordinateEquals(int column, int length) {
+                this.column = column;
+                this.length = length;
+            }
+
+            @Override
+            boolean isRootIncluded(Set<Class<?>> providedTags, SourceSection rootSourceSection) {
+                // we can't really check that here
+                // we rely on the combination with other predicates for that to be correct
+                return true;
+            }
+
+            @Override
+            boolean isIncluded(Set<Class<?>> providedTags, Node instrumentedNode, SourceSection sourceSection) {
+                return sourceSection.getStartColumn() == column && sourceSection.getCharLength() == length;
+            }
+
+            @Override
+            protected int getOrder() {
+                return 10;
+            }
+
+            @Override
+            public String toString() {
+                return "(column: " + column + " length: " + length + ")";
             }
         }
 


### PR DESCRIPTION
This complements the support for line breakpoints on URIs for which the code is not yet loaded.
Currently, only line breakpoints can be registered for URIs. With this addition, we can also request breakpoints for source sections based on line, column, and length.

/cc @mlvdv
