### PR TITLE
Remove properties that are not used

### DIFF
--- a/substratevm/src/native-image-maven-plugin/pom_template.xml
+++ b/substratevm/src/native-image-maven-plugin/pom_template.xml
@@ -66,8 +66,6 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>1.7</maven.compiler.source>
-        <maven.compiler.target>1.7</maven.compiler.target>
         <maven.version>3.3.9</maven.version>
     </properties>
 


### PR DESCRIPTION
The org.apache.maven.plugins:maven-compiler-plugin has its own configuration block. There, source and target are set to '8'. So the properties maven.compiler.source and maven.compiler.target are not used.