### PR TITLE
Reinstate JarURLConnection

### DIFF
--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/SunMiscSubstitutions.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/SunMiscSubstitutions.java
@@ -318,11 +318,6 @@ class Package_jdk_internal_loader implements Function<TargetClass, String> {
 final class Target_sun_misc_URLClassPath_JarLoader {
 }
 
-@TargetClass(java.net.JarURLConnection.class)
-@Delete
-final class Target_java_net_JarURLConnection {
-}
-
 /** Dummy class to have a class with the file's name. */
 public final class SunMiscSubstitutions {
 }


### PR DESCRIPTION
Since JarFile is back, we can now use JarURLConnection again.