### PR TITLE
Canonicalize a/num to a*(temp_num)>>n for non-power-of-2 constant division.

### DIFF
--- a/compiler/src/org.graalvm.compiler.core.test/src/org/graalvm/compiler/core/test/IntegerDivRemConstantTest.java
+++ b/compiler/src/org.graalvm.compiler.core.test/src/org/graalvm/compiler/core/test/IntegerDivRemConstantTest.java
@@ -1,0 +1,187 @@
+/*
+ * Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Arm Limited. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package org.graalvm.compiler.core.test;
+
+import org.junit.Test;
+
+public class IntegerDivRemConstantTest extends GraalCompilerTest {
+    public static int intDivPositiveConstant(int val) {
+        return val / 5;
+    }
+
+    @Test
+    public void testIntDivPositiveConstant() {
+        test("intDivPositiveConstant", -10);
+        test("intDivPositiveConstant", 0);
+        test("intDivPositiveConstant", 4256);
+        test("intDivPositiveConstant", Integer.MAX_VALUE);
+        test("intDivPositiveConstant", Integer.MIN_VALUE);
+    }
+
+    public static int intDivIntegerMax(int val) {
+        return val / Integer.MAX_VALUE;
+    }
+
+    @Test
+    public void testIntDivIntegerMax() {
+        test("intDivIntegerMax", -10);
+        test("intDivIntegerMax", 0);
+        test("intDivIntegerMax", 4256);
+        test("intDivIntegerMax", Integer.MAX_VALUE);
+        test("intDivIntegerMax", Integer.MIN_VALUE);
+    }
+
+    public static int intDivNegativeConstant(int val) {
+        return val / -1234;
+    }
+
+    @Test
+    public void testIntDivNegativeConstant() {
+        test("intDivNegativeConstant", -123);
+        test("intDivNegativeConstant", 0);
+        test("intDivNegativeConstant", 123);
+        test("intDivNegativeConstant", Integer.MAX_VALUE);
+        test("intDivNegativeConstant", Integer.MIN_VALUE);
+    }
+
+    public static int intDivIntegerMinOdd(int val) {
+        return val / (Integer.MIN_VALUE + 1);
+    }
+
+    @Test
+    public void testIntDivIntegerMinOdd() {
+        test("intDivIntegerMinOdd", -123);
+        test("intDivIntegerMinOdd", 0);
+        test("intDivIntegerMinOdd", 123);
+        test("intDivIntegerMinOdd", Integer.MAX_VALUE);
+        test("intDivIntegerMinOdd", Integer.MIN_VALUE);
+    }
+
+    public static long longDivPositiveConstant(long val) {
+        return val / 35170432;
+    }
+
+    @Test
+    public void testLongDivPositiveConstant() {
+        test("longDivPositiveConstant", -1234L);
+        test("longDivPositiveConstant", 0L);
+        test("longDivPositiveConstant", 214423L);
+        test("longDivPositiveConstant", Long.MAX_VALUE);
+        test("longDivPositiveConstant", Long.MIN_VALUE);
+    }
+
+    public static long longDivLongMax(long val) {
+        return val / Long.MAX_VALUE;
+    }
+
+    @Test
+    public void testLongDivLongMax() {
+        test("longDivLongMax", -1234L);
+        test("longDivLongMax", 0L);
+        test("longDivLongMax", 214423L);
+        test("longDivLongMax", Long.MAX_VALUE);
+        test("longDivLongMax", Long.MIN_VALUE);
+    }
+
+    public static long longDivNegativeConstant(long val) {
+        return val / -413;
+    }
+
+    @Test
+    public void testLongDivNegativeConstant() {
+        test("longDivNegativeConstant", -43L);
+        test("longDivNegativeConstant", 0L);
+        test("longDivNegativeConstant", 147065L);
+        test("longDivNegativeConstant", Long.MAX_VALUE);
+        test("longDivNegativeConstant", Long.MIN_VALUE);
+    }
+
+    public static long longDivLongMinOdd(long val) {
+        return val / (Long.MIN_VALUE + 1);
+    }
+
+    @Test
+    public void testLongDivLongMinOdd() {
+        test("longDivLongMinOdd", -1234L);
+        test("longDivLongMinOdd", 0L);
+        test("longDivLongMinOdd", 214423L);
+        test("longDivLongMinOdd", Long.MAX_VALUE);
+        test("longDivLongMinOdd", Long.MIN_VALUE);
+    }
+
+    public static int intRemPositiveConstant(int val) {
+        return val % 139968;
+    }
+
+    @Test
+    public void testIntRemPositiveConstant() {
+        test("intRemPositiveConstant", -10);
+        test("intRemPositiveConstant", 0);
+        test("intRemPositiveConstant", 4256);
+        test("intRemPositiveConstant", Integer.MAX_VALUE);
+        test("intRemPositiveConstant", Integer.MIN_VALUE);
+    }
+
+    public static int intRemNegativeConstant(int val) {
+        return val % -139968;
+    }
+
+    @Test
+    public void testIntRemNegativeConstant() {
+        test("intRemNegativeConstant", -10);
+        test("intRemNegativeConstant", 0);
+        test("intRemNegativeConstant", 4256);
+        test("intRemNegativeConstant", Integer.MAX_VALUE);
+        test("intRemNegativeConstant", Integer.MIN_VALUE);
+    }
+
+    public static long longRemPositiveConstant(long val) {
+        return val % 35170432;
+    }
+
+    @Test
+    public void testLongRemPositiveConstant() {
+        test("longRemPositiveConstant", -1234L);
+        test("longRemPositiveConstant", 0L);
+        test("longRemPositiveConstant", 214423L);
+        test("longRemPositiveConstant", Long.MAX_VALUE);
+        test("longRemPositiveConstant", Long.MIN_VALUE);
+    }
+
+    public static long longRemNegativeConstant(long val) {
+        return val % -413;
+    }
+
+    @Test
+    public void testLongRemNegativeConstant() {
+        test("longRemNegativeConstant", -43L);
+        test("longRemNegativeConstant", 0L);
+        test("longRemNegativeConstant", 147065L);
+        test("longRemNegativeConstant", Long.MAX_VALUE);
+        test("longRemNegativeConstant", Long.MIN_VALUE);
+    }
+}

--- a/compiler/src/org.graalvm.compiler.core.test/src/org/graalvm/compiler/core/test/MemoryScheduleTest.java
+++ b/compiler/src/org.graalvm.compiler.core.test/src/org/graalvm/compiler/core/test/MemoryScheduleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -260,7 +260,7 @@ public class MemoryScheduleTest extends GraphScheduleTest {
     @Test
     public void testLoop5() {
         ScheduleResult schedule = getFinalSchedule("testLoop5Snippet", TestMode.WITHOUT_FRAMESTATES);
-        assertDeepEquals(10, schedule.getCFG().getBlocks().length);
+        assertDeepEquals(9, schedule.getCFG().getBlocks().length);
         assertReadWithinStartBlock(schedule, false);
         assertReadWithinAllReturnBlocks(schedule, false);
     }
@@ -289,7 +289,7 @@ public class MemoryScheduleTest extends GraphScheduleTest {
     @Test
     public void testLoop6() {
         ScheduleResult schedule = getFinalSchedule("testLoop6Snippet", TestMode.WITHOUT_FRAMESTATES);
-        assertDeepEquals(13, schedule.getCFG().getBlocks().length);
+        assertDeepEquals(12, schedule.getCFG().getBlocks().length);
         assertReadWithinStartBlock(schedule, false);
         assertReadWithinAllReturnBlocks(schedule, false);
     }
@@ -322,7 +322,7 @@ public class MemoryScheduleTest extends GraphScheduleTest {
     @Test
     public void testLoop7() {
         ScheduleResult schedule = getFinalSchedule("testLoop7Snippet", TestMode.WITHOUT_FRAMESTATES);
-        assertDeepEquals(18, schedule.getCFG().getBlocks().length);
+        assertDeepEquals(17, schedule.getCFG().getBlocks().length);
         assertReadWithinStartBlock(schedule, false);
         assertReadWithinAllReturnBlocks(schedule, false);
     }

--- a/compiler/src/org.graalvm.compiler.nodes/src/org/graalvm/compiler/nodes/calc/IntegerMulHighNode.java
+++ b/compiler/src/org.graalvm.compiler.nodes/src/org/graalvm/compiler/nodes/calc/IntegerMulHighNode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,7 +22,7 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
-package org.graalvm.compiler.replacements.nodes.arithmetic;
+package org.graalvm.compiler.nodes.calc;
 
 import static org.graalvm.compiler.nodeinfo.NodeCycles.CYCLES_2;
 import static org.graalvm.compiler.nodeinfo.NodeSize.SIZE_2;
@@ -37,7 +37,6 @@ import org.graalvm.compiler.nodeinfo.NodeInfo;
 import org.graalvm.compiler.nodes.ConstantNode;
 import org.graalvm.compiler.nodes.NodeView;
 import org.graalvm.compiler.nodes.ValueNode;
-import org.graalvm.compiler.nodes.calc.BinaryArithmeticNode;
 import org.graalvm.compiler.nodes.spi.NodeLIRBuilderTool;
 
 import jdk.vm.ci.meta.Constant;

--- a/compiler/src/org.graalvm.compiler.nodes/src/org/graalvm/compiler/nodes/calc/SignedDivNode.java
+++ b/compiler/src/org.graalvm.compiler.nodes/src/org/graalvm/compiler/nodes/calc/SignedDivNode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -134,7 +134,7 @@ public class SignedDivNode extends IntegerDivRemNode implements LIRLowerable {
             }
             return shift;
         }
-        return null;
+        return canonicalizeDivConstant(forX, c, view);
     }
 
     @Override

--- a/compiler/src/org.graalvm.compiler.nodes/src/org/graalvm/compiler/nodes/calc/SignedRemNode.java
+++ b/compiler/src/org.graalvm.compiler.nodes/src/org/graalvm/compiler/nodes/calc/SignedRemNode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -104,6 +104,11 @@ public class SignedRemNode extends IntegerDivRemNode implements LIRLowerable {
                         // x - ((x / y) << log2(y))
                         return SubNode.create(forX, LeftShiftNode.create(SignedDivNode.canonical(forX, constY, view), ConstantNode.forInt(CodeUtil.log2(constY)), view), view);
                     }
+                }
+            } else if (!CodeUtil.isPowerOf2(constY)) {
+                ValueNode value = canonicalizeDivConstant(forX, forY.asJavaConstant().asLong(), view);
+                if (value != null) {
+                    return SubNode.create(forX, new MulNode(value, forY), view);
                 }
             }
         }

--- a/compiler/src/org.graalvm.compiler.truffle.compiler/src/org/graalvm/compiler/truffle/compiler/substitutions/TruffleGraphBuilderPlugins.java
+++ b/compiler/src/org.graalvm.compiler.truffle.compiler/src/org/graalvm/compiler/truffle/compiler/substitutions/TruffleGraphBuilderPlugins.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -79,7 +79,7 @@ import org.graalvm.compiler.nodes.virtual.EnsureVirtualizedNode;
 import org.graalvm.compiler.options.Option;
 import org.graalvm.compiler.options.OptionKey;
 import org.graalvm.compiler.options.OptionType;
-import org.graalvm.compiler.replacements.nodes.arithmetic.IntegerMulHighNode;
+import org.graalvm.compiler.nodes.calc.IntegerMulHighNode;
 import org.graalvm.compiler.replacements.nodes.arithmetic.UnsignedMulHighNode;
 import org.graalvm.compiler.truffle.common.TruffleCompilationTask;
 import org.graalvm.compiler.truffle.common.TruffleCompilerRuntime;


### PR DESCRIPTION
We want to use some cheaper instructions to implement a division operation, of which
the divisor is a constant but not a power of 2 one, instead of using "div" directly.
The main conversion theory is shown here:
"a/num -> a*(1/num) -> a*(temp_num)/2^n -> a*(temp_num)>>n".

I borrowed the existing algorithm from Hacker's Delight by Henry S. Warren, Jr, and
almost verbatim the codes from it with just translate the C codes to JAVA codes.

Here is two jmh performance results with -wi 10 -i 5:
```
             without this patch   with this patch   units
fasta              349.741             347.511       us/op
fastaredux         196.150             188.920       us/op
```

And here is a division unit test:
```
private final int func(int n, int[] arr) {
    int ret = 0;
    for (int i = 0; i < n; i++) {
        int var = arr[i];
        ret += var / 139968;
    }
    return ret;
}
```
and its performance results with -wi 15 -i 10:
```
               without this patch   with this patch    units
divConst         8824705,725        7350144,387     us/op
```

Change-Id: I2c7bbc99b2169e02616e77743991b5b100901c24