### PR TITLE
SubtrateVM/GC: Log byte values with proper unit

### DIFF
--- a/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/CollectionPolicy.java
+++ b/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/CollectionPolicy.java
@@ -247,13 +247,13 @@ public abstract class CollectionPolicy {
             final UnsignedWord expectedSize = youngSize.add(oldInUse).add(averagePromotion);
             final UnsignedWord maxHeapSize = HeapPolicy.getMaximumHeapSize();
             final boolean vote = maxHeapSize.belowThan(expectedSize);
-            trace.string("  youngSize: ").unsigned(youngSize)
-                            .string("  oldInUse: ").unsigned(oldInUse)
-                            .string("  averagePromotedUnpinnedChunkBytes: ").unsigned(getAccounting().averagePromotedUnpinnedChunkBytes())
-                            .string("  averagePromotedPinnedChunkBytes: ").unsigned(getAccounting().averagePromotedPinnedChunkBytes())
-                            .string("  averagePromotion: ").unsigned(averagePromotion)
-                            .string("  expectedSize: ").unsigned(expectedSize)
-                            .string("  maxHeapSize: ").unsigned(maxHeapSize)
+            trace.string("  youngSize: ").bytesInProperUnit(youngSize)
+                            .string("  oldInUse: ").bytesInProperUnit(oldInUse)
+                            .string("  averagePromotedUnpinnedChunkBytes: ").bytesInProperUnit(getAccounting().averagePromotedUnpinnedChunkBytes())
+                            .string("  averagePromotedPinnedChunkBytes: ").bytesInProperUnit(getAccounting().averagePromotedPinnedChunkBytes())
+                            .string("  averagePromotion: ").bytesInProperUnit(averagePromotion)
+                            .string("  expectedSize: ").bytesInProperUnit(expectedSize)
+                            .string("  maxHeapSize: ").bytesInProperUnit(maxHeapSize)
                             .string("  vote: ").bool(vote)
                             .newline();
             return vote;
@@ -266,9 +266,9 @@ public abstract class CollectionPolicy {
             final UnsignedWord heapInUse = youngSize.add(oldInUse);
             final UnsignedWord minHeapSize = HeapPolicy.getMinimumHeapSize();
             final boolean veto = heapInUse.belowThan(minHeapSize);
-            trace.string("  oldInUse: ").unsigned(oldInUse)
-                            .string("  heapInUse: ").unsigned(heapInUse)
-                            .string("  minHeapSize: ").unsigned(minHeapSize)
+            trace.string("  oldInUse: ").bytesInProperUnit(oldInUse)
+                            .string("  heapInUse: ").bytesInProperUnit(heapInUse)
+                            .string("  minHeapSize: ").bytesInProperUnit(minHeapSize)
                             .string("  veto: ").bool(veto)
                             .newline();
             return veto;

--- a/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/GCImpl.java
+++ b/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/GCImpl.java
@@ -338,11 +338,11 @@ public class GCImpl implements GC {
         if (SubstrateOptions.VerboseGC.getValue() && getCollectionEpoch().equal(1)) {
             /* Print the command line options that shape the heap. */
             verboseGCLog.string("[Heap policy parameters: ").newline();
-            verboseGCLog.string("  YoungGenerationSize: ").unsigned(HeapPolicy.getMaximumYoungGenerationSize()).newline();
-            verboseGCLog.string("      MaximumHeapSize: ").unsigned(HeapPolicy.getMaximumHeapSize()).newline();
-            verboseGCLog.string("      MinimumHeapSize: ").unsigned(HeapPolicy.getMinimumHeapSize()).newline();
-            verboseGCLog.string("     AlignedChunkSize: ").unsigned(HeapPolicy.getAlignedHeapChunkSize()).newline();
-            verboseGCLog.string("  LargeArrayThreshold: ").unsigned(HeapPolicy.getLargeArrayThreshold()).string("]").newline();
+            verboseGCLog.string("  YoungGenerationSize: ").bytesInProperUnit(HeapPolicy.getMaximumYoungGenerationSize()).newline();
+            verboseGCLog.string("      MaximumHeapSize: ").bytesInProperUnit(HeapPolicy.getMaximumHeapSize()).newline();
+            verboseGCLog.string("      MinimumHeapSize: ").bytesInProperUnit(HeapPolicy.getMinimumHeapSize()).newline();
+            verboseGCLog.string("     AlignedChunkSize: ").bytesInProperUnit(HeapPolicy.getAlignedHeapChunkSize()).newline();
+            verboseGCLog.string("  LargeArrayThreshold: ").bytesInProperUnit(HeapPolicy.getLargeArrayThreshold()).string("]").newline();
             if (HeapOptions.PrintHeapShape.getValue()) {
                 HeapImpl.getHeapImpl().bootImageHeapBoundariesToLog(verboseGCLog).newline();
             }
@@ -379,9 +379,9 @@ public class GCImpl implements GC {
                 }
                 printGCLog.string(completeCollection ? "Full GC" : "Incremental GC");
                 printGCLog.string(" (").string(cause).string(") ");
-                printGCLog.unsigned(sizeBefore.unsignedDivide(1024));
-                printGCLog.string("K->");
-                printGCLog.unsigned(sizeAfter.unsignedDivide(1024)).string("K, ");
+                printGCLog.bytesInProperUnit(sizeBefore);
+                printGCLog.string("->");
+                printGCLog.bytesInProperUnit(sizeAfter).string(", ");
                 printGCLog.rational(collectionTimer.getCollectedNanos(), TimeUtils.nanosPerSecond, DECIMALS_IN_TIME_PRINTING).string(" secs");
 
                 printGCLog.string("]").newline();
@@ -1382,9 +1382,9 @@ public class GCImpl implements GC {
                 pinnedObjectBytes = pinnedObjectBytes.add(allocatedPinnedObjectBytes);
                 normalObjectBytes = normalObjectBytes.add(youngObjectBytesBefore);
             }
-            trace.string("  youngChunkBytesBefore: ").unsigned(youngChunkBytesBefore)
-                            .string("  oldChunkBytesBefore: ").unsigned(oldChunkBytesBefore)
-                            .string("  pinnedChunkBytesBefore: ").unsigned(pinnedChunkBytesBefore);
+            trace.string("  youngChunkBytesBefore: ").bytesInProperUnit(youngChunkBytesBefore)
+                            .string("  oldChunkBytesBefore: ").bytesInProperUnit(oldChunkBytesBefore)
+                            .string("  pinnedChunkBytesBefore: ").bytesInProperUnit(pinnedChunkBytesBefore);
             trace.string("]").newline();
         }
 
@@ -1410,10 +1410,10 @@ public class GCImpl implements GC {
             promotedTotalChunkBytes = promotedTotalChunkBytes.add(getHistoryOf(promotedUnpinnedChunkBytes)).add(getHistoryOf(promotedPinnedChunkBytes));
             incrementalCollectionTotalNanos += collectionTimer.getCollectedNanos();
             trace.string("  incrementalCollectionCount: ").signed(incrementalCollectionCount)
-                            .string("  oldChunkBytesAfter: ").unsigned(oldChunkBytesAfter)
-                            .string("  oldChunkBytesBefore: ").unsigned(oldChunkBytesBefore)
-                            .string("  promotedUnpinnedChunkBytes: ").unsigned(getHistoryOf(promotedUnpinnedChunkBytes))
-                            .string("  promotedPinnedChunkBytes: ").unsigned(getHistoryOf(promotedPinnedChunkBytes));
+                            .string("  oldChunkBytesAfter: ").bytesInProperUnit(oldChunkBytesAfter)
+                            .string("  oldChunkBytesBefore: ").bytesInProperUnit(oldChunkBytesBefore)
+                            .string("  promotedUnpinnedChunkBytes: ").bytesInProperUnit(getHistoryOf(promotedUnpinnedChunkBytes))
+                            .string("  promotedPinnedChunkBytes: ").bytesInProperUnit(getHistoryOf(promotedPinnedChunkBytes));
             trace.string("]").newline();
         }
 
@@ -1427,8 +1427,8 @@ public class GCImpl implements GC {
             copiedTotalChunkBytes = copiedTotalChunkBytes.add(oldChunkBytesAfter).add(pinnedChunkBytesAfter);
             completeCollectionTotalNanos += collectionTimer.getCollectedNanos();
             trace.string("  completeCollectionCount: ").signed(completeCollectionCount)
-                            .string("  oldChunkBytesAfter: ").unsigned(oldChunkBytesAfter)
-                            .string("  pinnedChunkBytesAfter: ").unsigned(pinnedChunkBytesAfter);
+                            .string("  oldChunkBytesAfter: ").bytesInProperUnit(oldChunkBytesAfter)
+                            .string("  pinnedChunkBytesAfter: ").bytesInProperUnit(pinnedChunkBytesAfter);
             trace.string("]").newline();
         }
 
@@ -1647,10 +1647,10 @@ public class GCImpl implements GC {
         final String prefix = "PrintGCSummary: ";
 
         /* Print GC configuration. */
-        log.string(prefix).string("YoungGenerationSize: ").unsigned(HeapPolicy.getMaximumYoungGenerationSize()).newline();
-        log.string(prefix).string("MinimumHeapSize: ").unsigned(HeapPolicy.getMinimumHeapSize()).newline();
-        log.string(prefix).string("MaximumHeapSize: ").unsigned(HeapPolicy.getMaximumHeapSize()).newline();
-        log.string(prefix).string("AlignedChunkSize: ").unsigned(HeapPolicy.getAlignedHeapChunkSize()).newline();
+        log.string(prefix).string("YoungGenerationSize: ").bytesInProperUnit(HeapPolicy.getMaximumYoungGenerationSize()).newline();
+        log.string(prefix).string("MinimumHeapSize: ").bytesInProperUnit(HeapPolicy.getMinimumHeapSize()).newline();
+        log.string(prefix).string("MaximumHeapSize: ").bytesInProperUnit(HeapPolicy.getMaximumHeapSize()).newline();
+        log.string(prefix).string("AlignedChunkSize: ").bytesInProperUnit(HeapPolicy.getAlignedHeapChunkSize()).newline();
 
         /* Add in any young and pinned objects allocated since the last collection. */
         VMOperation.enqueueBlockingSafepoint("PrintGCSummaryShutdownHook", ThreadLocalAllocation::disableThreadLocalAllocation);
@@ -1671,14 +1671,14 @@ public class GCImpl implements GC {
         final UnsignedWord allocatedTotalObjectBytes = allocatedNormalObjectBytes.add(allocatedPinnedObjectBytes);
 
         /* Print the total bytes allocated and collected by chunks. */
-        log.string(prefix).string("CollectedTotalChunkBytes: ").signed(accounting.getCollectedTotalChunkBytes()).newline();
-        log.string(prefix).string("CollectedTotalObjectBytes: ").signed(accounting.getCollectedTotalObjectBytes()).newline();
-        log.string(prefix).string("AllocatedNormalChunkBytes: ").signed(allocatedNormalChunkBytes).newline();
-        log.string(prefix).string("AllocatedNormalObjectBytes: ").signed(allocatedNormalObjectBytes).newline();
-        log.string(prefix).string("AllocatedPinnedChunkBytes: ").signed(allocatedPinnedChunkBytes).newline();
-        log.string(prefix).string("AllocatedPinnedObjectBytes: ").signed(allocatedPinnedObjectBytes).newline();
-        log.string(prefix).string("AllocatedTotalChunkBytes: ").signed(allocatedTotalChunkBytes).newline();
-        log.string(prefix).string("AllocatedTotalObjectBytes: ").signed(allocatedTotalObjectBytes).newline();
+        log.string(prefix).string("CollectedTotalChunkBytes: ").bytesInProperUnit(accounting.getCollectedTotalChunkBytes()).newline();
+        log.string(prefix).string("CollectedTotalObjectBytes: ").bytesInProperUnit(accounting.getCollectedTotalObjectBytes()).newline();
+        log.string(prefix).string("AllocatedNormalChunkBytes: ").bytesInProperUnit(allocatedNormalChunkBytes).newline();
+        log.string(prefix).string("AllocatedNormalObjectBytes: ").bytesInProperUnit(allocatedNormalObjectBytes).newline();
+        log.string(prefix).string("AllocatedPinnedChunkBytes: ").bytesInProperUnit(allocatedPinnedChunkBytes).newline();
+        log.string(prefix).string("AllocatedPinnedObjectBytes: ").bytesInProperUnit(allocatedPinnedObjectBytes).newline();
+        log.string(prefix).string("AllocatedTotalChunkBytes: ").bytesInProperUnit(allocatedTotalChunkBytes).newline();
+        log.string(prefix).string("AllocatedTotalObjectBytes: ").bytesInProperUnit(allocatedTotalObjectBytes).newline();
 
         /* Print the collection counts and times. */
         final long incrementalNanos = accounting.getIncrementalCollectionTotalNanos();

--- a/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/HeapChunkProvider.java
+++ b/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/HeapChunkProvider.java
@@ -123,7 +123,7 @@ class HeapChunkProvider {
      */
     AlignedHeader produceAlignedChunk() {
         UnsignedWord chunkSize = HeapPolicy.getAlignedHeapChunkSize();
-        log().string("[HeapChunkProvider.produceAlignedChunk  chunk size: ").unsigned(chunkSize).newline();
+        log().string("[HeapChunkProvider.produceAlignedChunk  chunk size: ").bytesInProperUnit(chunkSize).newline();
 
         AlignedHeader result = popUnusedAlignedChunk();
         log().string("  unused chunk: ").hex(result).newline();
@@ -178,10 +178,10 @@ class HeapChunkProvider {
         /* If I am under the minimum heap size, then I can keep this chunk. */
         final boolean result = bytesInUse.belowThan(minimumHeapSize);
         trace
-                        .string("  minimumHeapSize: ").unsigned(minimumHeapSize)
-                        .string("  heapChunkBytes: ").unsigned(heapChunkBytes)
-                        .string("  unusedBytes: ").unsigned(unusedChunkBytes)
-                        .string("  bytesInUse: ").unsigned(bytesInUse)
+                        .string("  minimumHeapSize: ").bytesInProperUnit(minimumHeapSize)
+                        .string("  heapChunkBytes: ").bytesInProperUnit(heapChunkBytes)
+                        .string("  unusedBytes: ").bytesInProperUnit(unusedChunkBytes)
+                        .string("  bytesInUse: ").bytesInProperUnit(bytesInUse)
                         .string("  returns: ").bool(result)
                         .string(" ]").newline();
         return result;
@@ -273,7 +273,7 @@ class HeapChunkProvider {
      */
     UnalignedHeader produceUnalignedChunk(UnsignedWord objectSize) {
         UnsignedWord chunkSize = UnalignedHeapChunk.getChunkSizeForObject(objectSize);
-        log().string("[HeapChunkProvider.produceUnalignedChunk  objectSize: ").unsigned(objectSize).string("  chunkSize: ").hex(chunkSize).newline();
+        log().string("[HeapChunkProvider.produceUnalignedChunk  objectSize: ").bytesInProperUnit(objectSize).string("  chunkSize: ").hex(chunkSize).newline();
 
         noteFirstAllocationTime();
         UnalignedHeader result = (UnalignedHeader) CommittedMemoryProvider.get().allocate(chunkSize, CommittedMemoryProvider.UNALIGNED, false);

--- a/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/HeapImpl.java
+++ b/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/HeapImpl.java
@@ -454,15 +454,15 @@ public class HeapImpl extends Heap {
         final UnsignedWord result = fromBytes.add(toBytes).add(pinnedFromBytes).add(pinnedToBytes);
         if (trace.isEnabled()) {
             trace
-                            .string("  fromAligned: ").unsigned(from.getAlignedChunkBytes())
-                            .string("  fromUnaligned: ").signed(from.getUnalignedChunkBytes())
-                            .string("  toAligned: ").unsigned(to.getAlignedChunkBytes())
-                            .string("  toUnaligned: ").signed(to.getUnalignedChunkBytes())
-                            .string("  pinnedFromAligned: ").unsigned(pinnedFrom.getAlignedChunkBytes())
-                            .string("  pinnedFromUnaligned: ").signed(pinnedFrom.getUnalignedChunkBytes())
-                            .string("  pinnedToAligned: ").unsigned(pinnedTo.getAlignedChunkBytes())
-                            .string("  pinnedToUnaligned: ").signed(pinnedTo.getUnalignedChunkBytes())
-                            .string("  returns: ").unsigned(result).string(" ]").newline();
+                            .string("  fromAligned: ").bytesInProperUnit(from.getAlignedChunkBytes())
+                            .string("  fromUnaligned: ").bytesInProperUnit(from.getUnalignedChunkBytes())
+                            .string("  toAligned: ").bytesInProperUnit(to.getAlignedChunkBytes())
+                            .string("  toUnaligned: ").bytesInProperUnit(to.getUnalignedChunkBytes())
+                            .string("  pinnedFromAligned: ").bytesInProperUnit(pinnedFrom.getAlignedChunkBytes())
+                            .string("  pinnedFromUnaligned: ").bytesInProperUnit(pinnedFrom.getUnalignedChunkBytes())
+                            .string("  pinnedToAligned: ").bytesInProperUnit(pinnedTo.getAlignedChunkBytes())
+                            .string("  pinnedToUnaligned: ").bytesInProperUnit(pinnedTo.getUnalignedChunkBytes())
+                            .string("  returns: ").bytesInProperUnit(result).string(" ]").newline();
         }
         return result;
     }

--- a/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/HeapPolicy.java
+++ b/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/HeapPolicy.java
@@ -191,7 +191,7 @@ public class HeapPolicy {
         final Log trace = Log.noopLog().string("[HeapPolicy.getMaximumYoungGenerationSize:");
         if (maximumYoungGenerationSize.aboveThan(WordFactory.zero())) {
             /* If someone has set the young generation size, use that value. */
-            trace.string("  returns maximumYoungGenerationSize: ").unsigned(maximumYoungGenerationSize).string(" ]").newline();
+            trace.string("  returns maximumYoungGenerationSize: ").bytesInProperUnit(maximumYoungGenerationSize).string(" ]").newline();
             return maximumYoungGenerationSize;
         }
         final XOptions.XFlag xmn = XOptions.getXmn();
@@ -199,7 +199,7 @@ public class HeapPolicy {
             /* If `-Xmn` has been parsed from the command line, use that value. */
             trace.string("  -Xmn.epoch: ").unsigned(xmn.getEpoch()).string("  -Xmn.value: ").unsigned(xmn.getValue());
             setMaximumYoungGenerationSize(WordFactory.unsigned(xmn.getValue()));
-            trace.string("  returns: ").unsigned(maximumYoungGenerationSize)
+            trace.string("  returns: ").bytesInProperUnit(maximumYoungGenerationSize)
                             .string(" ]").newline();
             return maximumYoungGenerationSize;
         }
@@ -209,7 +209,7 @@ public class HeapPolicy {
         /* But not more than 256MB. */
         final UnsignedWord maxSize = m(256);
         final UnsignedWord youngSize = (youngSizeAsFraction.belowOrEqual(maxSize) ? youngSizeAsFraction : maxSize);
-        trace.string("  youngSize: ").unsigned(youngSize)
+        trace.string("  youngSize: ").bytesInProperUnit(youngSize)
                         .string(" ]").newline();
         /* But do not cache the result as it is based on values that might change. */
         return youngSize;
@@ -255,7 +255,7 @@ public class HeapPolicy {
         final Log trace = Log.noopLog().string("[HeapPolicy.setMaximumHeapSize:");
         final UnsignedWord result = maximumHeapSize;
         maximumHeapSize = value;
-        trace.string("  old: ").unsigned(result).string("  new: ").unsigned(maximumHeapSize).string(" ]").newline();
+        trace.string("  old: ").bytesInProperUnit(result).string("  new: ").bytesInProperUnit(maximumHeapSize).string(" ]").newline();
         return result;
     }
 
@@ -264,7 +264,7 @@ public class HeapPolicy {
         final Log trace = Log.noopLog().string("[HeapPolicy.getMinimumHeapSize:");
         if (minimumHeapSize.aboveThan(WordFactory.zero())) {
             /* If someone has set the minimum heap size, use that value. */
-            trace.string("  returns: ").unsigned(minimumHeapSize).string(" ]").newline();
+            trace.string("  returns: ").bytesInProperUnit(minimumHeapSize).string(" ]").newline();
             return minimumHeapSize;
         }
         final XOptions.XFlag xms = XOptions.getXms();
@@ -273,7 +273,7 @@ public class HeapPolicy {
             /* If `-Xms` has been parsed from the command line, use that value. */
             trace.string("  -Xms.epoch: ").unsigned(xms.getEpoch()).string("  -Xms.value: ").unsigned(xms.getValue());
             setMinimumHeapSize(WordFactory.unsigned(xms.getValue()));
-            trace.string("  returns: ").unsigned(minimumHeapSize).string(" ]").newline();
+            trace.string("  returns: ").bytesInProperUnit(minimumHeapSize).string(" ]").newline();
             return minimumHeapSize;
         }
         /* A default value chosen to delay the first full collection. */
@@ -283,7 +283,7 @@ public class HeapPolicy {
             result = getMaximumHeapSize();
         }
         /* But do not cache the result as it is based on values that might change. */
-        trace.string("  returns: ").unsigned(result).string(" ]").newline();
+        trace.string("  returns: ").bytesInProperUnit(result).string(" ]").newline();
         return result;
     }
 
@@ -432,6 +432,7 @@ public class HeapPolicy {
             @Override
             public void maybeCauseCollection() {
                 final HeapImpl heap = HeapImpl.getHeapImpl();
+                heap.getYoungGeneration().getSpace().getChunkBytes();
                 /* Has there been enough allocation to provoke a collection? */
                 if (bytesAllocatedSinceLastCollection.get().aboveOrEqual(getMaximumYoungGenerationSize())) {
                     heap.getGCImpl().collectWithoutAllocating("CollectOnAllocation.Sometimes");

--- a/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/PinnedAllocatorImpl.java
+++ b/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/PinnedAllocatorImpl.java
@@ -168,7 +168,7 @@ public final class PinnedAllocatorImpl extends PinnedAllocator {
 
         if (largestChunk.isNonNull()) {
             log().string("[PinnedAllocatorImpl.tryReuseExistingChunk:").string("  tlab: ").hex(tlab);
-            log().string("  available bytes: ").unsigned(largestAvailable);
+            log().string("  available bytes: ").bytesInProperUnit(largestAvailable);
             log().string("  re-using largestChunk: ").hex(largestChunk);
             log().string("  chunk space: ").string(largestChunk.getSpace().getName());
             log().string("]").newline();
@@ -177,7 +177,7 @@ public final class PinnedAllocatorImpl extends PinnedAllocator {
             reuseExistingChunkUninterruptibly(largestChunk, tlab);
 
         } else {
-            log().string("[PinnedAllocatorImpl.tryReuseExistingChunk:").string("  tlab: ").hex(tlab).string(" available bytes: ").unsigned(largestAvailable).string(
+            log().string("[PinnedAllocatorImpl.tryReuseExistingChunk:").string("  tlab: ").hex(tlab).string(" available bytes: ").bytesInProperUnit(largestAvailable).string(
                             " not reusing a chunk]").newline();
         }
     }

--- a/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/Space.java
+++ b/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/Space.java
@@ -229,7 +229,7 @@ public class Space {
      * This is "slow-path" memory allocation.
      */
     private Pointer allocateMemory(UnsignedWord objectSize) {
-        final Log trace = Log.noopLog().string("[SpaceImpl.allocateMemory:").string("  space: ").string(getName()).string("  size: ").unsigned(objectSize).newline();
+        final Log trace = Log.noopLog().string("[SpaceImpl.allocateMemory:").string("  space: ").string(getName()).string("  size: ").bytesInProperUnit(objectSize).newline();
         Pointer result = WordFactory.nullPointer();
         /* First try allocating in the last chunk. */
         final AlignedHeapChunk.AlignedHeader oldChunk = getLastAlignedHeapChunk();
@@ -643,13 +643,13 @@ public class Space {
         /* ObjectAccess.writeWord needs an Object as a 0th argument. */
         /* - Allocate memory for the copy in this Space. */
         final UnsignedWord copySize = LayoutEncoding.getSizeFromObject(originalObj);
-        trace.string("  copySize: ").unsigned(copySize);
+        trace.string("  copySize: ").bytesInProperUnit(copySize);
         final Pointer copyMemory = allocateMemory(copySize);
         trace.string("  copyMemory: ").hex(copyMemory);
         if (copyMemory.isNull()) {
             /* I am about to fail, but first log some things about the object. */
             final Log failureLog = Log.log().string("[! SpaceImpl.copyAlignedObject:").indent(true);
-            failureLog.string("  failure to allocate ").unsigned(copySize).string(" bytes").newline();
+            failureLog.string("  failure to allocate ").bytesInProperUnit(copySize).string(" bytes").newline();
             ObjectHeaderImpl.getObjectHeaderImpl().objectHeaderToLog(originalObj, failureLog);
             failureLog.string(" !]").indent(false);
             throw VMError.shouldNotReachHere("Promotion failure");
@@ -871,37 +871,37 @@ public class Space {
         }
 
         public void report(Log reportLog) {
-            reportLog.string("aligned: ").unsigned(alignedChunkBytes).string("/").unsigned(alignedCount);
+            reportLog.string("aligned: ").bytesInProperUnit(alignedChunkBytes).string("/").unsigned(alignedCount);
             reportLog.string(" ");
-            reportLog.string("unaligned: ").unsigned(unalignedChunkBytes).string("/").unsigned(unalignedCount);
+            reportLog.string("unaligned: ").bytesInProperUnit(unalignedChunkBytes).string("/").unsigned(unalignedCount);
         }
 
         void noteAlignedHeapChunk(UnsignedWord size) {
-            log.string("[Space.Accounting.NoteAlignedChunk(").string("size: ").unsigned(size).string(")");
+            log.string("[Space.Accounting.NoteAlignedChunk(").string("size: ").bytesInProperUnit(size).string(")");
             alignedCount += 1;
             alignedChunkBytes = alignedChunkBytes.add(size);
-            log.string("  alignedCount: ").unsigned(alignedCount).string("  alignedChunkBytes: ").unsigned(alignedChunkBytes).string("]").newline();
+            log.string("  alignedCount: ").unsigned(alignedCount).string("  alignedChunkBytes: ").bytesInProperUnit(alignedChunkBytes).string("]").newline();
         }
 
         void unnoteAlignedHeapChunk(UnsignedWord size) {
-            log.string("[Space.Accounting.unnoteAlignedChunk(").string("size: ").unsigned(size).string(")");
+            log.string("[Space.Accounting.unnoteAlignedChunk(").string("size: ").bytesInProperUnit(size).string(")");
             alignedCount -= 1;
             alignedChunkBytes = alignedChunkBytes.subtract(size);
-            log.string("  alignedCount: ").unsigned(alignedCount).string("  alignedChunkBytes: ").unsigned(alignedChunkBytes).string("]").newline();
+            log.string("  alignedCount: ").unsigned(alignedCount).string("  alignedChunkBytes: ").bytesInProperUnit(alignedChunkBytes).string("]").newline();
         }
 
         void noteUnalignedHeapChunk(UnsignedWord size) {
-            log.string("[Space.Accounting.NoteUnalignedChunk(").string("size: ").unsigned(size).string(")");
+            log.string("[Space.Accounting.NoteUnalignedChunk(").string("size: ").bytesInProperUnit(size).string(")");
             unalignedCount += 1;
             unalignedChunkBytes = unalignedChunkBytes.add(size);
-            log.string("  unalignedCount: ").unsigned(unalignedCount).string("  unalignedChunkBytes: ").unsigned(unalignedChunkBytes).newline();
+            log.string("  unalignedCount: ").unsigned(unalignedCount).string("  unalignedChunkBytes: ").bytesInProperUnit(unalignedChunkBytes).newline();
         }
 
         void unnoteUnalignedHeapChunk(UnsignedWord size) {
-            log.string("Space.Accounting.unnoteUnalignedChunk(").string("size: ").unsigned(size).string(")");
+            log.string("Space.Accounting.unnoteUnalignedChunk(").string("size: ").bytesInProperUnit(size).string(")");
             unalignedCount -= 1;
             unalignedChunkBytes = unalignedChunkBytes.subtract(size);
-            log.string("  unalignedCount: ").unsigned(unalignedCount).string("  unalignedChunkBytes: ").unsigned(unalignedChunkBytes).string("]").newline();
+            log.string("  unalignedCount: ").unsigned(unalignedCount).string("  unalignedChunkBytes: ").bytesInProperUnit(unalignedChunkBytes).string("]").newline();
         }
 
         public void reset() {

--- a/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/ThreadLocalAllocation.java
+++ b/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/ThreadLocalAllocation.java
@@ -529,7 +529,7 @@ public final class ThreadLocalAllocation {
             UnsignedWord aChunkUsedMemory = top.subtract(start);
             alignedUsedMemory = alignedUsedMemory.add(aChunkUsedMemory);
 
-            log.string("     aligned chunk: ").hex(aChunk).string(" | used memory: ").unsigned(aChunkUsedMemory).newline();
+            log.string("     aligned chunk: ").hex(aChunk).string(" | used memory: ").bytesInProperUnit(aChunkUsedMemory).newline();
             aChunk = next;
         }
 
@@ -541,16 +541,16 @@ public final class ThreadLocalAllocation {
             UnsignedWord uChunkUsedMemory = UnalignedHeapChunk.usedObjectMemoryOfUnalignedHeapChunk(uChunk);
             unalignedUsedMemory = unalignedUsedMemory.add(uChunkUsedMemory);
 
-            log.string("     unaligned chunk ").hex(uChunk).string(" | used memory: ").unsigned(uChunkUsedMemory).newline();
+            log.string("     unaligned chunk ").hex(uChunk).string(" | used memory: ").bytesInProperUnit(uChunkUsedMemory).newline();
             uChunk = next;
         }
 
         UnsignedWord tlabUsedMemory = alignedUsedMemory.add(unalignedUsedMemory);
 
         log.newline();
-        log.string("  aligned used memory: ").unsigned(alignedUsedMemory).newline();
-        log.string("  unaligned used memory: ").unsigned(unalignedUsedMemory).newline();
-        log.string("  TLAB used memory: ").unsigned(tlabUsedMemory).newline();
+        log.string("  aligned used memory: ").bytesInProperUnit(alignedUsedMemory).newline();
+        log.string("  unaligned used memory: ").bytesInProperUnit(unalignedUsedMemory).newline();
+        log.string("  TLAB used memory: ").bytesInProperUnit(tlabUsedMemory).newline();
 
         log.string("  ]").newline();
 

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/log/Log.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/log/Log.java
@@ -236,6 +236,12 @@ public abstract class Log implements AutoCloseable {
     @RestrictHeapAccess(access = RestrictHeapAccess.Access.NO_ALLOCATION, reason = "Must not allocate when logging.")
     public abstract Log unsigned(long value, int fill, int align);
 
+    /**
+     * Prints the value, treated as an unsigned value, in decimal format.
+     */
+    @RestrictHeapAccess(access = RestrictHeapAccess.Access.NO_ALLOCATION, reason = "Must not allocate when logging.")
+    public abstract Log bytesInProperUnit(WordBase value);
+
     @RestrictHeapAccess(access = RestrictHeapAccess.Access.NO_ALLOCATION, reason = "Must not allocate when logging.")
     public abstract Log rational(long numerator, long denominator, long decimals);
 
@@ -451,6 +457,11 @@ public abstract class Log implements AutoCloseable {
 
         @Override
         public Log unsigned(long value, int fill, int align) {
+            return this;
+        }
+
+        @Override
+        public Log bytesInProperUnit(WordBase value) {
             return this;
         }
 

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/log/RealLog.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/log/RealLog.java
@@ -45,6 +45,10 @@ import com.oracle.svm.core.util.VMError;
 
 public class RealLog extends Log {
 
+    private static final long K = 1024 * 1;
+    private static final long M = 1024 * K;
+    private static final long G = 1024 * M;
+
     private boolean autoflush = false;
     private int indent = 0;
 
@@ -283,6 +287,23 @@ public class RealLog extends Log {
     @Override
     public Log unsigned(long value, int fill, int align) {
         return number(value, 10, false, fill, align);
+    }
+
+    @Override
+    public Log bytesInProperUnit(WordBase value) {
+        long val = value.rawValue();
+        char unit = ' ';
+        if (val >= 100 * G) {
+            val = val / G;
+            unit ='G';
+        } else if (val >= 100 * M) {
+            val = val / M;
+            unit = 'M';
+        } else if (val >= 100 * K) {
+            val = val / K;
+            unit = 'K';
+        }
+        return number(val, 10, false).character(unit);
     }
 
     /**


### PR DESCRIPTION
Log messages in SubstrateVM's GC are logging all memory sizes in bytes, which is hard to read. I propose to auto-convert it into sensible units. E.g. 123456 becomes 123K, 1234567890 becomes 1234M and so on. This makes it much easier for humans to make sense of the numbers (IMO).