### PR TITLE
Avoid AMD64Kind in HashFunction

### DIFF
--- a/compiler/src/org.graalvm.compiler.lir/src/org/graalvm/compiler/lir/hashing/HashFunction.java
+++ b/compiler/src/org.graalvm.compiler.lir/src/org/graalvm/compiler/lir/hashing/HashFunction.java
@@ -32,7 +32,6 @@ import java.util.function.Function;
 
 import org.graalvm.compiler.lir.gen.ArithmeticLIRGenerator;
 
-import jdk.vm.ci.amd64.AMD64Kind;
 import jdk.vm.ci.meta.JavaConstant;
 import jdk.vm.ci.meta.Value;
 
@@ -143,15 +142,7 @@ public abstract class HashFunction {
 
             @Override
             public Value gen(Value val, Value min, ArithmeticLIRGenerator t) {
-                return gen.apply(t).apply(toDWORD(val, t), toDWORD(min, t));
-            }
-
-            private Value toDWORD(Value v, ArithmeticLIRGenerator t) {
-                if (v.getPlatformKind() != AMD64Kind.DWORD) {
-                    return t.emitNarrow(v, 32);
-                } else {
-                    return v;
-                }
+                return gen.apply(t).apply(t.emitNarrow(val, 32), t.emitNarrow(min, 32));
             }
         });
     }


### PR DESCRIPTION
@tkrodriguez @dougxc Here's the fix as requested in https://github.com/oracle/graal/pull/895#discussion_r254862466