### PR TITLE
Add modified DaCapo benchmark collecting hardware counters

### DIFF
--- a/compiler/mx.compiler/mx_graal_benchmark.py
+++ b/compiler/mx.compiler/mx_graal_benchmark.py
@@ -800,7 +800,7 @@ class DaCapoD3SBenchmarkSuite(DaCapoBenchmarkSuite): # pylint: disable=too-many-
         return "DACAPO_D3S"
 
     def successPatterns(self):
-        return ['']
+        return []
 
     def resultFilter(self, values, iteration, endOfWarmupIndex):
         """Count iterations, convert iteration time to milliseconds."""

--- a/compiler/mx.compiler/mx_graal_benchmark.py
+++ b/compiler/mx.compiler/mx_graal_benchmark.py
@@ -784,6 +784,163 @@ class DaCapoMoveProfilingBenchmarkSuite(DaCapoMoveProfilingBenchmarkMixin, DaCap
 
 mx_benchmark.add_bm_suite(DaCapoMoveProfilingBenchmarkSuite())
 
+class DaCapoD3SBenchmarkSuite(DaCapoBenchmarkSuite): # pylint: disable=too-many-ancestors
+    """DaCapo 9.12 Bach benchmark suite implementation with D3S modifications."""
+
+    def name(self):
+        return "dacapo-d3s"
+
+    def daCapoSuiteTitle(self):
+        return "DaCapo 9.12-D3S-20180206"
+
+    def daCapoClasspathEnvVarName(self):
+        return "DACAPO_D3S_CP"
+
+    def daCapoLibraryName(self):
+        return "DACAPO_D3S"
+
+    def successPatterns(self):
+        return ['']
+
+    def resultFilter(self, values, iteration, endOfWarmupIndex):
+        """Count iterations, convert iteration time to milliseconds."""
+        # Called from lambda, increment call counter
+        iteration['value'] = iteration['value'] + 1
+        # Skip warm-up?
+        if iteration['value'] < endOfWarmupIndex:
+            return None
+
+        values['iteration_time_ms'] = str(int(values['iteration_time_ns']) / 1000 / 1000)
+        return values
+
+    def rules(self, out, benchmarks, bmSuiteArgs):
+        runArgs = self.postprocessRunArgs(benchmarks[0], self.runArgs(bmSuiteArgs))
+        if runArgs is None:
+            return []
+        totalIterations = int(runArgs[runArgs.index("-n") + 1])
+        out = [
+          mx_benchmark.CSVFixedFileRule(
+            self.resultCsvFile,
+            None,
+            {
+              "benchmark": ("<benchmark>", str),
+              "bench-suite": self.benchSuiteName(),
+              "vm": "jvmci",
+              "config.name": "default",
+              "config.vm-flags": self.shorten_vm_flags(self.vmArgs(bmSuiteArgs)),
+              "metric.name": "warmup",
+              "metric.value": ("<iteration_time_ms>", int),
+              "metric.unit": "ms",
+              "metric.type": "numeric",
+              "metric.score-function": "id",
+              "metric.better": "lower",
+              "metric.iteration": ("$iteration", int)
+            },
+            filter_fn=lambda x, counter={'value': 0}: self.resultFilter(x, counter, 0)
+          ),
+          mx_benchmark.CSVFixedFileRule(
+            self.resultCsvFile,
+            None,
+            {
+              "benchmark": ("<benchmark>", str),
+              "bench-suite": self.benchSuiteName(),
+              "vm": "jvmci",
+              "config.name": "default",
+              "config.vm-flags": self.shorten_vm_flags(self.vmArgs(bmSuiteArgs)),
+              "metric.name": "final-time",
+              "metric.value": ("<iteration_time_ms>", int),
+              "metric.unit": "ms",
+              "metric.type": "numeric",
+              "metric.score-function": "id",
+              "metric.better": "lower",
+              "metric.iteration": ("$iteration", int)
+            },
+            filter_fn=lambda x, counter={'value': 0}: self.resultFilter(x, counter, totalIterations)
+          ),
+        ]
+
+        for ev in self.extraEvents:
+            out.append(
+              mx_benchmark.CSVFixedFileRule(
+                self.resultCsvFile,
+                None,
+                {
+                  "benchmark": ("<benchmark>", str),
+                  "bench-suite": self.benchSuiteName(),
+                  "vm": "jvmci",
+                  "config.name": "default",
+                  "config.vm-flags": self.shorten_vm_flags(self.vmArgs(bmSuiteArgs)),
+                  "metric.name": ev,
+                  "metric.value": ("<" + ev + ">", int),
+                  "metric.unit": "count",
+                  "metric.type": "numeric",
+                  "metric.score-function": "id",
+                  "metric.better": "lower",
+                  "metric.iteration": ("$iteration", int)
+                }
+              )
+            )
+
+        return out
+
+    def getUbenchAgentPaths(self):
+        archive = mx.library("UBENCH_AGENT_DIST").get_path(resolve=True)
+
+        agentExtractPath = join(os.path.dirname(archive), 'ubench-agent')
+        agentBaseDir = join(agentExtractPath, 'java-ubench-agent-2e5becaf97afcf64fd8aef3ac84fc05a3157bff5')
+        agentPathToJar = join(agentBaseDir, 'out', 'lib', 'ubench-agent.jar')
+        agentPathNative = join(agentBaseDir, 'out', 'lib', 'libubench-agent.so')
+
+        return {
+            'archive': archive,
+            'extract': agentExtractPath,
+            'base': agentBaseDir,
+            'jar': agentPathToJar,
+            'agentpath': agentPathNative
+        }
+
+    def createCommandLineArgs(self, benchmarks, bmSuiteArgs):
+        parser = argparse.ArgumentParser(add_help=False)
+        parser.add_argument("-o", default=None)
+        parser.add_argument("-e", default=None)
+        args, remaining = parser.parse_known_args(self.runArgs(bmSuiteArgs))
+
+        if args.o is None:
+            self.resultCsvFile = "result.csv"
+        else:
+            self.resultCsvFile = os.path.abspath(args.o)
+        remaining.append("-o")
+        remaining.append(self.resultCsvFile)
+
+        if not args.e is None:
+            remaining.append("-e")
+            remaining.append(args.e)
+            self.extraEvents = args.e.split(",")
+        else:
+            self.extraEvents = []
+
+        parentArgs = DaCapoBenchmarkSuite.createCommandLineArgs(self, benchmarks, ['--'] + remaining)
+        if parentArgs is None:
+            return None
+
+        paths = self.getUbenchAgentPaths()
+        return ['-agentpath:' + paths['agentpath']] + parentArgs
+
+    def run(self, benchmarks, bmSuiteArgs):
+        agentPaths = self.getUbenchAgentPaths()
+
+        if not exists(agentPaths['jar']):
+            if not exists(join(agentPaths['base'], 'build.xml')):
+                import zipfile
+                zf = zipfile.ZipFile(agentPaths['archive'], 'r')
+                zf.extractall(agentPaths['extract'])
+            mx.run(['ant', 'lib'], cwd=agentPaths['base'])
+
+        return DaCapoBenchmarkSuite.run(self, benchmarks, bmSuiteArgs)
+
+
+mx_benchmark.add_bm_suite(DaCapoD3SBenchmarkSuite())
+
 
 _daCapoScalaConfig = {
     "actors"      : 10,

--- a/compiler/mx.compiler/suite.py
+++ b/compiler/mx.compiler/suite.py
@@ -74,6 +74,13 @@ suite = {
       "sha1" : "59b64c974662b5cf9dbd3cf9045d293853dd7a51",
     },
 
+    "DACAPO_D3S" : {
+      "urls" : [
+        "http://d3s.mff.cuni.cz/software/benchmarking/files/dacapo-9.12-d3s.jar",
+      ],
+      "sha1" : "b072de027141ac81ab5d48706949fda86de62468",
+    },
+
     "JAVA_ALLOCATION_INSTRUMENTER" : {
       "urls" : ["https://lafo.ssw.uni-linz.ac.at/pub/graal-external-deps/java-allocation-instrumenter/java-allocation-instrumenter-8f0db117e64e.jar"],
       "sha1" : "476d9a44cd19d6b55f81571077dfa972a4f8a083",
@@ -120,6 +127,11 @@ suite = {
       "urls" : ["https://lafo.ssw.uni-linz.ac.at/pub/graal-external-deps/asm-tree-5.0.4.jar"],
       "dependencies" : ["ASM5"],
     },
+
+    "UBENCH_AGENT_DIST" : {
+      "urls" : ["https://github.com/D-iii-S/java-ubench-agent/archive/2e5becaf97afcf64fd8aef3ac84fc05a3157bff5.zip"],
+      "sha1" : "19087a34b80be8845e9a3e7f927ceb592de83762",
+    }
   },
 
   "projects" : {

--- a/compiler/mx.compiler/suite.py
+++ b/compiler/mx.compiler/suite.py
@@ -76,6 +76,7 @@ suite = {
 
     "DACAPO_D3S" : {
       "urls" : [
+        "https://lafo.ssw.uni-linz.ac.at/pub/graal-external-deps/dacapo-9.12-d3s.jar",
         "http://d3s.mff.cuni.cz/software/benchmarking/files/dacapo-9.12-d3s.jar",
       ],
       "sha1" : "b072de027141ac81ab5d48706949fda86de62468",


### PR DESCRIPTION
This PR adds a new benchmark `dacapo-d3s` that uses a modified version of the DaCapo benchmark that can query hardware performance counters (Linux only).

Hardware counters are accessed via [PAPI](http://icl.cs.utk.edu/papi/) through a simple C agent. The agent is compiled automatically when running the suite for the first time.

The [C agent is available](https://github.com/D-iii-S/java-ubench-agent) at GitHub, the JAR with the modified DaCapo is hosted by [Department of Distributed and Dependable Systems at Charles University](http://d3s.mff.cuni.cz/software/benchmarking/).

As an extra feature, the results can be also stored in a CSV file.

Example run to collect total number of instructions and L1 cache misses with results stored in `avrora.csv`:

```shell
mx --primary-suite compiler \
  benchmark dacapo-d3s:avrora \
  -- -- \
  -e PAPI_TOT_INS,PAPI_L1_DCM -o avrora.csv
```
