### PR TITLE
Generalize barrier info on nodes. Figure out GC specific properties i…

### DIFF
--- a/compiler/src/org.graalvm.compiler.hotspot.test/src/org/graalvm/compiler/hotspot/test/WriteBarrierAdditionTest.java
+++ b/compiler/src/org.graalvm.compiler.hotspot.test/src/org/graalvm/compiler/hotspot/test/WriteBarrierAdditionTest.java
@@ -315,9 +315,10 @@ public class WriteBarrierAdditionTest extends HotSpotGraalCompilerTest {
                     JavaConstant constDisp = ((OffsetAddressNode) read.getAddress()).getOffset().asJavaConstant();
                     Assert.assertNotNull(constDisp);
                     Assert.assertEquals(referentOffset(getMetaAccess()), constDisp.asLong());
-                    Assert.assertTrue(config.useG1GC);
-                    Assert.assertEquals(BarrierType.PRECISE, read.getBarrierType());
-                    Assert.assertTrue(read.next() instanceof G1ReferentFieldReadBarrier);
+                    Assert.assertEquals(BarrierType.WEAK_FIELD, read.getBarrierType());
+                    if (config.useG1GC) {
+                        Assert.assertTrue(read.next() instanceof G1ReferentFieldReadBarrier);
+                    }
                 }
             }
         } catch (Throwable e) {

--- a/compiler/src/org.graalvm.compiler.hotspot/src/org/graalvm/compiler/hotspot/gc/shared/BarrierSet.java
+++ b/compiler/src/org.graalvm.compiler.hotspot/src/org/graalvm/compiler/hotspot/gc/shared/BarrierSet.java
@@ -25,6 +25,7 @@
  */
 package org.graalvm.compiler.hotspot.gc.shared;
 
+import org.graalvm.compiler.hotspot.GraalHotSpotVMConfig;
 import org.graalvm.compiler.nodes.StructuredGraph;
 import org.graalvm.compiler.nodes.extended.ArrayRangeWrite;
 import org.graalvm.compiler.nodes.java.AbstractCompareAndSwapNode;
@@ -33,6 +34,16 @@ import org.graalvm.compiler.nodes.memory.ReadNode;
 import org.graalvm.compiler.nodes.memory.WriteNode;
 
 public abstract class BarrierSet {
+    private final GraalHotSpotVMConfig vmConfig;
+
+    protected BarrierSet(GraalHotSpotVMConfig vmConfig) {
+        this.vmConfig = vmConfig;
+    }
+
+    public final GraalHotSpotVMConfig getVMConfig() {
+        return vmConfig;
+    }
+
     public abstract void addReadNodeBarriers(ReadNode node, StructuredGraph graph);
 
     public abstract void addWriteNodeBarriers(WriteNode node, StructuredGraph graph);

--- a/compiler/src/org.graalvm.compiler.hotspot/src/org/graalvm/compiler/hotspot/meta/DefaultHotSpotLoweringProvider.java
+++ b/compiler/src/org.graalvm.compiler.hotspot/src/org/graalvm/compiler/hotspot/meta/DefaultHotSpotLoweringProvider.java
@@ -582,16 +582,6 @@ public class DefaultHotSpotLoweringProvider extends DefaultJavaLoweringProvider 
         graph.replaceFixed(storeHub, hub);
     }
 
-    @Override
-    public BarrierType fieldInitializationBarrier(JavaKind entryKind) {
-        return (entryKind == JavaKind.Object && !runtime.getVMConfig().useDeferredInitBarriers) ? BarrierType.IMPRECISE : BarrierType.NONE;
-    }
-
-    @Override
-    public BarrierType arrayInitializationBarrier(JavaKind entryKind) {
-        return (entryKind == JavaKind.Object && !runtime.getVMConfig().useDeferredInitBarriers) ? BarrierType.PRECISE : BarrierType.NONE;
-    }
-
     private void lowerOSRStartNode(OSRStartNode osrStart) {
         StructuredGraph graph = osrStart.graph();
         if (graph.getGuardsStage() == StructuredGraph.GuardsStage.FIXED_DEOPTS) {
@@ -782,12 +772,11 @@ public class DefaultHotSpotLoweringProvider extends DefaultJavaLoweringProvider 
     @Override
     protected BarrierType fieldLoadBarrierType(ResolvedJavaField f) {
         HotSpotResolvedJavaField loadField = (HotSpotResolvedJavaField) f;
-        BarrierType barrierType = BarrierType.NONE;
-        if (runtime.getVMConfig().useG1GC && loadField.getJavaKind() == JavaKind.Object && metaAccess.lookupJavaType(Reference.class).equals(loadField.getDeclaringClass()) &&
+        if (loadField.getJavaKind() == JavaKind.Object && metaAccess.lookupJavaType(Reference.class).equals(loadField.getDeclaringClass()) &&
                         loadField.getName().equals("referent")) {
-            barrierType = BarrierType.PRECISE;
+            return BarrierType.WEAK_FIELD;
         }
-        return barrierType;
+        return super.fieldLoadBarrierType(f);
     }
 
     @Override

--- a/compiler/src/org.graalvm.compiler.hotspot/src/org/graalvm/compiler/hotspot/phases/WriteBarrierAdditionPhase.java
+++ b/compiler/src/org.graalvm.compiler.hotspot/src/org/graalvm/compiler/hotspot/phases/WriteBarrierAdditionPhase.java
@@ -77,17 +77,17 @@ public class WriteBarrierAdditionPhase extends Phase {
 
     private BarrierSet createBarrierSet(GraalHotSpotVMConfig config) {
         if (config.useG1GC) {
-            return createG1BarrierSet();
+            return createG1BarrierSet(config);
         } else {
-            return createCardTableBarrierSet();
+            return createCardTableBarrierSet(config);
         }
     }
 
-    protected BarrierSet createCardTableBarrierSet() {
-        return new CardTableBarrierSet();
+    protected BarrierSet createCardTableBarrierSet(GraalHotSpotVMConfig config) {
+        return new CardTableBarrierSet(config);
     }
 
-    protected BarrierSet createG1BarrierSet() {
-        return new G1BarrierSet();
+    protected BarrierSet createG1BarrierSet(GraalHotSpotVMConfig config) {
+        return new G1BarrierSet(config);
     }
 }

--- a/compiler/src/org.graalvm.compiler.hotspot/src/org/graalvm/compiler/hotspot/phases/WriteBarrierVerificationPhase.java
+++ b/compiler/src/org.graalvm.compiler.hotspot/src/org/graalvm/compiler/hotspot/phases/WriteBarrierVerificationPhase.java
@@ -44,6 +44,7 @@ import org.graalvm.compiler.nodes.ValueNode;
 import org.graalvm.compiler.nodes.extended.ArrayRangeWrite;
 import org.graalvm.compiler.nodes.java.LoweredAtomicReadAndWriteNode;
 import org.graalvm.compiler.nodes.java.LogicCompareAndSwapNode;
+import org.graalvm.compiler.nodes.java.ValueCompareAndSwapNode;
 import org.graalvm.compiler.nodes.memory.FixedAccessNode;
 import org.graalvm.compiler.nodes.memory.HeapAccess;
 import org.graalvm.compiler.nodes.memory.HeapAccess.BarrierType;
@@ -127,6 +128,9 @@ public class WriteBarrierVerificationPhase extends Phase {
         boolean validatePreBarrier = useG1GC() && (isObjectWrite(node) || !((ArrayRangeWrite) node).isInitialization());
         if (node instanceof WriteNode) {
             WriteNode writeNode = (WriteNode) node;
+            if (config.useDeferredInitBarriers && writeNode.getLocationIdentity().isInit()) {
+                return true;
+            }
             if (writeNode.getLocationIdentity().isInit()) {
                 validatePreBarrier = false;
             }
@@ -191,7 +195,8 @@ public class WriteBarrierVerificationPhase extends Phase {
     }
 
     private static boolean validateBarrier(FixedAccessNode write, ObjectWriteBarrier barrier) {
-        assert write instanceof WriteNode || write instanceof LogicCompareAndSwapNode || write instanceof LoweredAtomicReadAndWriteNode : "Node must be of type requiring a write barrier " + write;
+        assert write instanceof WriteNode || write instanceof LogicCompareAndSwapNode || write instanceof ValueCompareAndSwapNode ||
+                        write instanceof LoweredAtomicReadAndWriteNode : "Node must be of type requiring a write barrier " + write;
         if (!barrier.usePrecise()) {
             if (barrier.getAddress() instanceof OffsetAddressNode && write.getAddress() instanceof OffsetAddressNode) {
                 return GraphUtil.unproxify(((OffsetAddressNode) barrier.getAddress()).getBase()) == GraphUtil.unproxify(((OffsetAddressNode) write.getAddress()).getBase());

--- a/compiler/src/org.graalvm.compiler.hotspot/src/org/graalvm/compiler/hotspot/replacements/UnsafeLoadSnippets.java
+++ b/compiler/src/org.graalvm.compiler.hotspot/src/org/graalvm/compiler/hotspot/replacements/UnsafeLoadSnippets.java
@@ -50,7 +50,7 @@ public class UnsafeLoadSnippets implements Snippets {
     public static Object lowerUnsafeLoad(Object object, long offset) {
         Object fixedObject = FixedValueAnchorNode.getObject(object);
         if (object instanceof java.lang.ref.Reference && referentOffset(INJECTED_METAACCESS) == offset) {
-            return Word.objectToTrackedPointer(fixedObject).readObject((int) offset, BarrierType.PRECISE);
+            return Word.objectToTrackedPointer(fixedObject).readObject((int) offset, BarrierType.WEAK_FIELD);
         } else {
             return Word.objectToTrackedPointer(fixedObject).readObject((int) offset, BarrierType.NONE);
         }

--- a/compiler/src/org.graalvm.compiler.nodes/src/org/graalvm/compiler/nodes/memory/HeapAccess.java
+++ b/compiler/src/org.graalvm.compiler.nodes/src/org/graalvm/compiler/nodes/memory/HeapAccess.java
@@ -34,17 +34,25 @@ public interface HeapAccess {
      */
     enum BarrierType {
         /**
-         * Primitive stores which do not necessitate barriers.
+         * Primitive access which do not necessitate barriers.
          */
         NONE,
         /**
-         * Array object stores which necessitate precise barriers.
+         * Array object access.
          */
-        PRECISE,
+        ARRAY,
         /**
-         * Field object stores which necessitate imprecise barriers.
+         * Field object access.
          */
-        IMPRECISE
+        FIELD,
+        /**
+         * Unknown (aka field or array) object access.
+         */
+        UNKNOWN,
+        /**
+         * Weak field access (e.g. Hotspot's Reference.referent field).
+         */
+        WEAK_FIELD
     }
 
     /**

--- a/compiler/src/org.graalvm.compiler.word/src/org/graalvm/compiler/word/WordOperationPlugin.java
+++ b/compiler/src/org.graalvm.compiler.word/src/org/graalvm/compiler/word/WordOperationPlugin.java
@@ -447,7 +447,7 @@ public class WordOperationPlugin implements NodePlugin, TypePlugin, InlineInvoke
 
     protected ValueNode readOp(GraphBuilderContext b, JavaKind readKind, AddressNode address, LocationIdentity location, Opcode op) {
         assert op == Opcode.READ_POINTER || op == Opcode.READ_OBJECT || op == Opcode.READ_BARRIERED;
-        final BarrierType barrier = (op == Opcode.READ_BARRIERED ? BarrierType.PRECISE : BarrierType.NONE);
+        final BarrierType barrier = (op == Opcode.READ_BARRIERED ? BarrierType.UNKNOWN : BarrierType.NONE);
         final boolean compressible = (op == Opcode.READ_OBJECT || op == Opcode.READ_BARRIERED);
 
         return readOp(b, readKind, address, location, barrier, compressible);
@@ -465,7 +465,7 @@ public class WordOperationPlugin implements NodePlugin, TypePlugin, InlineInvoke
 
     protected void writeOp(GraphBuilderContext b, JavaKind writeKind, AddressNode address, LocationIdentity location, ValueNode value, Opcode op) {
         assert op == Opcode.WRITE_POINTER || op == Opcode.WRITE_OBJECT || op == Opcode.WRITE_BARRIERED || op == Opcode.INITIALIZE;
-        final BarrierType barrier = (op == Opcode.WRITE_BARRIERED ? BarrierType.PRECISE : BarrierType.NONE);
+        final BarrierType barrier = (op == Opcode.WRITE_BARRIERED ? BarrierType.UNKNOWN : BarrierType.NONE);
         final boolean compressible = (op == Opcode.WRITE_OBJECT || op == Opcode.WRITE_BARRIERED);
         assert op != Opcode.INITIALIZE || location.isInit() : "must use init location for initializing";
         b.add(new JavaWriteNode(writeKind, address, location, value, barrier, compressible));

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/thread/VMThreadSTFeature.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/thread/VMThreadSTFeature.java
@@ -174,14 +174,14 @@ public class VMThreadSTFeature implements GraalFeature {
     private boolean handleGet(GraphBuilderContext b, ResolvedJavaMethod targetMethod, Receiver receiver) {
         VMThreadLocalInfo info = threadLocalCollector.findInfo(b, receiver.get());
         VMThreadLocalSTHolderNode holder = b.add(new VMThreadLocalSTHolderNode(info));
-        b.addPush(targetMethod.getSignature().getReturnKind(), new LoadVMThreadLocalNode(b.getMetaAccess(), info, holder, BarrierType.PRECISE));
+        b.addPush(targetMethod.getSignature().getReturnKind(), new LoadVMThreadLocalNode(b.getMetaAccess(), info, holder, BarrierType.ARRAY));
         return true;
     }
 
     private boolean handleSet(GraphBuilderContext b, Receiver receiver, ValueNode valueNode) {
         VMThreadLocalInfo info = threadLocalCollector.findInfo(b, receiver.get());
         VMThreadLocalSTHolderNode holder = b.add(new VMThreadLocalSTHolderNode(info));
-        b.add(new StoreVMThreadLocalNode(info, holder, valueNode, BarrierType.PRECISE));
+        b.add(new StoreVMThreadLocalNode(info, holder, valueNode, BarrierType.ARRAY));
         return true;
     }
 


### PR DESCRIPTION
As discussed here:
 https://mail.openjdk.java.net/pipermail/graal-dev/2019-February/005634.html
I would like to generalize the GC barrier information that we carry around in nodes. Instead of the rather GC specific PRECISE vs IMPRECISE information, I'd prefer to record whether or not the access is to array element or a field, and whether or not the access is to primitive field or object field. We also need to know if it's the special access to a Reference.referent field.

I tried to determine the primitive vs. object field information in the backend from the JavaKind of the node (or in case of writes, its value), but it turns out this not always consistent with the information carried in BarrierType. I suspect that object writes can sometimes be generated that don't require a barrier?

Notice that the implementation covers the need for current barriers. This means it's equivalent to what was there before. It's not yet generating the correct information for loads, yet (except for the referent field access), because no GC currently needs it. I will get to this later, when adding support for Shenandoah and/or ZGC, which will require this sort of information. I'd rather not do this blindly. ;-)
