### PR TITLE
Update reference to Graal JVMCI 8 repo

### DIFF
--- a/compiler/README.md
+++ b/compiler/README.md
@@ -85,7 +85,7 @@ For video tutorials, presentations and publications on Graal visit the [Publicat
 To create a JVMCI enabled JDK8 on other platforms (e.g., Windows):
 
 ```
-hg clone http://hg.openjdk.java.net/graal/graal-jvmci-8
+git clone https://github.com/graalvm/graal-jvmci-8
 cd graal-jvmci-8
 mx --java-home /path/to/jdk8 build
 mx --java-home /path/to/jdk8 unittest


### PR DESCRIPTION
This change simply updates the URL and repo type for Graal JVMCI 8, [since it recently moved](https://markmail.org/message/kdnj2kmhodmx47rs).