### PR TITLE
Fold base-pointer-size as a constant.

### DIFF
--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/aarch64/AArch64FrameAccess.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/aarch64/AArch64FrameAccess.java
@@ -25,6 +25,7 @@
 package com.oracle.svm.core.aarch64;
 
 import org.graalvm.nativeimage.hosted.Feature;
+import org.graalvm.compiler.api.replacements.Fold;
 import org.graalvm.nativeimage.ImageSingletons;
 import org.graalvm.nativeimage.Platform;
 import org.graalvm.nativeimage.Platforms;
@@ -56,6 +57,7 @@ public class AArch64FrameAccess extends FrameAccess {
         sourceSp.writeWord(-returnAddressSize() - wordSize(), newReturnAddress);
     }
 
+    @Fold
     @Override
     public int savedBasePointerSize() {
         if (SubstrateOptions.UseStackBasePointer.getValue()) {


### PR DESCRIPTION
Helps to allow for native-image to be native-image'd on aarch64.