### PR TITLE
Defensiveness around the polyglot launcher class names.

### DIFF
--- a/sdk/src/org.graalvm.launcher/src/org/graalvm/launcher/PolyglotLauncher.java
+++ b/sdk/src/org.graalvm.launcher/src/org/graalvm/launcher/PolyglotLauncher.java
@@ -222,8 +222,13 @@ public final class PolyglotLauncher extends Launcher {
 
     static {
         if (IS_AOT) {
-            Stream<String> classNames = Pattern.compile(",").splitAsStream(System.getProperty("com.oracle.graalvm.launcher.launcherclasses"));
-            AOT_LAUNCHER_CLASSES = classNames.map(PolyglotLauncher::getLauncherClass).collect(Collectors.toMap(Class::getName, Function.identity()));
+            String launcherClasses = System.getProperty("com.oracle.graalvm.launcher.launcherclasses");
+            if (launcherClasses == null || launcherClasses.isEmpty()) {
+                AOT_LAUNCHER_CLASSES = Collections.emptyMap();
+            } else {
+                Stream<String> classNames = Pattern.compile(",").splitAsStream(launcherClasses);
+                AOT_LAUNCHER_CLASSES = classNames.map(PolyglotLauncher::getLauncherClass).collect(Collectors.toMap(Class::getName, Function.identity()));
+            }
         } else {
             AOT_LAUNCHER_CLASSES = null;
         }


### PR DESCRIPTION
In the even the property is unset or empty, avoid either
an NPE or a ClassNotFoundException regarding an empty string,
since `splitAsStream` under JDK11 will apparently split an
empty string into a stream of 1 empty string, instead of
an empty stream of no strings.