### PR TITLE
elide membars and replace with ldar or stlr on AArch64

### DIFF
--- a/compiler/src/jdk.tools.jaotc/src/jdk/tools/jaotc/CallInfo.java
+++ b/compiler/src/jdk.tools.jaotc/src/jdk/tools/jaotc/CallInfo.java
@@ -40,7 +40,9 @@ final class CallInfo {
 
     private static boolean isStaticOpcode(Call call) {
         int opcode = getByteCode(call) & 0xFF;
-        return opcode == Bytecodes.INVOKESTATIC || opcode == Bytecodes.INVOKEDYNAMIC || opcode == Bytecodes.INVOKEVIRTUAL /* invokehandle */;
+        return opcode == Bytecodes.INVOKESTATIC || opcode == Bytecodes.INVOKEDYNAMIC || opcode == Bytecodes.INVOKEVIRTUAL /*
+                                                                                                                           * invokehandle
+                                                                                                                           */;
     }
 
     static boolean isStaticCall(Call call) {

--- a/compiler/src/jdk.tools.jaotc/src/jdk/tools/jaotc/CallInfo.java
+++ b/compiler/src/jdk.tools.jaotc/src/jdk/tools/jaotc/CallInfo.java
@@ -40,9 +40,8 @@ final class CallInfo {
 
     private static boolean isStaticOpcode(Call call) {
         int opcode = getByteCode(call) & 0xFF;
-        return opcode == Bytecodes.INVOKESTATIC || opcode == Bytecodes.INVOKEDYNAMIC || opcode == Bytecodes.INVOKEVIRTUAL /*
-                                                                                                                           * invokehandle
-                                                                                                                           */;
+        // invokehandle
+        return opcode == Bytecodes.INVOKESTATIC || opcode == Bytecodes.INVOKEDYNAMIC || opcode == Bytecodes.INVOKEVIRTUAL;
     }
 
     static boolean isStaticCall(Call call) {

--- a/compiler/src/org.graalvm.compiler.asm.aarch64.test/src/org/graalvm/compiler/asm/aarch64/test/TestProtectedAssembler.java
+++ b/compiler/src/org.graalvm.compiler.asm.aarch64.test/src/org/graalvm/compiler/asm/aarch64/test/TestProtectedAssembler.java
@@ -133,12 +133,12 @@ class TestProtectedAssembler extends AArch64Assembler {
     }
 
     @Override
-    protected void ldar(int size, Register rt, Register rn) {
+    public void ldar(int size, Register rt, Register rn) {
         super.ldar(size, rt, rn);
     }
 
     @Override
-    protected void stlr(int size, Register rt, Register rn) {
+    public void stlr(int size, Register rt, Register rn) {
         super.stlr(size, rt, rn);
     }
 

--- a/compiler/src/org.graalvm.compiler.asm.aarch64/src/org/graalvm/compiler/asm/aarch64/AArch64Assembler.java
+++ b/compiler/src/org.graalvm.compiler.asm.aarch64/src/org/graalvm/compiler/asm/aarch64/AArch64Assembler.java
@@ -1271,7 +1271,7 @@ public abstract class AArch64Assembler extends Assembler {
      * @param rt general purpose register. May not be null or stackpointer.
      * @param rn general purpose register.
      */
-    protected void ldar(int size, Register rt, Register rn) {
+    public void ldar(int size, Register rt, Register rn) {
         assert size == 8 || size == 16 || size == 32 || size == 64;
         int transferSize = NumUtil.log2Ceil(size / 8);
         exclusiveLoadInstruction(LDAR, rt, rn, transferSize);
@@ -1284,7 +1284,7 @@ public abstract class AArch64Assembler extends Assembler {
      * @param rt general purpose register. May not be null or stackpointer.
      * @param rn general purpose register.
      */
-    protected void stlr(int size, Register rt, Register rn) {
+    public void stlr(int size, Register rt, Register rn) {
         assert size == 8 || size == 16 || size == 32 || size == 64;
         int transferSize = NumUtil.log2Ceil(size / 8);
         // Hack: Passing the zero-register means it is ignored when building the encoding.
@@ -1340,7 +1340,7 @@ public abstract class AArch64Assembler extends Assembler {
      */
     private void exclusiveStoreInstruction(Instruction instr, Register rs, Register rt, Register rn, int log2TransferSize) {
         assert log2TransferSize >= 0 && log2TransferSize < 4;
-        assert rt.getRegisterCategory().equals(CPU) && rs.getRegisterCategory().equals(CPU) && !rs.equals(rt);
+        assert rt.getRegisterCategory().equals(CPU) && rs.getRegisterCategory().equals(CPU);
         int transferSizeEncoding = log2TransferSize << LoadStoreTransferSizeOffset;
         emitInt(transferSizeEncoding | instr.encoding | rs2(rs) | rn(rn) | rt(rt));
     }

--- a/compiler/src/org.graalvm.compiler.asm.aarch64/src/org/graalvm/compiler/asm/aarch64/AArch64MacroAssembler.java
+++ b/compiler/src/org.graalvm.compiler.asm.aarch64/src/org/graalvm/compiler/asm/aarch64/AArch64MacroAssembler.java
@@ -266,9 +266,7 @@ public class AArch64MacroAssembler extends AArch64Assembler {
      * @return AArch64Address pointing to memory at {@code base + displacement}.
      */
     public AArch64Address makeAddress(Register base, long displacement, int transferSize) {
-        return makeAddress(base, displacement, zr, /* signExtend */false, transferSize, zr, /*
-                                                                                             * allowOverwrite
-                                                                                             */false);
+        return makeAddress(base, displacement, zr, /* signExtend */false, transferSize, zr, /* allowOverwrite */false);
     }
 
     /**
@@ -1723,9 +1721,7 @@ public class AArch64MacroAssembler extends AArch64Assembler {
      */
     @Override
     public AArch64Address makeAddress(Register base, int displacement) {
-        return makeAddress(base, displacement, zr, /* signExtend */false, /* transferSize */0, zr, /*
-                                                                                                    * allowOverwrite
-                                                                                                    */false);
+        return makeAddress(base, displacement, zr, /* signExtend */false, /* transferSize */0, zr, /* allowOverwrite */false);
     }
 
     @Override

--- a/compiler/src/org.graalvm.compiler.asm.aarch64/src/org/graalvm/compiler/asm/aarch64/AArch64MacroAssembler.java
+++ b/compiler/src/org.graalvm.compiler.asm.aarch64/src/org/graalvm/compiler/asm/aarch64/AArch64MacroAssembler.java
@@ -266,7 +266,9 @@ public class AArch64MacroAssembler extends AArch64Assembler {
      * @return AArch64Address pointing to memory at {@code base + displacement}.
      */
     public AArch64Address makeAddress(Register base, long displacement, int transferSize) {
-        return makeAddress(base, displacement, zr, /* signExtend */false, transferSize, zr, /* allowOverwrite */false);
+        return makeAddress(base, displacement, zr, /* signExtend */false, transferSize, zr, /*
+                                                                                             * allowOverwrite
+                                                                                             */false);
     }
 
     /**
@@ -1721,7 +1723,9 @@ public class AArch64MacroAssembler extends AArch64Assembler {
      */
     @Override
     public AArch64Address makeAddress(Register base, int displacement) {
-        return makeAddress(base, displacement, zr, /* signExtend */false, /* transferSize */0, zr, /* allowOverwrite */false);
+        return makeAddress(base, displacement, zr, /* signExtend */false, /* transferSize */0, zr, /*
+                                                                                                    * allowOverwrite
+                                                                                                    */false);
     }
 
     @Override

--- a/compiler/src/org.graalvm.compiler.core.aarch64/src/org/graalvm/compiler/core/aarch64/AArch64ArithmeticLIRGenerator.java
+++ b/compiler/src/org.graalvm.compiler.core.aarch64/src/org/graalvm/compiler/core/aarch64/AArch64ArithmeticLIRGenerator.java
@@ -130,8 +130,8 @@ public class AArch64ArithmeticLIRGenerator extends ArithmeticLIRGenerator implem
             assert (address.getScaleFactor() == 1);
             return address;
         } else if ((addressingMode == AArch64Address.AddressingMode.REGISTER_OFFSET ||
-                addressingMode == AArch64Address.AddressingMode.EXTENDED_REGISTER_OFFSET) &&
-                address.getOffset().equals(Value.ILLEGAL)) {
+                        addressingMode == AArch64Address.AddressingMode.EXTENDED_REGISTER_OFFSET) &&
+                        address.getOffset().equals(Value.ILLEGAL)) {
             // this is equivalent to base register
             assert (address.getDisplacement() == 0);
             assert (address.getScaleFactor() == 1);
@@ -141,7 +141,7 @@ public class AArch64ArithmeticLIRGenerator extends ArithmeticLIRGenerator implem
             // address
             AllocatableValue base = getLIRGen().emitMove(address);
             return new AArch64AddressValue(LIRKind.value(AArch64Kind.QWORD), base, Value.ILLEGAL,
-                                           0, 1, AArch64Address.AddressingMode.BASE_REGISTER_ONLY);
+                            0, 1, AArch64Address.AddressingMode.BASE_REGISTER_ONLY);
         }
     }
 
@@ -519,7 +519,7 @@ public class AArch64ArithmeticLIRGenerator extends ArithmeticLIRGenerator implem
 
     @Override
     public void emitStore(ValueKind<?> lirKind, Value address, Value inputVal, LIRFrameState state) {
-         emitStore(lirKind, address, inputVal, state, false);
+        emitStore(lirKind, address, inputVal, state, false);
     }
 
     public void emitStore(ValueKind<?> lirKind, Value address, Value inputVal, LIRFrameState state, boolean isVolatile) {

--- a/compiler/src/org.graalvm.compiler.core.aarch64/src/org/graalvm/compiler/core/aarch64/AArch64ExtendingReadNode.java
+++ b/compiler/src/org.graalvm.compiler.core.aarch64/src/org/graalvm/compiler/core/aarch64/AArch64ExtendingReadNode.java
@@ -57,11 +57,13 @@ public class AArch64ExtendingReadNode extends ReadNode {
     private final boolean isSigned;
 
     public AArch64ExtendingReadNode(AddressNode address, LocationIdentity location, Stamp stamp, GuardingNode guard, BarrierType barrierType, boolean nullCheck,
-                                    FrameState stateBefore, IntegerStamp accessStamp, boolean isSigned) {
+                    FrameState stateBefore, IntegerStamp accessStamp, boolean isSigned) {
         this(TYPE, address, location, stamp, guard, barrierType, nullCheck, stateBefore, accessStamp, isSigned);
     }
-    protected AArch64ExtendingReadNode(NodeClass<? extends AArch64ExtendingReadNode> c, AddressNode address, LocationIdentity location, Stamp stamp, GuardingNode guard, BarrierType barrierType, boolean nullCheck,
-                                    FrameState stateBefore, IntegerStamp accessStamp, boolean isSigned) {
+
+    protected AArch64ExtendingReadNode(NodeClass<? extends AArch64ExtendingReadNode> c, AddressNode address, LocationIdentity location, Stamp stamp, GuardingNode guard, BarrierType barrierType,
+                    boolean nullCheck,
+                    FrameState stateBefore, IntegerStamp accessStamp, boolean isSigned) {
         super(c, address, location, stamp, guard, barrierType, nullCheck, stateBefore);
         this.accessStamp = accessStamp;
         this.isSigned = isSigned;
@@ -73,8 +75,8 @@ public class AArch64ExtendingReadNode extends ReadNode {
         AArch64ArithmeticLIRGenerator arithgen = (AArch64ArithmeticLIRGenerator) lirgen.getArithmetic();
         AArch64Kind readKind = (AArch64Kind) lirgen.getLIRKind(accessStamp).getPlatformKind();
         int resultBits = ((IntegerStamp) stamp(NodeView.DEFAULT)).getBits();
-        boolean isVolatile =  (this instanceof AArch64VolatileExtendingReadNode);
-        gen.setResult(this, arithgen.emitExtendMemory(isSigned, readKind, resultBits, (AArch64AddressValue) gen.operand(getAddress()), gen.state(this),isVolatile));
+        boolean isVolatile = (this instanceof AArch64VolatileExtendingReadNode);
+        gen.setResult(this, arithgen.emitExtendMemory(isSigned, readKind, resultBits, (AArch64AddressValue) gen.operand(getAddress()), gen.state(this), isVolatile));
     }
 
     /**
@@ -101,9 +103,9 @@ public class AArch64ExtendingReadNode extends ReadNode {
         AArch64ExtendingReadNode clone;
         boolean isVolatile = (readNode instanceof AArch64VolatileReadNode);
         if (isVolatile) {
-            clone =  new AArch64VolatileExtendingReadNode(address, location, stamp, guard, barrierType, nullCheck, stateBefore, accessStamp, isSigned);
+            clone = new AArch64VolatileExtendingReadNode(address, location, stamp, guard, barrierType, nullCheck, stateBefore, accessStamp, isSigned);
         } else {
-            clone =  new AArch64ExtendingReadNode(address, location, stamp, guard, barrierType, nullCheck, stateBefore, accessStamp, isSigned);
+            clone = new AArch64ExtendingReadNode(address, location, stamp, guard, barrierType, nullCheck, stateBefore, accessStamp, isSigned);
         }
         StructuredGraph graph = readNode.graph();
         graph.add(clone);

--- a/compiler/src/org.graalvm.compiler.core.aarch64/src/org/graalvm/compiler/core/aarch64/AArch64ExtendingReadReplacementPhase.java
+++ b/compiler/src/org.graalvm.compiler.core.aarch64/src/org/graalvm/compiler/core/aarch64/AArch64ExtendingReadReplacementPhase.java
@@ -38,12 +38,12 @@ import org.graalvm.compiler.phases.Phase;
  * to allow merging of zero and sign extension into the read operation.
  */
 
-public class AArch64ReadReplacementPhase extends Phase {
+public class AArch64ExtendingReadReplacementPhase extends Phase {
     @Override
     protected void run(StructuredGraph graph) {
         for (Node node : graph.getNodes()) {
             // don't process nodes we just added
-            if (node instanceof AArch64ReadNode) {
+            if (node instanceof AArch64ExtendingReadNode) {
                 continue;
             }
             if (node instanceof ReadNode) {
@@ -51,7 +51,7 @@ public class AArch64ReadReplacementPhase extends Phase {
                 if (readNode.hasExactlyOneUsage()) {
                     Node usage = readNode.getUsageAt(0);
                     if (usage instanceof ZeroExtendNode || usage instanceof SignExtendNode) {
-                        AArch64ReadNode.replace(readNode);
+                        AArch64ExtendingReadNode.replace(readNode);
                     }
                 }
             }

--- a/compiler/src/org.graalvm.compiler.core.aarch64/src/org/graalvm/compiler/core/aarch64/AArch64MembarElisionPhase.java
+++ b/compiler/src/org.graalvm.compiler.core.aarch64/src/org/graalvm/compiler/core/aarch64/AArch64MembarElisionPhase.java
@@ -5,7 +5,9 @@
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 only, as
- * published by the Free Software Foundation.
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
  *
  * This code is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or

--- a/compiler/src/org.graalvm.compiler.core.aarch64/src/org/graalvm/compiler/core/aarch64/AArch64MembarElisionPhase.java
+++ b/compiler/src/org.graalvm.compiler.core.aarch64/src/org/graalvm/compiler/core/aarch64/AArch64MembarElisionPhase.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, Red Hat Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package org.graalvm.compiler.core.aarch64;
+
+import jdk.vm.ci.code.MemoryBarriers;
+import org.graalvm.compiler.graph.Node;
+import org.graalvm.compiler.nodes.StructuredGraph;
+import org.graalvm.compiler.nodes.extended.MembarNode;
+import org.graalvm.compiler.nodes.memory.ReadNode;
+import org.graalvm.compiler.nodes.memory.WriteNode;
+import org.graalvm.compiler.phases.Phase;
+
+/**
+ * AArch64-specific phase which merges memory barriers into read or write nodes wherever possible.
+ */
+
+public class AArch64MembarElisionPhase extends Phase {
+    @Override
+    protected void run(StructuredGraph graph) {
+        for (Node node : graph.getNodes()) {
+            // don't process nodes we just added
+            if (node instanceof AArch64VolatileReadNode || node instanceof AArch64VolatileWriteNode) {
+                continue;
+            }
+            if (node instanceof ReadNode) {
+                checkReplaceWithVolatileRead((ReadNode) node);
+            } else if (node instanceof WriteNode) {
+                checkReplaceWithVolatileWrite((WriteNode) node);
+            }
+        }
+    }
+
+    private static void checkReplaceWithVolatileRead(ReadNode readNode) {
+        for (Node usage : readNode.usages()) {
+            if (usage instanceof MembarNode) {
+                MembarNode post = (MembarNode) usage;
+                if (post.getBarriers() == MemoryBarriers.JMM_POST_VOLATILE_READ &&
+                                post.getAccess() == readNode) {
+                    MembarNode pre = post.getLeading();
+                    if (pre.getBarriers() == MemoryBarriers.JMM_PRE_VOLATILE_READ) {
+                        AArch64VolatileReadNode.replace(readNode, pre, post);
+                        return;
+                    }
+                }
+            }
+        }
+    }
+
+    private static void checkReplaceWithVolatileWrite(WriteNode writeNode) {
+        for (Node usage : writeNode.usages()) {
+            if (usage instanceof MembarNode) {
+                MembarNode post = (MembarNode) usage;
+                if (post.getBarriers() == MemoryBarriers.JMM_POST_VOLATILE_WRITE &&
+                                post.getAccess() == writeNode) {
+                    MembarNode pre = post.getLeading();
+                    if (pre.getBarriers() == MemoryBarriers.JMM_PRE_VOLATILE_WRITE) {
+                        AArch64VolatileWriteNode.replace(writeNode, pre, post);
+                        return;
+                    }
+                }
+            }
+        }
+    }
+}

--- a/compiler/src/org.graalvm.compiler.core.aarch64/src/org/graalvm/compiler/core/aarch64/AArch64SuitesCreator.java
+++ b/compiler/src/org.graalvm.compiler.core.aarch64/src/org/graalvm/compiler/core/aarch64/AArch64SuitesCreator.java
@@ -38,10 +38,12 @@ import org.graalvm.compiler.phases.tiers.Suites;
 
 public class AArch64SuitesCreator extends DefaultSuitesCreator {
     private final Class<? extends Phase> insertReadReplacementBefore;
+    private final boolean useBarriersForVolatile;
 
-    public AArch64SuitesCreator(CompilerConfiguration compilerConfiguration, Plugins plugins, Class<? extends Phase> insertReadReplacementBefore) {
+    public AArch64SuitesCreator(CompilerConfiguration compilerConfiguration, Plugins plugins, Class<? extends Phase> insertReadReplacementBefore, boolean useBarriersForVolatile) {
         super(compilerConfiguration, plugins);
         this.insertReadReplacementBefore = insertReadReplacementBefore;
+        this.useBarriersForVolatile = useBarriersForVolatile;
     }
 
     @Override
@@ -54,7 +56,9 @@ public class AArch64SuitesCreator extends DefaultSuitesCreator {
             // Search for last occurrence of SchedulePhase
         }
         findPhase.previous();
-        findPhase.add(new AArch64MembarElisionPhase());
+        if (!useBarriersForVolatile) {
+            findPhase.add(new AArch64MembarElisionPhase());
+        }
         findPhase.add(new AArch64ExtendingReadReplacementPhase());
         return suites;
     }

--- a/compiler/src/org.graalvm.compiler.core.aarch64/src/org/graalvm/compiler/core/aarch64/AArch64SuitesCreator.java
+++ b/compiler/src/org.graalvm.compiler.core.aarch64/src/org/graalvm/compiler/core/aarch64/AArch64SuitesCreator.java
@@ -54,7 +54,8 @@ public class AArch64SuitesCreator extends DefaultSuitesCreator {
             // Search for last occurrence of SchedulePhase
         }
         findPhase.previous();
-        findPhase.add(new AArch64ReadReplacementPhase());
+        findPhase.add(new AArch64MembarElisionPhase());
+        findPhase.add(new AArch64ExtendingReadReplacementPhase());
         return suites;
     }
 }

--- a/compiler/src/org.graalvm.compiler.core.aarch64/src/org/graalvm/compiler/core/aarch64/AArch64VolatileExtendingReadNode.java
+++ b/compiler/src/org.graalvm.compiler.core.aarch64/src/org/graalvm/compiler/core/aarch64/AArch64VolatileExtendingReadNode.java
@@ -1,11 +1,13 @@
 /*
- * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2017, Red Hat Inc. All rights reserved.
+ * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, Red Hat Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 only, as
- * published by the Free Software Foundation.
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
  *
  * This code is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or

--- a/compiler/src/org.graalvm.compiler.core.aarch64/src/org/graalvm/compiler/core/aarch64/AArch64VolatileExtendingReadNode.java
+++ b/compiler/src/org.graalvm.compiler.core.aarch64/src/org/graalvm/compiler/core/aarch64/AArch64VolatileExtendingReadNode.java
@@ -43,7 +43,7 @@ public class AArch64VolatileExtendingReadNode extends AArch64ExtendingReadNode {
     public static final NodeClass<AArch64VolatileExtendingReadNode> TYPE = NodeClass.create(AArch64VolatileExtendingReadNode.class);
 
     public AArch64VolatileExtendingReadNode(AddressNode address, LocationIdentity location, Stamp stamp, GuardingNode guard, BarrierType barrierType, boolean nullCheck,
-                                            FrameState stateBefore, IntegerStamp accessStamp, boolean isSigned) {
+                    FrameState stateBefore, IntegerStamp accessStamp, boolean isSigned) {
         super(TYPE, address, location, stamp, guard, barrierType, nullCheck, stateBefore, accessStamp, isSigned);
     }
 

--- a/compiler/src/org.graalvm.compiler.core.aarch64/src/org/graalvm/compiler/core/aarch64/AArch64VolatileExtendingReadNode.java
+++ b/compiler/src/org.graalvm.compiler.core.aarch64/src/org/graalvm/compiler/core/aarch64/AArch64VolatileExtendingReadNode.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, Red Hat Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package org.graalvm.compiler.core.aarch64;
+
+import org.graalvm.compiler.core.common.type.IntegerStamp;
+import org.graalvm.compiler.core.common.type.Stamp;
+import org.graalvm.compiler.graph.NodeClass;
+import org.graalvm.compiler.nodeinfo.NodeInfo;
+import org.graalvm.compiler.nodes.FrameState;
+import org.graalvm.compiler.nodes.extended.GuardingNode;
+import org.graalvm.compiler.nodes.memory.address.AddressNode;
+import org.graalvm.word.LocationIdentity;
+
+/**
+ * AArch64-specific subclass of ReadNode that knows how to merge ZeroExtend and SignExtend into the
+ * read and also implements the read using a memory barrier.
+ */
+
+@NodeInfo
+public class AArch64VolatileExtendingReadNode extends AArch64ExtendingReadNode {
+    public static final NodeClass<AArch64VolatileExtendingReadNode> TYPE = NodeClass.create(AArch64VolatileExtendingReadNode.class);
+
+    public AArch64VolatileExtendingReadNode(AddressNode address, LocationIdentity location, Stamp stamp, GuardingNode guard, BarrierType barrierType, boolean nullCheck,
+                                            FrameState stateBefore, IntegerStamp accessStamp, boolean isSigned) {
+        super(TYPE, address, location, stamp, guard, barrierType, nullCheck, stateBefore, accessStamp, isSigned);
+    }
+
+}

--- a/compiler/src/org.graalvm.compiler.core.aarch64/src/org/graalvm/compiler/core/aarch64/AArch64VolatileReadNode.java
+++ b/compiler/src/org.graalvm.compiler.core.aarch64/src/org/graalvm/compiler/core/aarch64/AArch64VolatileReadNode.java
@@ -47,7 +47,7 @@ import org.graalvm.word.LocationIdentity;
 
 @NodeInfo
 public class AArch64VolatileReadNode extends ReadNode {
-                   public static final NodeClass<AArch64VolatileReadNode> TYPE = NodeClass.create(AArch64VolatileReadNode.class);
+    public static final NodeClass<AArch64VolatileReadNode> TYPE = NodeClass.create(AArch64VolatileReadNode.class);
 
     public AArch64VolatileReadNode(AddressNode address, LocationIdentity location, Stamp stamp, GuardingNode guard, BarrierType barrierType, boolean nullCheck,
                     FrameState stateBefore) {

--- a/compiler/src/org.graalvm.compiler.core.aarch64/src/org/graalvm/compiler/core/aarch64/AArch64VolatileReadNode.java
+++ b/compiler/src/org.graalvm.compiler.core.aarch64/src/org/graalvm/compiler/core/aarch64/AArch64VolatileReadNode.java
@@ -1,11 +1,13 @@
 /*
- * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2017, Red Hat Inc. All rights reserved.
+ * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, Red Hat Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 only, as
- * published by the Free Software Foundation.
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
  *
  * This code is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
@@ -25,8 +27,6 @@
 package org.graalvm.compiler.core.aarch64;
 
 import jdk.vm.ci.code.MemoryBarriers;
-import org.graalvm.compiler.core.aarch64.AArch64ArithmeticLIRGenerator;
-import org.graalvm.compiler.core.aarch64.AArch64LIRGenerator;
 import org.graalvm.compiler.core.common.LIRKind;
 import org.graalvm.compiler.core.common.type.Stamp;
 import org.graalvm.compiler.graph.NodeClass;

--- a/compiler/src/org.graalvm.compiler.core.aarch64/src/org/graalvm/compiler/core/aarch64/AArch64VolatileReadNode.java
+++ b/compiler/src/org.graalvm.compiler.core.aarch64/src/org/graalvm/compiler/core/aarch64/AArch64VolatileReadNode.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, Red Hat Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package org.graalvm.compiler.core.aarch64;
+
+import jdk.vm.ci.code.MemoryBarriers;
+import org.graalvm.compiler.core.aarch64.AArch64ArithmeticLIRGenerator;
+import org.graalvm.compiler.core.aarch64.AArch64LIRGenerator;
+import org.graalvm.compiler.core.common.LIRKind;
+import org.graalvm.compiler.core.common.type.Stamp;
+import org.graalvm.compiler.graph.NodeClass;
+import org.graalvm.compiler.nodeinfo.NodeInfo;
+import org.graalvm.compiler.nodes.FrameState;
+import org.graalvm.compiler.nodes.StructuredGraph;
+import org.graalvm.compiler.nodes.extended.GuardingNode;
+import org.graalvm.compiler.nodes.extended.MembarNode;
+import org.graalvm.compiler.nodes.memory.ReadNode;
+import org.graalvm.compiler.nodes.memory.address.AddressNode;
+import org.graalvm.compiler.nodes.spi.NodeLIRBuilderTool;
+import org.graalvm.word.LocationIdentity;
+
+/**
+ * AArch64-specific subclass of ReadNode that implements the read with a memory barrier appropriate
+ * for a Java volatile.
+ */
+
+@NodeInfo
+public class AArch64VolatileReadNode extends ReadNode {
+                   public static final NodeClass<AArch64VolatileReadNode> TYPE = NodeClass.create(AArch64VolatileReadNode.class);
+
+    public AArch64VolatileReadNode(AddressNode address, LocationIdentity location, Stamp stamp, GuardingNode guard, BarrierType barrierType, boolean nullCheck,
+                    FrameState stateBefore) {
+        super(TYPE, address, location, stamp, guard, barrierType, nullCheck, stateBefore);
+    }
+
+    @Override
+    public void generate(NodeLIRBuilderTool gen) {
+        AArch64LIRGenerator lirgen = (AArch64LIRGenerator) gen.getLIRGeneratorTool();
+        AArch64ArithmeticLIRGenerator arithgen = (AArch64ArithmeticLIRGenerator) lirgen.getArithmetic();
+        LIRKind readKind = lirgen.getLIRKind(getAccessStamp());
+        gen.setResult(this, arithgen.emitLoad(readKind, gen.operand(getAddress()), gen.state(this), true));
+    }
+
+    /**
+     * replace a ReadNode for a volatile field with an AArch64-specific variant which can be
+     * generated as ldar.
+     *
+     * @param readNode
+     */
+    public static void replace(ReadNode readNode, MembarNode pre, MembarNode post) {
+        assert pre.getBarriers() == MemoryBarriers.JMM_PRE_VOLATILE_READ;
+        assert post.getBarriers() == MemoryBarriers.JMM_POST_VOLATILE_READ;
+        assert post.getAccess() == readNode;
+        assert post.getLeading() == pre;
+
+        Stamp stamp = readNode.getAccessStamp();
+        AddressNode address = readNode.getAddress();
+        LocationIdentity location = readNode.getLocationIdentity();
+        GuardingNode guard = readNode.getGuard();
+        BarrierType barrierType = readNode.getBarrierType();
+        boolean nullCheck = readNode.getNullCheck();
+        FrameState stateBefore = readNode.stateBefore();
+        AArch64VolatileReadNode clone = new AArch64VolatileReadNode(address, location, stamp, guard, barrierType, nullCheck, stateBefore);
+        StructuredGraph graph = readNode.graph();
+        graph.add(clone);
+        // splice out the pre and post barriers
+        post.setAccess(null);
+        post.setLeading(null);
+        graph.removeFixed(pre);
+        graph.removeFixed(post);
+        // swap the clone for the read
+        graph.replaceFixedWithFixed(readNode, clone);
+    }
+}

--- a/compiler/src/org.graalvm.compiler.core.aarch64/src/org/graalvm/compiler/core/aarch64/AArch64VolatileWriteNode.java
+++ b/compiler/src/org.graalvm.compiler.core.aarch64/src/org/graalvm/compiler/core/aarch64/AArch64VolatileWriteNode.java
@@ -1,11 +1,13 @@
 /*
- * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2017, Red Hat Inc. All rights reserved.
+ * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, Red Hat Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 only, as
- * published by the Free Software Foundation.
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
  *
  * This code is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
@@ -25,8 +27,6 @@
 package org.graalvm.compiler.core.aarch64;
 
 import jdk.vm.ci.code.MemoryBarriers;
-import org.graalvm.compiler.core.aarch64.AArch64ArithmeticLIRGenerator;
-import org.graalvm.compiler.core.aarch64.AArch64LIRGenerator;
 import org.graalvm.compiler.core.common.LIRKind;
 import org.graalvm.compiler.graph.NodeClass;
 import org.graalvm.compiler.nodeinfo.NodeInfo;

--- a/compiler/src/org.graalvm.compiler.core.aarch64/src/org/graalvm/compiler/core/aarch64/AArch64VolatileWriteNode.java
+++ b/compiler/src/org.graalvm.compiler.core.aarch64/src/org/graalvm/compiler/core/aarch64/AArch64VolatileWriteNode.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, Red Hat Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package org.graalvm.compiler.core.aarch64;
+
+import jdk.vm.ci.code.MemoryBarriers;
+import org.graalvm.compiler.core.aarch64.AArch64ArithmeticLIRGenerator;
+import org.graalvm.compiler.core.aarch64.AArch64LIRGenerator;
+import org.graalvm.compiler.core.common.LIRKind;
+import org.graalvm.compiler.graph.NodeClass;
+import org.graalvm.compiler.nodeinfo.NodeInfo;
+import org.graalvm.compiler.nodes.NodeView;
+import org.graalvm.compiler.nodes.StructuredGraph;
+import org.graalvm.compiler.nodes.ValueNode;
+import org.graalvm.compiler.nodes.extended.MembarNode;
+import org.graalvm.compiler.nodes.memory.WriteNode;
+import org.graalvm.compiler.nodes.memory.address.AddressNode;
+import org.graalvm.compiler.nodes.spi.NodeLIRBuilderTool;
+import org.graalvm.word.LocationIdentity;
+
+/**
+ * AArch64-specific subclass of WriteNode that implements the write with a memory barrier
+ * appropriate for a Java volatile.
+ */
+
+@NodeInfo
+public class AArch64VolatileWriteNode extends WriteNode {
+    public static final NodeClass<AArch64VolatileWriteNode> TYPE = NodeClass.create(AArch64VolatileWriteNode.class);
+
+    public AArch64VolatileWriteNode(AddressNode address, LocationIdentity location, ValueNode value, BarrierType barrierType) {
+        super(TYPE, address, location, value, barrierType);
+    }
+
+    @Override
+    public void generate(NodeLIRBuilderTool gen) {
+        AArch64LIRGenerator lirgen = (AArch64LIRGenerator) gen.getLIRGeneratorTool();
+        AArch64ArithmeticLIRGenerator arithgen = (AArch64ArithmeticLIRGenerator) lirgen.getArithmetic();
+        LIRKind writeKind = lirgen.getLIRKind(value().stamp(NodeView.DEFAULT));
+        arithgen.emitStore(writeKind, gen.operand(getAddress()), gen.operand(value()), gen.state(this), true);
+    }
+
+    /**
+     * replace a ReadNode with an AArch64-specific variant which knows how to merge a downstream
+     * zero or sign extend into the read operation.
+     *
+     * @param writeNode
+     */
+    public static void replace(WriteNode writeNode, MembarNode pre, MembarNode post) {
+        assert pre.getBarriers() == MemoryBarriers.JMM_PRE_VOLATILE_WRITE;
+        assert post.getBarriers() == MemoryBarriers.JMM_POST_VOLATILE_WRITE;
+        assert post.getAccess() == writeNode;
+        assert post.getLeading() == pre;
+
+        AddressNode address = writeNode.getAddress();
+        LocationIdentity location = writeNode.getLocationIdentity();
+        ValueNode value = writeNode.value();
+        BarrierType barrierType = writeNode.getBarrierType();
+        AArch64VolatileWriteNode clone = new AArch64VolatileWriteNode(address, location, value, barrierType);
+        StructuredGraph graph = writeNode.graph();
+        graph.add(clone);
+        // splice out the pre and post nodes
+        post.setAccess(null);
+        post.setLeading(null);
+        graph.removeFixed(pre);
+        graph.removeFixed(post);
+        // swap the clone for the read
+        graph.replaceFixedWithFixed(writeNode, clone);
+    }
+}

--- a/compiler/src/org.graalvm.compiler.hotspot.aarch64.test/src/org/graalvm/compiler/hotspot/aarch64/test/UseBarriersForVolatileTest.java
+++ b/compiler/src/org.graalvm.compiler.hotspot.aarch64.test/src/org/graalvm/compiler/hotspot/aarch64/test/UseBarriersForVolatileTest.java
@@ -169,12 +169,12 @@ public class UseBarriersForVolatileTest extends GraalCompilerTest {
 
     private static boolean hasArg(String optionName) {
         if (optionName.equals("-cp") ||
-                optionName.equals("-classpath") ||
-                optionName.equals("--classpath" ) ||
-                optionName.equals("-p" ) ||
-                optionName.equals("--module-path" ) ||
-                optionName.equals("--ugrade-module-path" ) ||
-                optionName.equals("--add-modules" )) {
+                        optionName.equals("-classpath") ||
+                        optionName.equals("--classpath") ||
+                        optionName.equals("-p") ||
+                        optionName.equals("--module-path") ||
+                        optionName.equals("--ugrade-module-path") ||
+                        optionName.equals("--add-modules")) {
             return true;
         }
         return false;

--- a/compiler/src/org.graalvm.compiler.hotspot.aarch64.test/src/org/graalvm/compiler/hotspot/aarch64/test/UseBarriersForVolatileTest.java
+++ b/compiler/src/org.graalvm.compiler.hotspot.aarch64.test/src/org/graalvm/compiler/hotspot/aarch64/test/UseBarriersForVolatileTest.java
@@ -66,9 +66,9 @@ import static org.graalvm.compiler.test.SubprocessUtil.withoutDebuggerArguments;
  * The secondary test class is actually a static inner class of this class. This presents the
  * problem that test annotations on the inner class make it eligible for execution in the original
  * JVM as well as in the subordinate JVM. This problem is finessed by defining a system property
- * unique to each run and makeing the test succeed without executing when the property is not set.
- * Th e relevant system property is not setin the outer JVM but is set by the command line used to
- * create the subordinate JVM.
+ * whose name derives from the test class name and making the test succeed without executing when
+ * the property is not set. The relevant system property is not set in the outer JVM but is set by
+ * the command line used to create the subordinate JVM.
  */
 public class UseBarriersForVolatileTest extends GraalCompilerTest {
     /**
@@ -128,7 +128,7 @@ public class UseBarriersForVolatileTest extends GraalCompilerTest {
     public static List<String> getVMTestCommandLine() {
         List<String> args = getProcessCommandLine();
         if (args == null) {
-            throw new InternalError();
+            throw new InternalError("empty command line not expected!");
         } else {
             int index = findJUnitTestFilesIndex(args);
             return args.subList(0, index);
@@ -149,7 +149,7 @@ public class UseBarriersForVolatileTest extends GraalCompilerTest {
             }
         }
         if (i == commandLine.size()) {
-            throw new InternalError();
+            throw new InternalError("Could not find " + JUNIT_MAIN_CLASS_NAME + " on the command line for the current process");
         }
         i++;
         // skip all option args to the test runner class
@@ -164,11 +164,17 @@ public class UseBarriersForVolatileTest extends GraalCompilerTest {
                 i++;
             }
         }
-        throw new InternalError();
+        throw new InternalError("Could not find index of test class or @file argument");
     }
 
     private static boolean hasArg(String optionName) {
-        if (optionName.equals("-cp") || optionName.equals("-classpath")) {
+        if (optionName.equals("-cp") ||
+                optionName.equals("-classpath") ||
+                optionName.equals("--classpath" ) ||
+                optionName.equals("-p" ) ||
+                optionName.equals("--module-path" ) ||
+                optionName.equals("--ugrade-module-path" ) ||
+                optionName.equals("--add-modules" )) {
             return true;
         }
         return false;

--- a/compiler/src/org.graalvm.compiler.hotspot.aarch64.test/src/org/graalvm/compiler/hotspot/aarch64/test/UseBarriersForVolatileTest.java
+++ b/compiler/src/org.graalvm.compiler.hotspot.aarch64.test/src/org/graalvm/compiler/hotspot/aarch64/test/UseBarriersForVolatileTest.java
@@ -39,7 +39,6 @@ import org.graalvm.compiler.nodes.memory.MemoryCheckpoint;
 import org.graalvm.compiler.nodes.memory.ReadNode;
 import org.graalvm.compiler.nodes.memory.WriteNode;
 import org.graalvm.compiler.runtime.RuntimeProvider;
-import org.graalvm.compiler.serviceprovider.GraalServices;
 import org.graalvm.compiler.test.SubprocessUtil;
 import org.graalvm.word.LocationIdentity;
 import org.junit.Assert;

--- a/compiler/src/org.graalvm.compiler.hotspot.aarch64.test/src/org/graalvm/compiler/hotspot/aarch64/test/UseBarriersForVolatileTest.java
+++ b/compiler/src/org.graalvm.compiler.hotspot.aarch64.test/src/org/graalvm/compiler/hotspot/aarch64/test/UseBarriersForVolatileTest.java
@@ -100,6 +100,7 @@ public class UseBarriersForVolatileTest extends GraalCompilerTest {
 
     @Test
     public void testVarHandlesInSubJVM() throws IOException, InterruptedException {
+        Assume.assumeTrue(getTarget().arch instanceof AArch64);
         // the criterion for success is that all 4 tests finish ok
         Probe successProbe = new Probe("OK (2 tests)", 1);
         Probe testReadProbe = new Probe("Testing: testReadSnippet", 1);

--- a/compiler/src/org.graalvm.compiler.hotspot.aarch64.test/src/org/graalvm/compiler/hotspot/aarch64/test/UseBarriersForVolatileTest.java
+++ b/compiler/src/org.graalvm.compiler.hotspot.aarch64.test/src/org/graalvm/compiler/hotspot/aarch64/test/UseBarriersForVolatileTest.java
@@ -1,4 +1,5 @@
 package org.graalvm.compiler.hotspot.aarch64.test;
+
 import jdk.vm.ci.aarch64.AArch64;
 import jdk.vm.ci.meta.ResolvedJavaMethod;
 import org.graalvm.compiler.api.test.Graal;
@@ -27,27 +28,23 @@ import static org.graalvm.compiler.test.SubprocessUtil.getProcessCommandLine;
 import static org.graalvm.compiler.test.SubprocessUtil.withoutDebuggerArguments;
 
 /**
- * A test class to exercise AArch64 volatile reads and writes in a subordinate
- * JVM where OpenJDK config setting UseBarriersForVolatile is set to true.
+ * A test class to exercise AArch64 volatile reads and writes in a subordinate JVM where OpenJDK
+ * config setting UseBarriersForVolatile is set to true.
  *
- * The single test in this class creates a new JVM to run only the tests in
- * a specific secondary test class. It uses the same JVM configuration, test
- * runner and test configuration that it was started with, modulo a small set
- * of options added to the command line. The important changes are to reset the
- * OpenJDK option UseBarriersForVolatile from the default value false to true
- * amd to replace the original list of test classes with the secondary test
- * class.
+ * The single test in this class creates a new JVM to run only the tests in a specific secondary
+ * test class. It uses the same JVM configuration, test runner and test configuration that it was
+ * started with, modulo a small set of options added to the command line. The important changes are
+ * to reset the OpenJDK option UseBarriersForVolatile from the default value false to true amd to
+ * replace the original list of test classes with the secondary test class.
  *
- * The secondary test class is actually a static inner class of this class.
- * This presents the problem that test annotations on the inner class make it
- * eligible for execution in the original JVM as well as in the subordinate JVM.
- * This problem is finessed by defining a system property unique to each run
- * and makeing the test succeed without executing when the property is not set.
- * Th e relevant system property is not setin the outer JVM but is set by the
- * command line used to create the subordinate JVM.
+ * The secondary test class is actually a static inner class of this class. This presents the
+ * problem that test annotations on the inner class make it eligible for execution in the original
+ * JVM as well as in the subordinate JVM. This problem is finessed by defining a system property
+ * unique to each run and makeing the test succeed without executing when the property is not set.
+ * Th e relevant system property is not setin the outer JVM but is set by the command line used to
+ * create the subordinate JVM.
  */
-public class UseBarriersForVolatileTest extends GraalCompilerTest
-{
+public class UseBarriersForVolatileTest extends GraalCompilerTest {
     /**
      * Tests compilation requested by the VM.
      */
@@ -77,14 +74,13 @@ public class UseBarriersForVolatileTest extends GraalCompilerTest
     }
 
     @Test
-    public void testVarHandlesInSubJVM() throws IOException, InterruptedException
-    {
+    public void testVarHandlesInSubJVM() throws IOException, InterruptedException {
         // the criterion for success is that all 4 tests finish ok
         Probe successProbe = new Probe("OK (2 tests)", 1);
         Probe testReadProbe = new Probe("Testing: testReadSnippet", 1);
         Probe testWriteProbe = new Probe("Testing: testWriteSnippet", 1);
         List<Probe> probes = Arrays.asList(testReadProbe, testWriteProbe, successProbe);
-        List<String> extraOpts =  Arrays.asList("-XX:+UseBarriersForVolatile");
+        List<String> extraOpts = Arrays.asList("-XX:+UseBarriersForVolatile");
         // run the tests belonging to inner class Internal in a subordinate test JVM
         testHelper(probes, extraOpts, Internal.class.getName());
     }
@@ -92,16 +88,16 @@ public class UseBarriersForVolatileTest extends GraalCompilerTest
     private static final boolean VERBOSE = Boolean.getBoolean(UseBarriersForVolatileTest.class.getSimpleName() + ".verbose");
 
     // the name of the JUnit runner class we expect to find on the original command line
-    private static final String JUNIT_MAIN_CLASS_NAME =  "com.oracle.mxtool.junit.MxJUnitWrapper";
+    private static final String JUNIT_MAIN_CLASS_NAME = "com.oracle.mxtool.junit.MxJUnitWrapper";
 
     // the property used to inhibit execution of desired tests in the main
     // JVM and enable execution of desired tests in the subordinate JVM
     private static final String ENABLE_SUBORDINATE_TESTS_PROPERTY = UseBarriersForVolatileTest.class.getName() + ".enable.subordinate.tests";
 
-     /**
-     * Gets the command line used to start the current tests, including all VM arguments,
-     * the test runner class and its option flags. This can be used to spawn an identical
-     * test run for the secondary test class.
+    /**
+     * Gets the command line used to start the current tests, including all VM arguments, the test
+     * runner class and its option flags. This can be used to spawn an identical test run for the
+     * secondary test class.
      */
     public static List<String> getVMTestCommandLine() {
         List<String> args = getProcessCommandLine();
@@ -131,7 +127,7 @@ public class UseBarriersForVolatileTest extends GraalCompilerTest
         }
         i++;
         // skip all option args to the test runner class
-        while(i < commandLine.size()) {
+        while (i < commandLine.size()) {
             String s = commandLine.get(i);
             if (s.charAt(0) != '-') {
                 // this index identifies the first test class or an @file spec
@@ -145,7 +141,6 @@ public class UseBarriersForVolatileTest extends GraalCompilerTest
         throw new InternalError();
     }
 
-
     private static boolean hasArg(String optionName) {
         if (optionName.equals("-cp") || optionName.equals("-classpath")) {
             return true;
@@ -155,8 +150,7 @@ public class UseBarriersForVolatileTest extends GraalCompilerTest
 
     // run test on the provided class in a subordinate JVM with the extra
     // VM args provided and validate the output using the supplied probes
-    private static void testHelper(List<Probe> probes, List<String> extraVmArgs, String... mainClassAndArgs) throws IOException, InterruptedException
-    {
+    private static void testHelper(List<Probe> probes, List<String> extraVmArgs, String... mainClassAndArgs) throws IOException, InterruptedException {
         List<String> vmArgs = withoutDebuggerArguments(getVMTestCommandLine());
 
         int s = extraVmArgs.size();
@@ -171,20 +165,20 @@ public class UseBarriersForVolatileTest extends GraalCompilerTest
         vmArgs.add(idx + s, "-D" + ENABLE_SUBORDINATE_TESTS_PROPERTY);
 
         SubprocessUtil.Subprocess proc = SubprocessUtil.java(vmArgs, mainClassAndArgs);
-        if(VERBOSE) {
+        if (VERBOSE) {
             System.out.println(proc);
         }
 
         for (String line : proc.output) {
             for (UseBarriersForVolatileTest.Probe probe : probes) {
-                if(probe.matches(line)) {
+                if (probe.matches(line)) {
                     break;
                 }
             }
         }
         for (UseBarriersForVolatileTest.Probe probe : probes) {
             String error = probe.test();
-            if(error != null) {
+            if (error != null) {
                 Assert.fail(String.format("Did not find expected occurences of '%s' in output of command: %s%n%s", probe.substring, error, proc));
             }
         }
@@ -193,9 +187,9 @@ public class UseBarriersForVolatileTest extends GraalCompilerTest
     /**
      * An inner class used as the target for test runs in the subordinate JVM.
      *
-     * The tests in this class are automatically added to the list of tests
-     * to be run in the main JVM. A system property is used to disable them
-     * in that JVM and enable them in the subordinate JVM
+     * The tests in this class are automatically added to the list of tests to be run in the main
+     * JVM. A system property is used to disable them in that JVM and enable them in the subordinate
+     * JVM
      */
     public static class Internal extends GraalCompilerTest {
 
@@ -206,11 +200,11 @@ public class UseBarriersForVolatileTest extends GraalCompilerTest
         public static int testReadSnippet(Internal.Holder h) {
             return h.volatileField;
         }
-    
+
         public static void testWriteSnippet(Internal.Holder h) {
             h.volatileField = 123;
         }
-    
+
         void testAccess(String name, int expectedReads, int expectedWrites, int expectedMembars, int expectedAnyKill) {
             ResolvedJavaMethod method = getResolvedJavaMethod(name);
             StructuredGraph graph = parseForCompile(method);
@@ -220,7 +214,7 @@ public class UseBarriersForVolatileTest extends GraalCompilerTest
             Assert.assertEquals(expectedMembars, graph.getNodes().filter(MembarNode.class).count());
             Assert.assertEquals(expectedAnyKill, countAnyKill(graph));
         }
-    
+
         @Test
         public void testReadAArch64() {
             // run this test on AArch64
@@ -233,7 +227,7 @@ public class UseBarriersForVolatileTest extends GraalCompilerTest
             System.out.println("Testing: testReadSnippet");
             testAccess("testReadSnippet", 1, 0, 2, 2);
         }
-    
+
         @Test
         public void testWriteAArch64() {
             // run this test on AArch64
@@ -246,7 +240,7 @@ public class UseBarriersForVolatileTest extends GraalCompilerTest
             System.out.println("Testing: testWriteSnippet");
             testAccess("testWriteSnippet", 0, 1, 2, 2);
         }
-    
+
         private static int countAnyKill(StructuredGraph graph) {
             int anyKillCount = 0;
             int startNodes = 0;

--- a/compiler/src/org.graalvm.compiler.hotspot.aarch64.test/src/org/graalvm/compiler/hotspot/aarch64/test/UseBarriersForVolatileTest.java
+++ b/compiler/src/org.graalvm.compiler.hotspot.aarch64.test/src/org/graalvm/compiler/hotspot/aarch64/test/UseBarriersForVolatileTest.java
@@ -1,3 +1,29 @@
+/*
+ * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, Red Hat Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
 package org.graalvm.compiler.hotspot.aarch64.test;
 
 import jdk.vm.ci.aarch64.AArch64;

--- a/compiler/src/org.graalvm.compiler.hotspot.aarch64.test/src/org/graalvm/compiler/hotspot/aarch64/test/UseBarriersForVolatileTest.java
+++ b/compiler/src/org.graalvm.compiler.hotspot.aarch64.test/src/org/graalvm/compiler/hotspot/aarch64/test/UseBarriersForVolatileTest.java
@@ -1,0 +1,343 @@
+package org.graalvm.compiler.hotspot.aarch64.test;
+import jdk.vm.ci.aarch64.AArch64;
+import jdk.vm.ci.meta.ResolvedJavaMethod;
+import org.graalvm.compiler.api.test.Graal;
+import org.graalvm.compiler.core.test.GraalCompilerTest;
+import org.graalvm.compiler.debug.GraalError;
+import org.graalvm.compiler.graph.Node;
+import org.graalvm.compiler.hotspot.HotSpotGraalRuntimeProvider;
+import org.graalvm.compiler.nodes.StartNode;
+import org.graalvm.compiler.nodes.StructuredGraph;
+import org.graalvm.compiler.nodes.extended.MembarNode;
+import org.graalvm.compiler.nodes.memory.MemoryCheckpoint;
+import org.graalvm.compiler.nodes.memory.ReadNode;
+import org.graalvm.compiler.nodes.memory.WriteNode;
+import org.graalvm.compiler.runtime.RuntimeProvider;
+import org.graalvm.compiler.serviceprovider.GraalServices;
+import org.graalvm.compiler.test.SubprocessUtil;
+import org.graalvm.word.LocationIdentity;
+import org.junit.Assert;
+import org.junit.Assume;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.VarHandle;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.graalvm.compiler.test.SubprocessUtil.getProcessCommandLine;
+import static org.graalvm.compiler.test.SubprocessUtil.withoutDebuggerArguments;
+
+/**
+ * A test class to exercise AArch64 volatile reads and writes in a subordinate
+ * JVM where OpenJDK config setting UseBarriersForVolatile is set to true.
+ *
+ * The single test in this class creates a new JVM to run only the tests in
+ * a specific secondary test class. It uses the same JVM configuration, test
+ * runner and test configuration that it was started with, modulo a small set
+ * of options added to the command line. The important changes are to reset the
+ * OpenJDK option UseBarriersForVolatile from the default value false to true
+ * amd to replace the original list of test classes with the secondary test
+ * class.
+ *
+ * The secondary test class is actually a static inner class of this class.
+ * This presents the problem that test annotations on the inner class make it
+ * eligible for execution in the original JVM as well as in the subordinate JVM.
+ * This problem is finessed by defining a system property unique to each run
+ * and makeing the test succeed without executing when the property is not set.
+ * Th e relevant system property is not setin the outer JVM but is set by the
+ * command line used to create the subordinate JVM.
+ */
+public class UseBarriersForVolatileTest extends GraalCompilerTest
+{
+    /**
+     * Tests compilation requested by the VM.
+     */
+    static class Probe {
+        final String substring;
+        final int expectedOccurrences;
+        int actualOccurrences;
+        String lastMatchingLine;
+
+        Probe(String substring, int expectedOccurrences) {
+            this.substring = substring;
+            this.expectedOccurrences = expectedOccurrences;
+        }
+
+        boolean matches(String line) {
+            if (line.contains(substring)) {
+                actualOccurrences++;
+                lastMatchingLine = line;
+                return true;
+            }
+            return false;
+        }
+
+        String test() {
+            return expectedOccurrences == actualOccurrences ? null : String.format("expected %d, got %d occurrences", expectedOccurrences, actualOccurrences);
+        }
+    }
+
+    @Test
+    public void testVarHandlesInSubJVM() throws IOException, InterruptedException
+    {
+        // the criterion for success is that all 4 tests finish ok
+        List<Probe> probes = Arrays.asList(new Probe("OK (4 tests)", 1));
+        List<String> extraOpts =  Arrays.asList("-XX:+UseBarriersForVolatile");
+        // run the tests belonging to inner class Internal in a subordinate test JVM
+        testHelper(probes, extraOpts, Internal.class.getName());
+    }
+
+    private static final boolean VERBOSE = Boolean.getBoolean(UseBarriersForVolatileTest.class.getSimpleName() + ".verbose");
+
+    // the name of the JUnit runner class we expect to find on the original command line
+    private static final String JUNIT_MAIN_CLASS_NAME =  "com.oracle.mxtool.junit.MxJUnitWrapper";
+
+    // the property used to inhibit execution of desired tests in the main
+    // JVM and enable execution of desired tests in the subordinate JVM
+    private static final String ENABLE_SUBORDINATE_TESTS_PROPERTY = "enable.subordinate.tests." + System.currentTimeMillis();
+
+    /**
+     * Gets the command line used to start the current tests, including all VM arguments,
+     * the test runner class and its option flags. This can be used to spawn an identical
+     * test run for the secondary test class.
+     */
+    public static List<String> getVMTestCommandLine() {
+        List<String> args = getProcessCommandLine();
+        if (args == null) {
+            throw new InternalError();
+        } else {
+            int index = findJUnitTestFilesIndex(args);
+            return args.subList(0, index);
+        }
+    }
+
+    private static int findJUnitTestFilesIndex(List<String> commandLine) {
+        int i = 1; // Skip the java executable
+        // inlcude all args up to and including the test runner class
+        while (i < commandLine.size()) {
+            String s = commandLine.get(i);
+            if (JUNIT_MAIN_CLASS_NAME.equals(s)) {
+                break;
+            } else if (hasArg(s)) {
+                i += 2;
+            } else {
+                i++;
+            }
+        }
+        if (i == commandLine.size()) {
+            throw new InternalError();
+        }
+        i++;
+        // skip all option args to the test runner class
+        while(i < commandLine.size()) {
+            String s = commandLine.get(i);
+            if (s.charAt(0) != '-') {
+                // this index identifies the first test class or an @file spec
+                return i;
+            } else if (hasArg(s)) {
+                i += 2;
+            } else {
+                i++;
+            }
+        }
+        throw new InternalError();
+    }
+
+    // Graal does not currently work for jdk8-aarch64 but you never know ...
+    private static final boolean isJava8OrEarlier = GraalServices.Java8OrEarlier;
+
+    private static boolean hasArg(String optionName) {
+        if (optionName.equals("-cp") || optionName.equals("-classpath")) {
+            return true;
+        }
+        if (!isJava8OrEarlier) {
+            if (optionName.equals("--version") ||
+                            optionName.equals("--show-version") ||
+                            optionName.equals("--dry-run") ||
+                            optionName.equals("--disable-@files") ||
+                            optionName.equals("--dry-run") ||
+                            optionName.equals("--help") ||
+                            optionName.equals("--help-extra")) {
+                return false;
+            }
+            if (optionName.startsWith("--")) {
+                return optionName.indexOf('=') == -1;
+            }
+        }
+        return false;
+    }
+
+    // run test on the provided class in a subordinate JVM with the extra
+    // VM args provided and validate the output using the supplied probes
+    private static void testHelper(List<Probe> probes, List<String> extraVmArgs, String... mainClassAndArgs) throws IOException, InterruptedException
+    {
+        List<String> vmArgs = withoutDebuggerArguments(getVMTestCommandLine());
+
+        int s = extraVmArgs.size();
+        // extra JVM options need to be added before the test runner class
+        int idx = vmArgs.indexOf(JUNIT_MAIN_CLASS_NAME);
+        Assert.assertTrue(idx > 0);
+
+        for (int i = 0; i < s; i++) {
+            vmArgs.add(idx + i, extraVmArgs.get(i));
+        }
+        // setting this property enables tests on Internal in the sub-process
+        vmArgs.add(idx + s, "-D" + ENABLE_SUBORDINATE_TESTS_PROPERTY);
+
+        SubprocessUtil.Subprocess proc = SubprocessUtil.java(vmArgs, mainClassAndArgs);
+        if(VERBOSE) {
+            System.out.println(proc);
+        }
+
+        for (String line : proc.output) {
+            for (UseBarriersForVolatileTest.Probe probe : probes) {
+                if(probe.matches(line)) {
+                    break;
+                }
+            }
+        }
+        for (UseBarriersForVolatileTest.Probe probe : probes) {
+            String error = probe.test();
+            if(error != null) {
+                Assert.fail(String.format("Did not find expected occurences of '%s' in output of command: %s%n%s", probe.substring, error, proc));
+            }
+        }
+    }
+
+    /**
+     * An inner class used as the target for test runs in the subordinate JVM.
+     *
+     * The tests in this class are automatically added to the list of tests
+     * to be run in the main JVM. A system property is used to disable them
+     * in that JVM and enable them in the subordinate JVM
+     */
+    public static class Internal extends GraalCompilerTest {
+
+        static class Holder {
+            /* Field is declared volatile, but accessed with non-volatile semantics in the tests. */
+            volatile int volatileField = 42;
+    
+            /* Field is declared non-volatile, but accessed with volatile semantics in the tests. */
+            int field = 2018;
+    
+            static final VarHandle VOLATILE_FIELD;
+            static final VarHandle FIELD;
+    
+            static {
+                try {
+                    VOLATILE_FIELD = MethodHandles.lookup().findVarHandle(Internal.Holder.class, "volatileField", int.class);
+                    FIELD = MethodHandles.lookup().findVarHandle(Internal.Holder.class, "field", int.class);
+                } catch (ReflectiveOperationException ex) {
+                    throw GraalError.shouldNotReachHere(ex);
+                }
+            }
+        }
+    
+        public static int testRead1Snippet(Internal.Holder h) {
+            /* Explicitly access the volatile field with volatile access semantics. */
+            return (int) Internal.Holder.VOLATILE_FIELD.getVolatile(h);
+        }
+    
+        public static int testRead2Snippet(Internal.Holder h) {
+            /* Explicitly access the non-volatile field with volatile access semantics. */
+            return (int) Internal.Holder.FIELD.getVolatile(h);
+        }
+    
+        public static void testWrite1Snippet(Internal.Holder h) {
+            /* Explicitly access the volatile field with volatile access semantics. */
+            Internal.Holder.VOLATILE_FIELD.setVolatile(h, 123);
+        }
+    
+        public static void testWrite2Snippet(Internal.Holder h) {
+            /* Explicitly access the non-volatile field with volatile access semantics. */
+            Internal.Holder.FIELD.setVolatile(h, 123);
+        }
+    
+        void testAccess(String name, int expectedReads, int expectedWrites, int expectedMembars, int expectedAnyKill) {
+            ResolvedJavaMethod method = getResolvedJavaMethod(name);
+            StructuredGraph graph = parseForCompile(method);
+            compile(method, graph);
+            Assert.assertEquals(expectedReads, graph.getNodes().filter(ReadNode.class).count());
+            Assert.assertEquals(expectedWrites, graph.getNodes().filter(WriteNode.class).count());
+            Assert.assertEquals(expectedMembars, graph.getNodes().filter(MembarNode.class).count());
+            Assert.assertEquals(expectedAnyKill, countAnyKill(graph));
+        }
+    
+        @Test
+        public void testRead1AArch64() {
+            // run this test on AArch64
+            Assume.assumeTrue(getTarget().arch instanceof AArch64);
+            // only run when enabled in subordinate JVM
+            Assume.assumeTrue(System.getProperty(ENABLE_SUBORDINATE_TESTS_PROPERTY) != null);
+            RuntimeProvider runtimeProvider = Graal.getRequiredCapability(RuntimeProvider.class);
+            HotSpotGraalRuntimeProvider hotSpotProvider = (HotSpotGraalRuntimeProvider) runtimeProvider;
+            Assert.assertTrue(hotSpotProvider.getVMConfig().useBarriersForVolatile);
+            testAccess("testRead1Snippet", 1, 0, 2, 2);
+        }
+    
+        @Test
+        public void testRead2AArch64() {
+            // run this test on AArch64
+            Assume.assumeTrue(getTarget().arch instanceof AArch64);
+            // only run when enabled in subordinate JVM
+            Assume.assumeTrue(System.getProperty(ENABLE_SUBORDINATE_TESTS_PROPERTY) != null);
+            RuntimeProvider runtimeProvider = Graal.getRequiredCapability(RuntimeProvider.class);
+            HotSpotGraalRuntimeProvider hotSpotProvider = (HotSpotGraalRuntimeProvider) runtimeProvider;
+            Assert.assertTrue(hotSpotProvider.getVMConfig().useBarriersForVolatile);
+            testAccess("testRead2Snippet", 1, 0, 2, 2);
+        }
+    
+        @Test
+        public void testWrite1AArch64() {
+            // run this test on AArch64
+            Assume.assumeTrue(getTarget().arch instanceof AArch64);
+            // only run when enabled in subordinate JVM
+            Assume.assumeTrue(System.getProperty(ENABLE_SUBORDINATE_TESTS_PROPERTY) != null);
+            RuntimeProvider runtimeProvider = Graal.getRequiredCapability(RuntimeProvider.class);
+            HotSpotGraalRuntimeProvider hotSpotProvider = (HotSpotGraalRuntimeProvider) runtimeProvider;
+            Assert.assertTrue(hotSpotProvider.getVMConfig().useBarriersForVolatile);
+            testAccess("testWrite1Snippet", 0, 1, 2, 2);
+        }
+    
+        @Test
+        public void testWrite2AArch64() {
+            // run this test on AArch64
+            Assume.assumeTrue(getTarget().arch instanceof AArch64);
+            // only run when enabled in subordinate JVM
+            Assume.assumeTrue(System.getProperty(ENABLE_SUBORDINATE_TESTS_PROPERTY) != null);
+            RuntimeProvider runtimeProvider = Graal.getRequiredCapability(RuntimeProvider.class);
+            HotSpotGraalRuntimeProvider hotSpotProvider = (HotSpotGraalRuntimeProvider) runtimeProvider;
+            Assert.assertTrue(hotSpotProvider.getVMConfig().useBarriersForVolatile);
+            testAccess("testWrite2Snippet", 0, 1, 2, 2);
+        }
+    
+        private static int countAnyKill(StructuredGraph graph) {
+            int anyKillCount = 0;
+            int startNodes = 0;
+            for (Node n : graph.getNodes()) {
+                if (n instanceof StartNode) {
+                    startNodes++;
+                } else if (n instanceof MemoryCheckpoint.Single) {
+                    MemoryCheckpoint.Single single = (MemoryCheckpoint.Single) n;
+                    if (single.getLocationIdentity().isAny()) {
+                        anyKillCount++;
+                    }
+                } else if (n instanceof MemoryCheckpoint.Multi) {
+                    MemoryCheckpoint.Multi multi = (MemoryCheckpoint.Multi) n;
+                    for (LocationIdentity loc : multi.getLocationIdentities()) {
+                        if (loc.isAny()) {
+                            anyKillCount++;
+                            break;
+                        }
+                    }
+                }
+            }
+            // Ignore single StartNode.
+            Assert.assertEquals(1, startNodes);
+            return anyKillCount;
+        }
+    }
+}

--- a/compiler/src/org.graalvm.compiler.hotspot.aarch64.test/src/org/graalvm/compiler/hotspot/aarch64/test/UseBarriersForVolatileTest.java
+++ b/compiler/src/org.graalvm.compiler.hotspot.aarch64.test/src/org/graalvm/compiler/hotspot/aarch64/test/UseBarriersForVolatileTest.java
@@ -84,7 +84,9 @@ public class UseBarriersForVolatileTest extends GraalCompilerTest
     public void testVarHandlesInSubJVM() throws IOException, InterruptedException
     {
         // the criterion for success is that all 4 tests finish ok
-        List<Probe> probes = Arrays.asList(new Probe("OK (4 tests)", 1));
+        Probe successProbe = new Probe("OK (4 tests)", 1);
+        Probe testRunProbe = new Probe("Testing: ", 4);
+        List<Probe> probes = Arrays.asList(testRunProbe, successProbe);
         List<String> extraOpts =  Arrays.asList("-XX:+UseBarriersForVolatile");
         // run the tests belonging to inner class Internal in a subordinate test JVM
         testHelper(probes, extraOpts, Internal.class.getName());
@@ -97,9 +99,9 @@ public class UseBarriersForVolatileTest extends GraalCompilerTest
 
     // the property used to inhibit execution of desired tests in the main
     // JVM and enable execution of desired tests in the subordinate JVM
-    private static final String ENABLE_SUBORDINATE_TESTS_PROPERTY = "enable.subordinate.tests." + System.currentTimeMillis();
+    private static final String ENABLE_SUBORDINATE_TESTS_PROPERTY = UseBarriersForVolatileTest.class.getName() + ".enable.subordinate.tests";
 
-    /**
+     /**
      * Gets the command line used to start the current tests, including all VM arguments,
      * the test runner class and its option flags. This can be used to spawn an identical
      * test run for the secondary test class.
@@ -275,6 +277,7 @@ public class UseBarriersForVolatileTest extends GraalCompilerTest
             RuntimeProvider runtimeProvider = Graal.getRequiredCapability(RuntimeProvider.class);
             HotSpotGraalRuntimeProvider hotSpotProvider = (HotSpotGraalRuntimeProvider) runtimeProvider;
             Assert.assertTrue(hotSpotProvider.getVMConfig().useBarriersForVolatile);
+            System.out.println("Testing: testRead1Snippet");
             testAccess("testRead1Snippet", 1, 0, 2, 2);
         }
     
@@ -287,6 +290,7 @@ public class UseBarriersForVolatileTest extends GraalCompilerTest
             RuntimeProvider runtimeProvider = Graal.getRequiredCapability(RuntimeProvider.class);
             HotSpotGraalRuntimeProvider hotSpotProvider = (HotSpotGraalRuntimeProvider) runtimeProvider;
             Assert.assertTrue(hotSpotProvider.getVMConfig().useBarriersForVolatile);
+            System.out.println("Testing: testRead2Snippet");
             testAccess("testRead2Snippet", 1, 0, 2, 2);
         }
     
@@ -299,6 +303,7 @@ public class UseBarriersForVolatileTest extends GraalCompilerTest
             RuntimeProvider runtimeProvider = Graal.getRequiredCapability(RuntimeProvider.class);
             HotSpotGraalRuntimeProvider hotSpotProvider = (HotSpotGraalRuntimeProvider) runtimeProvider;
             Assert.assertTrue(hotSpotProvider.getVMConfig().useBarriersForVolatile);
+            System.out.println("Testing: testWrite1Snippet");
             testAccess("testWrite1Snippet", 0, 1, 2, 2);
         }
     
@@ -311,6 +316,7 @@ public class UseBarriersForVolatileTest extends GraalCompilerTest
             RuntimeProvider runtimeProvider = Graal.getRequiredCapability(RuntimeProvider.class);
             HotSpotGraalRuntimeProvider hotSpotProvider = (HotSpotGraalRuntimeProvider) runtimeProvider;
             Assert.assertTrue(hotSpotProvider.getVMConfig().useBarriersForVolatile);
+            System.out.println("Testing: testWrite2Snippet");
             testAccess("testWrite2Snippet", 0, 1, 2, 2);
         }
     

--- a/compiler/src/org.graalvm.compiler.hotspot.aarch64.test/src/org/graalvm/compiler/hotspot/aarch64/test/UseBarriersForVolatileTest.java
+++ b/compiler/src/org.graalvm.compiler.hotspot.aarch64.test/src/org/graalvm/compiler/hotspot/aarch64/test/UseBarriersForVolatileTest.java
@@ -145,26 +145,10 @@ public class UseBarriersForVolatileTest extends GraalCompilerTest
         throw new InternalError();
     }
 
-    // Graal does not currently work for jdk8-aarch64 but you never know ...
-    private static final boolean isJava8OrEarlier = GraalServices.Java8OrEarlier;
 
     private static boolean hasArg(String optionName) {
         if (optionName.equals("-cp") || optionName.equals("-classpath")) {
             return true;
-        }
-        if (!isJava8OrEarlier) {
-            if (optionName.equals("--version") ||
-                            optionName.equals("--show-version") ||
-                            optionName.equals("--dry-run") ||
-                            optionName.equals("--disable-@files") ||
-                            optionName.equals("--dry-run") ||
-                            optionName.equals("--help") ||
-                            optionName.equals("--help-extra")) {
-                return false;
-            }
-            if (optionName.startsWith("--")) {
-                return optionName.indexOf('=') == -1;
-            }
         }
         return false;
     }

--- a/compiler/src/org.graalvm.compiler.hotspot.aarch64/src/org/graalvm/compiler/hotspot/aarch64/AArch64HotSpotBackend.java
+++ b/compiler/src/org.graalvm.compiler.hotspot.aarch64/src/org/graalvm/compiler/hotspot/aarch64/AArch64HotSpotBackend.java
@@ -121,9 +121,7 @@ public class AArch64HotSpotBackend extends HotSpotHostBackend implements LIRGene
         AArch64MacroAssembler masm = (AArch64MacroAssembler) crb.asm;
         try (ScratchRegister sc = masm.getScratchRegister()) {
             Register scratch = sc.getRegister();
-            AArch64Address address = masm.makeAddress(sp, -bangOffset, scratch, 8, /*
-                                                                                    * allowOverwrite
-                                                                                    */false);
+            AArch64Address address = masm.makeAddress(sp, -bangOffset, scratch, 8, /* allowOverwrite */false);
             masm.str(64, zr, address);
         }
     }

--- a/compiler/src/org.graalvm.compiler.hotspot.aarch64/src/org/graalvm/compiler/hotspot/aarch64/AArch64HotSpotBackend.java
+++ b/compiler/src/org.graalvm.compiler.hotspot.aarch64/src/org/graalvm/compiler/hotspot/aarch64/AArch64HotSpotBackend.java
@@ -121,7 +121,9 @@ public class AArch64HotSpotBackend extends HotSpotHostBackend implements LIRGene
         AArch64MacroAssembler masm = (AArch64MacroAssembler) crb.asm;
         try (ScratchRegister sc = masm.getScratchRegister()) {
             Register scratch = sc.getRegister();
-            AArch64Address address = masm.makeAddress(sp, -bangOffset, scratch, 8, /* allowOverwrite */false);
+            AArch64Address address = masm.makeAddress(sp, -bangOffset, scratch, 8, /*
+                                                                                    * allowOverwrite
+                                                                                    */false);
             masm.str(64, zr, address);
         }
     }

--- a/compiler/src/org.graalvm.compiler.hotspot.aarch64/src/org/graalvm/compiler/hotspot/aarch64/AArch64HotSpotBackendFactory.java
+++ b/compiler/src/org.graalvm.compiler.hotspot.aarch64/src/org/graalvm/compiler/hotspot/aarch64/AArch64HotSpotBackendFactory.java
@@ -189,7 +189,7 @@ public class AArch64HotSpotBackendFactory implements HotSpotBackendFactory {
 
     protected HotSpotSuitesProvider createSuites(GraalHotSpotVMConfig config, HotSpotGraalRuntimeProvider runtime, CompilerConfiguration compilerConfiguration, Plugins plugins,
                     @SuppressWarnings("unused") Replacements replacements) {
-        AArch64SuitesCreator suitesCreator = new AArch64SuitesCreator(compilerConfiguration, plugins, SchedulePhase.class);
+        AArch64SuitesCreator suitesCreator = new AArch64SuitesCreator(compilerConfiguration, plugins, SchedulePhase.class, config.useBarriersForVolatile);
         Phase addressLoweringPhase = new AddressLoweringByUsePhase(new AArch64AddressLoweringByUse(new AArch64LIRKindTool()));
         return new AddressLoweringHotSpotSuitesProvider(suitesCreator, config, runtime, addressLoweringPhase);
     }

--- a/compiler/src/org.graalvm.compiler.hotspot/src/org/graalvm/compiler/hotspot/GraalHotSpotVMConfig.java
+++ b/compiler/src/org.graalvm.compiler.hotspot/src/org/graalvm/compiler/hotspot/GraalHotSpotVMConfig.java
@@ -96,6 +96,7 @@ public class GraalHotSpotVMConfig extends GraalHotSpotVMConfigBase {
     public final boolean useCRC32Intrinsics = getFlag("UseCRC32Intrinsics", Boolean.class);
     public final boolean useCRC32CIntrinsics = versioned.useCRC32CIntrinsics;
     public final boolean threadLocalHandshakes = getFlag("ThreadLocalHandshakes", Boolean.class, false);
+    public final boolean useBarriersForVolatile = getFlag("UseBarriersForVolatile", Boolean.class, false);
 
     private final boolean useMultiplyToLenIntrinsic = getFlag("UseMultiplyToLenIntrinsic", Boolean.class);
     private final boolean useSHA1Intrinsics = getFlag("UseSHA1Intrinsics", Boolean.class);

--- a/compiler/src/org.graalvm.compiler.lir.aarch64/src/org/graalvm/compiler/lir/aarch64/AArch64Move.java
+++ b/compiler/src/org.graalvm.compiler.lir.aarch64/src/org/graalvm/compiler/lir/aarch64/AArch64Move.java
@@ -274,6 +274,7 @@ public class AArch64Move {
         public LoadOp(AArch64Kind kind, AllocatableValue result, AArch64AddressValue address, LIRFrameState state) {
             this(kind, result, address, state, false);
         }
+
         public LoadOp(AArch64Kind kind, AllocatableValue result, AArch64AddressValue address, LIRFrameState state, boolean isVolatile) {
             super(TYPE, kind, address, state, isVolatile);
             this.result = result;
@@ -308,6 +309,7 @@ public class AArch64Move {
         public StoreOp(AArch64Kind kind, AArch64AddressValue address, AllocatableValue input, LIRFrameState state) {
             this(kind, address, input, state, false);
         }
+
         public StoreOp(AArch64Kind kind, AArch64AddressValue address, AllocatableValue input, LIRFrameState state, boolean isVolatile) {
             super(TYPE, kind, address, state, isVolatile);
             this.input = input;
@@ -329,7 +331,7 @@ public class AArch64Move {
 
         protected final JavaConstant input;
 
-         public StoreConstantOp(AArch64Kind kind, AArch64AddressValue address, JavaConstant input, LIRFrameState state, boolean isVolatile) {
+        public StoreConstantOp(AArch64Kind kind, AArch64AddressValue address, JavaConstant input, LIRFrameState state, boolean isVolatile) {
             super(TYPE, kind, address, state, isVolatile);
             this.input = input;
             if (!input.isDefaultForKind()) {
@@ -340,12 +342,12 @@ public class AArch64Move {
         @Override
         public void emitMemAccess(CompilationResultBuilder crb, AArch64MacroAssembler masm) {
             AArch64Address address = addressValue.toAddress();
-           if (isVolatile) {
-               emitVolatileStore(crb, masm, kind, address, zr.asValue(LIRKind.combine(addressValue)));
-           } else {
-               emitStore(crb, masm, kind, address, zr.asValue(LIRKind.combine(addressValue)));
-           }
-       }
+            if (isVolatile) {
+                emitVolatileStore(crb, masm, kind, address, zr.asValue(LIRKind.combine(addressValue)));
+            } else {
+                emitStore(crb, masm, kind, address, zr.asValue(LIRKind.combine(addressValue)));
+            }
+        }
     }
 
     public static final class NullCheckOp extends AArch64LIRInstruction implements NullCheck {

--- a/compiler/src/org.graalvm.compiler.lir.aarch64/src/org/graalvm/compiler/lir/aarch64/AArch64Unary.java
+++ b/compiler/src/org.graalvm.compiler.lir.aarch64/src/org/graalvm/compiler/lir/aarch64/AArch64Unary.java
@@ -51,6 +51,7 @@ public class AArch64Unary {
         public static final LIRInstructionClass<MemoryOp> TYPE = LIRInstructionClass.create(MemoryOp.class);
 
         private final boolean isSigned;
+        private final boolean isVolatile;
 
         @Def({REG}) protected AllocatableValue result;
         @Use({COMPOSITE}) protected AArch64AddressValue input;
@@ -60,7 +61,7 @@ public class AArch64Unary {
         private int targetSize;
         private int srcSize;
 
-        public MemoryOp(boolean isSigned, int targetSize, int srcSize, AllocatableValue result, AArch64AddressValue input, LIRFrameState state) {
+        public MemoryOp(boolean isSigned, int targetSize, int srcSize, AllocatableValue result, AArch64AddressValue input, LIRFrameState state, boolean isVolatile) {
             super(TYPE);
             this.targetSize = targetSize;
             this.srcSize = srcSize;
@@ -68,6 +69,7 @@ public class AArch64Unary {
             this.result = result;
             this.input = input;
             this.state = state;
+            this.isVolatile = isVolatile;
         }
 
         @Override
@@ -77,6 +79,9 @@ public class AArch64Unary {
             }
             AArch64Address address = input.toAddress();
             Register dst = asRegister(result);
+
+            assert (!isVolatile || address.getAddressingMode() == AArch64Address.AddressingMode.BASE_REGISTER_ONLY);
+
             if (isSigned) {
                 masm.ldrs(targetSize, srcSize, dst, address);
             } else {

--- a/compiler/src/org.graalvm.compiler.nodes/src/org/graalvm/compiler/nodes/extended/RawLoadNode.java
+++ b/compiler/src/org.graalvm.compiler.nodes/src/org/graalvm/compiler/nodes/extended/RawLoadNode.java
@@ -34,6 +34,7 @@ import org.graalvm.compiler.graph.Node;
 import org.graalvm.compiler.graph.NodeClass;
 import org.graalvm.compiler.graph.spi.Canonicalizable;
 import org.graalvm.compiler.graph.spi.CanonicalizerTool;
+import org.graalvm.compiler.nodeinfo.InputType;
 import org.graalvm.compiler.nodeinfo.NodeInfo;
 import org.graalvm.compiler.nodes.ConstantNode;
 import org.graalvm.compiler.nodes.NodeView;
@@ -59,7 +60,7 @@ import jdk.vm.ci.meta.ResolvedJavaType;
  * Load of a value from a location specified as an offset relative to an object. No null check is
  * performed before the load.
  */
-@NodeInfo(cycles = CYCLES_2, size = SIZE_1)
+@NodeInfo(cycles = CYCLES_2, size = SIZE_1, allowedUsageTypes = InputType.Association)
 public class RawLoadNode extends UnsafeAccessNode implements Lowerable, Virtualizable, Canonicalizable {
     public static final NodeClass<RawLoadNode> TYPE = NodeClass.create(RawLoadNode.class);
 

--- a/compiler/src/org.graalvm.compiler.nodes/src/org/graalvm/compiler/nodes/extended/RawStoreNode.java
+++ b/compiler/src/org.graalvm.compiler.nodes/src/org/graalvm/compiler/nodes/extended/RawStoreNode.java
@@ -30,6 +30,7 @@ import static org.graalvm.compiler.nodeinfo.NodeSize.SIZE_1;
 
 import org.graalvm.compiler.core.common.type.StampFactory;
 import org.graalvm.compiler.graph.NodeClass;
+import org.graalvm.compiler.nodeinfo.InputType;
 import org.graalvm.compiler.nodeinfo.NodeInfo;
 import org.graalvm.compiler.nodes.FrameState;
 import org.graalvm.compiler.nodes.StateSplit;
@@ -51,7 +52,7 @@ import jdk.vm.ci.meta.ResolvedJavaField;
  * Store of a value at a location specified as an offset relative to an object. No null check is
  * performed before the store.
  */
-@NodeInfo(cycles = CYCLES_2, size = SIZE_1)
+@NodeInfo(cycles = CYCLES_2, size = SIZE_1, allowedUsageTypes = InputType.Association)
 public final class RawStoreNode extends UnsafeAccessNode implements StateSplit, Lowerable, Virtualizable, MemoryCheckpoint.Single {
 
     public static final NodeClass<RawStoreNode> TYPE = NodeClass.create(RawStoreNode.class);

--- a/compiler/src/org.graalvm.compiler.nodes/src/org/graalvm/compiler/nodes/java/LoadFieldNode.java
+++ b/compiler/src/org.graalvm.compiler.nodes/src/org/graalvm/compiler/nodes/java/LoadFieldNode.java
@@ -34,6 +34,7 @@ import org.graalvm.compiler.core.common.type.StampPair;
 import org.graalvm.compiler.graph.NodeClass;
 import org.graalvm.compiler.graph.spi.Canonicalizable;
 import org.graalvm.compiler.graph.spi.CanonicalizerTool;
+import org.graalvm.compiler.nodeinfo.InputType;
 import org.graalvm.compiler.nodeinfo.NodeCycles;
 import org.graalvm.compiler.nodeinfo.NodeInfo;
 import org.graalvm.compiler.nodes.ConstantNode;
@@ -65,7 +66,7 @@ import jdk.vm.ci.meta.ResolvedJavaField;
 /**
  * The {@code LoadFieldNode} represents a read of a static or instance field.
  */
-@NodeInfo(nameTemplate = "LoadField#{p#field/s}")
+@NodeInfo(nameTemplate = "LoadField#{p#field/s}", allowedUsageTypes = InputType.Association)
 public final class LoadFieldNode extends AccessFieldNode implements Canonicalizable.Unary<ValueNode>, Virtualizable, UncheckedInterfaceProvider {
 
     public static final NodeClass<LoadFieldNode> TYPE = NodeClass.create(LoadFieldNode.class);

--- a/compiler/src/org.graalvm.compiler.nodes/src/org/graalvm/compiler/nodes/java/StoreFieldNode.java
+++ b/compiler/src/org.graalvm.compiler.nodes/src/org/graalvm/compiler/nodes/java/StoreFieldNode.java
@@ -44,7 +44,7 @@ import jdk.vm.ci.meta.ResolvedJavaField;
 /**
  * The {@code StoreFieldNode} represents a write to a static or instance field.
  */
-@NodeInfo(nameTemplate = "StoreField#{p#field/s}")
+@NodeInfo(nameTemplate = "StoreField#{p#field/s}", allowedUsageTypes = InputType.Association)
 public final class StoreFieldNode extends AccessFieldNode implements StateSplit, Virtualizable {
     public static final NodeClass<StoreFieldNode> TYPE = NodeClass.create(StoreFieldNode.class);
 

--- a/compiler/src/org.graalvm.compiler.nodes/src/org/graalvm/compiler/nodes/memory/FloatingReadNode.java
+++ b/compiler/src/org.graalvm.compiler.nodes/src/org/graalvm/compiler/nodes/memory/FloatingReadNode.java
@@ -36,6 +36,7 @@ import org.graalvm.compiler.graph.Node;
 import org.graalvm.compiler.graph.NodeClass;
 import org.graalvm.compiler.graph.spi.Canonicalizable;
 import org.graalvm.compiler.graph.spi.CanonicalizerTool;
+import org.graalvm.compiler.nodeinfo.InputType;
 import org.graalvm.compiler.nodeinfo.NodeInfo;
 import org.graalvm.compiler.nodes.NodeView;
 import org.graalvm.compiler.nodes.ValueNodeUtil;
@@ -49,7 +50,7 @@ import org.graalvm.word.LocationIdentity;
  * A floating read of a value from memory specified in terms of an object base and an object
  * relative location. This node does not null check the object.
  */
-@NodeInfo(nameTemplate = "Read#{p#location/s}", cycles = CYCLES_2, size = SIZE_1)
+@NodeInfo(nameTemplate = "Read#{p#location/s}", cycles = CYCLES_2, size = SIZE_1, allowedUsageTypes = InputType.Association)
 public final class FloatingReadNode extends FloatingAccessNode implements LIRLowerableAccess, Canonicalizable {
     public static final NodeClass<FloatingReadNode> TYPE = NodeClass.create(FloatingReadNode.class);
 

--- a/compiler/src/org.graalvm.compiler.nodes/src/org/graalvm/compiler/nodes/memory/ReadNode.java
+++ b/compiler/src/org.graalvm.compiler.nodes/src/org/graalvm/compiler/nodes/memory/ReadNode.java
@@ -59,7 +59,7 @@ import jdk.vm.ci.meta.MetaAccessProvider;
 /**
  * Reads an {@linkplain FixedAccessNode accessed} value.
  */
-@NodeInfo(nameTemplate = "Read#{p#location/s}", cycles = CYCLES_2, size = SIZE_1)
+@NodeInfo(nameTemplate = "Read#{p#location/s}", cycles = CYCLES_2, size = SIZE_1,allowedUsageTypes = InputType.Association )
 public class ReadNode extends FloatableAccessNode implements LIRLowerableAccess, Canonicalizable, Virtualizable, GuardingNode {
 
     public static final NodeClass<ReadNode> TYPE = NodeClass.create(ReadNode.class);

--- a/compiler/src/org.graalvm.compiler.nodes/src/org/graalvm/compiler/nodes/memory/ReadNode.java
+++ b/compiler/src/org.graalvm.compiler.nodes/src/org/graalvm/compiler/nodes/memory/ReadNode.java
@@ -59,7 +59,7 @@ import jdk.vm.ci.meta.MetaAccessProvider;
 /**
  * Reads an {@linkplain FixedAccessNode accessed} value.
  */
-@NodeInfo(nameTemplate = "Read#{p#location/s}", cycles = CYCLES_2, size = SIZE_1,allowedUsageTypes = InputType.Association )
+@NodeInfo(nameTemplate = "Read#{p#location/s}", cycles = CYCLES_2, size = SIZE_1, allowedUsageTypes = InputType.Association)
 public class ReadNode extends FloatableAccessNode implements LIRLowerableAccess, Canonicalizable, Virtualizable, GuardingNode {
 
     public static final NodeClass<ReadNode> TYPE = NodeClass.create(ReadNode.class);

--- a/compiler/src/org.graalvm.compiler.nodes/src/org/graalvm/compiler/nodes/memory/WriteNode.java
+++ b/compiler/src/org.graalvm.compiler.nodes/src/org/graalvm/compiler/nodes/memory/WriteNode.java
@@ -30,6 +30,7 @@ import org.graalvm.compiler.graph.Node;
 import org.graalvm.compiler.graph.NodeClass;
 import org.graalvm.compiler.graph.spi.Canonicalizable;
 import org.graalvm.compiler.graph.spi.CanonicalizerTool;
+import org.graalvm.compiler.nodeinfo.InputType;
 import org.graalvm.compiler.nodeinfo.NodeInfo;
 import org.graalvm.compiler.nodes.NodeView;
 import org.graalvm.compiler.nodes.ValueNode;
@@ -40,7 +41,7 @@ import org.graalvm.word.LocationIdentity;
 /**
  * Writes a given {@linkplain #value() value} a {@linkplain FixedAccessNode memory location}.
  */
-@NodeInfo(nameTemplate = "Write#{p#location/s}")
+@NodeInfo(nameTemplate = "Write#{p#location/s}", allowedUsageTypes = InputType.Association)
 public class WriteNode extends AbstractWriteNode implements LIRLowerableAccess, Canonicalizable {
 
     public static final NodeClass<WriteNode> TYPE = NodeClass.create(WriteNode.class);

--- a/compiler/src/org.graalvm.compiler.replacements.jdk9.test/src/org/graalvm/compiler/replacements/jdk9/test/VarHandleTest.java
+++ b/compiler/src/org.graalvm.compiler.replacements.jdk9.test/src/org/graalvm/compiler/replacements/jdk9/test/VarHandleTest.java
@@ -24,10 +24,8 @@
  */
 package org.graalvm.compiler.replacements.jdk9.test;
 
-import java.lang.invoke.MethodHandles;
-import java.lang.invoke.VarHandle;
-
 import jdk.vm.ci.aarch64.AArch64;
+import jdk.vm.ci.meta.ResolvedJavaMethod;
 import org.graalvm.compiler.core.test.GraalCompilerTest;
 import org.graalvm.compiler.debug.GraalError;
 import org.graalvm.compiler.graph.Node;
@@ -42,7 +40,8 @@ import org.junit.Assert;
 import org.junit.Assume;
 import org.junit.Test;
 
-import jdk.vm.ci.meta.ResolvedJavaMethod;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.VarHandle;
 
 public class VarHandleTest extends GraalCompilerTest {
 

--- a/compiler/src/org.graalvm.compiler.replacements.jdk9.test/src/org/graalvm/compiler/replacements/jdk9/test/VolatileVirtualizeTest.java
+++ b/compiler/src/org.graalvm.compiler.replacements.jdk9.test/src/org/graalvm/compiler/replacements/jdk9/test/VolatileVirtualizeTest.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Red Hat Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.graalvm.compiler.replacements.jdk9.test;
+
+import jdk.vm.ci.meta.ResolvedJavaMethod;
+import org.graalvm.compiler.core.test.GraalCompilerTest;
+import org.graalvm.compiler.debug.GraalError;
+import org.graalvm.compiler.nodes.StructuredGraph;
+import org.junit.Test;
+
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.VarHandle;
+import java.lang.reflect.Field;
+
+public class VolatileVirtualizeTest extends GraalCompilerTest {
+
+    static class Holder {
+        volatile int volatileField = 42;
+        int field = 2018;
+
+        static final VarHandle VOLATILE_HANDLE;
+        static final Field VOLATILE_FIELD;
+        static final long OFFSET;
+
+        static {
+            try {
+                VOLATILE_HANDLE = MethodHandles.lookup().findVarHandle(Holder.class, "volatileField", int.class);
+                VOLATILE_FIELD = Holder.class.getDeclaredField("volatileField");
+                OFFSET = UNSAFE.objectFieldOffset(VOLATILE_FIELD);
+            } catch (ReflectiveOperationException ex) {
+                throw GraalError.shouldNotReachHere(ex);
+            }
+        }
+
+        Holder(int i) {
+            field = field * i;
+        }
+    }
+
+    // test compilation of a virtualized unsafe volatile get
+    public static int testReadSnippet(int i) {
+        Holder h = new Holder(i);
+        h.field = UNSAFE.getIntVolatile(h, Holder.OFFSET);
+        return h.field;
+    }
+
+    // test compilation of a virtualized varhandle volatile set
+    public static int testWriteSnippet(int i) {
+        Holder h = new Holder(i);
+        Holder.VOLATILE_HANDLE.setVolatile(h, i);
+        return h.field;
+    }
+
+    // test compilation of a virtualized unsafe volatile set
+    public static int testWriteSnippet2(int i) {
+        Holder h = new Holder(i);
+        UNSAFE.putIntVolatile(h, Holder.OFFSET, i);
+        return h.field;
+    }
+
+    void testAccess(String name) {
+        ResolvedJavaMethod method = getResolvedJavaMethod(name);
+        StructuredGraph graph = parseForCompile(method);
+        compile(method, graph);
+    }
+
+    @Test
+    public void testRead() {
+        testAccess("testReadSnippet");
+    }
+
+    @Test
+    public void testWrite() {
+        testAccess("testWriteSnippet");
+    }
+
+    @Test
+    public void testWrite2() {
+        testAccess("testWriteSnippet2");
+    }
+}

--- a/compiler/src/org.graalvm.compiler.replacements.test/src/org/graalvm/compiler/replacements/test/StringIndexOfConstantTest.java
+++ b/compiler/src/org.graalvm.compiler.replacements.test/src/org/graalvm/compiler/replacements/test/StringIndexOfConstantTest.java
@@ -87,6 +87,8 @@ public class StringIndexOfConstantTest extends StringIndexOfTestBase {
     @Override
     protected InstalledCode getCode(final ResolvedJavaMethod installedCodeOwner, StructuredGraph graph0, boolean ignoreForceCompile, boolean ignoreInstallAsDefault, OptionValues options) {
         // Force recompile if constant binding should be done
-        return super.getCode(installedCodeOwner, graph0, /* forceCompile */true, /* installAsDefault */false, options);
+        return super.getCode(installedCodeOwner, graph0, /* forceCompile */true, /*
+                                                                                  * installAsDefault
+                                                                                  */false, options);
     }
 }

--- a/compiler/src/org.graalvm.compiler.replacements.test/src/org/graalvm/compiler/replacements/test/StringIndexOfConstantTest.java
+++ b/compiler/src/org.graalvm.compiler.replacements.test/src/org/graalvm/compiler/replacements/test/StringIndexOfConstantTest.java
@@ -87,8 +87,6 @@ public class StringIndexOfConstantTest extends StringIndexOfTestBase {
     @Override
     protected InstalledCode getCode(final ResolvedJavaMethod installedCodeOwner, StructuredGraph graph0, boolean ignoreForceCompile, boolean ignoreInstallAsDefault, OptionValues options) {
         // Force recompile if constant binding should be done
-        return super.getCode(installedCodeOwner, graph0, /* forceCompile */true, /*
-                                                                                  * installAsDefault
-                                                                                  */false, options);
+        return super.getCode(installedCodeOwner, graph0, /* forceCompile */true, /* installAsDefault */false, options);
     }
 }

--- a/compiler/src/org.graalvm.compiler.replacements/src/org/graalvm/compiler/replacements/DefaultJavaLoweringProvider.java
+++ b/compiler/src/org.graalvm.compiler.replacements/src/org/graalvm/compiler/replacements/DefaultJavaLoweringProvider.java
@@ -388,7 +388,7 @@ public abstract class DefaultJavaLoweringProvider implements LoweringProvider {
 
         ReadNode memoryRead = graph.add(new ReadNode(address, fieldLocationIdentity(field), loadStamp, fieldLoadBarrierType(field)));
         ValueNode readValue = implicitLoadConvert(graph, getStorageKind(field), memoryRead);
-         loadField.replaceAtUsages(InputType.Association, memoryRead);
+        loadField.replaceAtUsages(InputType.Association, memoryRead);
         loadField.replaceAtUsages(readValue);
         graph.replaceFixed(loadField, memoryRead);
 
@@ -397,7 +397,7 @@ public abstract class DefaultJavaLoweringProvider implements LoweringProvider {
             graph.addBeforeFixed(memoryRead, preMembar);
             MembarNode postMembar = graph.add(new MembarNode(JMM_POST_VOLATILE_READ));
             graph.addAfterFixed(memoryRead, postMembar);
-             // associate the memory barriers with the volatile read
+            // associate the memory barriers with the volatile read
             postMembar.setAccess(memoryRead);
             postMembar.setLeading(preMembar);
         }

--- a/compiler/src/org.graalvm.compiler.replacements/src/org/graalvm/compiler/replacements/DefaultJavaLoweringProvider.java
+++ b/compiler/src/org.graalvm.compiler.replacements/src/org/graalvm/compiler/replacements/DefaultJavaLoweringProvider.java
@@ -421,7 +421,7 @@ public abstract class DefaultJavaLoweringProvider implements LoweringProvider {
             graph.addBeforeFixed(memoryWrite, preMembar);
             MembarNode postMembar = graph.add(new MembarNode(JMM_POST_VOLATILE_WRITE));
             graph.addAfterFixed(memoryWrite, postMembar);
-            // associate the memory barriers with the volatile read
+            // associate the memory barriers with the volatile write
             postMembar.setAccess(memoryWrite);
             postMembar.setLeading(preMembar);
         }

--- a/compiler/src/org.graalvm.compiler.replacements/src/org/graalvm/compiler/replacements/StandardGraphBuilderPlugins.java
+++ b/compiler/src/org.graalvm.compiler.replacements/src/org/graalvm/compiler/replacements/StandardGraphBuilderPlugins.java
@@ -1090,7 +1090,7 @@ public class StandardGraphBuilderPlugins {
             if (accessKind.emitBarriers) {
                 // link the unsafe node to its leading and trailing membars
                 final MembarNode pre = new MembarNode(accessKind.preReadBarriers);
-                final RawLoadNode[] rawLoadNodes = new  RawLoadNode[1];
+                final RawLoadNode[] rawLoadNodes = new RawLoadNode[1];
                 final MembarNode post = new MembarNode(accessKind.postReadBarriers);
                 b.add(pre);
                 createUnsafeAccess(object, b, (obj, loc) -> {
@@ -1147,7 +1147,7 @@ public class StandardGraphBuilderPlugins {
                 b.add(post);
                 post.setAccess(rawStoreNodes[0]);
                 post.setLeading(pre);
-            }  else {
+            } else {
                 createUnsafeAccess(object, b, (obj, loc) -> new RawStoreNode(obj, offset, maskedValue, unsafeAccessKind, loc));
             }
             return true;

--- a/compiler/src/org.graalvm.compiler.replacements/src/org/graalvm/compiler/replacements/StandardGraphBuilderPlugins.java
+++ b/compiler/src/org.graalvm.compiler.replacements/src/org/graalvm/compiler/replacements/StandardGraphBuilderPlugins.java
@@ -1152,7 +1152,8 @@ public class StandardGraphBuilderPlugins {
                     post.setLeading(pre);
                 }
             } else {
-                createUnsafeAccess(object, b, (obj, loc) -> new RawStoreNode(obj, offset, maskedValue, unsafeAccessKind, loc));}
+                createUnsafeAccess(object, b, (obj, loc) -> new RawStoreNode(obj, offset, maskedValue, unsafeAccessKind, loc));
+            }
             return true;
         }
     }

--- a/compiler/src/org.graalvm.compiler.replacements/src/org/graalvm/compiler/replacements/StandardGraphBuilderPlugins.java
+++ b/compiler/src/org.graalvm.compiler.replacements/src/org/graalvm/compiler/replacements/StandardGraphBuilderPlugins.java
@@ -106,7 +106,6 @@ import org.graalvm.compiler.nodes.graphbuilderconf.InvocationPlugin;
 import org.graalvm.compiler.nodes.graphbuilderconf.InvocationPlugin.Receiver;
 import org.graalvm.compiler.nodes.graphbuilderconf.InvocationPlugins;
 import org.graalvm.compiler.nodes.graphbuilderconf.InvocationPlugins.Registration;
-import org.graalvm.compiler.nodes.java.AccessFieldNode;
 import org.graalvm.compiler.nodes.java.ClassIsAssignableFromNode;
 import org.graalvm.compiler.nodes.java.DynamicNewArrayNode;
 import org.graalvm.compiler.nodes.java.DynamicNewInstanceNode;
@@ -1067,12 +1066,11 @@ public class StandardGraphBuilderPlugins {
                 MembarNode pre2 = null;
                 if (accessKind.emitBarriers) {
                     pre1 =  new MembarNode(isLoad(access1) ? accessKind.preReadBarriers : accessKind.preWriteBarriers);
-                    // b.add(pre1);
                     pre2 =  new MembarNode(isLoad(access2) ? accessKind.preReadBarriers : accessKind.preWriteBarriers);
-                    // b.add(pre2);
+                    // sigh! IfNode expects leading nodes to have a source position so fake it
+                    pre1.setNodeSourcePosition(access1.getNodeSourcePosition());
+                    pre2.setNodeSourcePosition(access2.getNodeSourcePosition());
                     b.add(new IfNode(condition, pre1, pre2, 0.5));
-                    // pre1.setNext(access1);
-                    // pre2.setNext(access2);
                 } else {
                     b.add(new IfNode(condition, access1, access2, 0.5));
                 }

--- a/compiler/src/org.graalvm.compiler.replacements/src/org/graalvm/compiler/replacements/StandardGraphBuilderPlugins.java
+++ b/compiler/src/org.graalvm.compiler.replacements/src/org/graalvm/compiler/replacements/StandardGraphBuilderPlugins.java
@@ -1059,14 +1059,14 @@ public class StandardGraphBuilderPlugins {
                 }
             } else {
                 // add if logic to select the correct access
-                FixedWithNextNode[] accessNodes = new FixedWithNextNode[] {access1, access2};
+                FixedWithNextNode[] accessNodes = new FixedWithNextNode[]{access1, access2};
                 LogicNode condition = graph.addOrUniqueWithInputs(IsNullNode.create(value));
                 // bracket the access with memory barriers if needed
                 MembarNode pre1 = null;
                 MembarNode pre2 = null;
                 if (accessKind.emitBarriers) {
-                    pre1 =  new MembarNode(isLoad(access1) ? accessKind.preReadBarriers : accessKind.preWriteBarriers);
-                    pre2 =  new MembarNode(isLoad(access2) ? accessKind.preReadBarriers : accessKind.preWriteBarriers);
+                    pre1 = new MembarNode(isLoad(access1) ? accessKind.preReadBarriers : accessKind.preWriteBarriers);
+                    pre2 = new MembarNode(isLoad(access2) ? accessKind.preReadBarriers : accessKind.preWriteBarriers);
                     // sigh! IfNode expects leading nodes to have a source position so fake it
                     pre1.setNodeSourcePosition(access1.getNodeSourcePosition());
                     pre2.setNodeSourcePosition(access2.getNodeSourcePosition());

--- a/compiler/src/org.graalvm.compiler.test/src/org/graalvm/compiler/test/SubprocessUtil.java
+++ b/compiler/src/org.graalvm.compiler.test/src/org/graalvm/compiler/test/SubprocessUtil.java
@@ -94,7 +94,7 @@ public final class SubprocessUtil {
     public static List<String> withoutDebuggerArguments(List<String> args) {
         List<String> result = new ArrayList<>(args.size());
         for (String arg : args) {
-            if (!(arg.equals("-Xdebug") || arg.startsWith("-Xrunjdwp:"))) {
+            if (!(arg.equals("-Xdebug") || arg.startsWith("-Xrunjdwp:") || arg.startsWith("-agentlib:jdwp"))) {
                 result.add(arg);
             }
         }

--- a/compiler/src/org.graalvm.compiler.virtual/src/org/graalvm/compiler/virtual/phases/ea/GraphEffectList.java
+++ b/compiler/src/org.graalvm.compiler.virtual/src/org/graalvm/compiler/virtual/phases/ea/GraphEffectList.java
@@ -178,14 +178,10 @@ public final class GraphEffectList extends EffectList {
             if (node instanceof AccessFieldNode && node.hasUsages()) {
                 // see if it is associated with any membar nodes
                 // and if so remove the association
-                for (int i = 0; i < node.getUsageCount(); i++) {
-                    Node usage = node.getUsageAt(i);
-                    if (usage instanceof MembarNode) {
-                        MembarNode membar = (MembarNode) usage;
-                        if (membar.getAccess() == node) {
-                            membar.setAccess(null);
-                            membar.setLeading(null);
-                        }
+                for (MembarNode membar : node.usages().filter(MembarNode.class).snapshot()) {
+                    if (membar.getAccess() == node) {
+                        membar.setAccess(null);
+                        membar.setLeading(null);
                     }
                 }
             }
@@ -262,14 +258,10 @@ public final class GraphEffectList extends EffectList {
             if (node instanceof AccessFieldNode && node.hasUsages()) {
                 // see if it is associated with any membar nodes
                 // and if so remove the association
-                for (int i = 0; i < node.getUsageCount(); i++) {
-                    Node usage = node.getUsageAt(i);
-                    if (usage instanceof MembarNode) {
-                        MembarNode membar = (MembarNode) usage;
-                        if (membar.getAccess() == node) {
-                            membar.setAccess(null);
-                            membar.setLeading(null);
-                        }
+                for (MembarNode membar : node.usages().filter(MembarNode.class).snapshot()) {
+                    if (membar.getAccess() == node) {
+                        membar.setAccess(null);
+                        membar.setLeading(null);
                     }
                 }
             }


### PR DESCRIPTION
Hi Graal team,

I have been working on getting AArch64 to use ldar/stlr instructions for volatile reads/writes and I now have a fully functional prototype. I'm opening this as a pull request to get a review of the merits of this current implementation rather than to get it pulled into the main trunk.

What does it do?

This patch appears to work successfully. Iit generates the right instruction sequences for a a variety of test programs performing volatile reads and writes of all flavours. It also passes all existing unit tests. However, I am not sure there could not be a better implementation (I'll explain why below) so a pull of this version would be pre-emptive.

Also, the use of ldar/stlr in a second tier JIT compiler is only appropriate when the first tier compiler (i.e. C1 at present but this woudl also applyfor AOT when Andrew Haley has it ready) generates barrier-based code that has compatible semantics i.e. in the case of C1 when AArch64 product flag UseBarriersForVolatile is false (which is the default). So, the change in the AArch64SuitesProvider which adds AArch64MembarElisionPhase, the phase that implements the transform enabling use of ldar/stlr to be used, to the low-level tier still has to be modified to make addition of that phase conditional on this flag setting.

How does it work?

The current patch employs an extra phase, AArch64MembarElisionPhase, which, essentially, recognizes the presence of the LIR node sequences generated during parsing that are used to represent a normal or unsafe voilatile load/store

```
  Membar(PRE_VOL_READ) ; ReadNode ; Membar(POST_VOL_READ)
  Membar(PRE_VOL_READ) ; RawLoadNode ; Membar(POST_VOL_READ)
```
or
```
  Membar(PRE_VOL_WRITE) ; WriteNode ; MEMBAR(POST_VOL_WRITE)
  Membar(PRE_VOL_WRITE) ; RawStoreNode ; MEMBAR(POST_VOL_WRITE)
```
It replaces them with a single node, respectively,
```
  AArch64VolatileReadNode
```
or
```
  AArch64VolatileWriteNode
```
The AArch64 code generator recognises these nodes and inserts a Move node which is configured to plant an ldar or stlr instruction, accordingly, instea dof an ldr or str. Deletion of the Membar nodes avoids generation of the usual dmb instructions.

This transformation happens at the end of the low tier i.e. after all transformations which rely on the presence of the memory barriers (e.g. floating reads up the graph) have been completed. That also implies that the above account of how  AArch64MembarElisionPhase works is somewhat oversimplified. There are several aspects to this.

Firstly, the node graph introduced during parsing does not remain unchanged between the point of construction and the point where the AArch64MembarElisionPhase is run. In the load cases, the original load will be replaced by a FloatingReadNode and this will then be converted back to a ReadNode. In the store cases nodes that implement a GC barrier will be introduced between the two Membar nodes and the RawStoreNode will be replaced by a WriteNode.

In consequence it is not possible to retain the association between the original Membar nodes and the access nodes by simply tagging them with a property that indicates that they are associated with a volatile field. Firstly, this property would need to be propagated from each instance of the relevant node type to the node which replaces it and so on at each point of transformation/replacement until the node can be noticed by the AArch64MembarElisionPhase. That would require tracking all possible intervening nodes, changing their constructors to accept a flag indicating whether the access is volatile and updating all replacement sites to ensue the constructor is parameterised correctly. This woud lbe very fragile.

Secondly, even granted that the nodes were so tagged, in the write case the presence of the GC barrier nodes inserted into the graph between the Membars would make it very difficult to locate the relevant leading and trailing volatile Membars and associate them with the volatile WriteNode. To do so AArch64MembarElisionPhase would need to scan and match a complex graph shape specific to the currently configured GC.

I have resolved this problem of associating the relevant nodes by adding node -> node input links to the graph to model the relationship between the leading membar, the access and the trailing membar. This has the advantage that the linkage is automatically retained when access node substitutions occur in phases between the parser back end which creates the Membars/access and the AArch64MembarElisionPhase. Note that this is safe because the nodes are not going to be deleted otr moved outside the bracketing Membars.

The current linkage is a bit messy because of 1) restrictions on input types and 2) a desire to ensure that links are established in a logically 'forward' direction. So, I have implemented the links by adding fields to the trailing Membar -- which is logically downstream of the leading Membar and the access in Memory, Control and Value (dataflow) order.  Unfortunately, the different access nodes have different rules about what type of linkage they support. So, the Membar fields have had ot be defined as follows
```
    @OptionalInput
    private ValueNode load;
    // optional store with which this trailing memory barrier may be associated
    @OptionalInput(InputType.Memory)
    private ValueNode store;
    // optional leading memory barrier preceding any above access
    @OptionalInput(InputType.Memory)
    private MembarNode leading;
```
The loads can only be used as Value inputs. The Membar and WriteNode can only be used as Memory inputs. RawStoreNode is, bizarrely, only usable as a Value node (I think this must be an oversight). I modified its so that it declared InputType.Memory as a legitimate linkage). Clearly, it would be nicer to just have one input field for the access rather than having to keep a load link separate from a store link but I didn't want to modify the linkage rules to enable this as I thought it might be unwise to allow loads to be used as Memory inputs or writes to be used as Value inputs.

There is also a further wrinkle that the phase I added to merge Sign/ZeroExtend nodes into reads now needs to be merged into a normal ReadNode or an AArch64VolatileReadNode. So, I had to tweak the existing phase slightly to allow for that.

The back end also needed a minor tweak -- other than the requirement to track whether a load or store is volatile or not. This is because a ldar or an stlr can only use base register addressing (no index register, offset or shift). So, the back end has been tweaked to transform loads and stores which use any other form of address to use a base address computed via a preceding load effective address.

Request for Review:

So, if you could provide feedback on this change and suggest any better way to model the linkage I'd be very grateful. I guess it also needs some tests but I am not sure how to write a test which can guarantee that the relevant ldar/stlr instruction generation has occurred given some Java program using normal volatile field or unsafe volatile field reads/writes. So, advice on how to that woud lb4e appreciated (e.g. point me at an existing unit test that does something similar).
