### PR TITLE
Fixed comment

### DIFF
--- a/compiler/src/org.graalvm.compiler.lir.amd64/src/org/graalvm/compiler/lir/amd64/AMD64ArrayEqualsOp.java
+++ b/compiler/src/org.graalvm.compiler.lir.amd64/src/org/graalvm/compiler/lir/amd64/AMD64ArrayEqualsOp.java
@@ -277,7 +277,7 @@ public final class AMD64ArrayEqualsOp extends AMD64LIRInstruction {
         Label loopCheck = new Label();
         Label nanCheck = new Label();
 
-        // Compare 16-byte vectors
+        // Compare 32-byte vectors
         masm.andl(result, AVX_VECTOR_SIZE - 1); // tail count (in bytes)
         masm.andl(length, ~(AVX_VECTOR_SIZE - 1)); // vector count (in bytes)
         masm.jcc(ConditionFlag.Zero, compareTail);


### PR DESCRIPTION
Fixed comment. 
The AVX Vector has 32 byte and not 16.

Best,
Philipp