### PR TITLE
Unreflect fields instead findGetter/Setter

### DIFF
--- a/truffle/src/com.oracle.truffle.api.interop.java/src/com/oracle/truffle/api/interop/java/JavaFieldDesc.java
+++ b/truffle/src/com.oracle.truffle.api.interop.java/src/com/oracle/truffle/api/interop/java/JavaFieldDesc.java
@@ -192,29 +192,25 @@ abstract class SingleFieldDesc implements JavaFieldDesc {
 
         private MethodHandle makeGetMethodHandle() {
             try {
+                MethodHandle getter = MethodHandles.publicLookup().unreflectGetter(field);
                 if (Modifier.isStatic(field.getModifiers())) {
-                    MethodHandle getter = MethodHandles.publicLookup().findStaticGetter(field.getDeclaringClass(), field.getName(), field.getType());
                     return MethodHandles.dropArguments(getter.asType(MethodType.methodType(Object.class)), 0, Object.class);
                 } else {
-                    MethodHandle getter = MethodHandles.publicLookup().findGetter(field.getDeclaringClass(), field.getName(), field.getType());
                     return getter.asType(MethodType.methodType(Object.class, Object.class));
                 }
-            } catch (NoSuchFieldException | IllegalAccessException e) {
+            } catch (IllegalAccessException e) {
                 throw new IllegalStateException(e);
             }
         }
 
         private MethodHandle makeSetMethodHandle() {
             try {
+                MethodHandle setter = MethodHandles.publicLookup().unreflectSetter(field);
                 if (Modifier.isStatic(field.getModifiers())) {
-                    MethodHandle setter = MethodHandles.publicLookup().findStaticSetter(field.getDeclaringClass(), field.getName(), field.getType());
                     return MethodHandles.dropArguments(setter.asType(MethodType.methodType(void.class, Object.class)), 0, Object.class);
                 } else {
-                    MethodHandle setter = MethodHandles.publicLookup().findSetter(field.getDeclaringClass(), field.getName(), field.getType());
                     return setter.asType(MethodType.methodType(void.class, Object.class, Object.class));
                 }
-            } catch (NoSuchFieldException e) {
-                throw UnknownIdentifierException.raise(field.getName());
             } catch (IllegalAccessException e) {
                 if (Modifier.isFinal(field.getModifiers())) {
                     throw UnknownIdentifierException.raise(field.getName());

--- a/truffle/src/com.oracle.truffle.api.interop.java/src/com/oracle/truffle/api/interop/java/JavaInteropReflect.java
+++ b/truffle/src/com.oracle.truffle.api.interop.java/src/com/oracle/truffle/api/interop/java/JavaInteropReflect.java
@@ -26,7 +26,6 @@ package com.oracle.truffle.api.interop.java;
 
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
-import java.lang.invoke.MethodType;
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
@@ -464,7 +463,7 @@ final class FunctionProxyHandler implements InvocationHandler {
         assert declaringClass.isInterface() : declaringClass;
         MethodHandle mh;
         try {
-            mh = MethodHandles.lookup().findSpecial(declaringClass, method.getName(), MethodType.methodType(method.getReturnType(), method.getParameterTypes()), declaringClass);
+            mh = MethodHandles.lookup().unreflectSpecial(method, declaringClass);
         } catch (IllegalAccessException e) {
             throw new UnsupportedOperationException(method.getName(), e);
         }


### PR DESCRIPTION
I hacked together a dirty solution for #444 this weekend but this PR is the portion of the change that probably makes sense to put it in anyway.

I suspect that using findSetter/Getter() instead of unreflectSetter/Getter() was an oversight since lookups surrounding methods already use unreflect().
see:  com.oracle.truffle.api.interop.java.SingleMethodDesc:280

To the best of my knowledge, there is no behavioral difference but it has one advantage: it will respect the field.setAccessible(true). 