### PR TITLE
Push down constants in AddNode

### DIFF
--- a/compiler/src/org.graalvm.compiler.nodes/src/org/graalvm/compiler/nodes/calc/AddNode.java
+++ b/compiler/src/org.graalvm.compiler.nodes/src/org/graalvm/compiler/nodes/calc/AddNode.java
@@ -69,7 +69,7 @@ public class AddNode extends BinaryArithmeticNode<Add> implements NarrowableArit
 
     private static boolean isLoopIncrement(AddNode self) {
         return self.getX() instanceof PhiNode && ((PhiNode) self.getX()).isLoopPhi() ||
-                    self.getY() instanceof PhiNode && ((PhiNode) self.getY()).isLoopPhi();
+                        self.getY() instanceof PhiNode && ((PhiNode) self.getY()).isLoopPhi();
     }
 
     private static ValueNode canonical(AddNode addNode, BinaryOp<Add> op, ValueNode forX, ValueNode forY, NodeView view) {

--- a/compiler/src/org.graalvm.compiler.nodes/src/org/graalvm/compiler/nodes/calc/AddNode.java
+++ b/compiler/src/org.graalvm.compiler.nodes/src/org/graalvm/compiler/nodes/calc/AddNode.java
@@ -69,14 +69,8 @@ public class AddNode extends BinaryArithmeticNode<Add> implements NarrowableArit
     }
 
     private static boolean isLoopIncrement(AddNode self) {
-        assert self != null;
-        if (self.getX() instanceof PhiNode && ((PhiNode) self.getX()).isLoopPhi()) {
-            return true;
-        }
-        if (self.getY() instanceof PhiNode && ((PhiNode) self.getY()).isLoopPhi()) {
-            return true;
-        }
-        return false;
+        return self.getX() instanceof PhiNode && ((PhiNode) self.getX()).isLoopPhi() ||
+            self.getY() instanceof PhiNode && ((PhiNode) self.getY()).isLoopPhi();
     }
 
     private static ValueNode canonical(AddNode addNode, BinaryOp<Add> op, ValueNode forX, ValueNode forY, NodeView view) {

--- a/compiler/src/org.graalvm.compiler.nodes/src/org/graalvm/compiler/nodes/calc/AddNode.java
+++ b/compiler/src/org.graalvm.compiler.nodes/src/org/graalvm/compiler/nodes/calc/AddNode.java
@@ -104,6 +104,7 @@ public class AddNode extends BinaryArithmeticNode<Add> implements NarrowableArit
                 }
             }
             /*
+             * @formatter:off
              * Attempt to reassociate to push down constants.
              * We must check that self != null because
              * 1. If this add has not yet been created and as of the form (x + C1) + C2,
@@ -112,6 +113,7 @@ public class AddNode extends BinaryArithmeticNode<Add> implements NarrowableArit
              * undo the intended results.
              * Additionally, we must check this add isn't a loop induction variable,
              * since reassociation can break loop analysis
+             * @formatter:on
              */
             if (self != null && forX instanceof AddNode && !isLoopIncrement(self)) {
                 AddNode add = (AddNode) forX;

--- a/compiler/src/org.graalvm.compiler.nodes/src/org/graalvm/compiler/nodes/calc/AddNode.java
+++ b/compiler/src/org.graalvm.compiler.nodes/src/org/graalvm/compiler/nodes/calc/AddNode.java
@@ -35,7 +35,6 @@ import org.graalvm.compiler.nodes.ConstantNode;
 import org.graalvm.compiler.nodes.NodeView;
 import org.graalvm.compiler.nodes.PhiNode;
 import org.graalvm.compiler.nodes.ValueNode;
-import org.graalvm.compiler.nodes.ValuePhiNode;
 import org.graalvm.compiler.nodes.spi.NodeLIRBuilderTool;
 
 import jdk.vm.ci.meta.Constant;
@@ -70,7 +69,7 @@ public class AddNode extends BinaryArithmeticNode<Add> implements NarrowableArit
 
     private static boolean isLoopIncrement(AddNode self) {
         return self.getX() instanceof PhiNode && ((PhiNode) self.getX()).isLoopPhi() ||
-            self.getY() instanceof PhiNode && ((PhiNode) self.getY()).isLoopPhi();
+                    self.getY() instanceof PhiNode && ((PhiNode) self.getY()).isLoopPhi();
     }
 
     private static ValueNode canonical(AddNode addNode, BinaryOp<Add> op, ValueNode forX, ValueNode forY, NodeView view) {
@@ -104,7 +103,8 @@ public class AddNode extends BinaryArithmeticNode<Add> implements NarrowableArit
                     return sub.getX();
                 }
             }
-            /* Attempt to reassociate to push down constants.
+            /*
+             * Attempt to reassociate to push down constants.
              * We must check that self != null because
              * 1. If this add has not yet been created and as of the form (x + C1) + C2,
              * the constant reassociate() call has not yet happened and so we would infinitely recurse.


### PR DESCRIPTION
The current `reassociate` call only handles cases such as `(A+C1) + C2`. This adds cases for `(X+C1)+Y` and `X+(Y+C2)`, which allows simplifying
```
      (A+1)+(B+2)
    =>(A+(B+2))+1
    =>((A+B)+2)+1
```` 
from which the existing `reassociate` will pull out the 2 and we end up with `(A+B)+3`