### PR TITLE
add at-file support to jaotc

### DIFF
--- a/compiler/src/jdk.tools.jaotc/src/jdk/tools/jaotc/Main.java
+++ b/compiler/src/jdk.tools.jaotc/src/jdk/tools/jaotc/Main.java
@@ -96,7 +96,7 @@ public final class Main {
     private static String[] parse(String[] args) throws IOException {
         List<String> result = new ArrayList<>();
         for (String arg : args) {
-            if (arg.length() > 2 && arg.charAt(0) == '@') {
+            if (arg.length() > 1 && arg.charAt(0) == '@') {
                 String v = arg.substring(1);
                 if (v.charAt(0) == '@') {
                     result.add(v);

--- a/compiler/src/jdk.tools.jaotc/src/jdk/tools/jaotc/Main.java
+++ b/compiler/src/jdk.tools.jaotc/src/jdk/tools/jaotc/Main.java
@@ -90,9 +90,8 @@ public final class Main {
     }
 
     /**
-     * Exapnds '@file' in command line arguments by replacing '@file' with
-     * the content of 'file' parsed by StringTokenizer. '@' character can be
-     * quoted as '@@'.
+     * Expands '@file' in command line arguments by replacing '@file' with the content of 'file'
+     * parsed by StringTokenizer. '@' character can be quoted as '@@'.
      */
     private static String[] parse(String[] args) throws IOException {
         List<String> result = new ArrayList<>();
@@ -103,10 +102,7 @@ public final class Main {
                     result.add(v);
                 } else {
                     try (Stream<String> file = Files.lines(Paths.get(v))) {
-                        file.map(StringTokenizer::new).
-                             map(Collections::list).
-                             flatMap(l -> l.stream().map(o -> (String) o)).
-                             forEachOrdered(result::add);
+                        file.map(StringTokenizer::new).map(Collections::list).flatMap(l -> l.stream().map(o -> (String) o)).forEachOrdered(result::add);
                     }
                 }
             } else {
@@ -115,7 +111,6 @@ public final class Main {
         }
         return result.toArray(String[]::new);
     }
-
 
     private int run(String[] args) {
         log = new PrintWriter(System.out);

--- a/compiler/src/jdk.tools.jaotc/src/jdk/tools/jaotc/Main.java
+++ b/compiler/src/jdk.tools.jaotc/src/jdk/tools/jaotc/Main.java
@@ -29,11 +29,18 @@ import static org.graalvm.compiler.core.common.GraalOptions.GeneratePIC;
 import static org.graalvm.compiler.core.common.GraalOptions.ImmutableCode;
 import static org.graalvm.compiler.hotspot.meta.HotSpotAOTProfilingPlugin.Options.TieredAOT;
 
+import java.io.IOException;
 import java.io.PrintWriter;
 import java.text.MessageFormat;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.ListIterator;
 import java.util.Set;
+import java.util.StringTokenizer;
+import java.util.stream.Stream;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 
 import org.graalvm.compiler.api.replacements.SnippetReflectionProvider;
 import org.graalvm.compiler.api.runtime.GraalJVMCICompiler;
@@ -78,9 +85,37 @@ public final class Main {
 
     public static void main(String[] args) throws Exception {
         Main t = new Main();
-        final int exitCode = t.run(args);
+        final int exitCode = t.run(parse(args));
         System.exit(exitCode);
     }
+
+    /**
+     * Exapnds '@file' in command line arguments by replacing '@file' with
+     * the content of 'file' parsed by StringTokenizer. '@' character can be
+     * quoted as '@@'.
+     */
+    private static String[] parse(String[] args) throws IOException {
+        List<String> result = new ArrayList<>();
+        for (String arg : args) {
+            if (arg.length() > 2 && arg.charAt(0) == '@') {
+                String v = arg.substring(1);
+                if (v.charAt(0) == '@') {
+                    result.add(v);
+                } else {
+                    try (Stream<String> file = Files.lines(Paths.get(v))) {
+                        file.map(StringTokenizer::new).
+                             map(Collections::list).
+                             flatMap(l -> l.stream().map(o -> (String) o)).
+                             forEachOrdered(result::add);
+                    }
+                }
+            } else {
+                result.add(arg);
+            }
+        }
+        return result.toArray(String[]::new);
+    }
+
 
     private int run(String[] args) {
         log = new PrintWriter(System.out);


### PR DESCRIPTION
from [JDK-8215322](https://bugs.openjdk.java.net/browse/JDK-8215322):

currently, the number of jaotc argument is limited by max command line length, in some cases, it isn't enough, for example compiling a number of selected classes. many java tools have support for '@file' so adding the same support to jaotc is natural and will solve the problem w/ limitation.