### PR TITLE
Add support for binary sources

### DIFF
--- a/sdk/src/org.graalvm.polyglot/src/org/graalvm/polyglot/Engine.java
+++ b/sdk/src/org.graalvm.polyglot/src/org/graalvm/polyglot/Engine.java
@@ -587,6 +587,11 @@ public final class Engine implements AutoCloseable {
             }
 
             @Override
+            public Source build(String language, Object origin, URI uri, String name, CharSequence content, boolean interactive, boolean internal, boolean preserveBytes) throws IOException {
+                throw noPolyglotImplementationFound();
+            }
+
+            @Override
             public String findLanguage(File file) throws IOException {
                 return null;
             }

--- a/sdk/src/org.graalvm.polyglot/src/org/graalvm/polyglot/Source.java
+++ b/sdk/src/org.graalvm.polyglot/src/org/graalvm/polyglot/Source.java
@@ -32,6 +32,7 @@ import java.io.Reader;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.nio.ByteBuffer;
 import java.util.Objects;
 
 import org.graalvm.polyglot.impl.AbstractPolyglotImpl.AbstractSourceImpl;
@@ -99,6 +100,10 @@ import org.graalvm.polyglot.impl.AbstractPolyglotImpl.AbstractSourceImpl;
  * </p>
  *
  * @since 1.0
+ */
+/**
+ * @author salim
+ *
  */
 public final class Source {
 
@@ -407,6 +412,15 @@ public final class Source {
      */
     public static Builder newBuilder(String language, Reader source, String name) {
         return EMPTY.new Builder(language, source).name(name);
+    }
+
+    /**
+     * Creates a new source builder from language and byte buffer
+     *
+     * @since
+     */
+    public static Builder newBuilder(String language, ByteBuffer bytes, String name) {
+        return EMPTY.new Builder(language, bytes).name(name);
     }
 
     /**

--- a/sdk/src/org.graalvm.polyglot/src/org/graalvm/polyglot/Source.java
+++ b/sdk/src/org.graalvm.polyglot/src/org/graalvm/polyglot/Source.java
@@ -411,7 +411,7 @@ public final class Source {
     }
 
     /**
-     * Creates a new source builder from language and byte buffer
+     * Creates a new source builder from language and byte buffer.
      *
      * @since
      */
@@ -567,13 +567,25 @@ public final class Source {
 
         /**
          * Uses configuration of this builder to create new {@link Source} object. The method throws
-         * an {@link IOException} if an error loading the source occured.
+         * an {@link IOException} if an error loading the source occurred.
          *
          * @return the source object
          * @since 1.0
          */
         public Source build() throws IOException {
             return getImpl().build(language, origin, uri, name, content, interactive, internal);
+        }
+
+        /**
+         * Uses configuration of this builder to create new {@link Source} object. The method throws
+         * an {@link IOException} if an error loading the source occurred.
+         *
+         * @param preserveBytes True to preserve the original bytes of the source file
+         * @return the source object
+         * @since
+         */
+        public Source build(boolean preserveBytes) throws IOException {
+            return getImpl().build(language, origin, uri, name, content, interactive, internal, preserveBytes);
         }
 
         /**

--- a/sdk/src/org.graalvm.polyglot/src/org/graalvm/polyglot/Source.java
+++ b/sdk/src/org.graalvm.polyglot/src/org/graalvm/polyglot/Source.java
@@ -101,10 +101,6 @@ import org.graalvm.polyglot.impl.AbstractPolyglotImpl.AbstractSourceImpl;
  *
  * @since 1.0
  */
-/**
- * @author salim
- *
- */
 public final class Source {
 
     private static volatile AbstractSourceImpl IMPL;

--- a/sdk/src/org.graalvm.polyglot/src/org/graalvm/polyglot/impl/AbstractPolyglotImpl.java
+++ b/sdk/src/org.graalvm.polyglot/src/org/graalvm/polyglot/impl/AbstractPolyglotImpl.java
@@ -136,6 +136,8 @@ public abstract class AbstractPolyglotImpl {
 
         public abstract Source build(String language, Object origin, URI uri, String name, CharSequence content, boolean interactive, boolean internal) throws IOException;
 
+        public abstract Source build(String language, Object origin, URI uri, String name, CharSequence content, boolean interactive, boolean internal, boolean preserveBytes) throws IOException;
+
         public abstract String getName(Object impl);
 
         public abstract String getPath(Object impl);

--- a/truffle/src/com.oracle.truffle.api.source/src/com/oracle/truffle/api/source/BinarySourceImpl.java
+++ b/truffle/src/com.oracle.truffle.api.source/src/com/oracle/truffle/api/source/BinarySourceImpl.java
@@ -31,16 +31,33 @@ import java.net.URL;
 import java.nio.ByteBuffer;
 import java.util.Objects;
 
+/**
+ * Represent sources that depends on maintaining original bytes read.
+ *
+ * @since X
+ */
 public class BinarySourceImpl extends Content implements Content.CreateURI {
 
     private final String name;
 
+    /**
+     *
+     * @param name name of the source
+     * @param bytes to be preserved
+     * @param code the character sequence representation of the source bytes
+     *
+     * @since X
+     */
     public BinarySourceImpl(String name, ByteBuffer bytes, CharSequence code) {
         this.name = name;
         this.sourceBytes = bytes;
         this.code = enforceCharSequenceContract(code);
     }
 
+    /**
+     *
+     * @since X
+     */
     @Override
     public ByteBuffer getBytes() {
         return sourceBytes;
@@ -51,46 +68,82 @@ public class BinarySourceImpl extends Content implements Content.CreateURI {
         return null;
     }
 
+    /**
+     *
+     * @since X
+     */
     @Override
     public Reader getReader() throws IOException {
         return null;
     }
 
+    /**
+     *
+     * @since X
+     */
     @Override
     public CharSequence getCharacters() {
         return code;
     }
 
+    /**
+     *
+     * @since X
+     */
     @Override
     public String getName() {
         return name;
     }
 
+    /**
+     *
+     * @since X
+     */
     @Override
     Object getHashKey() {
         return code;
     }
 
+    /**
+     *
+     * @since X
+     */
     @Override
     public String getPath() {
         return null;
     }
 
+    /**
+     *
+     * @since X
+     */
     @Override
     public int hashCode() {
         return Objects.hash(name, code);
     }
 
+    /**
+     *
+     * @since X
+     */
     @Override
     public URL getURL() {
         return null;
     }
 
+    /**
+     *
+     * @since X
+     */
     @Override
     URI getURI() {
         return createURIOnce(this);
     }
 
+    /**
+     *
+     * @since X
+     */
     public URI createURI() {
         return getNamedURI(name, code.toString().getBytes());
     }

--- a/truffle/src/com.oracle.truffle.api.source/src/com/oracle/truffle/api/source/BinarySourceImpl.java
+++ b/truffle/src/com.oracle.truffle.api.source/src/com/oracle/truffle/api/source/BinarySourceImpl.java
@@ -37,13 +37,13 @@ public class BinarySourceImpl extends Content implements Content.CreateURI {
 
     public BinarySourceImpl(String name, ByteBuffer bytes, CharSequence code) {
         this.name = name;
-        this.bytes = bytes;
+        this.sourceBytes = bytes;
         this.code = enforceCharSequenceContract(code);
     }
 
     @Override
     public ByteBuffer getBytes() {
-        return bytes;
+        return sourceBytes;
     }
 
     @Override

--- a/truffle/src/com.oracle.truffle.api.source/src/com/oracle/truffle/api/source/BinarySourceImpl.java
+++ b/truffle/src/com.oracle.truffle.api.source/src/com/oracle/truffle/api/source/BinarySourceImpl.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2013, 2016, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package com.oracle.truffle.api.source;
+
+import java.io.IOException;
+import java.io.Reader;
+import java.net.URI;
+import java.net.URL;
+import java.nio.ByteBuffer;
+import java.util.Objects;
+
+public class BinarySourceImpl extends Content implements Content.CreateURI {
+
+    private final String name;
+
+    public BinarySourceImpl(String name, ByteBuffer bytes, CharSequence code) {
+        this.name = name;
+        this.bytes = bytes;
+        this.code = enforceCharSequenceContract(code);
+    }
+
+    @Override
+    public ByteBuffer getBytes() {
+        return bytes;
+    }
+
+    @Override
+    String findMimeType() throws IOException {
+        return null;
+    }
+
+    @Override
+    public Reader getReader() throws IOException {
+        return null;
+    }
+
+    @Override
+    public CharSequence getCharacters() {
+        return code;
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    Object getHashKey() {
+        return code;
+    }
+
+    @Override
+    public String getPath() {
+        return null;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name, code);
+    }
+
+    @Override
+    public URL getURL() {
+        return null;
+    }
+
+    @Override
+    URI getURI() {
+        return createURIOnce(this);
+    }
+
+    public URI createURI() {
+        return getNamedURI(name, code.toString().getBytes());
+    }
+
+}

--- a/truffle/src/com.oracle.truffle.api.source/src/com/oracle/truffle/api/source/Content.java
+++ b/truffle/src/com.oracle.truffle.api.source/src/com/oracle/truffle/api/source/Content.java
@@ -29,6 +29,7 @@ import java.io.Reader;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.nio.ByteBuffer;
 import java.util.Objects;
 
 abstract class Content {
@@ -37,6 +38,11 @@ abstract class Content {
 
     CharSequence code;
     private volatile URI uri;
+    ByteBuffer bytes;
+
+    public ByteBuffer getBytes() {
+        return null;
+    }
 
     abstract String findMimeType() throws IOException;
 

--- a/truffle/src/com.oracle.truffle.api.source/src/com/oracle/truffle/api/source/Content.java
+++ b/truffle/src/com.oracle.truffle.api.source/src/com/oracle/truffle/api/source/Content.java
@@ -38,7 +38,7 @@ abstract class Content {
 
     CharSequence code;
     private volatile URI uri;
-    ByteBuffer bytes;
+    ByteBuffer sourceBytes;
 
     public ByteBuffer getBytes() {
         return null;

--- a/truffle/src/com.oracle.truffle.api.source/src/com/oracle/truffle/api/source/FileSourceImpl.java
+++ b/truffle/src/com.oracle.truffle.api.source/src/com/oracle/truffle/api/source/FileSourceImpl.java
@@ -29,6 +29,7 @@ import java.io.IOException;
 import java.io.Reader;
 import java.net.URI;
 import java.net.URL;
+import java.nio.ByteBuffer;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.spi.FileTypeDetector;
@@ -51,6 +52,11 @@ final class FileSourceImpl extends Content implements Content.CreateURI {
         this.name = name;
         this.path = path;
         this.hashKey = path != null ? path : file.getPath();
+    }
+
+    FileSourceImpl(String content, File file, String name, String path, ByteBuffer bytes) {
+        this(content, file, name, path);
+        this.bytes = bytes;
     }
 
     @Override
@@ -96,6 +102,11 @@ final class FileSourceImpl extends Content implements Content.CreateURI {
     @Override
     public int hashCode() {
         return hashKey.hashCode();
+    }
+
+    @Override
+    public ByteBuffer getBytes() {
+        return bytes;
     }
 
     @Override

--- a/truffle/src/com.oracle.truffle.api.source/src/com/oracle/truffle/api/source/FileSourceImpl.java
+++ b/truffle/src/com.oracle.truffle.api.source/src/com/oracle/truffle/api/source/FileSourceImpl.java
@@ -56,7 +56,7 @@ final class FileSourceImpl extends Content implements Content.CreateURI {
 
     FileSourceImpl(String content, File file, String name, String path, ByteBuffer bytes) {
         this(content, file, name, path);
-        this.bytes = bytes;
+        this.sourceBytes = bytes;
     }
 
     @Override
@@ -106,7 +106,7 @@ final class FileSourceImpl extends Content implements Content.CreateURI {
 
     @Override
     public ByteBuffer getBytes() {
-        return bytes;
+        return sourceBytes;
     }
 
     @Override

--- a/truffle/src/com.oracle.truffle.api.source/src/com/oracle/truffle/api/source/Source.java
+++ b/truffle/src/com.oracle.truffle.api.source/src/com/oracle/truffle/api/source/Source.java
@@ -1001,12 +1001,12 @@ public abstract class Source {
         }
 
         private Content buildBytes() {
-            final ByteBuffer r = (ByteBuffer) origin;
+            final ByteBuffer bytes = (ByteBuffer) origin;
             if (content == null) {
-                content = new String(r.array());
+                content = new String(bytes.array());
             }
             BinarySourceImpl ret = new BinarySourceImpl(
-                            name, (ByteBuffer) origin, content);
+                            name, bytes, content);
             return ret;
         }
     }

--- a/truffle/src/com.oracle.truffle.api.source/src/com/oracle/truffle/api/source/Source.java
+++ b/truffle/src/com.oracle.truffle.api.source/src/com/oracle/truffle/api/source/Source.java
@@ -988,12 +988,12 @@ public abstract class Source {
         private Content buildFile(boolean read, boolean preserveBytes) throws IOException {
             final File file = (File) origin;
             File absoluteFile = file.getCanonicalFile();
-            byte[] bytes = Source.read(file);
+            byte[] bytes = read ? Source.read(file) : null;
             FileSourceImpl fileSource = new FileSourceImpl(
-                            read ? new String(bytes, StandardCharsets.UTF_8) : null,
+                            (read && bytes != null) ? new String(bytes, StandardCharsets.UTF_8) : null,
                             absoluteFile,
                             name == null ? file.getName() : name,
-                            path, preserveBytes ? ByteBuffer.wrap(bytes) : null);
+                            path, (preserveBytes && bytes != null) ? ByteBuffer.wrap(bytes) : null);
             return fileSource;
         }
 

--- a/truffle/src/com.oracle.truffle.api.test/src/com/oracle/truffle/api/test/source/BinarySourceBuilderTest.java
+++ b/truffle/src/com.oracle.truffle.api.test/src/com/oracle/truffle/api/test/source/BinarySourceBuilderTest.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2013, 2015, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package com.oracle.truffle.api.test.source;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.StringReader;
+import java.nio.ByteBuffer;
+import java.nio.file.Files;
+import java.util.Arrays;
+
+import org.junit.Test;
+
+import com.oracle.truffle.api.source.MissingMIMETypeException;
+import com.oracle.truffle.api.source.Source;
+import com.oracle.truffle.api.source.Source.Builder;
+
+public class BinarySourceBuilderTest {
+
+    @Test
+    public void assignMimeTypeAndIdentityForBinarySource() throws RuntimeException {
+        byte[] bytes = "Testing Source".getBytes();
+        ByteBuffer sourceBytes = ByteBuffer.wrap(bytes);
+        Builder<RuntimeException, RuntimeException, RuntimeException> builder = Source.newBuilder(sourceBytes).name("test.bc");
+        Source s1 = builder.mimeType("content/unknown").build();
+        assertEquals("Base type assigned", "content/unknown", s1.getMimeType());
+        assertTrue("Original bytes preserved", Arrays.equals(bytes, s1.getBytes().array()));
+        Source s2 = builder.mimeType("application/octet-stream").build();
+        assertEquals("They have the same content", s1.getCharacters(), s2.getCharacters());
+        assertEquals("Testing Source", s1.getCharacters());
+        assertNotEquals("But different type", s1.getMimeType(), s2.getMimeType());
+        assertNotEquals("So they are different", s1, s2);
+        assertNotNull("Every source must have URI", s1.getURI());
+        assertEquals("Source with different MIME type has the same URI", s1.getURI(), s2.getURI());
+    }
+
+    @Test
+    public void optionToPreserveOriginalFileBytes() throws Exception {
+        File file = File.createTempFile("Hello", ".bc").getCanonicalFile();
+        file.deleteOnExit();
+
+        String text = "// Hellobc";
+        Files.write(file.toPath(), text.getBytes());
+        Source.Builder<IOException, RuntimeException, RuntimeException> builder = Source.newBuilder(file);
+        Source s1 = builder.build(false);
+        assertEquals("Original bytes not preserved", null, s1.getBytes());
+        Source s2 = builder.build(true);
+        assertTrue("Original bytes preserved", Arrays.equals(Files.readAllBytes(file.toPath()), s2.getBytes().array()));
+        assertEquals("They have the same content", s1.getCharacters(), s2.getCharacters());
+        assertEquals("// Hellobc", s1.getCharacters());
+        assertNotEquals("But different bytes", s1.getBytes(), s2.getBytes());
+        assertEquals("File URI", file.toURI(), s1.getURI());
+        assertEquals("Source with different MIME type has the same URI", s1.getURI(), s2.getURI());
+    }
+
+    @Test
+    public void otherSourcesHaveNoBytes() throws Exception {
+        String text = "// Hello";
+        Source.Builder<IOException, MissingMIMETypeException, RuntimeException> builder = Source.newBuilder(new StringReader(text)).name("test.txt");
+        Source s1 = builder.name("Hello").mimeType("text/plain").build();
+        assertNull("No bytes preserved for reader", s1.getBytes());
+
+        final String code = "test code";
+        final String description = "test description";
+        final Source literal = Source.newBuilder(code).name(description).mimeType("content/unknown").build();
+        assertNull("No bytes preserved for literal source", literal.getBytes());
+
+        File file = File.createTempFile("Hello", ".java");
+        file.deleteOnExit();
+        Source.Builder<IOException, RuntimeException, RuntimeException> builder2 = Source.newBuilder(file.toURI().toURL()).name("Hello.java");
+        Source s2 = builder.build();
+        assertNull("No source preserved for URL sources", s2.getBytes());
+    }
+}

--- a/truffle/src/com.oracle.truffle.api.test/src/com/oracle/truffle/api/test/source/BinarySourceBuilderTest.java
+++ b/truffle/src/com.oracle.truffle.api.test/src/com/oracle/truffle/api/test/source/BinarySourceBuilderTest.java
@@ -94,7 +94,7 @@ public class BinarySourceBuilderTest {
         File file = File.createTempFile("Hello", ".java");
         file.deleteOnExit();
         Source.Builder<IOException, RuntimeException, RuntimeException> builder2 = Source.newBuilder(file.toURI().toURL()).name("Hello.java");
-        Source s2 = builder.build();
+        Source s2 = builder2.build();
         assertNull("No source preserved for URL sources", s2.getBytes());
     }
 }

--- a/truffle/src/com.oracle.truffle.api.vm/src/com/oracle/truffle/api/vm/PolyglotSource.java
+++ b/truffle/src/com.oracle.truffle.api.vm/src/com/oracle/truffle/api/vm/PolyglotSource.java
@@ -30,6 +30,7 @@ import java.io.InputStream;
 import java.io.Reader;
 import java.net.URI;
 import java.net.URL;
+import java.nio.ByteBuffer;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -237,6 +238,8 @@ class PolyglotSource extends AbstractSourceImpl {
             needsName = true;
         } else if (origin instanceof URL) {
             builder = com.oracle.truffle.api.source.Source.newBuilder((URL) origin);
+        } else if (origin instanceof ByteBuffer) {
+            builder = com.oracle.truffle.api.source.Source.newBuilder((ByteBuffer) origin);
         } else {
             throw new AssertionError();
         }

--- a/truffle/src/com.oracle.truffle.api.vm/src/com/oracle/truffle/api/vm/PolyglotSource.java
+++ b/truffle/src/com.oracle.truffle.api.vm/src/com/oracle/truffle/api/vm/PolyglotSource.java
@@ -222,9 +222,14 @@ class PolyglotSource extends AbstractSourceImpl {
         return impl.equals(otherImpl);
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public Source build(String language, Object origin, URI uri, String name, CharSequence content, boolean interactive, boolean internal) throws IOException {
+        return build(language, origin, uri, name, content, interactive, internal, false);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public Source build(String language, Object origin, URI uri, String name, CharSequence content, boolean interactive, boolean internal, boolean preserveBytes) throws IOException {
         assert language != null;
         com.oracle.truffle.api.source.Source.Builder<?, ?, ?> builder;
         boolean needsName = false;
@@ -269,7 +274,7 @@ class PolyglotSource extends AbstractSourceImpl {
         builder.language(language);
 
         try {
-            return engineImpl.getAPIAccess().newSource(language, ((com.oracle.truffle.api.source.Source.Builder<IOException, ?, ?>) builder).build());
+            return engineImpl.getAPIAccess().newSource(language, ((com.oracle.truffle.api.source.Source.Builder<IOException, ?, ?>) builder).build(preserveBytes));
         } catch (IOException e) {
             throw e;
         } catch (RuntimeException e) {


### PR DESCRIPTION
Provide support for languages that need to maintain the original bytes of the source file.

For instance, Sulong currently ignores the file read by the Source class and re-read it again at the Runner class as the original bytes are not preserved. This trick is not possible when reading from standard input.