### PR TITLE
Enhance updategraalinopenjdk for development use (on Windows)

### DIFF
--- a/compiler/mx.compiler/mx_updategraalinopenjdk.py
+++ b/compiler/mx.compiler/mx_updategraalinopenjdk.py
@@ -31,6 +31,7 @@ import shutil
 from collections import namedtuple
 from argparse import ArgumentParser
 from os.path import join, exists, dirname
+import re
 
 import mx
 import mx_compiler
@@ -126,6 +127,7 @@ def updategraalinopenjdk(args):
         m_src_dir = join('src', m.name)
         mx.log('Checking ' + m_src_dir)
         out = run_output(['hg', 'status', m_src_dir], cwd=jdkrepo)
+        out = re.sub(r'^\?.*(\r\n|\r|\n)?', '', out, flags=re.MULTILINE)
         if out:
             mx.abort(jdkrepo + ' is not "hg clean":' + '\n' + out[:min(200, len(out))] + '...')
 


### PR DESCRIPTION
The `updategraalinopenjdk` command in the compiler suite checks to see if the target jdk repo has any uncommitted changes using `hg status`, but this also recognizes untracked files as uncommitted changes.

This PR lets the command ignore untracked files.

---

Another Windows specific issue is; Python uses system native line endings when reading/writing from/to a file in text mode. When copying files from the graal repo into an openjdk repo using updategraalinopenjdk, this will change all the unix line endings to windows ones when someone is developing on windows.

This PR instead opens the files in binary mode which preserves the line endings.