### PR TITLE
Skip jdk11 CONSTANT_Dynamic tag

### DIFF
--- a/compiler/src/org.graalvm.compiler.replacements/src/org/graalvm/compiler/replacements/classfile/ClassfileConstant.java
+++ b/compiler/src/org.graalvm.compiler.replacements/src/org/graalvm/compiler/replacements/classfile/ClassfileConstant.java
@@ -54,6 +54,7 @@ abstract class ClassfileConstant {
     public static final byte CONSTANT_NameAndType        = 12;
     public static final byte CONSTANT_MethodHandle       = 15;
     public static final byte CONSTANT_MethodType         = 16;
+    public static final byte CONSTANT_Dynamic            = 17;
     public static final byte CONSTANT_InvokeDynamic      = 18;
     // @formatter:on
 

--- a/compiler/src/org.graalvm.compiler.replacements/src/org/graalvm/compiler/replacements/classfile/ClassfileConstantPool.java
+++ b/compiler/src/org.graalvm.compiler.replacements/src/org/graalvm/compiler/replacements/classfile/ClassfileConstantPool.java
@@ -112,7 +112,10 @@ class ClassfileConstantPool implements ConstantPool {
             case ClassfileConstant.CONSTANT_MethodType:
                 skipFully(stream, 2); // descriptor_index
                 return new ClassfileConstant.Unsupported(tag, "CONSTANT_MethodType_info");
-            case ClassfileConstant.CONSTANT_InvokeDynamic:
+            case ClassfileConstant.CONSTANT_Dynamic:
+                skipFully(stream, 4); // bootstrap_method_attr_index, name_and_type_index
+                return new ClassfileConstant.Unsupported(tag, "CONSTANT_Dynamic_info");
+             case ClassfileConstant.CONSTANT_InvokeDynamic:
                 skipFully(stream, 4); // bootstrap_method_attr_index, name_and_type_index
                 return new ClassfileConstant.Unsupported(tag, "CONSTANT_InvokeDynamic_info");
             default:


### PR DESCRIPTION
Small addition to the patch that bumps supported classfile version to JDK11(55). Skip new CONSTANT_Dynamic tag.