### PR TITLE
Need to try all paths listed by 'java.library.path' before throwing UnsatisfiedLinkError

### DIFF
--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/NativeLibrarySupport.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/NativeLibrarySupport.java
@@ -150,6 +150,9 @@ public final class NativeLibrarySupport {
                 if (libraryInitializer != null) {
                     libraryInitializer.initialize(lib);
                 }
+            } catch (UnsatisfiedLinkError e) {
+                // Allow caller to try the next path:
+                return false;
             } finally {
                 NativeLibrary top = currentLoadContext.pop();
                 assert top == lib;


### PR DESCRIPTION

I believe this could be the fix for #438 

The code in :
https://github.com/oracle/graal/blob/cbadcf6f7a1890562984e1c581f7c3b31809b34e/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/NativeLibrarySupport.java#L91-L95

is able to deal with the requirement to list multiple paths for the _java.library.path_ system property, but then the code attempting to load the libraries is expecting to have "false" returned on failure from one path, so to try the next path.

However the failed attempt to load the library from the first path immediately causes an `UnsatisfiedLinkError` to be thrown, so the additional paths are never tested.

see also:
 - https://github.com/quarkusio/quarkus/pull/1674

I'd be happy to add an integration test, but I'm not familiar with how you might prefer something like this to be structured. If you could point me to something similar I'd be glad to learn and try putting one together.

Thanks