### PR TITLE
Add function to select the right lib folder

### DIFF
--- a/compiler/mx.compiler/mx_compiler.py
+++ b/compiler/mx.compiler/mx_compiler.py
@@ -973,9 +973,10 @@ def java_base_unittest(args):
         shutil.rmtree(basejdk_dir)
     mx.run([jlink, '--output', basejdk_dir, '--add-modules', basemodules, '--module-path', join(jdk.home, 'jmods')])
     jdwp = mx.add_lib_suffix(mx.add_lib_prefix('jdwp'))
-    shutil.copy(join(jdk.home, 'lib', jdwp), join(basejdk_dir, 'lib', jdwp))
+    lib_folder = 'bin' if mx.get_os() == 'windows' else 'lib'
+    shutil.copy(join(jdk.home, lib_folder, jdwp), join(basejdk_dir, lib_folder, jdwp))
     dt_socket = mx.add_lib_suffix(mx.add_lib_prefix('dt_socket'))
-    shutil.copy(join(jdk.home, 'lib', dt_socket), join(basejdk_dir, 'lib', dt_socket))
+    shutil.copy(join(jdk.home, lib_folder, dt_socket), join(basejdk_dir, lib_folder, dt_socket))
 
     if not args:
         args = []


### PR DESCRIPTION
When running ~`mx makegraaljdk build`~ `mx gate` while using JDK 11 in the compiler suite I was seeing an error about the file `/lib/jdwp.dll` not existing. That is indeed the case, because the file is under `/bin` on windows.

This PR adds a function to return the right lib folder based on the platform, and uses that instead of the hardcoded `lib` directory.