### PR TITLE
Use <pre/> instead of <code/> for example snippet

### DIFF
--- a/truffle/src/com.oracle.truffle.api.dsl/src/com/oracle/truffle/api/dsl/Cached.java
+++ b/truffle/src/com.oracle.truffle.api.dsl/src/com/oracle/truffle/api/dsl/Cached.java
@@ -140,7 +140,7 @@ import java.lang.annotation.Target;
  * instantiated. Alternatively if the <code>replaces</code> relation is omitted then all
  * <code>doCached</code> instances remain but no new instances are created.
  *
- * <code>
+ * <pre>
  * &#064;Specialization(guards = &quot;operand == cachedOperand&quot;)
  * void doCached(int operand, {@code @Cached}(&quot;operand&quot;) int cachedOperand) {
  *    CompilerAsserts.compilationConstant(cachedOperand);
@@ -166,7 +166,7 @@ import java.lang.annotation.Target;
  * execute(3) => doNormal(3)    // new instantiation of doNormal due to limit overflow
  * execute(1) => doCached(1, 1)
  *
- * </code>
+ * </pre>
  *
  * </li>
  * <li>This next example shows how methods from the enclosing node can be used to initialize cached


### PR DESCRIPTION
This should fix the formatting of the third example. Currently, it looks like this:
![image](https://user-images.githubusercontent.com/2368856/40806372-90aca606-6521-11e8-9426-1b8a8118a778.png)
