### PR TITLE
Float, Double Scalar FMA intrinsics

### DIFF
--- a/compiler/src/org.graalvm.compiler.asm.amd64/src/org/graalvm/compiler/asm/amd64/AMD64Assembler.java
+++ b/compiler/src/org.graalvm.compiler.asm.amd64/src/org/graalvm/compiler/asm/amd64/AMD64Assembler.java
@@ -906,7 +906,8 @@ public class AMD64Assembler extends AMD64BaseAssembler {
         CPU_XMM(CPUFeature.AVX, null, CPU, null, XMM, null),
         AVX1_2_CPU_XMM(CPUFeature.AVX, CPUFeature.AVX2, CPU, null, XMM, null),
         BMI1(CPUFeature.BMI1, null, CPU, CPU, CPU, null),
-        BMI2(CPUFeature.BMI2, null, CPU, CPU, CPU, null);
+        BMI2(CPUFeature.BMI2, null, CPU, CPU, CPU, null),
+        FMA(CPUFeature.FMA, null, XMM, XMM, XMM, null);
 
         private final CPUFeature l128feature;
         private final CPUFeature l256feature;
@@ -1308,6 +1309,8 @@ public class AMD64Assembler extends AMD64BaseAssembler {
         public static final VexRVMOp VPCMPGTW  = new VexRVMOp("VPCMPGTW",  P_66, M_0F,   WIG, 0x65, VEXOpAssertion.AVX1_2);
         public static final VexRVMOp VPCMPGTD  = new VexRVMOp("VPCMPGTD",  P_66, M_0F,   WIG, 0x66, VEXOpAssertion.AVX1_2);
         public static final VexRVMOp VPCMPGTQ  = new VexRVMOp("VPCMPGTQ",  P_66, M_0F38, WIG, 0x37, VEXOpAssertion.AVX1_2);
+        public static final VexRVMOp VFMADD231SS = new VexRVMOp("VFMADD231SS", P_66, M_0F38, W0, 0xB9, VEXOpAssertion.FMA);
+        public static final VexRVMOp VFMADD231SD = new VexRVMOp("VFMADD231SD", P_66, M_0F38, W1, 0xB9, VEXOpAssertion.FMA);
         // @formatter:on
 
         private VexRVMOp(String opcode, int pp, int mmmmm, int w, int op) {

--- a/compiler/src/org.graalvm.compiler.graph/src/org/graalvm/compiler/graph/spi/Canonicalizable.java
+++ b/compiler/src/org.graalvm.compiler.graph/src/org/graalvm/compiler/graph/spi/Canonicalizable.java
@@ -155,4 +155,49 @@ public interface Canonicalizable {
          */
         Node maybeCommuteInputs();
     }
+
+    /**
+     * This sub-interface of {@link Canonicalizable} is intended for nodes that have exactly three
+     * inputs. It has an additional {@link #canonical(CanonicalizerTool, Node, Node, Node)} method
+     * that looks at the given inputs instead of the current inputs of the node - which can be used
+     * to ask "what if this input is changed to this node" - questions.
+     *
+     * @param <T> the common supertype of all inputs of this node
+     */
+    public interface Ternary<T extends Node> extends Canonicalizable {
+
+        /**
+         * Similar to {@link Canonicalizable#canonical(CanonicalizerTool)}, except that
+         * implementations should act as if the current input of the node was the given one, i.e.,
+         * they should never look at the inputs via the this pointer.
+         */
+        Node canonical(CanonicalizerTool tool, T forX, T forY, T forZ);
+
+        /**
+         * Gets the current value of the input, so that calling
+         * {@link #canonical(CanonicalizerTool, Node, Node, Node)} with the value returned from this
+         * method should behave exactly like {@link Canonicalizable#canonical(CanonicalizerTool)}.
+         */
+        T getX();
+
+        /**
+         * Gets the current value of the input, so that calling
+         * {@link #canonical(CanonicalizerTool, Node, Node, Node)} with the value returned from this
+         * method should behave exactly like {@link Canonicalizable#canonical(CanonicalizerTool)}.
+         */
+        T getY();
+
+        /**
+         * Gets the current value of the input, so that calling
+         * {@link #canonical(CanonicalizerTool, Node, Node, Node)} with the value returned from this
+         * method should behave exactly like {@link Canonicalizable#canonical(CanonicalizerTool)}.
+         */
+        T getZ();
+
+        @SuppressWarnings("unchecked")
+        @Override
+        default T canonical(CanonicalizerTool tool) {
+            return (T) canonical(tool, getX(), getY(), getZ());
+        }
+    }
 }

--- a/compiler/src/org.graalvm.compiler.hotspot.amd64/src/org/graalvm/compiler/hotspot/amd64/AMD64HotSpotBackendFactory.java
+++ b/compiler/src/org.graalvm.compiler.hotspot.amd64/src/org/graalvm/compiler/hotspot/amd64/AMD64HotSpotBackendFactory.java
@@ -161,7 +161,7 @@ public class AMD64HotSpotBackendFactory implements HotSpotBackendFactory {
                     HotSpotConstantReflectionProvider constantReflection, HotSpotHostForeignCallsProvider foreignCalls, HotSpotMetaAccessProvider metaAccess,
                     HotSpotSnippetReflectionProvider snippetReflection, HotSpotReplacementsImpl replacements, HotSpotWordTypes wordTypes, OptionValues options) {
         Plugins plugins = HotSpotGraphBuilderPlugins.create(compilerConfiguration, config, wordTypes, metaAccess, constantReflection, snippetReflection, foreignCalls, replacements, options);
-        AMD64GraphBuilderPlugins.register(plugins, replacements.getDefaultReplacementBytecodeProvider(), (AMD64) target.arch, false, JAVA_SPECIFICATION_VERSION >= 9);
+        AMD64GraphBuilderPlugins.register(plugins, replacements.getDefaultReplacementBytecodeProvider(), config.useFMAIntrinsics, (AMD64) target.arch, false, JAVA_SPECIFICATION_VERSION >= 9);
         return plugins;
     }
 

--- a/compiler/src/org.graalvm.compiler.hotspot.test/src/org/graalvm/compiler/hotspot/test/CheckGraalIntrinsics.java
+++ b/compiler/src/org.graalvm.compiler.hotspot.test/src/org/graalvm/compiler/hotspot/test/CheckGraalIntrinsics.java
@@ -272,10 +272,6 @@ public class CheckGraalIntrinsics extends GraalTest {
                             "jdk/jfr/internal/JVM.getClassId(Ljava/lang/Class;)J");
 
             add(toBeInvestigated,
-                            // HotSpot MacroAssembler-based intrinsic
-                            "java/lang/Math.fma(DDD)D",
-                            // HotSpot MacroAssembler-based intrinsic
-                            "java/lang/Math.fma(FFF)F",
                             // Just check if the argument is a compile time constant
                             "java/lang/invoke/MethodHandleImpl.isCompileConstant(Ljava/lang/Object;)Z",
                             // Only used as a marker for vectorization?

--- a/compiler/src/org.graalvm.compiler.hotspot/src/org/graalvm/compiler/hotspot/GraalHotSpotVMConfig.java
+++ b/compiler/src/org.graalvm.compiler.hotspot/src/org/graalvm/compiler/hotspot/GraalHotSpotVMConfig.java
@@ -108,6 +108,7 @@ public class GraalHotSpotVMConfig extends GraalHotSpotVMConfigBase {
     private final boolean useMulAddIntrinsic = getFlag("UseMulAddIntrinsic", Boolean.class, false);
     private final boolean useSquareToLenIntrinsic = getFlag("UseSquareToLenIntrinsic", Boolean.class, false);
     public final boolean useVectorizedMismatchIntrinsic = getFlag("UseVectorizedMismatchIntrinsic", Boolean.class, false);
+    public final boolean useFMAIntrinsics = getFlag("UseFMA", Boolean.class, false);
 
     /*
      * These are methods because in some JDKs the flags are visible but the stubs themselves haven't

--- a/compiler/src/org.graalvm.compiler.lir.amd64/src/org/graalvm/compiler/lir/amd64/AMD64Ternary.java
+++ b/compiler/src/org.graalvm.compiler.lir.amd64/src/org/graalvm/compiler/lir/amd64/AMD64Ternary.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.graalvm.compiler.lir.amd64;
+
+import static jdk.vm.ci.code.ValueUtil.asRegister;
+import static jdk.vm.ci.code.ValueUtil.isRegister;
+import static jdk.vm.ci.code.ValueUtil.isStackSlot;
+import static org.graalvm.compiler.lir.LIRInstruction.OperandFlag.HINT;
+import static org.graalvm.compiler.lir.LIRInstruction.OperandFlag.REG;
+import static org.graalvm.compiler.lir.LIRInstruction.OperandFlag.STACK;
+
+import org.graalvm.compiler.asm.amd64.AMD64Address;
+import org.graalvm.compiler.asm.amd64.AMD64Assembler.VexRVMOp;
+import org.graalvm.compiler.asm.amd64.AMD64MacroAssembler;
+import org.graalvm.compiler.asm.amd64.AVXKind.AVXSize;
+import org.graalvm.compiler.lir.LIRInstructionClass;
+import org.graalvm.compiler.lir.Opcode;
+import org.graalvm.compiler.lir.asm.CompilationResultBuilder;
+
+import jdk.vm.ci.meta.AllocatableValue;
+
+/**
+ * AMD64 LIR instructions that have three inputs and one output.
+ */
+public class AMD64Ternary {
+
+    /**
+     * Instruction that has two {@link AllocatableValue} operands.
+     */
+    public static class ThreeOp extends AMD64LIRInstruction {
+        public static final LIRInstructionClass<ThreeOp> TYPE = LIRInstructionClass.create(ThreeOp.class);
+
+        @Opcode private final VexRVMOp opcode;
+        private final AVXSize size;
+
+        @Def({REG, HINT}) protected AllocatableValue result;
+        @Use({REG}) protected AllocatableValue x;
+        /**
+         * This argument must be Alive to ensure that result and y are not assigned to the same
+         * register, which would break the code generation by destroying y too early.
+         */
+        @Alive({REG}) protected AllocatableValue y;
+        @Alive({REG, STACK}) protected AllocatableValue z;
+
+        public ThreeOp(VexRVMOp opcode, AVXSize size, AllocatableValue result, AllocatableValue x, AllocatableValue y, AllocatableValue z) {
+            super(TYPE);
+            this.opcode = opcode;
+            this.size = size;
+
+            this.result = result;
+            this.x = x;
+            this.y = y;
+            this.z = z;
+        }
+
+        @Override
+        public void emitCode(CompilationResultBuilder crb, AMD64MacroAssembler masm) {
+            AMD64Move.move(crb, masm, result, x);
+            if (isRegister(z)) {
+                opcode.emit(masm, size, asRegister(result), asRegister(y), asRegister(z));
+            } else {
+                assert isStackSlot(z);
+                opcode.emit(masm, size, asRegister(result), asRegister(y), (AMD64Address) crb.asAddress(z));
+            }
+        }
+    }
+}

--- a/compiler/src/org.graalvm.compiler.lir/src/org/graalvm/compiler/lir/gen/ArithmeticLIRGeneratorTool.java
+++ b/compiler/src/org.graalvm.compiler.lir/src/org/graalvm/compiler/lir/gen/ArithmeticLIRGeneratorTool.java
@@ -103,6 +103,11 @@ public interface ArithmeticLIRGeneratorTool {
     void emitStore(ValueKind<?> kind, Value address, Value input, LIRFrameState state);
 
     @SuppressWarnings("unused")
+    default Value emitFusedMultiplyAdd(Value a, Value b, Value c) {
+        throw GraalError.unimplemented("No specialized implementation available");
+    }
+
+    @SuppressWarnings("unused")
     default Value emitMathLog(Value input, boolean base10) {
         throw GraalError.unimplemented("No specialized implementation available");
     }

--- a/compiler/src/org.graalvm.compiler.nodes/src/org/graalvm/compiler/nodes/calc/TernaryNode.java
+++ b/compiler/src/org.graalvm.compiler.nodes/src/org/graalvm/compiler/nodes/calc/TernaryNode.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2009, 2018, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.graalvm.compiler.nodes.calc;
+
+import org.graalvm.compiler.core.common.type.Stamp;
+import org.graalvm.compiler.graph.NodeClass;
+import org.graalvm.compiler.graph.spi.Canonicalizable;
+import org.graalvm.compiler.nodeinfo.NodeInfo;
+import org.graalvm.compiler.nodes.NodeView;
+import org.graalvm.compiler.nodes.ValueNode;
+
+/**
+ * The {@code TernaryNode} class is the base of arithmetic and logic operations with three inputs.
+ */
+@NodeInfo
+public abstract class TernaryNode extends FloatingNode implements Canonicalizable.Ternary<ValueNode> {
+
+    public static final NodeClass<TernaryNode> TYPE = NodeClass.create(TernaryNode.class);
+    @Input protected ValueNode x;
+    @Input protected ValueNode y;
+    @Input protected ValueNode z;
+
+    @Override
+    public ValueNode getX() {
+        return x;
+    }
+
+    @Override
+    public ValueNode getY() {
+        return y;
+    }
+
+    @Override
+    public ValueNode getZ() {
+        return z;
+    }
+
+    public void setX(ValueNode x) {
+        updateUsages(this.x, x);
+        this.x = x;
+    }
+
+    public void setY(ValueNode y) {
+        updateUsages(this.y, y);
+        this.y = y;
+    }
+
+    public void setZ(ValueNode z) {
+        updateUsages(this.z, z);
+        this.z = z;
+    }
+
+    /**
+     * Creates a new TernaryNode instance.
+     *
+     * @param stamp the result type of this instruction
+     * @param x the first input instruction
+     * @param y the second input instruction
+     * @param z the second input instruction
+     */
+    protected TernaryNode(NodeClass<? extends TernaryNode> c, Stamp stamp, ValueNode x, ValueNode y, ValueNode z) {
+        super(c, stamp);
+        this.x = x;
+        this.y = y;
+        this.z = z;
+    }
+
+    @Override
+    public boolean inferStamp() {
+        return updateStamp(foldStamp(getX().stamp(NodeView.DEFAULT), getY().stamp(NodeView.DEFAULT), getZ().stamp(NodeView.DEFAULT)));
+    }
+
+    /**
+     * Compute an improved for this node using the passed in stamps. The stamps must be compatible
+     * with the current values of {@link #x}, {@link #y} and {@link #z}. This code is used to
+     * provide the default implementation of {@link #inferStamp()} and may be used by external
+     * optimizations.
+     *
+     * @param stampX
+     * @param stampY
+     * @param stampZ
+     */
+    public abstract Stamp foldStamp(Stamp stampX, Stamp stampY, Stamp stampZ);
+}

--- a/compiler/src/org.graalvm.compiler.replacements.amd64/src/org/graalvm/compiler/replacements/amd64/AMD64GraphBuilderPlugins.java
+++ b/compiler/src/org.graalvm.compiler.replacements.amd64/src/org/graalvm/compiler/replacements/amd64/AMD64GraphBuilderPlugins.java
@@ -39,8 +39,13 @@ import java.util.Arrays;
 
 import org.graalvm.compiler.bytecode.BytecodeProvider;
 import org.graalvm.compiler.lir.amd64.AMD64ArithmeticLIRGeneratorTool.RoundingMode;
+import org.graalvm.compiler.nodes.ComputeObjectAddressNode;
+import org.graalvm.compiler.nodes.ConstantNode;
+import org.graalvm.compiler.nodes.NodeView;
 import org.graalvm.compiler.nodes.PauseNode;
 import org.graalvm.compiler.nodes.ValueNode;
+import org.graalvm.compiler.nodes.calc.AddNode;
+import org.graalvm.compiler.nodes.extended.ForeignCallNode;
 import org.graalvm.compiler.nodes.graphbuilderconf.GraphBuilderConfiguration.Plugins;
 import org.graalvm.compiler.nodes.graphbuilderconf.GraphBuilderContext;
 import org.graalvm.compiler.nodes.graphbuilderconf.InvocationPlugin;
@@ -59,6 +64,7 @@ import org.graalvm.compiler.replacements.StandardGraphBuilderPlugins.UnsafePutPl
 import org.graalvm.compiler.replacements.nodes.BinaryMathIntrinsicNode;
 import org.graalvm.compiler.replacements.nodes.BinaryMathIntrinsicNode.BinaryOperation;
 import org.graalvm.compiler.replacements.nodes.BitCountNode;
+import org.graalvm.compiler.replacements.nodes.FusedMultiplyAddNode;
 import org.graalvm.compiler.replacements.nodes.UnaryMathIntrinsicNode;
 import org.graalvm.compiler.replacements.nodes.UnaryMathIntrinsicNode.UnaryOperation;
 
@@ -70,7 +76,8 @@ import sun.misc.Unsafe;
 
 public class AMD64GraphBuilderPlugins {
 
-    public static void register(Plugins plugins, BytecodeProvider replacementsBytecodeProvider, AMD64 arch, boolean explicitUnsafeNullChecks, boolean emitJDK9StringSubstitutions) {
+    public static void register(Plugins plugins, BytecodeProvider replacementsBytecodeProvider, boolean useFMAIntrinsics, AMD64 arch, boolean explicitUnsafeNullChecks,
+                    boolean emitJDK9StringSubstitutions) {
         InvocationPlugins invocationPlugins = plugins.getInvocationPlugins();
         invocationPlugins.defer(new Runnable() {
             @Override
@@ -86,7 +93,7 @@ public class AMD64GraphBuilderPlugins {
                     registerStringLatin1Plugins(invocationPlugins, replacementsBytecodeProvider);
                     registerStringUTF16Plugins(invocationPlugins, replacementsBytecodeProvider);
                 }
-                registerMathPlugins(invocationPlugins, arch, replacementsBytecodeProvider);
+                registerMathPlugins(invocationPlugins, useFMAIntrinsics, arch, replacementsBytecodeProvider);
                 registerArraysEqualsPlugins(invocationPlugins, replacementsBytecodeProvider);
             }
         });
@@ -130,6 +137,7 @@ public class AMD64GraphBuilderPlugins {
         }
         if (arch.getFeatures().contains(AMD64.CPUFeature.BMI1) && arch.getFlags().contains(AMD64.Flag.UseCountTrailingZerosInstruction)) {
             r.register1("numberOfTrailingZeros", type, new InvocationPlugin() {
+
                 @Override
                 public boolean apply(GraphBuilderContext b, ResolvedJavaMethod targetMethod, Receiver receiver, ValueNode value) {
                     ValueNode folded = AMD64CountTrailingZerosNode.tryFold(value);
@@ -154,9 +162,10 @@ public class AMD64GraphBuilderPlugins {
                 }
             });
         }
+
     }
 
-    private static void registerMathPlugins(InvocationPlugins plugins, AMD64 arch, BytecodeProvider bytecodeProvider) {
+    private static void registerMathPlugins(InvocationPlugins plugins, boolean useFMAIntrinsics, AMD64 arch, BytecodeProvider bytecodeProvider) {
         Registration r = new Registration(plugins, Math.class, bytecodeProvider);
         registerUnaryMath(r, "log", LOG);
         registerUnaryMath(r, "log10", LOG10);
@@ -171,6 +180,45 @@ public class AMD64GraphBuilderPlugins {
             registerRound(r, "ceil", RoundingMode.UP);
             registerRound(r, "floor", RoundingMode.DOWN);
         }
+
+        if (useFMAIntrinsics && arch.getFeatures().contains(CPUFeature.FMA)) {
+            registerFMA(r);
+        }
+    }
+
+    private static void registerFMA(Registration r) {
+        r.register3("fma",
+                        Double.TYPE,
+                        Double.TYPE,
+                        Double.TYPE,
+                        new InvocationPlugin() {
+                            @Override
+                            public boolean apply(GraphBuilderContext b,
+                                            ResolvedJavaMethod targetMethod,
+                                            Receiver receiver,
+                                            ValueNode na,
+                                            ValueNode nb,
+                                            ValueNode nc) {
+                                b.push(JavaKind.Double, b.append(new FusedMultiplyAddNode(na, nb, nc)));
+                                return true;
+                            }
+                        });
+        r.register3("fma",
+                        Float.TYPE,
+                        Float.TYPE,
+                        Float.TYPE,
+                        new InvocationPlugin() {
+                            @Override
+                            public boolean apply(GraphBuilderContext b,
+                                            ResolvedJavaMethod targetMethod,
+                                            Receiver receiver,
+                                            ValueNode na,
+                                            ValueNode nb,
+                                            ValueNode nc) {
+                                b.push(JavaKind.Float, b.append(new FusedMultiplyAddNode(na, nb, nc)));
+                                return true;
+                            }
+                        });
     }
 
     private static void registerUnaryMath(Registration r, String name, UnaryOperation operation) {

--- a/compiler/src/org.graalvm.compiler.replacements/src/org/graalvm/compiler/replacements/nodes/FusedMultiplyAddNode.java
+++ b/compiler/src/org.graalvm.compiler.replacements/src/org/graalvm/compiler/replacements/nodes/FusedMultiplyAddNode.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2012, 2019, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.graalvm.compiler.replacements.nodes;
+
+import static org.graalvm.compiler.nodeinfo.NodeCycles.CYCLES_2;
+import static org.graalvm.compiler.nodeinfo.NodeSize.SIZE_1;
+
+import org.graalvm.compiler.core.common.type.FloatStamp;
+import org.graalvm.compiler.core.common.type.Stamp;
+import org.graalvm.compiler.core.common.type.StampFactory;
+import org.graalvm.compiler.graph.NodeClass;
+import org.graalvm.compiler.graph.spi.CanonicalizerTool;
+import org.graalvm.compiler.lir.gen.ArithmeticLIRGeneratorTool;
+import org.graalvm.compiler.nodeinfo.NodeInfo;
+import org.graalvm.compiler.nodes.ConstantNode;
+import org.graalvm.compiler.nodes.NodeView;
+import org.graalvm.compiler.nodes.ValueNode;
+import org.graalvm.compiler.nodes.calc.TernaryNode;
+import org.graalvm.compiler.nodes.spi.ArithmeticLIRLowerable;
+import org.graalvm.compiler.nodes.spi.NodeLIRBuilderTool;
+
+import jdk.vm.ci.meta.JavaConstant;
+import jdk.vm.ci.meta.JavaKind;
+
+@NodeInfo(cycles = CYCLES_2, size = SIZE_1)
+public final class FusedMultiplyAddNode extends TernaryNode implements ArithmeticLIRLowerable {
+
+    public static final NodeClass<FusedMultiplyAddNode> TYPE = NodeClass.create(FusedMultiplyAddNode.class);
+
+    public FusedMultiplyAddNode(ValueNode a, ValueNode b, ValueNode c) {
+        super(TYPE, computeStamp(a, b, c), a, b, c);
+        assert a.getStackKind() == JavaKind.Float || a.getStackKind() == JavaKind.Double;
+        assert b.getStackKind() == JavaKind.Float || b.getStackKind() == JavaKind.Double;
+        assert c.getStackKind() == JavaKind.Float || c.getStackKind() == JavaKind.Double;
+    }
+
+    @Override
+    public Stamp foldStamp(Stamp stampX, Stamp stampY, Stamp stampZ) {
+        return computeStamp(getX(), getY(), getZ());
+    }
+
+    static Stamp computeStamp(ValueNode a, ValueNode b, ValueNode c) {
+        FloatStamp fstampX = (FloatStamp) a.stamp(NodeView.DEFAULT);
+        FloatStamp fstampY = (FloatStamp) b.stamp(NodeView.DEFAULT);
+        FloatStamp fstampZ = (FloatStamp) c.stamp(NodeView.DEFAULT);
+
+        double lower = Math.min(fstampX.lowerBound(), fstampY.lowerBound());
+        lower = Math.min(lower, fstampZ.lowerBound());
+
+        double upper = Math.max(fstampX.upperBound(), fstampY.upperBound());
+        upper = Math.min(lower, fstampZ.upperBound());
+
+        boolean isNonNan = fstampX.isNonNaN() && fstampY.isNonNaN() && fstampZ.isNonNaN();
+
+        return StampFactory.forFloat(a.getStackKind(), lower, upper, isNonNan);
+    }
+
+    @Override
+    public ValueNode canonical(CanonicalizerTool tool, ValueNode a, ValueNode b, ValueNode c) {
+        if (a.isConstant() && b.isConstant() && c.isConstant()) {
+            JavaConstant ca = a.asJavaConstant();
+            JavaConstant cb = b.asJavaConstant();
+            JavaConstant cc = c.asJavaConstant();
+
+            ValueNode res;
+            if (a.getStackKind() == JavaKind.Float) {
+                res = ConstantNode.forFloat(Math.fma(ca.asFloat(), cb.asFloat(), cc.asFloat()));
+            } else {
+                res = ConstantNode.forDouble(Math.fma(ca.asDouble(), cb.asDouble(), cc.asDouble()));
+            }
+            return res;
+        }
+        return this;
+    }
+
+    @Override
+    public void generate(NodeLIRBuilderTool builder, ArithmeticLIRGeneratorTool gen) {
+        builder.setResult(this, gen.emitFusedMultiplyAdd(builder.operand(getX()), builder.operand(getY()), builder.operand(getZ())));
+    }
+}


### PR DESCRIPTION
Initial PR for FMA intrinsics support. It implements the design suggested on the graal mailinglist, namely:

1. Add FMA instructions in VexRVMOp in AMD64Assembler
     a. It requires to add the VexOpAssertion.FMA and use CPUFeature.FMA flags
2. Add UseFMA flag from HotSpot flags in GraalHotSpotVMConfig.java
3. Add a registerFMA method in AMD64GraphBuilderPlugins::registerMathPlugins
     a. This requires to add a specific FusedMultiplyNodeNode, which will emit the corresponding FMA instructions.
           --> Need for TernaryNode support and AMD64Ternary support

I have a few questions regarding this PR considering this is the first time I touch a couple of things. I will post comments to make it easier.