### PR TITLE
virtualize unsafe compare and swap calls

### DIFF
--- a/compiler/src/org.graalvm.compiler.core.test/src/org/graalvm/compiler/core/test/ea/UnsafeCompareAndSwapVirtualizationTest.java
+++ b/compiler/src/org.graalvm.compiler.core.test/src/org/graalvm/compiler/core/test/ea/UnsafeCompareAndSwapVirtualizationTest.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 2011, 2016, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.graalvm.compiler.core.test.ea;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.graalvm.compiler.nodes.java.LogicCompareAndSwapNode;
+import org.junit.Test;
+
+import jdk.vm.ci.meta.JavaConstant;
+
+public class UnsafeCompareAndSwapVirtualizationTest extends EATestBase {
+
+    private static Object obj1 = new Object();
+    private static Object obj2 = new Object();
+
+    public static boolean bothVirtualNoMatch() {
+        AtomicReference<Object> a = new AtomicReference<>();
+        return a.compareAndSet(new Object(), new Object());
+    }
+
+    @Test
+    public void bothVirtualNoMatchTest() {
+        testEscapeAnalysis("bothVirtualNoMatch", JavaConstant.INT_0, true);
+        assertTrue(graph.getNodes(LogicCompareAndSwapNode.TYPE).isEmpty());
+    }
+
+    public static boolean bothVirtualMatch() {
+        Object expect = new Object();
+        AtomicReference<Object> a = new AtomicReference<>(expect);
+        return a.compareAndSet(expect, new Object());
+    }
+
+    @Test
+    public void bothVirtualMatchTest() {
+        testEscapeAnalysis("bothVirtualMatch", JavaConstant.INT_1, true);
+        assertTrue(graph.getNodes(LogicCompareAndSwapNode.TYPE).isEmpty());
+    }
+
+    public static boolean expectedVirtualMatch() {
+        Object o = new Object();
+        AtomicReference<Object> a = new AtomicReference<>(o);
+        return a.compareAndSet(o, obj1);
+    }
+
+    @Test
+    public void expectedVirtualMatchTest() {
+        testEscapeAnalysis("expectedVirtualMatch", null, true);
+        assertTrue(graph.getNodes(LogicCompareAndSwapNode.TYPE).isEmpty());
+    }
+
+    public static boolean expectedVirtualNoMatch() {
+        Object o = new Object();
+        AtomicReference<Object> a = new AtomicReference<>();
+        return a.compareAndSet(o, obj1);
+    }
+
+    @Test
+    public void expectedVirtualNoMatchTest() {
+        testEscapeAnalysis("expectedVirtualNoMatch", null, true);
+        assertTrue(graph.getNodes(LogicCompareAndSwapNode.TYPE).isEmpty());
+    }
+
+    public static boolean bothNonVirtualNoMatch() {
+        AtomicReference<Object> a = new AtomicReference<>();
+        return a.compareAndSet(obj1, obj2);
+    }
+
+    @Test
+    public void bothNonVirtualNoMatchTest() {
+        testEscapeAnalysis("bothNonVirtualNoMatch", null, true);
+        assertTrue(graph.getNodes(LogicCompareAndSwapNode.TYPE).isEmpty());
+    }
+
+    public static boolean bothNonVirtualMatch() {
+        AtomicReference<Object> a = new AtomicReference<>(obj1);
+        return a.compareAndSet(obj1, obj2);
+    }
+
+    @Test
+    public void bothNonVirtualMatchTest() {
+        testEscapeAnalysis("bothNonVirtualMatch", null, true);
+        assertTrue(graph.getNodes(LogicCompareAndSwapNode.TYPE).isEmpty());
+    }
+
+    public static boolean onlyInitialValueVirtualMatch() {
+        AtomicReference<Object> a = new AtomicReference<>(new Object());
+        return a.compareAndSet(obj1, obj2);
+    }
+}


### PR DESCRIPTION
## Problem

Compare and swap calls using `Unsafe` are currently always lowered to an atomic operation. That's unnecessary when the CAS mutates a field of an instance that is virtual. It introduces some performance overhead and prevents other optimizations.

Let's take this JMH benchmark class as an example:

```java
public class VirtualCASBench {

  public static final long valueOffset = UnsafeUtil.fieldOffset(TestClass.class, "value");

  private static class TestClass {
    public volatile int value;

    public TestClass(int value) {
      this.value = value;
    }
  }

  @Benchmark
  public boolean testUnsafe() {
    TestClass t = new TestClass(0);
    return UnsafeUtil.unsafe.compareAndSwapInt(t, valueOffset, 0, 1);
  }

  @Benchmark
  public boolean testIfElse() {
    TestClass t = new TestClass(0);
    synchronized (t) {
      if (t.value != 0)
        return false;
      else {
        t.value = 1;
        return true;
      }
    }
  }
}
```

The if/else version has much better performance than the version using the unsafe compare and swap:

![image](https://user-images.githubusercontent.com/831175/44609860-4d6df500-a7ae-11e8-9d56-87e2458e4fa0.png)

It is optimized before lowering to a graph that returns a constant:

![image](https://user-images.githubusercontent.com/831175/44609869-65457900-a7ae-11e8-934d-8cbdf1050f47.png)

That's expected since the instance doesn't escape and constant folding can determine that the CAS will always return true. The same doesn't happen with the unsafe version since the compare and swap node is opaque to constant folding:

![image](https://user-images.githubusercontent.com/831175/44609904-87d79200-a7ae-11e8-9450-6f17b61144c5.png)

## Solution

When an object is virtualized, compare and swap can be replaced by a guard and the new value can be set using the `VirtualizerTool`. I've implemented such optimization and the benchmark results are promising:

![image](https://user-images.githubusercontent.com/831175/44609913-945bea80-a7ae-11e8-9e7f-ba129c1abbd8.png)

With the CAS virtualization, the unsafe compare and swap benchmark is also optimized to a constant:

![image](https://user-images.githubusercontent.com/831175/44609921-a3db3380-a7ae-11e8-991e-a4519dce5a34.png)

## Notes and questions

1. I've used a guard that will trigger deoptimization in case the current value doesn't match the expected value. It assumes that users won't write code that will makes a CAS operation fail since the object doesn't escape and can't be used concurrently.

2. I couldn't link the guard node to the predecessor using the `VirtualizerTool`, so I set it in `UnsafeCompareAndSwapNode.virtualize`. I'm not sure if that could be problematic since it seems that all effects should be done through the tool during virtualization.

3. The optimization is applied only when the field can be resolved. If the user uses a dynamic or invalid offset, it won't be applied.

4. I've added an option to enable the optimization. Should it be enabled by default?