### PR TITLE
Add missing comma

### DIFF
--- a/substratevm/REFLECTION.md
+++ b/substratevm/REFLECTION.md
@@ -58,7 +58,7 @@ where `reflectconfig` is a JSON file in the following format (use `--expert-opti
 	  {
 	    "name" : "java.lang.Class",
         "allDeclaredConstructors" : true,
-        "allPublicConstructors" : true
+        "allPublicConstructors" : true,
 	    "allDeclaredMethods" : true,
 	    "allPublicMethods" : true
 	  },


### PR DESCRIPTION
Fixes an issue in the docs that causes this error when run:

`line 6 column 4 Expected , or } but found "`