### PR TITLE
Allow immediates to be used in getAndAddInt for AArch64

### DIFF
--- a/compiler/src/org.graalvm.compiler.asm.aarch64/src/org/graalvm/compiler/asm/aarch64/AArch64MacroAssembler.java
+++ b/compiler/src/org.graalvm.compiler.asm.aarch64/src/org/graalvm/compiler/asm/aarch64/AArch64MacroAssembler.java
@@ -643,6 +643,26 @@ public class AArch64MacroAssembler extends AArch64Assembler {
     }
 
     /**
+     * dst = src + immediate.
+     *
+     * @param size register size. Has to be 32 or 64.
+     * @param dst general purpose register. May not be null or zero-register.
+     * @param src general purpose register. May not be null or zero-register.
+     * @param immediate 64-bit signed int
+     */
+    public void add(int size, Register dst, Register src, long immediate) {
+        if (NumUtil.isInt(immediate)) {
+            add(size, dst, src, (int) immediate);
+        } else {
+            assert (!dst.equals(zr) && !src.equals(zr));
+            assert !dst.equals(src);
+            assert size == 64;
+            mov(dst, immediate);
+            add(size, src, dst, dst);
+        }
+    }
+
+    /**
      * dst = src + aimm and sets condition flags.
      *
      * @param size register size. Has to be 32 or 64.

--- a/compiler/src/org.graalvm.compiler.core.aarch64/src/org/graalvm/compiler/core/aarch64/AArch64LIRGenerator.java
+++ b/compiler/src/org.graalvm.compiler.core.aarch64/src/org/graalvm/compiler/core/aarch64/AArch64LIRGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2018, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -53,8 +53,10 @@ import org.graalvm.compiler.lir.aarch64.AArch64ControlFlow.BranchOp;
 import org.graalvm.compiler.lir.aarch64.AArch64ControlFlow.CondMoveOp;
 import org.graalvm.compiler.lir.aarch64.AArch64ControlFlow.StrategySwitchOp;
 import org.graalvm.compiler.lir.aarch64.AArch64ControlFlow.TableSwitchOp;
+import org.graalvm.compiler.lir.aarch64.AArch64LIRFlagsVersioned;
 import org.graalvm.compiler.lir.aarch64.AArch64Move;
 import org.graalvm.compiler.lir.aarch64.AArch64AtomicMove.AtomicReadAndAddOp;
+import org.graalvm.compiler.lir.aarch64.AArch64AtomicMove.AtomicReadAndAddLSEOp;
 import org.graalvm.compiler.lir.aarch64.AArch64AtomicMove.CompareAndSwapOp;
 import org.graalvm.compiler.lir.aarch64.AArch64AtomicMove.AtomicReadAndWriteOp;
 import org.graalvm.compiler.lir.aarch64.AArch64Move.MembarOp;
@@ -160,9 +162,11 @@ public abstract class AArch64LIRGenerator extends LIRGenerator {
     @Override
     public Value emitAtomicReadAndAdd(Value address, ValueKind<?> kind, Value delta) {
         Variable result = newVariable(kind);
-        Variable scratch1 = newVariable(kind);
-        Variable scratch2 = newVariable(kind);
-        append(new AtomicReadAndAddOp((AArch64Kind) kind.getPlatformKind(), asAllocatable(result), asAllocatable(address), delta, asAllocatable(scratch1), asAllocatable(scratch2)));
+        if (AArch64LIRFlagsVersioned.useLSE(target().arch)) {
+            append(new AtomicReadAndAddLSEOp((AArch64Kind) kind.getPlatformKind(), asAllocatable(result), asAllocatable(address), asAllocatable(delta)));
+        } else {
+            append(new AtomicReadAndAddOp((AArch64Kind) kind.getPlatformKind(), asAllocatable(result), asAllocatable(address), delta));
+        }
         return result;
     }
 

--- a/compiler/src/org.graalvm.compiler.core.aarch64/src/org/graalvm/compiler/core/aarch64/AArch64LIRGenerator.java
+++ b/compiler/src/org.graalvm.compiler.core.aarch64/src/org/graalvm/compiler/core/aarch64/AArch64LIRGenerator.java
@@ -162,7 +162,7 @@ public abstract class AArch64LIRGenerator extends LIRGenerator {
         Variable result = newVariable(kind);
         Variable scratch1 = newVariable(kind);
         Variable scratch2 = newVariable(kind);
-        append(new AtomicReadAndAddOp((AArch64Kind) kind.getPlatformKind(), asAllocatable(result), asAllocatable(address), asAllocatable(delta), asAllocatable(scratch1), asAllocatable(scratch2)));
+        append(new AtomicReadAndAddOp((AArch64Kind) kind.getPlatformKind(), asAllocatable(result), asAllocatable(address), delta, asAllocatable(scratch1), asAllocatable(scratch2)));
         return result;
     }
 

--- a/compiler/src/org.graalvm.compiler.lir.aarch64.jdk11/src/org/graalvm/compiler/lir/aarch64/AArch64LIRFlagsVersioned.java
+++ b/compiler/src/org.graalvm.compiler.lir.aarch64.jdk11/src/org/graalvm/compiler/lir/aarch64/AArch64LIRFlagsVersioned.java
@@ -24,13 +24,14 @@
  */
 package org.graalvm.compiler.lir.aarch64;
 
-import org.graalvm.compiler.asm.aarch64.AArch64MacroAssembler;
-
+import jdk.vm.ci.aarch64.AArch64;
 import jdk.vm.ci.aarch64.AArch64.CPUFeature;
 import jdk.vm.ci.aarch64.AArch64.Flag;
+import jdk.vm.ci.code.Architecture;
 
 public class AArch64LIRFlagsVersioned {
-    public static boolean useLSE(AArch64MacroAssembler masm) {
-        return masm.supports(CPUFeature.LSE) || masm.isFlagSet(Flag.UseLSE);
+    public static boolean useLSE(Architecture arch) {
+        AArch64 aarch64 = (AArch64) arch;
+        return aarch64.getFeatures().contains(CPUFeature.LSE) || aarch64.getFlags().contains(Flag.UseLSE);
     }
 }

--- a/compiler/src/org.graalvm.compiler.lir.aarch64/src/org/graalvm/compiler/lir/aarch64/AArch64AtomicMove.java
+++ b/compiler/src/org.graalvm.compiler.lir.aarch64/src/org/graalvm/compiler/lir/aarch64/AArch64AtomicMove.java
@@ -25,15 +25,15 @@
 package org.graalvm.compiler.lir.aarch64;
 
 import static jdk.vm.ci.code.ValueUtil.asRegister;
-import static jdk.vm.ci.code.ValueUtil.asAllocatableValue;
-
-import static org.graalvm.compiler.lir.LIRValueUtil.asJavaConstant;
-import static org.graalvm.compiler.lir.LIRValueUtil.isJavaConstant;
+import static org.graalvm.compiler.lir.LIRInstruction.OperandFlag.CONST;
+import static org.graalvm.compiler.lir.LIRInstruction.OperandFlag.REG;
 
 import org.graalvm.compiler.asm.Label;
 import org.graalvm.compiler.asm.aarch64.AArch64Assembler;
 import org.graalvm.compiler.asm.aarch64.AArch64MacroAssembler;
+import org.graalvm.compiler.asm.aarch64.AArch64MacroAssembler.ScratchRegister;
 import org.graalvm.compiler.lir.LIRInstructionClass;
+import org.graalvm.compiler.lir.LIRValueUtil;
 import org.graalvm.compiler.lir.Opcode;
 import org.graalvm.compiler.lir.asm.CompilationResultBuilder;
 
@@ -41,7 +41,6 @@ import jdk.vm.ci.aarch64.AArch64Kind;
 import jdk.vm.ci.code.Register;
 import jdk.vm.ci.meta.AllocatableValue;
 import jdk.vm.ci.meta.Value;
-import jdk.vm.ci.meta.JavaConstant;
 
 public class AArch64AtomicMove {
     /**
@@ -81,7 +80,7 @@ public class AArch64AtomicMove {
             Register address = asRegister(addressValue);
             Register result = asRegister(resultValue);
             Register newVal = asRegister(newValue);
-            if (AArch64LIRFlagsVersioned.useLSE(masm)) {
+            if (AArch64LIRFlagsVersioned.useLSE(masm.target.arch)) {
                 Register expected = asRegister(expectedValue);
                 masm.mov(size, result, expected);
                 masm.cas(size, expected, newVal, address, true /* acquire */, true /* release */);
@@ -119,33 +118,16 @@ public class AArch64AtomicMove {
 
         private final AArch64Kind accessKind;
 
-        @Def protected AllocatableValue resultValue;
-        @Alive protected AllocatableValue addressValue;
-        @Alive protected Value deltaValue;
-        @Temp protected AllocatableValue scratchValue1;
-        @Temp protected AllocatableValue scratchValue2;
+        @Def({REG}) protected AllocatableValue resultValue;
+        @Alive({REG}) protected AllocatableValue addressValue;
+        @Alive({REG, CONST}) protected Value deltaValue;
 
-        public AtomicReadAndAddOp(AArch64Kind kind, AllocatableValue result, AllocatableValue address, Value delta, AllocatableValue scratch1, AllocatableValue scratch2) {
+        public AtomicReadAndAddOp(AArch64Kind kind, AllocatableValue result, AllocatableValue address, Value delta) {
             super(TYPE);
             this.accessKind = kind;
             this.resultValue = result;
             this.addressValue = address;
             this.deltaValue = delta;
-            this.scratchValue1 = scratch1;
-            this.scratchValue2 = scratch2;
-        }
-
-        private boolean isImmediateValue(Value value) {
-            if (isJavaConstant(value)) {
-                JavaConstant constant = asJavaConstant(value);
-                if (constant != null && constant.getJavaKind().isNumericInteger()) {
-                    int v = constant.asInt();
-                    if (v >= 0 && v < 4096) {
-                        return true;
-                    }
-                }
-            }
-            return false;
         }
 
         @Override
@@ -156,23 +138,70 @@ public class AArch64AtomicMove {
             Register address = asRegister(addressValue);
             Register result = asRegister(resultValue);
 
-            if (AArch64LIRFlagsVersioned.useLSE(masm)) {
-                masm.ldadd(size, asRegister(asAllocatableValue(deltaValue)), result, address, true, true);
-            } else {
-                Register scratch1 = asRegister(scratchValue1);
-                Register scratch2 = asRegister(scratchValue2);
-                Label retry = new Label();
-                masm.bind(retry);
-                masm.ldaxr(size, result, address);
-                if (isImmediateValue(deltaValue)) {
-                    masm.add(size, scratch1, result, asJavaConstant(deltaValue).asInt());
-                } else {
-                    masm.add(size, scratch1, result, asRegister(asAllocatableValue(deltaValue)));
+            Label retry = new Label();
+            masm.bind(retry);
+            masm.ldaxr(size, result, address);
+            try (ScratchRegister scratchRegister1 = masm.getScratchRegister()) {
+                Register scratch1 = scratchRegister1.getRegister();
+                if (LIRValueUtil.isConstantValue(deltaValue)) {
+                    long delta = LIRValueUtil.asConstantValue(deltaValue).getJavaConstant().asLong();
+                    masm.add(size, scratch1, result, delta);
+                } else { // must be a register then
+                    masm.add(size, scratch1, result, asRegister(deltaValue));
                 }
-                masm.stlxr(size, scratch2, scratch1, address);
-                // if scratch2 == 0 then write successful, else retry
-                masm.cbnz(32, scratch2, retry);
+                try (ScratchRegister scratchRegister2 = masm.getScratchRegister()) {
+                    Register scratch2 = scratchRegister2.getRegister();
+                    masm.stlxr(size, scratch2, scratch1, address);
+                    // if scratch2 == 0 then write successful, else retry
+                    masm.cbnz(32, scratch2, retry);
+                }
             }
+        }
+    }
+
+    /**
+     * Load (Read) and Add instruction. Does the following atomically: <code>
+     *  ATOMIC_READ_AND_ADD(addend, result, address):
+     *    result = *address
+     *    *address = result + addend
+     *    return result
+     * </code>
+     *
+     * The LSE version has different properties with regards to the register allocator. To define
+     * these differences, we have to create a separate LIR instruction class.
+     *
+     * The difference to {@linkplain AtomicReadAndAddOp} is:
+     * <li>{@linkplain #deltaValue} must be a register (@Use({REG}) instead @Alive({REG,CONST}))
+     * <li>{@linkplain #resultValue} may be an alias for the input registers (@Use instead
+     * of @Alive)
+     */
+    @Opcode("ATOMIC_READ_AND_ADD")
+    public static final class AtomicReadAndAddLSEOp extends AArch64LIRInstruction {
+        public static final LIRInstructionClass<AtomicReadAndAddLSEOp> TYPE = LIRInstructionClass.create(AtomicReadAndAddLSEOp.class);
+
+        private final AArch64Kind accessKind;
+
+        @Def({REG}) protected AllocatableValue resultValue;
+        @Use({REG}) protected AllocatableValue addressValue;
+        @Use({REG}) protected AllocatableValue deltaValue;
+
+        public AtomicReadAndAddLSEOp(AArch64Kind kind, AllocatableValue result, AllocatableValue address, AllocatableValue delta) {
+            super(TYPE);
+            this.accessKind = kind;
+            this.resultValue = result;
+            this.addressValue = address;
+            this.deltaValue = delta;
+        }
+
+        @Override
+        public void emitCode(CompilationResultBuilder crb, AArch64MacroAssembler masm) {
+            assert accessKind.isInteger();
+            final int size = accessKind.getSizeInBytes() * Byte.SIZE;
+
+            Register address = asRegister(addressValue);
+            Register delta = asRegister(deltaValue);
+            Register result = asRegister(resultValue);
+            masm.ldadd(size, delta, result, address, true, true);
         }
     }
 
@@ -213,7 +242,7 @@ public class AArch64AtomicMove {
             Register value = asRegister(newValue);
             Register result = asRegister(resultValue);
 
-            if (AArch64LIRFlagsVersioned.useLSE(masm)) {
+            if (AArch64LIRFlagsVersioned.useLSE(masm.target.arch)) {
                 masm.swp(size, value, result, address, true, true);
             } else {
                 Register scratch = asRegister(scratchValue);

--- a/compiler/src/org.graalvm.compiler.lir.aarch64/src/org/graalvm/compiler/lir/aarch64/AArch64AtomicMove.java
+++ b/compiler/src/org.graalvm.compiler.lir.aarch64/src/org/graalvm/compiler/lir/aarch64/AArch64AtomicMove.java
@@ -25,6 +25,10 @@
 package org.graalvm.compiler.lir.aarch64;
 
 import static jdk.vm.ci.code.ValueUtil.asRegister;
+import static jdk.vm.ci.code.ValueUtil.asAllocatableValue;
+
+import static org.graalvm.compiler.lir.LIRValueUtil.asJavaConstant;
+import static org.graalvm.compiler.lir.LIRValueUtil.isJavaConstant;
 
 import org.graalvm.compiler.asm.Label;
 import org.graalvm.compiler.asm.aarch64.AArch64Assembler;
@@ -37,6 +41,7 @@ import jdk.vm.ci.aarch64.AArch64Kind;
 import jdk.vm.ci.code.Register;
 import jdk.vm.ci.meta.AllocatableValue;
 import jdk.vm.ci.meta.Value;
+import jdk.vm.ci.meta.JavaConstant;
 
 public class AArch64AtomicMove {
     /**
@@ -116,11 +121,11 @@ public class AArch64AtomicMove {
 
         @Def protected AllocatableValue resultValue;
         @Alive protected AllocatableValue addressValue;
-        @Alive protected AllocatableValue deltaValue;
+        @Alive protected Value deltaValue;
         @Temp protected AllocatableValue scratchValue1;
         @Temp protected AllocatableValue scratchValue2;
 
-        public AtomicReadAndAddOp(AArch64Kind kind, AllocatableValue result, AllocatableValue address, AllocatableValue delta, AllocatableValue scratch1, AllocatableValue scratch2) {
+        public AtomicReadAndAddOp(AArch64Kind kind, AllocatableValue result, AllocatableValue address, Value delta, AllocatableValue scratch1, AllocatableValue scratch2) {
             super(TYPE);
             this.accessKind = kind;
             this.resultValue = result;
@@ -130,24 +135,40 @@ public class AArch64AtomicMove {
             this.scratchValue2 = scratch2;
         }
 
+        private boolean isImmediateValue(Value value) {
+            if (isJavaConstant(value)) {
+                JavaConstant constant = asJavaConstant(value);
+                if (constant != null && constant.getJavaKind().isNumericInteger()) {
+                    int v = constant.asInt();
+                    if (v >= 0 && v < 4096) {
+                        return true;
+                    }
+                }
+            }
+            return false;
+        }
+
         @Override
         public void emitCode(CompilationResultBuilder crb, AArch64MacroAssembler masm) {
             assert accessKind.isInteger();
             final int size = accessKind.getSizeInBytes() * Byte.SIZE;
 
             Register address = asRegister(addressValue);
-            Register delta = asRegister(deltaValue);
             Register result = asRegister(resultValue);
 
             if (AArch64LIRFlagsVersioned.useLSE(masm)) {
-                masm.ldadd(size, delta, result, address, true, true);
+                masm.ldadd(size, asRegister(asAllocatableValue(deltaValue)), result, address, true, true);
             } else {
                 Register scratch1 = asRegister(scratchValue1);
                 Register scratch2 = asRegister(scratchValue2);
                 Label retry = new Label();
                 masm.bind(retry);
                 masm.ldaxr(size, result, address);
-                masm.add(size, scratch1, result, delta);
+                if (isImmediateValue(deltaValue)) {
+                    masm.add(size, scratch1, result, asJavaConstant(deltaValue).asInt());
+                } else {
+                    masm.add(size, scratch1, result, asRegister(asAllocatableValue(deltaValue)));
+                }
                 masm.stlxr(size, scratch2, scratch1, address);
                 // if scratch2 == 0 then write successful, else retry
                 masm.cbnz(32, scratch2, retry);

--- a/compiler/src/org.graalvm.compiler.lir.aarch64/src/org/graalvm/compiler/lir/aarch64/AArch64LIRFlagsVersioned.java
+++ b/compiler/src/org.graalvm.compiler.lir.aarch64/src/org/graalvm/compiler/lir/aarch64/AArch64LIRFlagsVersioned.java
@@ -24,11 +24,11 @@
  */
 package org.graalvm.compiler.lir.aarch64;
 
-import org.graalvm.compiler.asm.aarch64.AArch64MacroAssembler;
+import jdk.vm.ci.code.Architecture;
 
 public class AArch64LIRFlagsVersioned {
     @SuppressWarnings("unused")
-    public static boolean useLSE(AArch64MacroAssembler masm) {
+    public static boolean useLSE(Architecture masm) {
         return false;
     }
 }


### PR DESCRIPTION
This adds support for using immediate values in the add instruction within the getAndAddInt() intrinsic for AArch64.