### PR TITLE
Misttyped lfance caused lfence to not be emitted

### DIFF
--- a/sulong/projects/com.oracle.truffle.llvm.asm.amd64/src/com/oracle/truffle/llvm/asm/amd64/AsmFactory.java
+++ b/sulong/projects/com.oracle.truffle.llvm.asm.amd64/src/com/oracle/truffle/llvm/asm/amd64/AsmFactory.java
@@ -480,7 +480,7 @@ class AsmFactory {
                 // TODO: implement properly
                 break;
             case "mfence":
-            case "lfance":
+            case "lfence":
             case "sfence":
                 statements.add(LLVMFenceNodeGen.create());
                 break;


### PR DESCRIPTION
The case statement had a misstyped instruction as `lfance` when it should be `lfence`

No testing done, but clearly this is a typo.