### PR TITLE
Capitalize Sulong's language name

### DIFF
--- a/sulong/projects/com.oracle.truffle.llvm.runtime/src/com/oracle/truffle/llvm/runtime/LLVMLanguage.java
+++ b/sulong/projects/com.oracle.truffle.llvm.runtime/src/com/oracle/truffle/llvm/runtime/LLVMLanguage.java
@@ -56,7 +56,8 @@ public abstract class LLVMLanguage extends TruffleLanguage<LLVMContext> {
     public static final String MAIN_ARGS_KEY = "Sulong Main Args";
     public static final String PARSE_ONLY_KEY = "Parse only";
 
-    public static final String NAME = "llvm";
+    public static final String ID = "llvm";
+    public static final String NAME = "LLVM";
 
     public abstract LLVMContext findLLVMContext();
 

--- a/sulong/projects/com.oracle.truffle.llvm.test/src/com/oracle/truffle/llvm/test/ParserTortureSuite.java
+++ b/sulong/projects/com.oracle.truffle.llvm.test/src/com/oracle/truffle/llvm/test/ParserTortureSuite.java
@@ -70,7 +70,7 @@ public final class ParserTortureSuite {
                 }
 
                 try (Context context = Context.newBuilder().option("llvm.lazyParsing", String.valueOf(false)).allowAllAccess(true).build()) {
-                    context.eval(org.graalvm.polyglot.Source.newBuilder(LLVMLanguage.NAME, candidate.toFile()).build());
+                    context.eval(org.graalvm.polyglot.Source.newBuilder(LLVMLanguage.ID, candidate.toFile()).build());
                 }
             }
         }

--- a/sulong/projects/com.oracle.truffle.llvm.test/src/com/oracle/truffle/llvm/test/debug/LLVMDebugTestBase.java
+++ b/sulong/projects/com.oracle.truffle.llvm.test/src/com/oracle/truffle/llvm/test/debug/LLVMDebugTestBase.java
@@ -54,7 +54,7 @@ import static org.junit.Assert.assertEquals;
 
 public abstract class LLVMDebugTestBase {
 
-    private static final String LANG_NAME = LLVMLanguage.NAME;
+    private static final String LANG_ID = LLVMLanguage.ID;
 
     private static final String[] SOURCE_FILE_EXTENSIONS = new String[]{".c", ".cpp", ".ll"};
     private static final String TRACE_EXT = ".txt";
@@ -84,7 +84,7 @@ public abstract class LLVMDebugTestBase {
 
     @Before
     public void before() {
-        final Context.Builder contextBuilder = Context.newBuilder(LANG_NAME);
+        final Context.Builder contextBuilder = Context.newBuilder(LANG_ID);
         contextBuilder.allowAllAccess(true);
         contextBuilder.option(OPTION_LAZY_PARSING, String.valueOf(false));
         setContextOptions(contextBuilder);
@@ -100,7 +100,7 @@ public abstract class LLVMDebugTestBase {
         Source source;
         try {
             final File canonicalFile = file.getCanonicalFile();
-            source = Source.newBuilder(LANG_NAME, canonicalFile).build();
+            source = Source.newBuilder(LANG_ID, canonicalFile).build();
         } catch (IOException ex) {
             throw new AssertionError("Could not load source: " + file.getPath(), ex);
         }

--- a/sulong/projects/com.oracle.truffle.llvm.test/src/com/oracle/truffle/llvm/test/util/ProcessUtil.java
+++ b/sulong/projects/com.oracle.truffle.llvm.test/src/com/oracle/truffle/llvm/test/util/ProcessUtil.java
@@ -131,11 +131,11 @@ public class ProcessUtil {
 
     public static ProcessResult executeSulongTestMain(File bitcodeFile, String[] args, Map<String, String> options, Function<Context.Builder, CaptureOutput> captureOutput) throws IOException {
         if (TestOptions.TEST_AOT_IMAGE == null) {
-            org.graalvm.polyglot.Source source = org.graalvm.polyglot.Source.newBuilder(LLVMLanguage.NAME, bitcodeFile).build();
+            org.graalvm.polyglot.Source source = org.graalvm.polyglot.Source.newBuilder(LLVMLanguage.ID, bitcodeFile).build();
             Builder builder = Context.newBuilder();
             try (CaptureOutput out = captureOutput.apply(builder)) {
                 int result;
-                try (Context context = builder.arguments(LLVMLanguage.NAME, args).options(options).allowAllAccess(true).build()) {
+                try (Context context = builder.arguments(LLVMLanguage.ID, args).options(options).allowAllAccess(true).build()) {
                     Value main = context.eval(source);
                     if (!main.canExecute()) {
                         throw new LLVMLinkerException("No main function found.");

--- a/sulong/projects/com.oracle.truffle.llvm/src/com/oracle/truffle/llvm/Sulong.java
+++ b/sulong/projects/com.oracle.truffle.llvm/src/com/oracle/truffle/llvm/Sulong.java
@@ -64,7 +64,7 @@ import com.oracle.truffle.llvm.runtime.memory.LLVMMemory;
 import com.oracle.truffle.llvm.runtime.options.SulongEngineOption;
 import com.oracle.truffle.llvm.runtime.pointer.LLVMPointer;
 
-@TruffleLanguage.Registration(id = "llvm", name = "llvm", version = "6.0.0", internal = false, interactive = false, defaultMimeType = Sulong.LLVM_BITCODE_MIME_TYPE, //
+@TruffleLanguage.Registration(id = Sulong.ID, name = Sulong.NAME, version = "6.0.0", internal = false, interactive = false, defaultMimeType = Sulong.LLVM_BITCODE_MIME_TYPE, //
                 byteMimeTypes = {Sulong.LLVM_BITCODE_MIME_TYPE, Sulong.LLVM_ELF_SHARED_MIME_TYPE, Sulong.LLVM_ELF_EXEC_MIME_TYPE}, //
                 characterMimeTypes = {Sulong.LLVM_BITCODE_BASE64_MIME_TYPE, Sulong.LLVM_SULONG_TYPE})
 @ProvidedTags({StandardTags.StatementTag.class, StandardTags.CallTag.class, StandardTags.RootTag.class, DebuggerTags.AlwaysHalt.class})


### PR DESCRIPTION
This PR capitalizes Sulong's language name to make it more consistent with other Truffle languages (see [TruffleRuby](https://github.com/oracle/truffleruby/blob/13bd0c45ec508e43a67e1f176c20ebe360f5a146/src/main/java/org/truffleruby/RubyLanguage.java#L36) or [Graal.Python](https://github.com/graalvm/graalpython/blob/master/graalpython/com.oracle.graal.python/src/com/oracle/graal/python/PythonLanguage.java#L99)).