### PR TITLE
Fix errors in aarch64 TBZ implementation.

### DIFF
--- a/compiler/src/org.graalvm.compiler.core.aarch64.test/src/org/graalvm/compiler/core/aarch64/test/AArch64TestBitAndBranchTest.java
+++ b/compiler/src/org.graalvm.compiler.core.aarch64.test/src/org/graalvm/compiler/core/aarch64/test/AArch64TestBitAndBranchTest.java
@@ -62,7 +62,7 @@ public class AArch64TestBitAndBranchTest extends LIRTest {
     }
 
     public static long testBit42Snippet(long a, long b, long c) {
-        if ((a & (1 << 42)) == 0) {
+        if ((a & (1L << 42)) == 0) {
             return b;
         } else {
             return c;
@@ -71,12 +71,12 @@ public class AArch64TestBitAndBranchTest extends LIRTest {
 
     @Test
     public void testBit42() {
-        test("testBit42Snippet", 1L << 42L, Long.MAX_VALUE, Long.MIN_VALUE);
-        test("testBit42Snippet", ~(1L << 42L), Long.MAX_VALUE, Long.MIN_VALUE);
+        test("testBit42Snippet", 1L << 42, Long.MAX_VALUE, Long.MIN_VALUE);
+        test("testBit42Snippet", ~(1L << 42), Long.MAX_VALUE, Long.MIN_VALUE);
         checkLIR("testBit42Snippet", checkForBitTestAndBranchOp, 1);
     }
 
-    private static final LargeOpSpec largeOpSingleNop = new LargeOpSpec((1 << 14 - 2), 2);
+    private static final LargeOpSpec largeOpSingleNop = new LargeOpSpec((1 << 14 - 2) - 10, 2);
 
     /**
      * Tests the graceful case, where the estimation for
@@ -99,7 +99,7 @@ public class AArch64TestBitAndBranchTest extends LIRTest {
         checkLIR("testBitTestAndBranchSingleSnippet", checkForBitTestAndBranchOp, 1);
     }
 
-    private static final LargeOpSpec largeOpFourNop = new LargeOpSpec((1 << 14 - 2), 8);
+    private static final LargeOpSpec largeOpFourNop = new LargeOpSpec((1 << 14 - 2) - 10, 8);
 
     /**
      * Tests the case, where the estimation for

--- a/compiler/src/org.graalvm.compiler.lir.aarch64/src/org/graalvm/compiler/lir/aarch64/AArch64ControlFlow.java
+++ b/compiler/src/org.graalvm.compiler.lir.aarch64/src/org/graalvm/compiler/lir/aarch64/AArch64ControlFlow.java
@@ -157,7 +157,10 @@ public class AArch64ControlFlow {
             boolean isFarBranch;
 
             if (label.isBound()) {
-                isFarBranch = NumUtil.isSignedNbit(18, masm.position() - label.position());
+                // The label.position() is a byte based index. The TBZ instruction has 14 bits for
+                // the offset and AArch64 instruction is 4 bytes aligned. So TBZ can encode 16 bits
+                // signed offset.
+                isFarBranch = !NumUtil.isSignedNbit(16, masm.position() - label.position());
             } else {
                 // Max range of tbz is +-2^13 instructions. We estimate that each LIR instruction
                 // emits 2 AArch64 instructions on average. Thus we test for maximum 2^12 LIR

--- a/compiler/src/org.graalvm.compiler.lir/src/org/graalvm/compiler/lir/asm/CompilationResultBuilder.java
+++ b/compiler/src/org.graalvm.compiler.lir/src/org/graalvm/compiler/lir/asm/CompilationResultBuilder.java
@@ -598,8 +598,8 @@ public class CompilationResultBuilder {
                         if (label != null) {
                             labelBindLirPositions.put(label, instructionPosition);
                         }
-                        lirPositions.put(op, instructionPosition);
                     }
+                    lirPositions.put(op, instructionPosition);
                     instructionPosition++;
                 }
             }


### PR DESCRIPTION
Change buildLabelOffsets to also record the LIR instruction offset
besides recording label. It will make labelWithinRange work with
BitTestAndBranchOp on AArch64.

Also correctify the isFarBranch flag value in BitTestAndBranchOp emit
and fix the AArch64TestBitAndBranchTest.

Change-Id: Idf3454f7db0895360c63ef6ca434fb51e5db2fcc