### PR TITLE
[JDK-8198574] Add support for andn, blsi, blsr and blsmsk x86 instructions

### DIFF
--- a/compiler/src/org.graalvm.compiler.asm.amd64/src/org/graalvm/compiler/asm/amd64/AMD64Assembler.java
+++ b/compiler/src/org.graalvm.compiler.asm.amd64/src/org/graalvm/compiler/asm/amd64/AMD64Assembler.java
@@ -1333,7 +1333,7 @@ public class AMD64Assembler extends AMD64BaseAssembler {
         }
     }
 
-    public static final class VexGeneralPurposeRVMOp extends VexOp {
+    public static final class VexGeneralPurposeRVMOp extends VexRVMOp {
         // @formatter:off
         public static final VexGeneralPurposeRVMOp ANDN   = new VexGeneralPurposeRVMOp("ANDN",   P_,   M_0F38, WIG, 0xF2, VEXOpAssertion.BMI1);
         public static final VexGeneralPurposeRVMOp MULX   = new VexGeneralPurposeRVMOp("MULX",   P_F2, M_0F38, WIG, 0xF6, VEXOpAssertion.BMI2);
@@ -1345,6 +1345,7 @@ public class AMD64Assembler extends AMD64BaseAssembler {
             super(opcode, pp, mmmmm, w, op, assertion);
         }
 
+        @Override
         public void emit(AMD64Assembler asm, AVXSize size, Register dst, Register src1, Register src2) {
             assert assertion.check((AMD64) asm.target.arch, LZ, dst, src1, src2, null);
             assert size == AVXSize.DWORD || size == AVXSize.QWORD;
@@ -1353,6 +1354,7 @@ public class AMD64Assembler extends AMD64BaseAssembler {
             asm.emitModRM(dst, src2);
         }
 
+        @Override
         public void emit(AMD64Assembler asm, AVXSize size, Register dst, Register src1, AMD64Address src2) {
             assert assertion.check((AMD64) asm.target.arch, LZ, dst, src1, null, null);
             assert size == AVXSize.DWORD || size == AVXSize.QWORD;
@@ -1389,6 +1391,36 @@ public class AMD64Assembler extends AMD64BaseAssembler {
             asm.vexPrefix(dst, src2, src1, size, pp, mmmmm, size == AVXSize.DWORD ? W0 : W1);
             asm.emitByte(op);
             asm.emitOperandHelper(dst, src1, 0);
+        }
+    }
+
+    public static final class VexGeneralPurposeRMOp extends VexRMOp {
+        // @formatter:off
+        public static final VexGeneralPurposeRMOp BLSI    = new VexGeneralPurposeRMOp("BLSI",   P_,    M_0F38, WIG, 0xF3, 3, VEXOpAssertion.BMI1);
+        public static final VexGeneralPurposeRMOp BLSMSK  = new VexGeneralPurposeRMOp("BLSMSK", P_,    M_0F38, WIG, 0xF3, 2, VEXOpAssertion.BMI1);
+        public static final VexGeneralPurposeRMOp BLSR    = new VexGeneralPurposeRMOp("BLSR",   P_,    M_0F38, WIG, 0xF3, 1, VEXOpAssertion.BMI1);
+        // @formatter:on
+        private final int ext;
+
+        private VexGeneralPurposeRMOp(String opcode, int pp, int mmmmm, int w, int op, int ext, VEXOpAssertion assertion) {
+            super(opcode, pp, mmmmm, w, op, assertion);
+            this.ext = ext;
+        }
+
+        @Override
+        public void emit(AMD64Assembler asm, AVXSize size, Register dst, Register src) {
+            assert assertion.check((AMD64) asm.target.arch, size, dst, null, null);
+            asm.vexPrefix(AMD64.cpuRegisters[ext], dst, src, size, pp, mmmmm, size == AVXSize.DWORD ? W0 : W1);
+            asm.emitByte(op);
+            asm.emitModRM(ext, src);
+        }
+
+        @Override
+        public void emit(AMD64Assembler asm, AVXSize size, Register dst, AMD64Address src) {
+            assert assertion.check((AMD64) asm.target.arch, size, dst, null, null);
+            asm.vexPrefix(AMD64.cpuRegisters[ext], dst, src, size, pp, mmmmm, size == AVXSize.DWORD ? W0 : W1);
+            asm.emitByte(op);
+            asm.emitOperandHelper(ext, src, 0);
         }
     }
 

--- a/compiler/src/org.graalvm.compiler.core.amd64/src/org/graalvm/compiler/core/amd64/AMD64NodeMatchRules.java
+++ b/compiler/src/org.graalvm.compiler.core.amd64/src/org/graalvm/compiler/core/amd64/AMD64NodeMatchRules.java
@@ -81,6 +81,7 @@ import org.graalvm.compiler.nodes.util.GraphUtil;
 import jdk.vm.ci.amd64.AMD64Kind;
 import jdk.vm.ci.meta.AllocatableValue;
 import jdk.vm.ci.meta.JavaConstant;
+import jdk.vm.ci.meta.JavaKind;
 import jdk.vm.ci.meta.PlatformKind;
 import jdk.vm.ci.meta.Value;
 import jdk.vm.ci.meta.ValueKind;
@@ -270,6 +271,68 @@ public class AMD64NodeMatchRules extends NodeMatchRules {
         AMD64AddressValue address = (AMD64AddressValue) operand(access.getAddress());
         LIRFrameState state = getState(access);
         return getArithmeticLIRGenerator().emitLoad(to, address, state);
+    }
+
+    @MatchRule("(And (Not a) b)")
+    @MatchRule("(And b (Not a))")
+    public ComplexMatchResult logicalAndNot(ValueNode a, ValueNode b) {
+        return builder -> getArithmeticLIRGenerator().emitLogicalAndNot(operand(a), operand(b));
+    }
+
+    @MatchRule("(And a (Negate a))")
+    @MatchRule("(And (Negate a) a)")
+    public ComplexMatchResult lowestSetIsolatedBit(ValueNode a) {
+        return builder -> getArithmeticLIRGenerator().emitLowestSetIsolatedBit(operand(a));
+    }
+
+    @MatchRule("(Xor a (Add a b))")
+    @MatchRule("(Xor (Add a b) a)")
+    public ComplexMatchResult getMaskUpToLowestSetBit(ValueNode a, ValueNode b) {
+        // Make sure that the pattern matches a subtraction by one.
+        if (!b.isJavaConstant()) {
+            return null;
+        }
+
+        JavaConstant bCst = b.asJavaConstant();
+        long bValue;
+        if (bCst.getJavaKind() == JavaKind.Int) {
+            bValue = bCst.asInt();
+        } else if (bCst.getJavaKind() == JavaKind.Long) {
+            bValue = bCst.asLong();
+        } else {
+            return null;
+        }
+
+        if (bValue == -1) {
+            return builder -> getArithmeticLIRGenerator().emitGetMaskUpToLowestSetBit(operand(a));
+        } else {
+            return null;
+        }
+    }
+
+    @MatchRule("(And a (Add a b))")
+    @MatchRule("(And (Add a b) a)")
+    public ComplexMatchResult resetLowestSetBit(ValueNode a, ValueNode b) {
+        // Make sure that the pattern matches a subtraction by one.
+        if (!b.isJavaConstant()) {
+            return null;
+        }
+
+        JavaConstant bCst = b.asJavaConstant();
+        long bValue;
+        if (bCst.getJavaKind() == JavaKind.Int) {
+            bValue = bCst.asInt();
+        } else if (bCst.getJavaKind() == JavaKind.Long) {
+            bValue = bCst.asLong();
+        } else {
+            return null;
+        }
+
+        if (bValue == -1) {
+            return builder -> getArithmeticLIRGenerator().emitResetLowestSetBit(operand(a));
+        } else {
+            return null;
+        }
     }
 
     @MatchRule("(If (IntegerTest Read=access value))")

--- a/compiler/src/org.graalvm.compiler.core/src/org/graalvm/compiler/core/gen/NodeMatchRules.java
+++ b/compiler/src/org.graalvm.compiler.core/src/org/graalvm/compiler/core/gen/NodeMatchRules.java
@@ -47,6 +47,8 @@ import org.graalvm.compiler.nodes.calc.IntegerTestNode;
 import org.graalvm.compiler.nodes.calc.LeftShiftNode;
 import org.graalvm.compiler.nodes.calc.MulNode;
 import org.graalvm.compiler.nodes.calc.NarrowNode;
+import org.graalvm.compiler.nodes.calc.NegateNode;
+import org.graalvm.compiler.nodes.calc.NotNode;
 import org.graalvm.compiler.nodes.calc.ObjectEqualsNode;
 import org.graalvm.compiler.nodes.calc.OrNode;
 import org.graalvm.compiler.nodes.calc.PointerEqualsNode;
@@ -78,6 +80,8 @@ import jdk.vm.ci.meta.Value;
 @MatchableNode(nodeClass = WriteNode.class, inputs = {"address", "value"})
 @MatchableNode(nodeClass = ZeroExtendNode.class, inputs = {"value"})
 @MatchableNode(nodeClass = AndNode.class, inputs = {"x", "y"}, commutative = true)
+@MatchableNode(nodeClass = NegateNode.class, inputs = {"value"})
+@MatchableNode(nodeClass = NotNode.class, inputs = {"value"})
 @MatchableNode(nodeClass = FloatEqualsNode.class, inputs = {"x", "y"}, commutative = true)
 @MatchableNode(nodeClass = FloatLessThanNode.class, inputs = {"x", "y"}, commutative = true)
 @MatchableNode(nodeClass = PointerEqualsNode.class, inputs = {"x", "y"}, commutative = true)

--- a/compiler/src/org.graalvm.compiler.hotspot.amd64.test/src/org/graalvm/compiler/hotspot/amd64/test/BmiAndn.java
+++ b/compiler/src/org.graalvm.compiler.hotspot.amd64.test/src/org/graalvm/compiler/hotspot/amd64/test/BmiAndn.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.graalvm.compiler.hotspot.amd64.test;
+
+import org.junit.Test;
+import org.junit.Assert;
+
+/**
+ * Tests Bit Manipulation Instruction andn pattern matching and result.
+ */
+public class BmiAndn extends BmiCompilerTest {
+    // from Intel manual VEX.NDS.LZ.0F38.W0 F2 /r, example c4e260f2c2
+    private final byte[] instrMask = new byte[]{
+                    (byte) 0xFF,
+                    (byte) 0x1F,
+                    (byte) 0x00,
+                    (byte) 0xFF};
+    private final byte[] instrPattern = new byte[]{
+                    (byte) 0xC4, // prefix for 3-byte VEX instruction
+                    (byte) 0x02, // 00010 implied 0F 38 leading opcode bytes
+                    (byte) 0x00,
+                    (byte) 0xF2};
+
+    public int andni(int n1, int n2) {
+        return (n1 & (~n2));
+    }
+
+    public long andnl(long n1, long n2) {
+        return (n1 & (~n2));
+    }
+
+    // Pattern matching check for andni
+    @Test
+    public void test1() {
+        Assert.assertTrue(verifyPositive("andni", instrMask, instrPattern));
+    }
+
+    // Pattern matching check for andnl
+    @Test
+    public void test2() {
+        Assert.assertTrue(verifyPositive("andnl", instrMask, instrPattern));
+    }
+
+    // Result correctness check
+    @Test
+    public void test3() {
+        int n1 = 42;
+        int n2 = 100;
+        test("andni", n1, n2);
+    }
+
+    @Test
+    public void test4() {
+        long n1 = 420000000;
+        long n2 = 1000000000;
+        test("andnl", n1, n2);
+    }
+}

--- a/compiler/src/org.graalvm.compiler.hotspot.amd64.test/src/org/graalvm/compiler/hotspot/amd64/test/BmiBlsi.java
+++ b/compiler/src/org.graalvm.compiler.hotspot.amd64.test/src/org/graalvm/compiler/hotspot/amd64/test/BmiBlsi.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.graalvm.compiler.hotspot.amd64.test;
+
+import org.junit.Test;
+import org.junit.Assert;
+
+/**
+ * Tests Bit Manipulation Instruction blsi pattern matching and result.
+ */
+public class BmiBlsi extends BmiCompilerTest {
+    // from Intel manual VEX.NDD.LZ.0F38.W0 F3 /3, example c4e260f2c2
+    private final byte[] instrMask = new byte[]{
+                    (byte) 0xFF,
+                    (byte) 0x1F,
+                    (byte) 0x00,
+                    (byte) 0xFF,
+                    (byte) 0b0011_1000};
+    private final byte[] instrPattern = new byte[]{
+                    (byte) 0xC4, // prefix for 3-byte VEX instruction
+                    (byte) 0x02, // 00010 implied 0F 38 leading opcode bytes
+                    (byte) 0x00,
+                    (byte) 0xF3,
+                    (byte) 0b0001_1000}; // bits 543 == 011 (3)
+
+    public int blsii(int n1) {
+        return (n1 & (-n1));
+    }
+
+    public long blsil(long n1) {
+        return (n1 & (-n1));
+    }
+
+    // Pattern matching check for blsii
+    @Test
+    public void test1() {
+        Assert.assertTrue(verifyPositive("blsii", instrMask, instrPattern));
+    }
+
+    // Pattern matching check for blsil
+    @Test
+    public void test2() {
+        Assert.assertTrue(verifyPositive("blsil", instrMask, instrPattern));
+    }
+
+    // Result correctness check
+    @Test
+    public void test3() {
+        int n1 = 42;
+        test("blsii", n1);
+    }
+
+    @Test
+    public void test4() {
+        long n1 = 420000000;
+        test("blsil", n1);
+    }
+}

--- a/compiler/src/org.graalvm.compiler.hotspot.amd64.test/src/org/graalvm/compiler/hotspot/amd64/test/BmiBlsmsk.java
+++ b/compiler/src/org.graalvm.compiler.hotspot.amd64.test/src/org/graalvm/compiler/hotspot/amd64/test/BmiBlsmsk.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.graalvm.compiler.hotspot.amd64.test;
+
+import org.junit.Test;
+import org.junit.Assert;
+
+/**
+ * Tests Bit Manipulation Instruction blsmsk pattern matching and result.
+ */
+public class BmiBlsmsk extends BmiCompilerTest {
+    // from Intel manual VEX.NDD.LZ.0F38.W0 F3 /2, example c4e260f2c2
+    private final byte[] instrMask = new byte[]{
+                    (byte) 0xFF,
+                    (byte) 0x1F,
+                    (byte) 0x00,
+                    (byte) 0xFF,
+                    (byte) 0b0011_1000};
+    private final byte[] instrPattern = new byte[]{
+                    (byte) 0xC4, // prefix for 3-byte VEX instruction
+                    (byte) 0x02, // 00010 implied 0F 38 leading opcode bytes
+                    (byte) 0x00,
+                    (byte) 0xF3,
+                    (byte) 0b0001_0000}; // bits 543 == 010 (2)
+
+    public int blsmski(int n1) {
+        return (n1 ^ (n1 - 1));
+    }
+
+    public long blsmskl(long n1) {
+        return (n1 ^ (n1 - 1));
+    }
+
+    // Pattern matching check for blsmski
+    @Test
+    public void test1() {
+        Assert.assertTrue(verifyPositive("blsmski", instrMask, instrPattern));
+    }
+
+    // Pattern matching check for blsmskl
+    @Test
+    public void test2() {
+        Assert.assertTrue(verifyPositive("blsmskl", instrMask, instrPattern));
+    }
+
+    // Result correctness check
+    @Test
+    public void test3() {
+        int n1 = 42;
+        test("blsmski", n1);
+    }
+
+    @Test
+    public void test4() {
+        long n1 = 420000000;
+        test("blsmskl", n1);
+    }
+}

--- a/compiler/src/org.graalvm.compiler.hotspot.amd64.test/src/org/graalvm/compiler/hotspot/amd64/test/BmiBlsr.java
+++ b/compiler/src/org.graalvm.compiler.hotspot.amd64.test/src/org/graalvm/compiler/hotspot/amd64/test/BmiBlsr.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.graalvm.compiler.hotspot.amd64.test;
+
+import org.junit.Test;
+import org.junit.Assert;
+
+/**
+ * Tests Bit Manipulation Instruction blsr pattern matching and result.
+ */
+public class BmiBlsr extends BmiCompilerTest {
+    // from Intel manual VEX.NDD.LZ.0F38.W0 F3 /3, example c4e260f2c2
+    private final byte[] instrMask = new byte[]{
+                    (byte) 0xFF,
+                    (byte) 0x1F,
+                    (byte) 0x00,
+                    (byte) 0xFF,
+                    (byte) 0b0011_1000};
+    private final byte[] instrPattern = new byte[]{
+                    (byte) 0xC4, // prefix for 3-byte VEX instruction
+                    (byte) 0x02, // 00010 implied 0F 38 leading opcode bytes
+                    (byte) 0x00,
+                    (byte) 0xF3,
+                    (byte) 0b0000_1000}; // bits 543 == 011 (3)
+
+    public int blsri(int n1) {
+        return (n1 & (n1 - 1));
+    }
+
+    public long blsrl(long n1) {
+        return (n1 & (n1 - 1));
+    }
+
+    // Pattern matching check for blsri
+    @Test
+    public void test1() {
+        Assert.assertTrue(verifyPositive("blsri", instrMask, instrPattern));
+    }
+
+    // Pattern matching check for blsrl
+    @Test
+    public void test2() {
+        Assert.assertTrue(verifyPositive("blsrl", instrMask, instrPattern));
+    }
+
+    // Result correctness check
+    @Test
+    public void test3() {
+        int n1 = 42;
+        test("blsri", n1);
+    }
+
+    @Test
+    public void test4() {
+        long n1 = 420000000;
+        test("blsrl", n1);
+    }
+}

--- a/compiler/src/org.graalvm.compiler.hotspot.amd64.test/src/org/graalvm/compiler/hotspot/amd64/test/BmiCompilerTest.java
+++ b/compiler/src/org.graalvm.compiler.hotspot.amd64.test/src/org/graalvm/compiler/hotspot/amd64/test/BmiCompilerTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.graalvm.compiler.hotspot.amd64.test;
+
+import org.graalvm.compiler.code.CompilationResult;
+import org.graalvm.compiler.core.test.GraalCompilerTest;
+import org.graalvm.compiler.nodes.StructuredGraph;
+import org.junit.Assert;
+
+import jdk.vm.ci.meta.ResolvedJavaMethod;
+
+public class BmiCompilerTest extends GraalCompilerTest {
+
+    public boolean verifyPositive(String methodName, byte[] instrMask, byte[] instrPattern) {
+        ResolvedJavaMethod method = getResolvedJavaMethod(methodName);
+        StructuredGraph graph = parseForCompile(method);
+
+        CompilationResult c = compile(method, graph);
+        byte[] targetCode = c.getTargetCode();
+
+        return countCpuInstructions(targetCode, instrMask, instrPattern) >= 1;
+    }
+
+    public static int countCpuInstructions(byte[] nativeCode, byte[] instrMask, byte[] instrPattern) {
+        int count = 0;
+        int patternSize = Math.min(instrMask.length, instrPattern.length);
+        boolean found;
+        Assert.assertTrue(patternSize > 0);
+        for (int i = 0, n = nativeCode.length - patternSize; i < n;) {
+            found = true;
+            for (int j = 0; j < patternSize; j++) {
+                if ((nativeCode[i + j] & instrMask[j]) != instrPattern[j]) {
+                    found = false;
+                    break;
+                }
+            }
+            if (found) {
+                ++count;
+                i += patternSize - 1;
+            }
+            i++;
+        }
+        return count;
+    }
+}

--- a/compiler/src/org.graalvm.compiler.lir.amd64/src/org/graalvm/compiler/lir/amd64/AMD64ArithmeticLIRGeneratorTool.java
+++ b/compiler/src/org.graalvm.compiler.lir.amd64/src/org/graalvm/compiler/lir/amd64/AMD64ArithmeticLIRGeneratorTool.java
@@ -39,6 +39,14 @@ public interface AMD64ArithmeticLIRGeneratorTool extends ArithmeticLIRGeneratorT
 
     Value emitCountTrailingZeros(Value value);
 
+    Value emitLogicalAndNot(Value value1, Value value2);
+
+    Value emitLowestSetIsolatedBit(Value value);
+
+    Value emitGetMaskUpToLowestSetBit(Value value);
+
+    Value emitResetLowestSetBit(Value value);
+
     enum RoundingMode {
         NEAREST(0),
         DOWN(1),


### PR DESCRIPTION
This pull request adds support for the andn, blsi, blsr and blsmsk pattern matchings for amd64 architectures.