### PR TITLE
Add AArch64 support() function for determining CPUFeature support.

### DIFF
--- a/compiler/src/org.graalvm.compiler.asm.aarch64/src/org/graalvm/compiler/asm/aarch64/AArch64Assembler.java
+++ b/compiler/src/org.graalvm.compiler.asm.aarch64/src/org/graalvm/compiler/asm/aarch64/AArch64Assembler.java
@@ -118,6 +118,8 @@ import org.graalvm.compiler.core.common.NumUtil;
 import org.graalvm.compiler.asm.aarch64.AArch64Address.AddressingMode;
 import org.graalvm.compiler.debug.GraalError;
 
+import jdk.vm.ci.aarch64.AArch64;
+import jdk.vm.ci.aarch64.AArch64.CPUFeature;
 import jdk.vm.ci.code.Register;
 import jdk.vm.ci.code.TargetDescription;
 
@@ -738,6 +740,10 @@ public abstract class AArch64Assembler extends Assembler {
 
     public AArch64Assembler(TargetDescription target) {
         super(target);
+    }
+
+    public boolean supports(CPUFeature feature) {
+        return ((AArch64) target.arch).getFeatures().contains(feature);
     }
 
     /* Conditional Branch (5.2.1) */


### PR DESCRIPTION
Adding a function for determining the support for AArch64 CPUFeatures. This is a small function to prepare the way for implementing certain intrinsics which require atomic instructions only available on AArch64 architectures that have implemented certain 8.X extensions.

This function is modeled after the same function in AMD64.