### PR TITLE
Update README with license move from GPL to UPL

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,8 +44,7 @@ GralVM allows running of following languages which are being developed and teste
 ## License
 
 Each GraalVM component is licensed:
-* [Truffle](/truffle/) and its dependency [Graal SDK](/sdk/) are licensed under
-the [GPL 2 with Classpath exception](truffle/LICENSE.GPL.md).
+* [Truffle](/truffle/) and its dependency [Graal SDK](/sdk/) are licensed under the [Universal Permissive License](truffle/LICENSE.md).
 * [Tools](/tools/) project is licensed under the [GPL 2 with Classpath exception](tools/LICENSE.GPL.md).
 * [TRegex](/regex/) project is licensed under the [GPL 2 with Classpath exception](regex/LICENSE.GPL.md).
 * The [Graal compiler](/compiler/) is licensed under the [GPL 2 with Classpath exception](compiler/LICENSE.md).


### PR DESCRIPTION
As part of [[GR-11502] Relicense Truffle and the SDK to UPL](/oracle/graal/commit/0f8c00b5241ec89154a79ac6e7627dbfbaf4dce6).