### PR TITLE
#845 - NPE in native image driver if something goes wrong too early

### DIFF
--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/NativeImageGenerator.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/NativeImageGenerator.java
@@ -765,30 +765,31 @@ public class NativeImageGenerator {
                  * Execute analysis reporting here. This code is executed even if unsupported
                  * features are reported or the analysis fails due to any other reasons.
                  */
+                if ( bigbang != null ) {
+                    if (AnalysisReportsOptions.PrintAnalysisCallTree.getValue(options)) {
+                        String reportName = imageName.substring(imageName.lastIndexOf("/") + 1);
+                        CallTreePrinter.print(bigbang, SubstrateOptions.Path.getValue(), reportName);
+                    }
 
-                if (AnalysisReportsOptions.PrintAnalysisCallTree.getValue(options)) {
-                    String reportName = imageName.substring(imageName.lastIndexOf("/") + 1);
-                    CallTreePrinter.print(bigbang, SubstrateOptions.Path.getValue(), reportName);
-                }
+                    if (AnalysisReportsOptions.PrintImageObjectTree.getValue(options)) {
+                        String reportName = imageName.substring(imageName.lastIndexOf("/") + 1);
+                        ObjectTreePrinter.print(bigbang, SubstrateOptions.Path.getValue(), reportName);
+                    }
 
-                if (AnalysisReportsOptions.PrintImageObjectTree.getValue(options)) {
-                    String reportName = imageName.substring(imageName.lastIndexOf("/") + 1);
-                    ObjectTreePrinter.print(bigbang, SubstrateOptions.Path.getValue(), reportName);
-                }
+                    if (PointstoOptions.ReportAnalysisStatistics.getValue(options)) {
+                        PointsToStats.report(bigbang, imageName.replace("images/", ""));
+                    }
 
-                if (PointstoOptions.ReportAnalysisStatistics.getValue(options)) {
-                    PointsToStats.report(bigbang, imageName.replace("images/", ""));
-                }
-
-                if (PointstoOptions.PrintSynchronizedAnalysis.getValue(options)) {
-                    TypeState allSynchronizedTypeState = bigbang.getAllSynchronizedTypeState();
-                    String typesString = allSynchronizedTypeState.closeToAllInstantiated(bigbang) ? "close to all instantiated" : //
-                                    StreamSupport.stream(allSynchronizedTypeState.types().spliterator(), false).map(AnalysisType::getName).collect(Collectors.joining(", "));
-                    System.out.println();
-                    System.out.println("AllSynchronizedTypes");
-                    System.out.println("Synchronized types #: " + allSynchronizedTypeState.typesCount());
-                    System.out.println("Types: " + typesString);
-                    System.out.println();
+                    if (PointstoOptions.PrintSynchronizedAnalysis.getValue(options)) {
+                        TypeState allSynchronizedTypeState = bigbang.getAllSynchronizedTypeState();
+                        String typesString = allSynchronizedTypeState.closeToAllInstantiated(bigbang) ? "close to all instantiated" : //
+                                StreamSupport.stream(allSynchronizedTypeState.types().spliterator(), false).map(AnalysisType::getName).collect(Collectors.joining(", "));
+                        System.out.println();
+                        System.out.println("AllSynchronizedTypes");
+                        System.out.println("Synchronized types #: " + allSynchronizedTypeState.typesCount());
+                        System.out.println("Types: " + typesString);
+                        System.out.println();
+                    }
                 }
             }
             if (error == null && NativeImageOptions.ReturnAfterAnalysis.getValue()) {


### PR DESCRIPTION
During native image generation, if any analysis reporting has been enabled and an exception occurs in the inner try block in com.oracle.svm.hosted.NativeImageGenerator.doRun() before the bigbang variable has been instantiated, the analysis report printers fail with a NPE when they attempt to access any bigbang members.

The original exception message is never displayed to the user.

An 'is null' check before calling the reporting printers prevents the NPE and allows the NativeImageGenerator to display the original exception message