### PR TITLE
Use AArch64 instruction tbz #31 to do negative check in Graal

### DIFF
--- a/compiler/src/org.graalvm.compiler.core.aarch64.test/src/org/graalvm/compiler/core/aarch64/test/AArch64TestBitAndBranchTest.java
+++ b/compiler/src/org.graalvm.compiler.core.aarch64.test/src/org/graalvm/compiler/core/aarch64/test/AArch64TestBitAndBranchTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,10 +24,9 @@
  */
 package org.graalvm.compiler.core.aarch64.test;
 
-import static org.junit.Assume.assumeTrue;
-
-import java.util.function.Predicate;
-
+import jdk.vm.ci.aarch64.AArch64;
+import jdk.vm.ci.code.TargetDescription;
+import jdk.vm.ci.meta.Value;
 import org.graalvm.compiler.api.directives.GraalDirectives;
 import org.graalvm.compiler.asm.aarch64.AArch64MacroAssembler;
 import org.graalvm.compiler.lir.LIR;
@@ -48,9 +47,9 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-import jdk.vm.ci.aarch64.AArch64;
-import jdk.vm.ci.code.TargetDescription;
-import jdk.vm.ci.meta.Value;
+import java.util.function.Predicate;
+
+import static org.junit.Assume.assumeTrue;
 
 public class AArch64TestBitAndBranchTest extends LIRTest {
     private static final Predicate<LIRInstruction> checkForBitTestAndBranchOp = op -> (op instanceof AArch64ControlFlow.BitTestAndBranchOp);
@@ -122,6 +121,73 @@ public class AArch64TestBitAndBranchTest extends LIRTest {
         checkLIR("testBitTestAndBranchFourSnippet", checkForBitTestAndBranchOp, 1);
     }
 
+    private static final float trueTarget = Float.MAX_VALUE;
+    private static final float falseTarget = Float.MIN_VALUE;
+
+    public static float testLessThanZeroSnippet(long a, long b) {
+        if (b + a - b < 0) {
+            return trueTarget - a;
+        } else {
+            return falseTarget + a;
+        }
+    }
+
+    @Test
+    public void testLessThanZero() {
+        test("testLessThanZeroSnippet", 1L, 777L);
+        test("testLessThanZeroSnippet", 0L, 777L);
+        test("testLessThanZeroSnippet", -1L, 777L);
+        checkLIR("testLessThanZeroSnippet", checkForBitTestAndBranchOp, 1);
+    }
+
+    public static float testLessThanEqualZeroSnippet(long a) {
+        if (a <= 0) {
+            return trueTarget - a;
+        } else {
+            return falseTarget + a;
+        }
+    }
+
+    @Test
+    public void testLessThanEqualZero() {
+        test("testLessThanEqualZeroSnippet", 1L);
+        test("testLessThanEqualZeroSnippet", 0L);
+        test("testLessThanEqualZeroSnippet", -1L);
+        checkLIR("testLessThanEqualZeroSnippet", checkForBitTestAndBranchOp, 0);
+    }
+
+    public static float testGreaterThanZeroSnippet(int a) {
+        if (a > 0) {
+            return trueTarget - a;
+        } else {
+            return falseTarget + a;
+        }
+    }
+
+    @Test
+    public void testGreaterThanZero() {
+        test("testGreaterThanZeroSnippet", 1);
+        test("testGreaterThanZeroSnippet", 0);
+        test("testGreaterThanZeroSnippet", -1);
+        checkLIR("testGreaterThanZeroSnippet", checkForBitTestAndBranchOp, 0);
+    }
+
+    public static float testGreaterThanEqualZeroSnippet(int a) {
+        if (a >= 0) {
+            return trueTarget - a;
+        } else {
+            return falseTarget + a;
+        }
+    }
+
+    @Test
+    public void testGreaterThanEqualZero() {
+        test("testGreaterThanEqualZeroSnippet", 1);
+        test("testGreaterThanEqualZeroSnippet", 0);
+        test("testGreaterThanEqualZeroSnippet", -1);
+        checkLIR("testGreaterThanEqualZeroSnippet", checkForBitTestAndBranchOp, 1);
+    }
+
     private static class LargeOpSpec extends LIRTestSpecification {
         private final int n;
         private final int nopCount;
@@ -172,7 +238,9 @@ public class AArch64TestBitAndBranchTest extends LIRTest {
 
     public class CheckPhase extends LIRPhase<PreAllocationOptimizationContext> {
         @Override
-        protected void run(TargetDescription target, LIRGenerationResult lirGenRes, PreAllocationOptimizationContext context) {
+        protected void run(
+                        TargetDescription target, LIRGenerationResult lirGenRes,
+                        PreAllocationOptimizationContext context) {
             lir = lirGenRes.getLIR();
         }
     }

--- a/compiler/src/org.graalvm.compiler.core.aarch64/src/org/graalvm/compiler/core/aarch64/AArch64NodeMatchRules.java
+++ b/compiler/src/org.graalvm.compiler.core.aarch64/src/org/graalvm/compiler/core/aarch64/AArch64NodeMatchRules.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@
 
 package org.graalvm.compiler.core.aarch64;
 
+import jdk.vm.ci.aarch64.AArch64Kind;
 import jdk.vm.ci.meta.AllocatableValue;
 import jdk.vm.ci.meta.JavaKind;
 import jdk.vm.ci.meta.Value;
@@ -32,6 +33,7 @@ import org.graalvm.collections.EconomicMap;
 import org.graalvm.collections.Equivalence;
 import org.graalvm.compiler.asm.aarch64.AArch64MacroAssembler;
 import org.graalvm.compiler.core.common.LIRKind;
+import org.graalvm.compiler.core.common.calc.CanonicalCondition;
 import org.graalvm.compiler.core.gen.NodeMatchRules;
 import org.graalvm.compiler.core.match.ComplexMatchResult;
 import org.graalvm.compiler.core.match.MatchRule;
@@ -44,12 +46,14 @@ import org.graalvm.compiler.lir.aarch64.AArch64ControlFlow;
 import org.graalvm.compiler.lir.gen.LIRGeneratorTool;
 import org.graalvm.compiler.nodes.ConstantNode;
 import org.graalvm.compiler.nodes.DeoptimizingNode;
+import org.graalvm.compiler.nodes.FixedNode;
 import org.graalvm.compiler.nodes.IfNode;
 import org.graalvm.compiler.nodes.NodeView;
 import org.graalvm.compiler.nodes.ValueNode;
 import org.graalvm.compiler.nodes.calc.AddNode;
 import org.graalvm.compiler.nodes.calc.AndNode;
 import org.graalvm.compiler.nodes.calc.BinaryNode;
+import org.graalvm.compiler.nodes.calc.IntegerLessThanNode;
 import org.graalvm.compiler.nodes.calc.LeftShiftNode;
 import org.graalvm.compiler.nodes.calc.NotNode;
 import org.graalvm.compiler.nodes.calc.OrNode;
@@ -58,8 +62,6 @@ import org.graalvm.compiler.nodes.calc.SubNode;
 import org.graalvm.compiler.nodes.calc.UnsignedRightShiftNode;
 import org.graalvm.compiler.nodes.calc.XorNode;
 import org.graalvm.compiler.nodes.memory.Access;
-
-import jdk.vm.ci.aarch64.AArch64Kind;
 
 public class AArch64NodeMatchRules extends NodeMatchRules {
     private static final EconomicMap<Class<? extends Node>, AArch64ArithmeticOp> nodeOpMap;
@@ -99,7 +101,8 @@ public class AArch64NodeMatchRules extends NodeMatchRules {
         return getLIRGeneratorTool().moveSp(value);
     }
 
-    private ComplexMatchResult emitBinaryShift(AArch64ArithmeticOp op, ValueNode value, BinaryNode shift, boolean isShiftNot) {
+    private ComplexMatchResult emitBinaryShift(AArch64ArithmeticOp op, ValueNode value, BinaryNode shift,
+                    boolean isShiftNot) {
         AArch64MacroAssembler.ShiftType shiftType = shiftTypeMap.get(shift.getClass());
         assert shiftType != null;
         assert value.getStackKind().isNumericInteger();
@@ -115,6 +118,18 @@ public class AArch64NodeMatchRules extends NodeMatchRules {
             int shiftAmount = shift.getY().asJavaConstant().asInt();
             gen.append(new AArch64ArithmeticOp.BinaryShiftOp(op, result, x, y, shiftType, shiftAmount, isShiftNot));
             return result;
+        };
+    }
+
+    private ComplexMatchResult emitBitTestAndBranch(FixedNode trueSuccessor, FixedNode falseSuccessor,
+                    ValueNode value, double trueProbability, int nbits) {
+        return builder -> {
+            LabelRef trueDestination = getLIRBlock(trueSuccessor);
+            LabelRef falseDestination = getLIRBlock(falseSuccessor);
+            AllocatableValue src = moveSp(gen.asAllocatable(operand(value)));
+            gen.append(new AArch64ControlFlow.BitTestAndBranchOp(trueDestination, falseDestination, src,
+                            trueProbability, nbits));
+            return null;
         };
     }
 
@@ -189,16 +204,24 @@ public class AArch64NodeMatchRules extends NodeMatchRules {
         if (value.getStackKind().isNumericInteger()) {
             long constant = a.asJavaConstant().asLong();
             if (Long.bitCount(constant) == 1) {
-                int bitToTest = Long.numberOfTrailingZeros(constant);
-                return builder -> {
-                    LabelRef trueDestination = getLIRBlock(root.trueSuccessor());
-                    LabelRef falseDestination = getLIRBlock(root.falseSuccessor());
-                    AllocatableValue src = moveSp(gen.asAllocatable(operand(value)));
-                    double trueDestinationProbability = root.getTrueSuccessorProbability();
-                    gen.append(new AArch64ControlFlow.BitTestAndBranchOp(trueDestination, falseDestination, src, trueDestinationProbability, bitToTest));
-                    return null;
-                };
+                return emitBitTestAndBranch(root.trueSuccessor(), root.falseSuccessor(), value,
+                                root.getTrueSuccessorProbability(), Long.numberOfTrailingZeros(constant));
             }
+        }
+        return null;
+    }
+
+    /**
+     * if !(n < 0) <=> tbz n, sizeOfBits(n) - 1, label.
+     */
+    @MatchRule("(If (IntegerLessThan=lessNode value Constant))")
+    public ComplexMatchResult checkNegativeAndBranch(IfNode root, IntegerLessThanNode lessNode) {
+        JavaKind xKind = lessNode.getX().getStackKind();
+        assert xKind.isNumericInteger();
+        ValueNode y = lessNode.getY();
+        if (y.isJavaConstant() && (0 == y.asJavaConstant().asLong()) && lessNode.condition().equals(CanonicalCondition.LT)) {
+            return emitBitTestAndBranch(root.falseSuccessor(), root.trueSuccessor(), lessNode.getX(),
+                            root.getTrueSuccessorProbability(), xKind.getBitCount() - 1);
         }
         return null;
     }


### PR DESCRIPTION
As  we have "if !(n < 0) <=> tbz n, sizeOfBits(n) - 1, label" in AArch64, this patch add a special match rule to find the case where IfNode has the condition that the greater value of  IntergerLessThanNode is zero and then simplify the generated assembly code from cmp, b.lt to tbz.

Change-Id: I7e72e12a0efea65b4fdc513200d105220590babe