### PR TITLE
Use add(extended) to generate array index offset for AArch64.

### DIFF
--- a/compiler/src/org.graalvm.compiler.core.aarch64.test/src/org/graalvm/compiler/core/aarch64/test/AArch64ArrayAddressTest.java
+++ b/compiler/src/org.graalvm.compiler.core.aarch64.test/src/org/graalvm/compiler/core/aarch64/test/AArch64ArrayAddressTest.java
@@ -1,0 +1,224 @@
+/*
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Arm Limited. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.graalvm.compiler.core.aarch64.test;
+
+import org.graalvm.compiler.lir.LIRInstruction;
+import org.graalvm.compiler.lir.aarch64.AArch64ArithmeticOp.ExtendedAddShiftOp;
+import org.junit.Test;
+
+import java.util.ArrayDeque;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.function.Predicate;
+
+public class AArch64ArrayAddressTest extends AArch64MatchRuleTest {
+    private static final Predicate<LIRInstruction> predicate = op -> (op instanceof ExtendedAddShiftOp);
+
+    public static byte loadByte(byte[] arr, int n) {
+        return arr[n];
+    }
+
+    @Test
+    public void testLoadByte() {
+        byte[] arr = {3, 4, 5, 6, 7, 8};
+        test("loadByte", arr, 5);
+        checkLIR("loadByte", predicate, 1, 1);
+    }
+
+    public static char loadChar(char[] arr, int n) {
+        return arr[n];
+    }
+
+    @Test
+    public void testLoadChar() {
+        char[] arr = {'a', 'b', 'c', 'd', 'e', 'f', 'g'};
+        test("loadChar", arr, 5);
+        checkLIR("loadChar", predicate, 1, 1);
+    }
+
+    public static short loadShort(short[] arr, int n) {
+        return arr[n];
+    }
+
+    @Test
+    public void testLoadShort() {
+        short[] arr = {3, 4, 5, 6, 7, 8};
+        test("loadShort", arr, 5);
+        checkLIR("loadShort", predicate, 1, 1);
+    }
+
+    public static int loadInt(int[] arr, int n) {
+        return arr[n];
+    }
+
+    @Test
+    public void testLoadInt() {
+        int[] arr = {3, 4, 5, 6, 7, 8};
+        test("loadInt", arr, 5);
+        checkLIR("loadInt", predicate, 1, 1);
+    }
+
+    public static long loadLong(long[] arr, int n) {
+        return arr[n];
+    }
+
+    @Test
+    public void testLoadLong() {
+        long[] arr = {3L, 4L, 5L, 6L, 7L, 8L};
+        test("loadLong", arr, 5);
+        checkLIR("loadLong", predicate, 1, 1);
+    }
+
+    public static float loadFloat(float[] arr, int n) {
+        return arr[n];
+    }
+
+    @Test
+    public void testLoadFloat() {
+        float[] arr = {3.0F, 4.0F, 5.0F, 6.0F, 7.0F, 8.0F};
+        test("loadFloat", arr, 5);
+        checkLIR("loadFloat", predicate, 1, 1);
+    }
+
+    public static double loadDouble(double[] arr, int n) {
+        return arr[n];
+    }
+
+    @Test
+    public void testLoadDouble() {
+        double[] arr = {3.0, 4.0, 5.0, 6.0, 7.0, 8.0};
+        test("loadDouble", arr, 5);
+        checkLIR("loadDouble", predicate, 1, 1);
+    }
+
+    public static String loadObject(String[] arr, int n) {
+        return arr[n];
+    }
+
+    @Test
+    public void testLoadObject() {
+        String[] arr = {"ac", "ad", "ew", "asf", "sdad", "aff"};
+        test("loadObject", arr, 5);
+        checkLIRforAll("loadObject", predicate, 1);
+    }
+
+    public static int storeInt(int[] arr, int n) {
+        arr[n] = n * n;
+        return arr[n];
+    }
+
+    @Test
+    public void testStoreInt() {
+        int[] arr = {3, 4, 5, 6, 7, 8};
+        test("storeInt", arr, 5);
+        checkLIRforAll("storeInt", predicate, 1);
+    }
+
+    public static Integer loadAndStoreObject(Integer[] arr, int i) {
+        if (arr[i] > 0) {
+            return 0;
+        }
+        arr[i] += 3;
+        return arr[i];
+    }
+
+    @Test
+    public void testLoadAndStoreObject() {
+        Integer[] arr = new Integer[]{1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
+        test("loadAndStoreObject", arr, 2);
+        checkLIRforAll("loadAndStoreObject", predicate, 2);
+    }
+
+    public static int useArrayInLoop(int[] arr) {
+        int ret = 0;
+        for (int i = 0; i < arr.length; i++) {
+            ret += arr[i];
+        }
+        return ret;
+    }
+
+    @Test
+    public void testUseArrayInLoop() {
+        int[] arr = {1, 2, 3, 4, 5, 6, 7, 8};
+        test("useArrayInLoop", arr);
+        checkLIRforAll("useArrayInLoop", predicate, 1);
+    }
+
+    public static int useArrayDeque(ArrayDeque<Integer> ad) {
+        ad.addFirst(4);
+        return ad.removeFirst();
+    }
+
+    @Test
+    public void testUseArrayDeque() {
+        ArrayDeque<Integer> ad = new ArrayDeque<>();
+        test("useArrayDeque", ad);
+    }
+
+    // Array load test when the index is narrowed firstly.
+    private static class Frame {
+        int index;
+
+        Frame(int index) {
+            this.index = index;
+        }
+    }
+
+    private static final Frame[] frameCache = new Frame[256];
+
+    private static Frame newFrame(byte data) {
+        return frameCache[data & 255];
+    }
+
+    public static int getFrameIndex(int n) {
+        return newFrame((byte) n).index;
+    }
+
+    @Test
+    public void testGetFrameIndex() {
+        for (int i = 0; i < 256; i++) {
+            frameCache[i] = new Frame(i * i);
+        }
+        test("getFrameIndex", 258);
+        checkLIRforAll("getFrameIndex", predicate, 1);
+    }
+
+    static Set<Long> allBarcodes = new HashSet<>();
+    static Set<Long> localBarcodes = new HashSet<>();
+
+    public static long useConstReferenceAsBase(long l) {
+        localBarcodes.add(l);
+        allBarcodes.add(l);
+        return l;
+    }
+
+    @Test
+    public void testUseConstReferenceAsBase() {
+        test("useConstReferenceAsBase", 2L);
+        int l = localBarcodes.size() + allBarcodes.size();
+        test("useConstReferenceAsBase", (long) l);
+    }
+}

--- a/compiler/src/org.graalvm.compiler.core.aarch64.test/src/org/graalvm/compiler/core/aarch64/test/AArch64ArrayAddressTest.java
+++ b/compiler/src/org.graalvm.compiler.core.aarch64.test/src/org/graalvm/compiler/core/aarch64/test/AArch64ArrayAddressTest.java
@@ -25,6 +25,7 @@
  */
 package org.graalvm.compiler.core.aarch64.test;
 
+import org.graalvm.compiler.api.directives.GraalDirectives;
 import org.graalvm.compiler.lir.LIRInstruction;
 import org.graalvm.compiler.lir.aarch64.AArch64ArithmeticOp.ExtendedAddShiftOp;
 import org.junit.Test;
@@ -155,7 +156,7 @@ public class AArch64ArrayAddressTest extends AArch64MatchRuleTest {
     public static int useArrayInLoop(int[] arr) {
         int ret = 0;
         for (int i = 0; i < arr.length; i++) {
-            ret += arr[i];
+            ret += GraalDirectives.opaque(arr[i]);
         }
         return ret;
     }

--- a/compiler/src/org.graalvm.compiler.core.aarch64/src/org/graalvm/compiler/core/aarch64/AArch64PointerAddNode.java
+++ b/compiler/src/org.graalvm.compiler.core.aarch64/src/org/graalvm/compiler/core/aarch64/AArch64PointerAddNode.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Arm Limited. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.graalvm.compiler.core.aarch64;
+
+import static org.graalvm.compiler.nodeinfo.NodeCycles.CYCLES_1;
+import static org.graalvm.compiler.nodeinfo.NodeSize.SIZE_1;
+
+import jdk.vm.ci.meta.AllocatableValue;
+import jdk.vm.ci.meta.Value;
+import org.graalvm.compiler.core.common.LIRKind;
+import org.graalvm.compiler.core.common.type.AbstractPointerStamp;
+import org.graalvm.compiler.core.common.type.IntegerStamp;
+import org.graalvm.compiler.core.common.type.StampFactory;
+import org.graalvm.compiler.graph.NodeClass;
+import org.graalvm.compiler.lir.aarch64.AArch64ArithmeticOp;
+import org.graalvm.compiler.lir.gen.ArithmeticLIRGeneratorTool;
+import org.graalvm.compiler.lir.gen.LIRGeneratorTool;
+import org.graalvm.compiler.nodeinfo.NodeInfo;
+import org.graalvm.compiler.nodes.NodeView;
+import org.graalvm.compiler.nodes.ValueNode;
+import org.graalvm.compiler.nodes.calc.FloatingNode;
+import org.graalvm.compiler.nodes.spi.ArithmeticLIRLowerable;
+import org.graalvm.compiler.nodes.spi.NodeLIRBuilderTool;
+
+@NodeInfo(nameTemplate = "AArch64PointerAdd", cycles = CYCLES_1, size = SIZE_1)
+public class AArch64PointerAddNode extends FloatingNode implements ArithmeticLIRLowerable {
+
+    public static final NodeClass<AArch64PointerAddNode> TYPE = NodeClass.create(AArch64PointerAddNode.class);
+
+    @Input ValueNode base;
+    @Input ValueNode offset;
+
+    public AArch64PointerAddNode(ValueNode base, ValueNode offset) {
+        super(TYPE, StampFactory.pointer());
+        this.base = base;
+        this.offset = offset;
+        assert base != null && (base.stamp(NodeView.DEFAULT) instanceof AbstractPointerStamp ||
+                        IntegerStamp.getBits(base.stamp(NodeView.DEFAULT)) == 64);
+        assert offset != null && offset.getStackKind().isNumericInteger();
+    }
+
+    public ValueNode getBase() {
+        return base;
+    }
+
+    public ValueNode getOffset() {
+        return offset;
+    }
+
+    @Override
+    public void generate(NodeLIRBuilderTool builder, ArithmeticLIRGeneratorTool gen) {
+        LIRGeneratorTool tool = builder.getLIRGeneratorTool();
+        Value x = builder.operand(base);
+        Value y = builder.operand(offset);
+        AllocatableValue baseValue = tool.asAllocatable(x);
+        AllocatableValue baseReference = LIRKind.derivedBaseFromValue(baseValue);
+        LIRKind kind = LIRKind.combineDerived(tool.getLIRKind(stamp(NodeView.DEFAULT)), baseReference, null);
+        builder.setResult(this, ((AArch64ArithmeticLIRGenerator) gen).emitBinary(kind, AArch64ArithmeticOp.ADD, true, x, y));
+    }
+}

--- a/compiler/src/org.graalvm.compiler.core.match.processor/src/org/graalvm/compiler/core/match/processor/MatchProcessor.java
+++ b/compiler/src/org.graalvm.compiler.core.match.processor/src/org/graalvm/compiler/core/match/processor/MatchProcessor.java
@@ -519,6 +519,9 @@ public class MatchProcessor extends AbstractProcessor {
             out.println("import org.graalvm.compiler.core.gen.NodeMatchRules;");
             out.println("import org.graalvm.compiler.graph.Position;");
             for (String p : info.requiredPackages) {
+                if (p.equals(pkg)) {
+                    continue;
+                }
                 out.println("import " + p + ".*;");
             }
             out.println("");
@@ -774,7 +777,7 @@ public class MatchProcessor extends AbstractProcessor {
                 if (mirror != null) {
                     matchableNodeAnnotations = getAnnotationValueList(mirror, "value", AnnotationMirror.class);
                 } else {
-                    mirror = getAnnotation(element, getType(MATCHABLE_NODES_CLASS_NAME));
+                    mirror = getAnnotation(element, getType(MATCHABLE_NODE_CLASS_NAME));
                     if (mirror != null) {
                         matchableNodeAnnotations = Collections.singletonList(mirror);
                     } else {

--- a/compiler/src/org.graalvm.compiler.hotspot/src/org/graalvm/compiler/hotspot/HotSpotReferenceMapBuilder.java
+++ b/compiler/src/org.graalvm.compiler.hotspot/src/org/graalvm/compiler/hotspot/HotSpotReferenceMapBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -114,7 +114,9 @@ public final class HotSpotReferenceMapBuilder extends ReferenceMapBuilder {
                 if (kind.isDerivedReference()) {
                     Variable baseVariable = (Variable) kind.getDerivedReferenceBase();
                     Value baseValue = state.getLiveBasePointers().get(baseVariable.index);
-                    assert baseValue.getPlatformKind().getVectorLength() == 1 && ((LIRKind) baseValue.getValueKind()).isReference(0) && !((LIRKind) baseValue.getValueKind()).isDerivedReference();
+                    assert baseValue.getPlatformKind().getVectorLength() == 1 &&
+                                    ((LIRKind) baseValue.getValueKind()).isReference(0) &&
+                                    !((LIRKind) baseValue.getValueKind()).isDerivedReference();
                     base = toLocation(baseValue, 0);
                 }
 

--- a/compiler/src/org.graalvm.compiler.lir/src/org/graalvm/compiler/lir/alloc/lsra/LinearScanLifetimeAnalysisPhase.java
+++ b/compiler/src/org.graalvm.compiler.lir/src/org/graalvm/compiler/lir/alloc/lsra/LinearScanLifetimeAnalysisPhase.java
@@ -48,6 +48,7 @@ import org.graalvm.compiler.debug.Assertions;
 import org.graalvm.compiler.debug.DebugContext;
 import org.graalvm.compiler.debug.GraalError;
 import org.graalvm.compiler.debug.Indent;
+import org.graalvm.compiler.lir.InstructionStateProcedure;
 import org.graalvm.compiler.lir.InstructionValueConsumer;
 import org.graalvm.compiler.lir.LIRInstruction;
 import org.graalvm.compiler.lir.LIRInstruction.OperandFlag;
@@ -70,6 +71,7 @@ import jdk.vm.ci.meta.Constant;
 import jdk.vm.ci.meta.JavaConstant;
 import jdk.vm.ci.meta.Value;
 import jdk.vm.ci.meta.ValueKind;
+import org.graalvm.compiler.lir.util.IndexedValueMap;
 
 public class LinearScanLifetimeAnalysisPhase extends LinearScanAllocationPhase {
 
@@ -749,12 +751,34 @@ public class LinearScanLifetimeAnalysisPhase extends LinearScanAllocationPhase {
                 }
             };
 
-            InstructionValueConsumer stateProc = (op, operand, mode, flags) -> {
+            InstructionValueConsumer nonBasePointersStateProc = (op, operand, mode, flags) -> {
                 if (LinearScan.isVariableOrRegister(operand)) {
                     int opId = op.id();
                     int blockFrom = allocator.getFirstLirInstructionId((allocator.blockForId(opId)));
                     addUse((AllocatableValue) operand, blockFrom, opId + 1, RegisterPriority.None, operand.getValueKind(), detailedAsserts);
                 }
+            };
+            InstructionValueConsumer basePointerStateProc = (op, operand, mode, flags) -> {
+                if (LinearScan.isVariableOrRegister(operand)) {
+                    int opId = op.id();
+                    int blockFrom = allocator.getFirstLirInstructionId((allocator.blockForId(opId)));
+                    /*
+                     * Setting priority of base pointers to ShouldHaveRegister to avoid
+                     * rematerialization (see #getMaterializedValue).
+                     */
+                    addUse((AllocatableValue) operand, blockFrom, opId + 1, RegisterPriority.ShouldHaveRegister, operand.getValueKind(), detailedAsserts);
+                }
+            };
+
+            InstructionStateProcedure stateProc = (op, state) -> {
+                IndexedValueMap liveBasePointers = state.getLiveBasePointers();
+                // temporarily unset the base pointers to that the procedure will not visit them
+                state.setLiveBasePointers(null);
+                state.visitEachState(op, nonBasePointersStateProc);
+                // visit the base pointers explicitly
+                liveBasePointers.visitEach(op, OperandMode.ALIVE, null, basePointerStateProc);
+                // reset the base pointers
+                state.setLiveBasePointers(liveBasePointers);
             };
 
             // create a list with all caller-save registers (cpu, fpu, xmm)
@@ -828,7 +852,7 @@ public class LinearScanLifetimeAnalysisPhase extends LinearScanAllocationPhase {
                              * the live range is extended to a call site, the value would be in a
                              * register at the call otherwise).
                              */
-                            op.visitEachState(stateProc);
+                            op.forEachState(stateProc);
 
                             // special steps for some instructions (especially moves)
                             handleMethodArguments(op);

--- a/compiler/src/org.graalvm.compiler.lir/src/org/graalvm/compiler/lir/dfa/RegStackValueSet.java
+++ b/compiler/src/org.graalvm.compiler.lir/src/org/graalvm/compiler/lir/dfa/RegStackValueSet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -162,5 +162,10 @@ final class RegStackValueSet extends ValueSet<RegStackValueSet> {
                 refMap.addLiveValue(v);
             }
         }
+    }
+
+    @Override
+    public String toString() {
+        return "registers: " + registers.toString() + "\n" + "stack: " + stack.toString();
     }
 }

--- a/compiler/src/org.graalvm.compiler.lir/src/org/graalvm/compiler/lir/phases/EconomyAllocationStage.java
+++ b/compiler/src/org.graalvm.compiler.lir/src/org/graalvm/compiler/lir/phases/EconomyAllocationStage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,12 +26,15 @@ package org.graalvm.compiler.lir.phases;
 
 import org.graalvm.compiler.lir.alloc.lsra.LinearScanPhase;
 import org.graalvm.compiler.lir.dfa.LocationMarkerPhase;
+import org.graalvm.compiler.lir.dfa.MarkBasePointersPhase;
 import org.graalvm.compiler.lir.phases.AllocationPhase.AllocationContext;
 import org.graalvm.compiler.lir.stackslotalloc.SimpleStackSlotAllocator;
 import org.graalvm.compiler.options.OptionValues;
 
 public class EconomyAllocationStage extends LIRPhaseSuite<AllocationContext> {
     public EconomyAllocationStage(@SuppressWarnings("unused") OptionValues options) {
+        appendPhase(new MarkBasePointersPhase());
+
         appendPhase(new LinearScanPhase());
 
         // build frame map

--- a/substratevm/src/com.oracle.svm.core.graal.aarch64/src/com/oracle/svm/core/graal/aarch64/SubstrateAArch64Backend.java
+++ b/substratevm/src/com.oracle.svm.core.graal.aarch64/src/com/oracle/svm/core/graal/aarch64/SubstrateAArch64Backend.java
@@ -921,6 +921,6 @@ public class SubstrateAArch64Backend extends SubstrateBackend implements LIRGene
 
     @Override
     public Phase newAddressLoweringPhase(CodeCacheProvider codeCache) {
-        return new AddressLoweringByUsePhase(new AArch64AddressLoweringByUse(createLirKindTool()));
+        return new AddressLoweringByUsePhase(new AArch64AddressLoweringByUse(createLirKindTool(), false));
     }
 }


### PR DESCRIPTION
We want to find a better way to implement array offset calculation.
The old pattern for an int array member loading is:

     and      x4, x3, #0xffffffff
     lsl      x4, x4, #2
     add      x4, x4, #0x10
     ldr      x0, [x2, x4]


And the optimized pattern is:
       
    add      x1, x2, w3, uxtw #2
    ldr      x0, [x1, #16]


Here is a jmh unit test for int array member loading:

```
private final int func(int[] arr) {
        int ret = 0;
        for (int i=0; i < field0; i++) {
            ret += arr[i];
        }
        return ret;
}
```


And the jmh performance results:

```
without this patch       with this patch       units
    1173501.595               948290.420         us/op
```


Here are the additional issues fixed related to this patch:
1. Finetune MarkBasePointers to get better derived reference marking.
  Currently there is an issue when marking live base pointers. The liveness
of the derived reference will decide whether its base pointer is marked.
If one derived reference is dead at some position, its base pointer will be
removed. So if there are two or more derived references that have the same
base pointer, one of them died will make other derived reference cann't
find its base pointer when building the oop map.
  This patch add a map which will record the base pointer and its derived
references. One base pointer can be removed only when all its derived references
are dead.

2. Set RegisterPriority of basepointers according to the STATE_FLAGS when
building its interval.
  As we all know, the constant value will be re-materialized while not be
spilled to stack when there are not free registers. And its location will be
set to invalid after register allocation. So does the constant reference.
So there will be some exceptions when building the oop map, because the compiler
need to save the locations of live references. If a derived reference has a
constant base pointer which is re-materialized, the compiler will not get its
location. So the jvmci will treat the derived reference as a normal reference
because its base part is null, which may cause the gc crash if the derived
reference is not an real object.
  To resolve this issue, I set the register priority of base pointers to "ShouleHaveRegister",
thus the compiler will not materialize the constant base pointer when doing register
allocation. Also the LIRFrameState has a STATE_FLAG for state values, that is
either a register or a stack slot.

3. Fix an issue on ConstantLoadOptimization. When a constant value is replaced with a
new one, we should also check whether this value is a base pointer of a derived reference.
If so, the base pointer of the derived reference should also be replaced with the new value.
Or there will be some issues when doing register allocation.

4. Fix an issue in MatchProcessor, so that we can process platform specific
node as a matchable node.

mx bootstrap passes.

Change-Id: Ia34f2bf044ca6863be075cf000b29524ca44c42d