### PR TITLE
[#557] Add system property 'os.version' to the list of eager substitutions

### DIFF
--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/SystemPropertiesSupport.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/SystemPropertiesSupport.java
@@ -52,7 +52,7 @@ public abstract class SystemPropertiesSupport {
                      */
                     "line.separator", "path.separator", "file.separator",
                     /* We do not support cross-compilation for now. */
-                    "os.arch", "os.name",
+                    "os.arch", "os.name", "os.version",
                     /* For our convenience for now. */
                     "file.encoding", "sun.jnu.encoding",
     };


### PR DESCRIPTION
Fixes #557.

Soft API change: new system property

oca-signed: Oleg Chirukhin
(http://www.oracle.com/technetwork/community/oca-486395.html)