### PR TITLE
Improve memory usage

### DIFF
--- a/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/headers/PosixDirectives.java
+++ b/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/headers/PosixDirectives.java
@@ -81,6 +81,7 @@ public class PosixDirectives implements CContext.Directives {
     private static final String[] darwinLibs = new String[]{
                     "<CoreFoundation/CoreFoundation.h>",
                     "<sys/event.h>",
+                    "<mach/mach.h>",
                     "<mach/mach_time.h>",
                     "<mach-o/dyld.h>",
                     "<netinet6/in6_var.h>",

--- a/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/headers/Stat.java
+++ b/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/headers/Stat.java
@@ -206,6 +206,9 @@ public class Stat {
     @CFunction
     public static native int fstat(int fd, stat buf);
 
+    @CFunction(value = "fstat", transition = CFunction.Transition.NO_TRANSITION)
+    public static native int fstat_no_transition(int fd, stat buf);
+
     /**
      * Similar to stat, get the attributes for FILE and put them in BUF. Relative path names are
      * interpreted relative to FD unless FD is AT_FDCWD.

--- a/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/headers/Unistd.java
+++ b/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/headers/Unistd.java
@@ -1808,6 +1808,15 @@ public class Unistd {
 
     public static class NoTransitions {
         @CFunction(transition = Transition.NO_TRANSITION)
+        public static native int close(int fd);
+
+        @CFunction(transition = Transition.NO_TRANSITION)
+        public static native SignedWord read(int fd, PointerBase buf, UnsignedWord nbytes);
+
+        @CFunction(transition = Transition.NO_TRANSITION)
+        public static native SignedWord write(int fd, PointerBase buf, UnsignedWord n);
+
+        @CFunction(transition = Transition.NO_TRANSITION)
         public static native long sysconf(int name);
     }
 }

--- a/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/headers/darwin/DarwinVirtualMemory.java
+++ b/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/headers/darwin/DarwinVirtualMemory.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package com.oracle.svm.core.posix.headers.darwin;
+
+import com.oracle.svm.core.posix.headers.PosixDirectives;
+import org.graalvm.nativeimage.Platform;
+import org.graalvm.nativeimage.Platforms;
+import org.graalvm.nativeimage.c.CContext;
+import org.graalvm.nativeimage.c.function.CFunction;
+import org.graalvm.nativeimage.c.type.WordPointer;
+import org.graalvm.word.UnsignedWord;
+import org.graalvm.word.WordBase;
+
+@CContext(PosixDirectives.class)
+@Platforms(Platform.DARWIN.class)
+public class DarwinVirtualMemory {
+
+    @CFunction(transition = CFunction.Transition.NO_TRANSITION)
+    public static native int mach_task_self();
+
+    @CFunction(transition = CFunction.Transition.NO_TRANSITION)
+    public static native int vm_allocate(int targetTask, WordPointer address, UnsignedWord size, boolean anywhere);
+
+    @CFunction(transition = CFunction.Transition.NO_TRANSITION)
+    public static native int vm_copy(int targetTask, WordBase sourceAddress, UnsignedWord count, WordBase destAddress);
+
+    @CFunction(transition = CFunction.Transition.NO_TRANSITION)
+    public static native int vm_deallocate(int targetTask, WordBase address, UnsignedWord size);
+
+}

--- a/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/linux/LinuxImageHeapProvider.java
+++ b/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/linux/LinuxImageHeapProvider.java
@@ -1,0 +1,273 @@
+/*
+ * Copyright (c) 2019, 2018, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package com.oracle.svm.core.posix.linux;
+
+import static com.oracle.svm.core.Isolates.IMAGE_HEAP_RELOCATABLE_BEGIN;
+import static com.oracle.svm.core.Isolates.IMAGE_HEAP_RELOCATABLE_END;
+import static com.oracle.svm.core.Isolates.IMAGE_HEAP_WRITABLE_BEGIN;
+import static com.oracle.svm.core.Isolates.IMAGE_HEAP_WRITABLE_END;
+import static com.oracle.svm.core.posix.linux.ProcFSSupport.findMapping;
+import static com.oracle.svm.core.util.PointerUtils.roundUp;
+
+import com.oracle.svm.core.Isolates;
+import com.oracle.svm.core.MemoryUtil;
+import com.oracle.svm.core.SubstrateOptions;
+import com.oracle.svm.core.UnsafeAccess;
+import com.oracle.svm.core.annotate.AutomaticFeature;
+import com.oracle.svm.core.annotate.Uninterruptible;
+import com.oracle.svm.core.c.CGlobalData;
+import com.oracle.svm.core.c.CGlobalDataFactory;
+import com.oracle.svm.core.c.function.CEntryPointErrors;
+import com.oracle.svm.core.os.CopyingImageHeapProvider;
+import com.oracle.svm.core.os.ImageHeapProvider;
+import com.oracle.svm.core.os.VirtualMemoryProvider;
+import com.oracle.svm.core.os.VirtualMemoryProvider.Access;
+import com.oracle.svm.core.posix.headers.Fcntl;
+import com.oracle.svm.core.posix.headers.LibC;
+import com.oracle.svm.core.posix.headers.Stat;
+import com.oracle.svm.core.posix.headers.Unistd;
+import com.oracle.svm.core.util.UnsignedUtils;
+import org.graalvm.compiler.api.replacements.Fold;
+import org.graalvm.compiler.word.Word;
+import org.graalvm.nativeimage.Feature;
+import org.graalvm.nativeimage.ImageInfo;
+import org.graalvm.nativeimage.ImageSingletons;
+import org.graalvm.nativeimage.Platform;
+import org.graalvm.nativeimage.Platforms;
+import org.graalvm.nativeimage.StackValue;
+import org.graalvm.nativeimage.c.type.CCharPointer;
+import org.graalvm.nativeimage.c.type.CIntPointer;
+import org.graalvm.nativeimage.c.type.CLongPointer;
+import org.graalvm.nativeimage.c.type.WordPointer;
+import org.graalvm.word.LocationIdentity;
+import org.graalvm.word.Pointer;
+import org.graalvm.word.PointerBase;
+import org.graalvm.word.UnsignedWord;
+import org.graalvm.word.WordFactory;
+
+@AutomaticFeature
+@Platforms({Platform.LINUX.class})
+class LinuxImageHeapProviderFeature implements Feature {
+    @Override
+    public void beforeAnalysis(BeforeAnalysisAccess access) {
+        if (!ImageSingletons.contains(ImageHeapProvider.class)) {
+            ImageSingletons.add(ImageHeapProvider.class, new LinuxImageHeapProvider());
+        }
+    }
+}
+
+/**
+ * An optimal image heap provider for Linux which creates isolate image heaps
+ * that retain the copy-on-write, lazy loading and reclamation semantics
+ * provided by the original heap's backing resource.
+ *
+ * This is accomplished by discovering the backing executable or shared object
+ * file the kernel has mmapped to the original heap image virtual address, as
+ * well as the location in the file storing the original heap. A new memory map
+ * is created to a new virtual range pointing to this same location. This allows
+ * the kernel to share the same physical pages between multiple heaps that have
+ * not been modified, as well as lazily load them only when needed.
+ *
+ * The implementation avoids dirtying the pages of the original, and only
+ * referencing what is strictly required.
+ *
+ * This provider falls back to the POSIX friendly
+ * <code>CopyImageHeapProvider</code> if either the architecture is not
+ * supported, or an error occurs during the mapping process.
+ */
+public class LinuxImageHeapProvider extends CopyingImageHeapProvider {
+    private static final CGlobalData<CCharPointer> SELF_EXE = CGlobalDataFactory.createCString("/proc/self/exe");
+    private static final CGlobalData<CCharPointer> MAPS = CGlobalDataFactory.createCString("/proc/self/maps");
+    private static final CGlobalData<Pointer> OBJECT_FD = CGlobalDataFactory.createWord(WordFactory.signed(-1), null);
+    private static final CGlobalData<Pointer> FD_OFFSET = CGlobalDataFactory.createWord(WordFactory.signed(-1), null);
+    private static final CGlobalData<Pointer> SVM_BASE = CGlobalDataFactory.createWord(WordFactory.signed(-1), null);
+
+    private static final int MAX_PATHLEN = 4096;
+
+    @Fold
+    static boolean isExecutable() {
+        return ImageInfo.isExecutable();
+    }
+
+    @Override
+    @Uninterruptible(reason = "Called during isolate initialization.")
+    public int initialize(PointerBase begin, UnsignedWord reservedSize, WordPointer basePointer, WordPointer endPointer) {
+        int result = cowInitialize(begin, reservedSize, basePointer, endPointer);
+        if (result != CEntryPointErrors.NO_ERROR) {
+            return super.initialize(begin, reservedSize, basePointer, endPointer);
+        }
+
+        return result;
+    }
+
+    @Uninterruptible(reason = "Called during isolate initialization.")
+    private int cowInitialize(PointerBase begin, UnsignedWord reservedSize, WordPointer basePointer, WordPointer endPointer) {
+        Word imageHeapBegin = Isolates.IMAGE_HEAP_BEGIN.get();
+        Word imageHeapSize = Isolates.IMAGE_HEAP_END.get().subtract(imageHeapBegin);
+        if (begin.isNonNull() && reservedSize.belowThan(imageHeapSize)) {
+            return CEntryPointErrors.UNSPECIFIED;
+        }
+
+        boolean executable = isExecutable();
+
+        // Reuse the already loaded file descriptor and discovered offset for
+        // all subsequent isolate initializations. To avoid stalling threads we
+        // intentionally allow for racing during first-time initialization. It's
+        // the lesser of evils, since the overhead of proc parsing and required
+        // i/o is nominal, due to its virtual nature.
+        //
+        // However, we ensure this remains temporary and consensus is quickly
+        // reached on a single FD,
+        UnsafeAccess.UNSAFE.loadFence();
+        int fd = (int)OBJECT_FD.get().readLong(0);
+
+        if (fd != -1) {
+           return createMapping(begin, basePointer, endPointer, imageHeapBegin, imageHeapSize, fd, FD_OFFSET.get().readLong(0), !executable);
+        }
+
+        int mapFD = Fcntl.NoTransitions.open(MAPS.get(), Fcntl.O_RDONLY(), 0);
+        if (mapFD == -1) {
+            return CEntryPointErrors.MAP_HEAP_FAILED;
+        }
+
+        final CCharPointer buffer = LibC.malloc(WordFactory.unsigned(MAX_PATHLEN));
+        final CLongPointer startAddr = StackValue.get(CLongPointer.class);
+        final CLongPointer offset = StackValue.get(CLongPointer.class);
+        final CIntPointer dev = StackValue.get(CIntPointer.class);
+        final CLongPointer inode = StackValue.get(CLongPointer.class);
+
+        boolean found = findMapping(mapFD, buffer, MAX_PATHLEN, imageHeapBegin.rawValue(), startAddr, offset, dev, inode, !executable);
+        Unistd.NoTransitions.close(mapFD);
+
+        if (! found) {
+            LibC.free(buffer);
+            return CEntryPointErrors.MAP_HEAP_FAILED;
+        }
+
+        fd = Fcntl.NoTransitions.open(executable ? SELF_EXE.get() : buffer, Fcntl.O_RDONLY(), 0);
+        LibC.free(buffer);
+
+        if (fd == -1) {
+            return CEntryPointErrors.MAP_HEAP_FAILED;
+        }
+
+        // Unfortunately, in the case of a shared library, we must open the
+        // library by the registered file name, since we don't have a usable
+        // equivalent of /proc/self/exe, which remains even if the file is
+        // deleted, since it keeps an inode reference active. The kernel does
+        // provide a similar notion in /proc/map_files, but directly opening
+        // those entries intentionally requires CAP_SYS_ADMIN, out of security
+        // concerns (see discussion in https://lkml.org/lkml/2015/5/19/896)
+        //
+        // In practice, this is unlikely to be a problem since the window for an
+        // unlink race is tiny. We immediately read the file in the earliest
+        // stages of start, and we cache the FD after. Once we have the FD we
+        // can still access the mapped file even after it has been deleted.
+        //
+        // As a precaution we verify the file we open matches the inode
+        // associated with the true mapped in original. In the case it does
+        // not we must abort and fall back to the copy strategy. In the case of
+        // native executables, it will always match due to /proc/self/exe.
+        if (! executable) {
+            Stat.stat stat = StackValue.get(Stat.stat.class);
+            if (Stat.fstat_no_transition(fd, stat) != 0 && stat.st_ino() != inode.read() && stat.st_dev() != dev.read()) {
+                Unistd.NoTransitions.close(fd);
+                return CEntryPointErrors.MAP_HEAP_FAILED;
+            }
+        }
+
+        long newOffset = offset.read() + (imageHeapBegin.rawValue() - startAddr.read());
+
+        if (!FD_OFFSET.get().logicCompareAndSwapLong(0, -1, newOffset, LocationIdentity.ANY_LOCATION)) {
+            // Another thread won, busy-wait until we can use it's descriptor
+            Unistd.NoTransitions.close(fd);
+            do {
+                UnsafeAccess.UNSAFE.loadFence();
+                fd = (int)OBJECT_FD.get().readLong(0);
+            } while (fd == -1);
+            newOffset = FD_OFFSET.get().readLong(0);
+        } else {
+            SVM_BASE.get().writeLong(0, startAddr.read() - offset.read());
+            OBJECT_FD.get().writeLong(0, fd);
+            // Ensure we have a Store-Load barrier to match up with loads
+            // so that we get volatile access semantics
+            UnsafeAccess.UNSAFE.fullFence();
+        }
+
+        return createMapping(begin, basePointer, endPointer, imageHeapBegin, imageHeapSize, fd, newOffset, !executable);
+    }
+
+    @Uninterruptible(reason = "Called during isolate initialization.")
+    private int createMapping(PointerBase begin, WordPointer basePointer, WordPointer endPointer, Word imageHeapBegin, Word imageHeapSize, int fd, long offset, boolean patch) {
+
+        Pointer heap = VirtualMemoryProvider.get().mapFile(begin, imageHeapSize, WordFactory.unsigned(fd), WordFactory.unsigned(offset), Access.READ | Access.WRITE);
+        if (heap.isNull()) {
+            return CEntryPointErrors.MAP_HEAP_FAILED;
+        }
+
+        UnsignedWord pageSize = VirtualMemoryProvider.get().getGranularity();
+
+        if (patch) {
+            // Create an overlapping anonymous area replacing the relocatable
+            // section of heap, and overwrite with the already relocated original
+            UnsignedWord relocationOffset = UnsignedUtils.roundDown(IMAGE_HEAP_RELOCATABLE_BEGIN.get().subtract(imageHeapBegin), pageSize);
+            UnsignedWord relocationEndOffset = UnsignedUtils.roundUp(IMAGE_HEAP_RELOCATABLE_END.get().subtract(imageHeapBegin), pageSize);
+            UnsignedWord size = relocationEndOffset.subtract(relocationOffset);
+
+            Pointer from = imageHeapBegin.add(relocationOffset);
+            Pointer to = heap.add(relocationOffset);
+
+            VirtualMemoryProvider.get().commit(to, size, Access.READ | Access.WRITE);
+            MemoryUtil.copyConjointMemoryAtomic(from, to, size);
+        }
+
+        UnsignedWord writableBeginPageOffset = UnsignedUtils.roundDown(IMAGE_HEAP_WRITABLE_BEGIN.get().subtract(imageHeapBegin), pageSize);
+        if (writableBeginPageOffset.aboveThan(0)) {
+            if (VirtualMemoryProvider.get().protect(heap, writableBeginPageOffset, Access.READ) != 0) {
+                return CEntryPointErrors.PROTECT_HEAP_FAILED;
+            }
+        }
+        UnsignedWord writableEndPageOffset = UnsignedUtils.roundUp(IMAGE_HEAP_WRITABLE_END.get().subtract(imageHeapBegin), pageSize);
+        if (writableEndPageOffset.belowThan(imageHeapSize)) {
+            Pointer afterWritableBoundary = heap.add(writableEndPageOffset);
+            Word afterWritableSize = imageHeapSize.subtract(writableEndPageOffset);
+            if (VirtualMemoryProvider.get().protect(afterWritableBoundary, afterWritableSize, Access.READ) != 0) {
+                return CEntryPointErrors.PROTECT_HEAP_FAILED;
+            }
+        }
+
+        basePointer.write(heap);
+        if (endPointer.isNonNull()) {
+            endPointer.write(roundUp(heap.add(imageHeapSize), pageSize));
+        }
+
+        return CEntryPointErrors.NO_ERROR;
+    }
+
+    @Uninterruptible(reason = "Called from uninterruptible code.")
+    private static <T extends PointerBase> T nullPointer() {
+        return WordFactory.nullPointer();
+    }
+}

--- a/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/linux/ProcFSSupport.java
+++ b/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/linux/ProcFSSupport.java
@@ -1,0 +1,217 @@
+/*
+ * Copyright (c) 2019, 2019, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package com.oracle.svm.core.posix.linux;
+
+import com.oracle.svm.core.annotate.Uninterruptible;
+import com.oracle.svm.core.posix.headers.Errno;
+import com.oracle.svm.core.posix.headers.Unistd;
+import org.graalvm.nativeimage.c.type.CCharPointer;
+import org.graalvm.nativeimage.c.type.CIntPointer;
+import org.graalvm.nativeimage.c.type.CLongPointer;
+import org.graalvm.word.WordFactory;
+
+class ProcFSSupport {
+    private static final int ST_ADDR_START = 1;
+    private static final int ST_ADDR_END = 2;
+    private static final int ST_PERMS = 3;
+    private static final int ST_OFFSET = 4;
+    private static final int ST_DEV = 5;
+    private static final int ST_INODE = 6;
+    private static final int ST_SPACE = 7;
+    private static final int ST_FILENAME = 8;
+    private static final int ST_SKIP = 9;
+
+    /**
+     * Find a mapping in /proc/self/maps format which corresponds to the
+     * specified address. The buffer is dual-purpose and used to return the
+     * file's path name if requested via the needName parameter. As such the
+     * buffer should be large enough to accommodate a path. If not enough buffer
+     * capacity is available, and needName is true, false will be returned and
+     * the buffer null prefixed to prevent accidental use.
+     *
+     * If a mapping is not found, or an error has occured, false will be
+     * returned.
+     *
+     * @param fd an FD pointing to /proc/self/maps
+     * @param buffer a buffer for reading operations, and optionally returning
+     *               the path name of the mapping.
+     * @param bufferLen the length of the buffer
+     * @param address the address to search for that is within a mapping entry's
+     *                address range
+     * @param startAddrPtr the start address range for a found mapping
+     * @param offsetPtr the file offset for the backing file of the found
+     *                  mapping
+     * @param devPtr    the device id of the matching mapping's backing file
+     * @param inodePtr  the inode of the matching mapping's backing file
+     * @param needName  whether the matching path name is desired and should be
+     *                  returned in buffer
+     * @return true if a mapping is found and no errors, false otherwise.
+     */
+    @Uninterruptible(reason = "Called during isolate initialization.")
+    @SuppressWarnings("fallthrough")
+    static boolean findMapping(int fd, CCharPointer buffer, int bufferLen, long address, CLongPointer startAddrPtr,
+                               CLongPointer offsetPtr, CIntPointer devPtr, CLongPointer inodePtr, boolean needName) {
+        int rem = 0;
+        int pos = 0;
+        int state = ST_ADDR_START;
+        int b;
+        int dev = 0;
+        long inode = 0;
+        long offs = 0;
+        long start = 0;
+        long end = 0;
+        int fns = 0;
+        OUT: for (;;) {
+            while (pos == rem) {
+                // fill buffer
+                int res;
+                do {
+                    res = (int) Unistd.NoTransitions.read(fd, buffer.addressOf(fns), WordFactory.unsigned(bufferLen - fns)).rawValue();
+                } while (res == -1 && Errno.errno() == Errno.EINTR());
+                if (res == -1 || res == 0) {
+                    // read failure or EOF == not matched
+                    return false;
+                }
+                pos = fns;
+                rem = res + fns;
+            }
+            b = buffer.read(pos++) & 0xff;
+            switch (state) {
+                case ST_ADDR_START: {
+                    if (b == '-') {
+                        state = address > start ? ST_ADDR_END : ST_SKIP;
+                    } else if ('0' <= b && b <= '9') {
+                        start = (start << 4) + (b - '0');
+                    } else if ('a' <= b && b <= 'f') {
+                        start = (start << 4) + (b - 'a' + 10);
+                    } else {
+                        // garbage == not matched
+                        return false;
+                    }
+                    break;
+                }
+                case ST_ADDR_END: {
+                    if (b == ' ') {
+                        state = address < end ? ST_PERMS : ST_SKIP;
+                    } else if ('0' <= b && b <= '9') {
+                        end = (end << 4) + (b - '0');
+                    } else if ('a' <= b && b <= 'f') {
+                        end = (end << 4) + (b - 'a' + 10);
+                    } else {
+                        // garbage == not matched
+                        return false;
+                    }
+                    break;
+                }
+                case ST_PERMS: {
+                    if (b == ' ') {
+                        offs = 0;
+                        state = ST_OFFSET;
+                    }
+                    // ignore anything else
+                    break;
+                }
+                case ST_OFFSET: {
+                    if (b == ' ') {
+                        dev = 0;
+                        state = ST_DEV;
+                    } else if ('0' <= b && b <= '9') {
+                        offs = (offs << 4) + (b - '0');
+                    } else if ('a' <= b && b <= 'f') {
+                        offs = (offs << 4) + (b - 'a' + 10);
+                    } else {
+                        // garbage == not matched
+                        return false;
+                    }
+                    break;
+                }
+                case ST_DEV: {
+                    if (b == ' ') {
+                        inode = 0;
+                        state = ST_INODE;
+                    } else if (b == ':') {
+                        // ignore
+                    } else if ('0' <= b && b <= '9') {
+                        dev = (dev << 4) + (b - '0');
+                    } else if ('a' <= b && b <= 'f') {
+                        dev = (dev << 4) + (b - 'a' + 10);
+                    }
+                    break;
+                }
+                case ST_INODE: {
+                    if (b == ' ') {
+                        fns = 0;
+                        if (!needName) {
+                            buffer.write(0, (byte)0);
+                            break OUT;
+                        }
+                        state = ST_SPACE;
+                    } else if ('0' <= b && b <= '9') {
+                        inode = (inode << 3) + (inode << 1) + (b - '0');
+                    } else {
+                        // garbage == not matched
+                        return false;
+                    }
+                    break;
+                }
+                case ST_SPACE: {
+                    if (b == ' ') {
+                        break;
+                    }
+                    state = ST_FILENAME;
+                    // fall thru
+                }
+                case ST_FILENAME: {
+                    if (b == '\n') {
+                        buffer.write(fns, (byte) 0);
+                        break OUT;
+                    } else {
+                        if (fns < pos - 1) {
+                            buffer.write(fns, (byte)(b & 0xFF));
+                        }
+                        if (++fns >= bufferLen) {
+                            // advance out of capacity, garbage
+                            return false;
+                        }
+                    }
+                    break;
+                }
+                case ST_SKIP: {
+                    if (b == '\n') {
+                        start = 0;
+                        end = 0;
+                        state = ST_ADDR_START;
+                    }
+                    break;
+                }
+            }
+        }
+        if (startAddrPtr.isNonNull()) startAddrPtr.write(start);
+        if (offsetPtr.isNonNull()) offsetPtr.write(offs);
+        if (devPtr.isNonNull()) devPtr.write(dev);
+        if (inodePtr.isNonNull()) inodePtr.write(inode);
+        return true;
+    }
+}

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/os/CopyingImageHeapProvider.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/os/CopyingImageHeapProvider.java
@@ -28,7 +28,12 @@ import static com.oracle.svm.core.Isolates.IMAGE_HEAP_WRITABLE_BEGIN;
 import static com.oracle.svm.core.Isolates.IMAGE_HEAP_WRITABLE_END;
 import static com.oracle.svm.core.util.PointerUtils.roundUp;
 
+import com.oracle.svm.core.annotate.AutomaticFeature;
 import org.graalvm.compiler.word.Word;
+import org.graalvm.nativeimage.Feature;
+import org.graalvm.nativeimage.ImageSingletons;
+import org.graalvm.nativeimage.Platform;
+import org.graalvm.nativeimage.Platforms;
 import org.graalvm.nativeimage.c.type.WordPointer;
 import org.graalvm.word.Pointer;
 import org.graalvm.word.PointerBase;
@@ -40,6 +45,17 @@ import com.oracle.svm.core.annotate.Uninterruptible;
 import com.oracle.svm.core.c.function.CEntryPointErrors;
 import com.oracle.svm.core.os.VirtualMemoryProvider.Access;
 import com.oracle.svm.core.util.UnsignedUtils;
+
+@AutomaticFeature
+@Platforms({Platform.DARWIN.class, Platform.WINDOWS.class})
+class CopyingImageHeapProviderFeature implements Feature {
+    @Override
+    public void beforeAnalysis(BeforeAnalysisAccess access) {
+        if (!ImageSingletons.contains(ImageHeapProvider.class)) {
+            ImageSingletons.add(ImageHeapProvider.class, new CopyingImageHeapProvider());
+        }
+    }
+}
 
 public class CopyingImageHeapProvider implements ImageHeapProvider {
     @Override

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/os/OSCommittedMemoryProvider.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/os/OSCommittedMemoryProvider.java
@@ -55,7 +55,6 @@ class OSCommittedMemoryProviderFeature implements Feature {
     @Override
     public void beforeAnalysis(BeforeAnalysisAccess access) {
         if (!ImageSingletons.contains(CommittedMemoryProvider.class)) {
-            ImageSingletons.add(ImageHeapProvider.class, new CopyingImageHeapProvider());
             ImageSingletons.add(CommittedMemoryProvider.class, new OSCommittedMemoryProvider());
         }
     }


### PR DESCRIPTION
# Memory usage improvements 

## Changelog

- 1/21/19 - Added Darwin COW support
- 1/21/19 - Dropped commit that changed SpawnIsolates default to false for executables
- 1/23/19 - Updated Linux COW to utilize overlapped anon relocatable section instead of patching, removed UseCOWIsolateHeaps,  removed UseCompressedReferences & spawn isolates usage (will continue discussion around that change separately)

## Overview

This pull request includes a set of changes to improve the memory usage of native images. I have broken these changes into ~3~ 2 separate commits to make it easier to review, and also make it easier to apply in piecemeal if any are contentious. If preferred, I can break these into separate PRs, just let me know. Also, I am happy to address any other concerns raised. The changes in this PR (justifications further down) are:

 1. The introduction of a new copy-on-write Linux implementation for efficient isolate heap image construction, when SpawnIsolates is enabled.
 2. The introduction of a new Darwin implementation for COW isolate heap image construction.
 3. ~The resurrection of UseHeapBase as UseCompressedReferences (defaulted on) to enable more efficient heap usage when SpawnIsolates is disabled.~


## New COW LinuxImageHeapProvider

Currently, when enabling isolates (the default since RC7), the CopyImageHeap provider constructs a new anonymous memory segment, and performs a user-space copy of the heap image embedded within the native executable/library into the new segment. This has two main drawbacks: one, it defeats lazy loading provided by the memory mapped region, forcing the full heap area to load, and two, the new anonymous backed copy won't be freed until swapping occurs. Compared to isolates disabled, this leads to an increase from r to (t - r) + t usage where r is the subset in use, and t is the total heap image.  

The newly introduced LinuxImageHeapProvider in this patch addresses this problem by creating a duplicate memory mapped segment for the isolate heap portion of the executable. The kernel is then able to share the underlying physical pages in a copy-on-write fashion. The resulting memory usage is comparable to when SpawnIsolates is disabled (see demonstration section below).  Due to the lack of a general interface for this purpose, the implementation is OS specific and includes a small portion of machine architecture specific code that is intended to be easy to expand.  It also falls back in the case of any failure to the standard copy provider.

## New COW DarwinImageHeapProvider

The similar functionality as above, but achieved on Darwin. This utilizes mach's vm_copy kernel interface which maps COW pages instead of performing an actual copy. 

On the Windows side, I have not looked into whether a COW strategy is possible, but from glancing at the WIN API set, it appears to have the hooks required. I plan to contribute this in the future, but due to potential reporting tool perception issues and to squeeze out a few more CPU cycles, I am also advocating for the subsequent changes listed.

## ~~Resurrection of UseHeapBase as UseCompressedReferences~~

~~A simple solution to the additional memory consumption imposed by SpawnIsolates is to just disable it. However, disabling it also has the negative side-effect of disabling compressed pointers as well.  Previously this was two separate settings, which I assume were collapsed to simplify complexity and usability. Hopefully the information included in this synopsis is enough to justify restoring it.  Keeping to that assumption, this change also renames the setting to match a familiar setting on OpenJDK, and it defaults it to true, which I argue is the more desirable value that a user should rarely need to touch. This also has the additional benefit of keeping the separate code paths of SpawnIsolates in the off and on case a bit closer than they were before this change.~~

## Example Linux Reproducer

```java
public class Test {
    private static int[] array = new int[5000000];    

    static {
        for (int i = 0; i < 5000000; i++) {
            array[i]=i;
        }
    }

    public static void main(String[] args)  throws Exception {
        int x = 0;
        for (int i = 0; i < 100; i++) {
           x+=array[(i > 50) ? i : (4999949+i)];
        }

        new ProcessBuilder("/bin/sh",  "-c", " ps aux | grep test | grep -v grep | awk '{print \"RSS(K): \"$6}'")
            .redirectOutput(ProcessBuilder.Redirect.INHERIT)
            .start().waitFor();

        System.out.println();
        new ProcessBuilder("/bin/sh",  "-c", " pmap -x `ps aux | grep test | grep -v grep | awk '{print $2}'`")
            .redirectOutput(ProcessBuilder.Redirect.INHERIT)
            .start().waitFor();


        new java.io.FileOutputStream("/dev/null").write(x);
    }
}
```


### Running with todays defaults (SpawnIsolates enabled, no COW)

This example consumes ~ 40MB of heap. The output below is annotated for clarity.

```
$ mx native-image Test -H:-UseCOWIsolateHeaps -H:+SpawnIsolates && ./test
RSS(K): 43728
 
15550:   ./test
Address           Kbytes     RSS   Dirty Mode  Mapping
0000000000400000   21920   21856   21856 r-x-- test         <-- COPY OPERATION FORCED FULL LOADING
0000000001b67000       4       4       4 r---- test
0000000001b68000      12      12      12 rw--- test
00000000021ee000     132       4       4 rw---   [ anon ]
00007f96dc000000     132       4       4 rw---   [ anon ]
00007f96dc021000   65404       0       0 -----   [ anon ]
00007f96e1e00000    1024       8       8 rw---   [ anon ]
00007f96e2000000    1024       8       8 rw---   [ anon ]
00007f96e2200000    1024      88      88 rw---   [ anon ]
 
00007f96e2309000     872     872     872 r----   [ anon ]   <--- COPIED ISOLATE HEAP AREAS HERE
00007f96e23e3000   19824   19824   19824 rw---   [ anon ]   <--- AND HERE, FULLY LOADED
 
-snip-
```

### Running with COW enabled and SpawnIsolates enabled

This scenario results in ~ 3MB. Note, with this PR these are the default settings.

```
$ mx native-image Test -H:+UseCOWIsolateHeaps -H:+SpawnIsolates && ./test

RSS(K): 2832

15239:   ./test
Address           Kbytes     RSS   Dirty Mode  Mapping
0000000000400000   21924    1216    1216 r-x-- test     <---- ONLY A FEW PAGES LOADED
0000000001b68000       4       4       4 r---- test
0000000001b69000      12      12      12 rw--- test
0000000001ba0000     132       8       8 rw---   [ anon ]
00007f20ac000000     132       4       4 rw---   [ anon ]
00007f20ac021000   65404       0       0 -----   [ anon ]
00007f20b2200000    1024       8       8 rw---   [ anon ]
00007f20b2400000    1024       8       8 rw---   [ anon ]
00007f20b2600000    1024      88      88 rw---   [ anon ]

00007f20b278b000     872     404     404 r---- test     <---- MMAPPED COW AREAS HERE
00007f20b2865000   19824     324     324 rw--- test     <---- AND HERE, PARTIALLY LOADED

-snip-
```

### Running with SpawnIsolates disabled

This scenario results in similar numbers to the COW + Isolates scenario, ~ 3MB of usage. 

```
$ mx native-image Test -H:-SpawnIsolates && ./test
RSS(K): 2796                                           <---- COW HAS SIMILAR RESULTS WITH ISOLATES DISABLED

15878:   ./test
Address           Kbytes     RSS   Dirty Mode  Mapping
0000000000400000    1220    1152    1152 r-x-- test    <---- COW HAS SIMILAR RESULTS WITH ISOLATES DISABLED
0000000000730000       4       4       4 r---- test
0000000000731000   20700     736     736 rw--- test
00000000030f9000     132       4       4 rw---   [ anon ]
00007fef34000000     132       4       4 rw---   [ anon ]
```
