### PR TITLE
Automatically register classes used with ServiceLoader

### DIFF
--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/NativeImageGenerator.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/NativeImageGenerator.java
@@ -1046,7 +1046,7 @@ public class NativeImageGenerator {
         MetaAccessProvider pluginsMetaAccess = hosted && !analysis ? hMetaAccess : aMetaAccess;
         assert pluginsMetaAccess != null;
         SubstrateGraphBuilderPlugins.registerInvocationPlugins(pluginsMetaAccess, providers.getConstantReflection(), hostedSnippetReflection, plugins.getInvocationPlugins(),
-                        replacementBytecodeProvider, analysis);
+                        replacementBytecodeProvider, loader, analysis);
 
         featureHandler.forEachGraalFeature(feature -> feature.registerInvocationPlugins(providers, hostedSnippetReflection, plugins.getInvocationPlugins(), analysis, hosted));
 

--- a/substratevm/src/com.oracle.svm.test/src/META-INF/services/com.oracle.svm.test.services.service1.Service1Base
+++ b/substratevm/src/com.oracle.svm.test/src/META-INF/services/com.oracle.svm.test.services.service1.Service1Base
@@ -1,0 +1,2 @@
+com.oracle.svm.test.services.service1.Service1Implementation0
+com.oracle.svm.test.services.service1.Service1Implementation1

--- a/substratevm/src/com.oracle.svm.test/src/META-INF/services/com.oracle.svm.test.services.service2.Service2Base
+++ b/substratevm/src/com.oracle.svm.test/src/META-INF/services/com.oracle.svm.test.services.service2.Service2Base
@@ -1,0 +1,3 @@
+com.oracle.svm.test.services.service2.Service2Implementation0
+com.oracle.svm.test.services.service2.Service2Implementation1
+com.oracle.svm.test.services.service2.Service2Implementation2

--- a/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/ServiceLoaderTest.java
+++ b/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/ServiceLoaderTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2018, 2018, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package com.oracle.svm.test;
+
+import com.oracle.svm.test.services.service1.Service1Base;
+import com.oracle.svm.test.services.service2.Service2Base;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Iterator;
+import java.util.ServiceLoader;
+
+public class ServiceLoaderTest {
+    private int countLoadedServices(ServiceLoader<?> services) {
+        Iterator<?> iterator = services.iterator();
+
+        int i = 0;
+        while(iterator.hasNext()) {
+            i++;
+            iterator.next();
+        }
+
+        return i;
+    }
+
+    @Test
+    public void testServiceLoaderLoad1() {
+        ServiceLoader<Service1Base> services = ServiceLoader.load(Service1Base.class);
+
+        Assert.assertEquals(2, countLoadedServices(services));
+    }
+
+    @Test
+    public void testServiceLoaderLoad2() {
+        ServiceLoader<Service2Base> services = ServiceLoader.load(Service2Base.class, getClass().getClassLoader());
+
+        Assert.assertEquals(3, countLoadedServices(services));
+    }
+}

--- a/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/services/service1/Service1Base.java
+++ b/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/services/service1/Service1Base.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2018, 2018, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package com.oracle.svm.test.services.service1;
+
+public interface Service1Base {
+}

--- a/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/services/service1/Service1Implementation0.java
+++ b/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/services/service1/Service1Implementation0.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2018, 2018, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package com.oracle.svm.test.services.service1;
+
+public class Service1Implementation0 implements Service1Base {
+}

--- a/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/services/service1/Service1Implementation1.java
+++ b/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/services/service1/Service1Implementation1.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2018, 2018, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package com.oracle.svm.test.services.service1;
+
+public class Service1Implementation1 implements Service1Base {
+}

--- a/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/services/service2/Service2Base.java
+++ b/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/services/service2/Service2Base.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2018, 2018, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package com.oracle.svm.test.services.service2;
+
+public interface Service2Base {
+}

--- a/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/services/service2/Service2Implementation0.java
+++ b/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/services/service2/Service2Implementation0.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2018, 2018, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package com.oracle.svm.test.services.service2;
+
+public class Service2Implementation0 implements Service2Base {
+}

--- a/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/services/service2/Service2Implementation1.java
+++ b/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/services/service2/Service2Implementation1.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2018, 2018, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package com.oracle.svm.test.services.service2;
+
+public class Service2Implementation1 implements Service2Base {
+}

--- a/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/services/service2/Service2Implementation2.java
+++ b/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/services/service2/Service2Implementation2.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2018, 2018, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package com.oracle.svm.test.services.service2;
+
+public class Service2Implementation2 implements Service2Base {
+}


### PR DESCRIPTION
Here is my attempt to fix https://github.com/oracle/graal/issues/563. The PR is still a WIP as it does not contain any test and as it relies on hacks. Would love to get feedbacks on it.

Here are my main concerns:
1. Is it a good idea to force the user to use something like the `-H:IncludeResources=META-INF/services/service.ServiceBase` to find the concrete classes? I am not sure we want to include these files in the final image. We can just parse all `META-INF/*/*` files for example.
2. If you want to use the above option, how can I access the resources from the feature? Currently I rely on a public variable in `Resources.java`.
3. Should we abort if no concrete class is found (currently a log is emitted is the tracing is enabled)?
4. Is there a better way than my `ServiceRegistry.java` to share data between the feature and the plugin?
5. Is the feature in the correct package?