### PR TITLE
Add implementation of NetworkInterface.isUp0()

### DIFF
--- a/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/PosixJavaNetSubstitutions.java
+++ b/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/PosixJavaNetSubstitutions.java
@@ -3776,6 +3776,11 @@ final class Target_java_net_NetworkInterface {
         return null;
     }
 
+    @Substitute
+    static boolean isUp0(String name, int ind) throws SocketException {
+        return JavaNetNetworkInterface.isUp0(name, ind);
+    }
+
     // { Do not format quoted code: @formatter:off
     // Translation of jdk/src/solaris/native/java/net/NetworkInterface.c?v=Java_1.8.0_40_b10.
     // 410 /*

--- a/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/headers/NetIf.java
+++ b/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/headers/NetIf.java
@@ -64,6 +64,12 @@ public class NetIf {
     @CConstant
     public static native int IFF_BROADCAST();
 
+    @CConstant
+    public static native int IFF_UP();
+
+    @CConstant
+    public static native int IFF_RUNNING();
+
     /* { Do not reformat commented out C code: @formatter:off */
     @CContext(PosixDirectives.class)
     @Platforms({Platform.LINUX.class, Platform.DARWIN.class})

--- a/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/linux/LinuxJavaNetNetworkInterface.java
+++ b/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/linux/LinuxJavaNetNetworkInterface.java
@@ -455,7 +455,7 @@ public class LinuxJavaNetNetworkInterface {
             int sock;
             // 1274
             // 1275     if ((sock = openSocketWithFallback(env, ifname)) < 0) {
-            if ((sock = openSocketWithFallback(ifname)) < 0) {
+            if ((sock = JavaNetNetworkInterface.openSocketWithFallback(ifname)) < 0) {
                 // 1276         return -1;
                 return -1;
             }
@@ -495,53 +495,6 @@ public class LinuxJavaNetNetworkInterface {
             // 1296
             // 1297     return -1;
             return -1;
-        }
-
-        // 1089 #if defined(AF_INET6)
-        /* Pushing this #if inside the method body. */
-        // 1090 /*
-        // 1091  * Opens a socket for further ioctl calls. Tries AF_INET socket first and
-        // 1092  * if it fails return AF_INET6 socket.
-        // 1093  */
-        // 1094 static int openSocketWithFallback(JNIEnv *env, const char *ifname) {
-        @SuppressWarnings({"unused"})
-        static int openSocketWithFallback(CCharPointer ifname) throws SocketException {
-            if (IsDefined.socket_AF_INET6()) {
-                // 1095     int sock;
-                int sock;
-                // 1096
-                // 1097     if ((sock = JVM_Socket(AF_INET, SOCK_DGRAM, 0)) < 0) {
-                if ((sock = VmPrimsJVM.JVM_Socket(Socket.AF_INET(), Socket.SOCK_DGRAM(), 0)) < 0) {
-                    // 1098         if (errno == EPROTONOSUPPORT) {
-                    if (Errno.errno() == Errno.EPROTONOSUPPORT()) {
-                        // 1099             if ((sock = JVM_Socket(AF_INET6, SOCK_DGRAM, 0)) < 0) {
-                        if ((sock = VmPrimsJVM.JVM_Socket(Socket.AF_INET6(), Socket.SOCK_DGRAM(), 0)) < 0) {
-                            // 1100                 NET_ThrowByNameWithLastError
-                            // 1101                     (env, JNU_JAVANETPKG "SocketException", "IPV6 Socket creation failed");
-                            throw new SocketException(PosixUtils.lastErrorString("IPV6 Socket creation failed"));
-                            // 1102                 return -1;
-                            /* Unreachable. */
-                        }
-                    } else { // errno is not NOSUPPORT
-                        // 1105             NET_ThrowByNameWithLastError
-                        // 1106                 (env, JNU_JAVANETPKG "SocketException", "IPV4 Socket creation failed");
-                        throw new SocketException(PosixUtils.lastErrorString("IPV4 Socket creation failed"));
-                        // 1107             return -1;
-                        /* Unreachable. */
-                    }
-                }
-                // 1110
-                // 1111     // Linux starting from 2.6.? kernel allows ioctl call with either IPv4 or
-                // 1112     // IPv6 socket regardless of type of address of an interface.
-                // 1113     return sock;
-                return sock;
-            } else {
-            // 1115 #else
-            // 1116 static int openSocketWithFallback(JNIEnv *env, const char *ifname) {
-            // 1117     return openSocket(env, AF_INET);
-            return JavaNetNetworkInterface.openSocket(Socket.AF_INET());
-            }
-            // 1119 #endif
         }
 
         /** A Java representation of the information parsed from a line from /proc/net/if_inet6. */


### PR DESCRIPTION
Hello,

this is my very 1st contribution. I appreciate any feedback on this. 
I am struggling with:
1. How to test this? Is there any example I could follow?
2. How to test this on different platforms? Is there any CI suite?
3. Are they any static check I can run locally? checkstyle/findbugs/etcc.


This is now working:
```java
public class Main {
    public static void main(String[] args) throws SocketException {
        Enumeration<NetworkInterface> ifEnum = NetworkInterface.getNetworkInterfaces();
        while (ifEnum.hasMoreElements()) {
            NetworkInterface netIf = ifEnum.nextElement();
            boolean up = netIf.isUp();
            System.out.println("Interface: " + netIf.getName() + ", Up: " + up);
        }
    }
}
```

Before:
```
$ ./graalisuptest-1.0-SNAPSHOT
Exception in thread "main" java.lang.UnsatisfiedLinkError: java.net.NetworkInterface.isUp0(Ljava/lang/String;I)Z [symbol: Java_java_net_NetworkInterface_isUp0 or Java_java_net_NetworkInterface_isUp0__Ljava_lang_String_2I]
	at com.oracle.svm.jni.access.JNINativeLinkage.getOrFindEntryPoint(JNINativeLinkage.java:145)
	at com.oracle.svm.jni.JNIGeneratedMethodSupport.nativeCallAddress(JNIGeneratedMethodSupport.java:54)
	at java.net.NetworkInterface.isUp0(NetworkInterface.java)
	at java.net.NetworkInterface.isUp(NetworkInterface.java:399)
	at info.jerrinot.graalisuptest.Main.main(Main.java:12)
```

After:
```
Interface: docker0, Up: false
Interface: br-c8ae87af46d3, Up: false
Interface: br-24c50199ca31, Up: false
Interface: br-20d5ca7515af, Up: false
Interface: br-1da21fca6dba, Up: false
Interface: wlp4s0, Up: true
Interface: lo, Up: true
```