### PR TITLE
fix NullPointerException when previous instruction in updateLastInstruction() is null

### DIFF
--- a/compiler/src/org.graalvm.compiler.replacements/src/org/graalvm/compiler/replacements/IntrinsicGraphBuilder.java
+++ b/compiler/src/org.graalvm.compiler.replacements/src/org/graalvm/compiler/replacements/IntrinsicGraphBuilder.java
@@ -127,7 +127,9 @@ public class IntrinsicGraphBuilder implements GraphBuilderContext, Receiver {
     private <T extends ValueNode> void updateLastInstruction(T v) {
         if (v instanceof FixedNode) {
             FixedNode fixedNode = (FixedNode) v;
-            lastInstr.setNext(fixedNode);
+            if (lastInstr != null) {
+                lastInstr.setNext(fixedNode);
+            }
             if (fixedNode instanceof FixedWithNextNode) {
                 FixedWithNextNode fixedWithNextNode = (FixedWithNextNode) fixedNode;
                 assert fixedWithNextNode.next() == null : "cannot append instruction to instruction which isn't end";


### PR DESCRIPTION
### Problem

There is a NullPointerException in `IntrinsicGraphBuilder.java`.

### Solution

Check for null in `.updateLastInstruction()`.

### Repro

Running the script at https://gist.github.com/cosmicexplorer/b8b4128315dfb4a30f462c5e73e5cd83 on `master` should produce:
```
# ... (lots of graal stacktraces)
Caused by: java.lang.NullPointerException
        at org.graalvm.compiler.replacements.IntrinsicGraphBuilder.updateLastInstruction(IntrinsicGraphBuilder.java:130)
        at org.graalvm.compiler.replacements.IntrinsicGraphBuilder.append(IntrinsicGraphBuilder.java:148)
        at org.graalvm.compiler.replacements.StandardGraphBuilderPlugins$UnsafeAccessPlugin.createUnsafeAccess(StandardGraphBuilderPlugins.java:1058)
        at org.graalvm.compiler.replacements.StandardGraphBuilderPlugins$UnsafePutPlugin.apply(StandardGraphBuilderPlugins.java:1154)
        at org.graalvm.compiler.nodes.graphbuilderconf.InvocationPlugin.execute(InvocationPlugin.java:197)
        at org.graalvm.compiler.replacements.IntrinsicGraphBuilder.buildGraph(IntrinsicGraphBuilder.java:267)
        at com.oracle.graal.pointsto.flow.MethodTypeFlowBuilder.parse(MethodTypeFlowBuilder.java:191)
        at com.oracle.graal.pointsto.flow.MethodTypeFlowBuilder.apply(MethodTypeFlowBuilder.java:330)
        at com.oracle.graal.pointsto.flow.MethodTypeFlow.doParse(MethodTypeFlow.java:310)
        ... 12 more
Error: Image building with exit status 1
```

### Background

Executing the script at https://gist.github.com/cosmicexplorer/b8b4128315dfb4a30f462c5e73e5cd83 will build the wrapper for zinc (https://github.com/sbt/zinc) in the pants build tool (https://github.com/pantsbuild/pants) using `native-image`.

After starting off with https://github.com/graalvm/graalvm-demos/tree/master/scala-days-2018/scalac-native for scalac, which zinc wraps, I had spent some time figuring out which classes specifically were starting threads in static initializers (using `-H:NumberOfThreads=1` made the stacktraces usable here), and after using the new java agent in `substratevm/CONFIGURE.md` (and just removing entries that caused errors), I was able to get pretty close to making a native-image of this highly nontrivial and somewhat dynamic piece of Java/Scala. I experienced multiple errors while figuring out which entries to remove in the configuration generated by `native-image-configure`, which can be seen in the commit history. Only the one fix is now necessary after figuring this out -- it is not clear whether any of the other fixes are actual bugs, so I have removed them from the final diff.

This 100% works to compile code too, that was just a bit much for a minimal repro. I'm not sure if this change is correct -- I got to it just by looking at stack traces.