### PR TITLE
This commit begins support for AArch64 native-image support.

### DIFF
--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/ELFMachine.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/ELFMachine.java
@@ -45,6 +45,12 @@ public enum ELFMachine/* implements Integral */ {
             return ELFX86_64Relocation.class;
         }
     },
+    AArch64 {
+        @Override
+        Class<? extends Enum<? extends RelocationMethod>> relocationTypes() {
+            return ELFAArch64Relocation.class;
+        }
+    },
     CAVA {
         @Override
         Class<? extends Enum<? extends RelocationMethod>> relocationTypes() {
@@ -97,6 +103,25 @@ public enum ELFMachine/* implements Integral */ {
                     case UNKNOWN:
                         throw new IllegalArgumentException("cannot map unknown relocation kind to an ELF x86-64 relocation type");
                 }
+            case AArch64:
+                switch (k) {
+                    case DIRECT:
+                        switch (sizeInBytes) {
+                            case 8:
+                                return ELFAArch64Relocation.R_AARCH64_ABS64;
+                            case 4:
+                                return ELFAArch64Relocation.R_AARCH64_ABS32;
+                            case 2:
+                                return ELFAArch64Relocation.R_AARCH64_ABS16;
+                            case 1:
+                            default:
+                                return ELFAArch64Relocation.R_AARCH64_NONE;
+                        }
+                    default:
+                    case UNKNOWN:
+                        throw new IllegalArgumentException("cannot map unknown relocation kind to an ELF aarch64 relocation type: " + k);
+
+                }
             case CAVA:
                 switch (k) {
                     case DIRECT_LO:
@@ -129,6 +154,8 @@ public enum ELFMachine/* implements Integral */ {
                 return NONE;
             case 62:
                 return X86_64;
+            case 0xB7:
+                return AArch64;
             default:
                 throw new IllegalStateException("unknown ELF machine type");
         }
@@ -139,6 +166,8 @@ public enum ELFMachine/* implements Integral */ {
             return (short) 0;
         } else if (this == X86_64) {
             return 62;
+        } else if ( this == AArch64 ) {
+            return (short) 0xB7;
         } else if (this == CAVA) {
             return (short) 0xcafe;
         } else {
@@ -147,7 +176,11 @@ public enum ELFMachine/* implements Integral */ {
     }
 
     public static ELFMachine getSystemNativeValue() {
-        return X86_64; // FIXME: query system
+        String arch = System.getProperty("os.arch");
+        if (arch.equals("aarch64")) {
+            return AArch64;
+        }
+        return X86_64;
     }
 }
 
@@ -347,6 +380,198 @@ enum ELFX86_64Relocation implements ELFRelocationMethod {
     @Override
     public int getRelocatedByteSize() {
         throw new UnsupportedOperationException(); // better safe than sorry
+    }
+}
+
+/**
+ * Reference: http://infocenter.arm.com/help/topic/com.arm.doc.ihi0056b/IHI0056B_aaelf64.pdf
+ */
+enum ELFAArch64Relocation implements ELFRelocationMethod {
+    R_AARCH64_NONE(0),
+    R_AARCH64_ABS64(0x101) {
+        @Override
+        public RelocationKind getKind() {
+            return RelocationKind.DIRECT;
+        }
+
+        @Override
+        public int getRelocatedByteSize() {
+            return 8;
+        }
+    },
+    R_AARCH64_ABS32(0x102) {
+        @Override
+        public RelocationKind getKind() {
+            return RelocationKind.DIRECT;
+        }
+
+        @Override
+        public int getRelocatedByteSize() {
+            return 4;
+        }
+    },
+    R_AARCH64_ABS16(0x103) {
+        @Override
+        public RelocationKind getKind() {
+            return RelocationKind.DIRECT;
+        }
+
+        @Override
+        public int getRelocatedByteSize() {
+            return 2;
+        }
+    },
+    R_AARCH64_PREL64(0x104),
+    R_AARCH64_PREL32(0x105),
+    R_AARCH64_PREL16(0x106),
+    R_AARCH64_MOVW_UABS_G0(0x107),
+    R_AARCH64_MOVW_UABS_G0_NC(0x108),
+    R_AARCH64_MOVW_UABS_G1(0x109),
+    R_AARCH64_MOVW_UABS_G1_NC(0x10a),
+    R_AARCH64_MOVW_UABS_G2(0x10b),
+    R_AARCH64_MOVW_UABS_G2_NC(0x10c),
+    R_AARCH64_MOVW_UABS_G3(0x10d),
+    R_AARCH64_MOVW_SABS_G0(0x10e),
+    R_AARCH64_MOVW_SABS_G1(0x10f),
+    R_AARCH64_MOVW_SABS_G2(0x110),
+    R_AARCH64_LD_PREL_LO19(0x111),
+    R_AARCH64_ADR_PREL_LO21(0x112),
+    R_AARCH64_ADR_PREL_PG_HI21(0x113),
+    R_AARCH64_ADR_PREL_PG_HI21_NC(0x114),
+    R_AARCH64_ADD_ABS_LO12_NC(0x115),
+    R_AARCH64_LDST8_ABS_LO12_NC(0x116),
+    R_AARCH64_TSTBR14(0x117),
+    R_AARCH64_CONDBR19(0x118),
+    R_AARCH64_JUMP26(0x11a),
+    R_AARCH64_CALL26(0x11b),
+    R_AARCH64_LDST16_ABS_LO12_NC(0x11c),
+    R_AARCH64_LDST32_ABS_LO12_NC(0x11d),
+    R_AARCH64_LDST64_ABS_LO12_NC(0x11e),
+    R_AARCH64_MOVW_PREL_G0(0x11f),
+    R_AARCH64_MOVW_PREL_G0_NC(0x120),
+    R_AARCH64_MOVW_PREL_G1(0x121),
+    R_AARCH64_MOVW_PREL_G1_NC(0x122),
+    R_AARCH64_MOVW_PREL_G2(0x123),
+    R_AARCH64_MOVW_PREL_G2_NC(0x124),
+    R_AARCH64_MOVW_PREL_G3(0x125),
+    R_AARCH64_LDST128_ABS_LO12_NC(0x12b),
+    R_AARCH64_MOVW_GOTOFF_G0(0x12c),
+    R_AARCH64_MOVW_GOTOFF_G0_NC(0x12d),
+    R_AARCH64_MOVW_GOTOFF_G1(0x12e),
+    R_AARCH64_MOVW_GOTOFF_G1_NC(0x12f),
+    R_AARCH64_MOVW_GOTOFF_G2(0x130),
+    R_AARCH64_MOVW_GOTOFF_G2_NC(0x131),
+    R_AARCH64_MOVW_GOTOFF_G3(0x132),
+    R_AARCH64_GOTREL64(0x133),
+    R_AARCH64_GOTREL32(0x134),
+    R_AARCH64_GOT_LD_PREL19(0x135),
+    R_AARCH64_LD64_GOTOFF_LO15(0x136),
+    R_AARCH64_ADR_GOT_PAGE(0x137),
+    R_AARCH64_LD64_GOT_LO12_NC(0x138),
+    R_AARCH64_LD64_GOTPAGE_LO15(0x139),
+    R_AARCH64_TLSGD_ADR_PREL21(0x200),
+    R_AARCH64_TLSGD_ADR_PAGE21(0x201),
+    R_AARCH64_TLSGD_ADD_LO12_NC(0x202),
+    R_AARCH64_TLSGD_MOVW_G1(0x203),
+    R_AARCH64_TLSGD_MOVW_G0_NC(0x204),
+    R_AARCH64_TLSLD_ADR_PREL21(0x205),
+    R_AARCH64_TLSLD_ADR_PAGE21(0x206),
+    R_AARCH64_TLSLD_ADD_LO12_NC(0x207),
+    R_AARCH64_TLSLD_MOVW_G1(0x208),
+    R_AARCH64_TLSLD_MOVW_G0_NC(0x209),
+    R_AARCH64_TLSLD_LD_PREL19(0x20a),
+    R_AARCH64_TLSLD_MOVW_DTPREL_G2(0x20b),
+    R_AARCH64_TLSLD_MOVW_DTPREL_G1(0x20c),
+    R_AARCH64_TLSLD_MOVW_DTPREL_G1_NC(0x20d),
+    R_AARCH64_TLSLD_MOVW_DTPREL_G0(0x20e),
+    R_AARCH64_TLSLD_MOVW_DTPREL_G0_NC(0x20f),
+    R_AARCH64_TLSLD_ADD_DTPREL_HI12(0x210),
+    R_AARCH64_TLSLD_ADD_DTPREL_LO12(0x211),
+    R_AARCH64_TLSLD_ADD_DTPREL_LO12_NC(0x212),
+    R_AARCH64_TLSLD_LDST8_DTPREL_LO12(0x213),
+    R_AARCH64_TLSLD_LDST8_DTPREL_LO12_NC(0x214),
+    R_AARCH64_TLSLD_LDST16_DTPREL_LO12(0x215),
+    R_AARCH64_TLSLD_LDST16_DTPREL_LO12_NC(0x216),
+    R_AARCH64_TLSLD_LDST32_DTPREL_LO12(0x217),
+    R_AARCH64_TLSLD_LDST32_DTPREL_LO12_NC(0x218),
+    R_AARCH64_TLSLD_LDST64_DTPREL_LO12(0x219),
+    R_AARCH64_TLSLD_LDST64_DTPREL_LO12_NC(0x21a),
+    R_AARCH64_TLSIE_MOVW_GOTTPREL_G1(0x21b),
+    R_AARCH64_TLSIE_MOVW_GOTTPREL_G0_NC(0x21c),
+    R_AARCH64_TLSIE_ADR_GOTTPREL_PAGE21(0x21d),
+    R_AARCH64_TLSIE_LD64_GOTTPREL_LO12_NC(0x21e),
+    R_AARCH64_TLSIE_LD_GOTTPREL_PREL19(0x21f),
+    R_AARCH64_TLSLE_MOVW_TPREL_G2(0x220),
+    R_AARCH64_TLSLE_MOVW_TPREL_G1(0x221),
+    R_AARCH64_TLSLE_MOVW_TPREL_G1_NC(0x222),
+    R_AARCH64_TLSLE_MOVW_TPREL_G0(0x223),
+    R_AARCH64_TLSLE_MOVW_TPREL_G0_NC(0x224),
+    R_AARCH64_TLSLE_ADD_TPREL_HI12(0x225),
+    R_AARCH64_TLSLE_ADD_TPREL_LO12(0x226),
+    R_AARCH64_TLSLE_ADD_TPREL_LO12_NC(0x227),
+    R_AARCH64_TLSLE_LDST8_TPREL_LO12(0x228),
+    R_AARCH64_TLSLE_LDST8_TPREL_LO12_NC(0x229),
+    R_AARCH64_TLSLE_LDST16_TPREL_LO12(0x22a),
+    R_AARCH64_TLSLE_LDST16_TPREL_LO12_NC(0x22b),
+    R_AARCH64_TLSLE_LDST32_TPREL_LO12(0x22c),
+    R_AARCH64_TLSLE_LDST32_TPREL_LO12_NC(0x22d),
+    R_AARCH64_TLSLE_LDST64_TPREL_LO12(0x22e),
+    R_AARCH64_TLSLE_LDST64_TPREL_LO12_NC(0x22f),
+    R_AARCH64_TLSDESC_LD_PREL19(0x230),
+    R_AARCH64_TLSDESC_ADR_PREL21(0x231),
+    R_AARCH64_TLSDESC_ADR_PAGE21(0x232),
+    R_AARCH64_TLSDESC_LD64_LO12_NC(0x233),
+    R_AARCH64_TLSDESC_ADD_LO12_NC(0x234),
+    R_AARCH64_TLSDESC_OFF_G1(0x235),
+    R_AARCH64_TLSDESC_OFF_G0_NC(0x236),
+    R_AARCH64_TLSDESC_LDR(0x237),
+    R_AARCH64_TLSDESC_ADD(0x238),
+    R_AARCH64_TLSDESC_CALL(0x239),
+    R_AARCH64_TLSLE_LDST128_TPREL_LO12(0x23a),
+    R_AARCH64_TLSLE_LDST128_TPREL_LO12_NC(0x23b),
+    R_AARCH64_TLSLD_LDST128_DTPREL_LO12(0x23c),
+    R_AARCH64_TLSLD_LDST128_DTPREL_LO12_NC(0x23d),
+    R_AARCH64_COPY(0x400),
+    R_AARCH64_GLOB_DAT(0x401),
+    R_AARCH64_JUMP_SLOT(0x402),
+    R_AARCH64_RELATIVE(0x403),
+    R_AARCH64_TLS_DTPREL64(0x404),
+    R_AARCH64_TLS_DTPMOD64(0x405),
+    R_AARCH64_TLS_TPREL64(0x406),
+    R_AARCH64_TLSDESC(0x407),
+    R_AARCH64_IRELATIVE(0x408)
+
+    ;
+
+    private final long code;
+
+    private ELFAArch64Relocation(long code) {
+        this.code = code;
+    }
+
+    @Override
+    public RelocationKind getKind() {
+        return RelocationKind.UNKNOWN;
+    }
+
+    @Override
+    public boolean canUseImplicitAddend() {
+        return false;
+    }
+
+    @Override
+    public boolean canUseExplicitAddend() {
+        return true;
+    }
+
+    @Override
+    public int getRelocatedByteSize() {
+        throw new UnsupportedOperationException(); // better safe than sorry
+    }
+
+    @Override
+    public long toLong() {
+        return code;
     }
 }
 

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/ELFObjectFile.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/ELFObjectFile.java
@@ -72,19 +72,28 @@ public class ELFObjectFile extends ObjectFile {
     private long processorSpecificFlags; // FIXME: to encapsulate (EF_* in elf.h)
     private final boolean runtimeDebugInfoGeneration;
 
-    public ELFObjectFile(boolean runtimeDebugInfoGeneration) {
+    public ELFObjectFile(ELFMachine machine, boolean runtimeDebugInfoGeneration) {
         this.runtimeDebugInfoGeneration = runtimeDebugInfoGeneration;
         // Create the elements of an empty ELF file:
         // 1. create header
         header = new ELFHeader("ELFHeader");
+        this.machine = machine;
         // 2. create shstrtab
         shstrtab = new SectionHeaderStrtab();
         // 3. create section header table
         sht = new SectionHeaderTable(/* shstrtab */);
     }
 
+    public ELFObjectFile(ELFMachine machine) {
+        this(machine, false);
+    }
+
     public ELFObjectFile() {
-        this(false);
+        this(ELFMachine.getSystemNativeValue());
+    }
+
+    public ELFObjectFile(boolean runtimeDebugInfoGeneration) {
+        this(ELFMachine.getSystemNativeValue(), runtimeDebugInfoGeneration);
     }
 
     @Override
@@ -567,8 +576,7 @@ public class ELFObjectFile extends ObjectFile {
 
         public ELFHeader(String name) { // create an "empty" default ELF header
             super(name);
-            // FIXME: is it really appropriate to initialize the owning ELFObjectFile's fields here?
-            ELFObjectFile.this.machine = ELFMachine.X86_64;
+            //ELFObjectFile.this.machine = ELFMachine.X86_64;
             ELFObjectFile.this.version = 1;
             ELFObjectFile.this.processorSpecificFlags = 0;
         }

--- a/substratevm/src/com.oracle.svm.native.libchelper/src/cpuid.c
+++ b/substratevm/src/com.oracle.svm.native.libchelper/src/cpuid.c
@@ -25,6 +25,7 @@
 
 #include "cpufeatures.h"
 
+#ifdef __x86_64__
 #ifndef _WIN64
 #include <cpuid.h>
 
@@ -71,6 +72,7 @@ int get_cpuid (unsigned int leaf, unsigned int *eax, unsigned int *ebx, unsigned
 }
 
 #endif
+
 
 
 #define bit_CX8_compat           0x00000100
@@ -170,3 +172,10 @@ void determineCPUFeatures(CPUFeatures* features) {
   }
 }
 
+#else
+/*
+ * Dummy for non AMD64
+ */
+void determineCPUFeatures(CPUFeatures* features) {
+}
+#endif


### PR DESCRIPTION
* cpuid.c no-op for non-AMD64 machine (via sanzinger; cherry-picked)
* ELFMachine expansion for AArch64 type and elf_machine magic.
* Provides direct relocation types for AArch64.
* Allows ELFMachine selection based on os.arch system property
* (unused) provides for ELFMachine to be specified in the ELFObjectFile constructor
  anticipating a future cross-compilation support, instead of determining
  the type based upon the host architecture.