### PR TITLE
Fix compiling issue after LLVM backend patch merged.

### DIFF
--- a/compiler/mx.compiler/suite.py
+++ b/compiler/mx.compiler/suite.py
@@ -240,6 +240,10 @@ suite = {
               "classifier": "linux-x86_64"
             },
           },
+          "<others>": {
+            "path": "",
+            "optional": True
+          }
         },
         "darwin": {
           "amd64": {
@@ -251,6 +255,10 @@ suite = {
               "classifier": "macosx-x86_64"
             }
           },
+          "<others>": {
+            "path": "",
+            "optional": True
+          }
         },
         "windows": {
           "amd64": {
@@ -262,6 +270,10 @@ suite = {
               "classifier": "windows-x86_64"
             },
           },
+          "<others>": {
+            "path": "",
+            "optional": True
+          }
         },
         "<others>": {
           "<others>": {


### PR DESCRIPTION
The graal master compiles fails on AArch64 when running "mx build",
due to the omissive settings of LLVM_PLATFORM_SPECIFIC. This patch
will add optional attribute to it for other platforms except amd64.

Change-Id: I57bb3c1b075483ff475d66ea6be6bf3a02c85614