### PR TITLE
Fix mistypes for RESTARTABLE macros in JavaNetNetUtil

### DIFF
--- a/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/JavaNetNetUtil.java
+++ b/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/JavaNetNetUtil.java
@@ -2295,7 +2295,7 @@ class Target_os {
         // 164   RESTARTABLE( (size_t) ::read(fd, buf, (size_t) nBytes), res);
         do {
             res = Unistd.read(fd, buf, WordFactory.unsigned(nBytes)).rawValue();
-        } while ((res == VmRuntimeOS.OSReturn.OS_ERR()) || (Errno.errno() == Errno.EINTR()));
+        } while ((res == VmRuntimeOS.OSReturn.OS_ERR()) && (Errno.errno() == Errno.EINTR()));
         // 165   return res;
         return res;
     }
@@ -2312,7 +2312,7 @@ class Target_os {
         // 4095 RESTARTABLE(::ioctl(fd, FIONREAD, pbytes), ret);
         do {
             ret = Ioctl.ioctl(fd, Ioctl.FIONREAD(), pbytes);
-        } while ((ret == VmRuntimeOS.OSReturn.OS_ERR()) || (Errno.errno() == Errno.EINTR()));
+        } while ((ret == VmRuntimeOS.OSReturn.OS_ERR()) && (Errno.errno() == Errno.EINTR()));
         // 4096
         // 4097 //%% note ioctl can return 0 when successful, JVM_SocketAvailable
         // 4098 // is expected to return 0 on failure and 1 on success to the jdk.
@@ -2328,7 +2328,7 @@ class Target_os {
             int _result;
             do {
                 _result = (int) Socket.send(fd, buf, WordFactory.unsigned(nBytes), flags).rawValue();
-            } while ((_result == VmRuntimeOS.OSReturn.OS_ERR()) || (Errno.errno() == Errno.EINTR()));
+            } while ((_result == VmRuntimeOS.OSReturn.OS_ERR()) && (Errno.errno() == Errno.EINTR()));
             return _result;
         } while (false);
     }
@@ -2340,7 +2340,7 @@ class Target_os {
             int _result;
             do {
                 _result = (int) Socket.sendto(fd, buf, WordFactory.unsigned(n), flags, addr, addr_len).rawValue();
-            } while ((_result == VmRuntimeOS.OSReturn.OS_ERR()) || (Errno.errno() == Errno.EINTR()));
+            } while ((_result == VmRuntimeOS.OSReturn.OS_ERR()) && (Errno.errno() == Errno.EINTR()));
             return _result;
         } while (false);
     }
@@ -2352,7 +2352,7 @@ class Target_os {
             int _result;
             do {
                 _result = (int) Socket.recvfrom(fd, buf, WordFactory.unsigned(n), flags, addr, addr_len).rawValue();
-            } while ((_result == VmRuntimeOS.OSReturn.OS_ERR()) || (Errno.errno() == Errno.EINTR()));
+            } while ((_result == VmRuntimeOS.OSReturn.OS_ERR()) && (Errno.errno() == Errno.EINTR()));
             return _result;
         } while (false);
     }


### PR DESCRIPTION
This simple patch fixes problems with hanging socket's operations (oracle#934) in SVM.