### PR TITLE
Refactor additional architecture-specific CPU feature manipulation.

### DIFF
--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/CPUFeatureAccess.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/CPUFeatureAccess.java
@@ -28,4 +28,6 @@ import jdk.vm.ci.code.Architecture;
 
 public interface CPUFeatureAccess {
     void verifyHostSupportsArchitecture(Architecture imageArchitecture);
+
+    void enableFeatures(Architecture architecture);
 }

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/aarch64/AArch64CPUFeatureAccess.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/aarch64/AArch64CPUFeatureAccess.java
@@ -57,4 +57,11 @@ public class AArch64CPUFeatureAccess implements CPUFeatureAccess {
     public void verifyHostSupportsArchitecture(Architecture imageArchitecture) {
 
     }
+
+    @Override
+    public void enableFeatures(Architecture runtimeArchitecture) {
+        AArch64 architecture = (AArch64) runtimeArchitecture;
+        EnumSet<AArch64.CPUFeature> features = determineHostCPUFeatures();
+        architecture.getFeatures().addAll(features);
+    }
 }

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/amd64/AMD64CPUFeatureAccess.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/amd64/AMD64CPUFeatureAccess.java
@@ -179,4 +179,12 @@ public class AMD64CPUFeatureAccess implements CPUFeatureAccess {
             throw VMError.shouldNotReachHere("Current target does not support the following CPU features that are required by the image: " + missingFeatures);
         }
     }
+
+    @Override
+    public void enableFeatures(Architecture runtimeArchitecture) {
+        AMD64 architecture = (AMD64) runtimeArchitecture;
+        EnumSet<AMD64.CPUFeature> features = determineHostCPUFeatures();
+        architecture.getFeatures().addAll(features);
+    }
+
 }

--- a/substratevm/src/com.oracle.svm.graal/src/com/oracle/svm/graal/SubstrateGraalUtils.java
+++ b/substratevm/src/com.oracle.svm.graal/src/com/oracle/svm/graal/SubstrateGraalUtils.java
@@ -28,9 +28,9 @@ import static com.oracle.svm.core.util.VMError.shouldNotReachHere;
 
 import java.io.PrintStream;
 import java.util.EnumMap;
-import java.util.EnumSet;
 import java.util.Map;
 
+import jdk.vm.ci.code.Architecture;
 import org.graalvm.compiler.code.CompilationResult;
 import org.graalvm.compiler.core.CompilationWrapper;
 import org.graalvm.compiler.core.CompilationWrapper.ExceptionAction;
@@ -50,7 +50,6 @@ import org.graalvm.nativeimage.ImageSingletons;
 
 import com.oracle.svm.core.CPUFeatureAccess;
 import com.oracle.svm.core.SubstrateUtil;
-import com.oracle.svm.core.amd64.AMD64CPUFeatureAccess;
 import com.oracle.svm.core.graal.code.SubstrateCompilationIdentifier;
 import com.oracle.svm.core.graal.code.SubstrateCompilationResult;
 import com.oracle.svm.core.graal.meta.InstalledCodeBuilder;
@@ -61,7 +60,6 @@ import com.oracle.svm.core.option.RuntimeOptionKey;
 import com.oracle.svm.graal.meta.SubstrateInstalledCodeImpl;
 import com.oracle.svm.graal.meta.SubstrateMethod;
 
-import jdk.vm.ci.amd64.AMD64;
 import jdk.vm.ci.code.InstalledCode;
 
 public class SubstrateGraalUtils {
@@ -187,11 +185,9 @@ public class SubstrateGraalUtils {
             CPUFeatureAccess cpuFeatureAccess = ImageSingletons.lookup(CPUFeatureAccess.class);
             if (cpuFeatureAccess != null) {
                 cpuFeatureAccess.verifyHostSupportsArchitecture(graalBackend.getCodeCache().getTarget().arch);
+                Architecture architecture = graalBackend.getCodeCache().getTarget().arch;
+                cpuFeatureAccess.enableFeatures(architecture);
             }
-
-            AMD64 architecture = (AMD64) graalBackend.getCodeCache().getTarget().arch;
-            EnumSet<AMD64.CPUFeature> features = AMD64CPUFeatureAccess.determineHostCPUFeatures();
-            architecture.getFeatures().addAll(features);
         }
     }
 


### PR DESCRIPTION
Hide architecture-specific CPU feature manipulation behind
the specific installed CPUFeatureAccess relevant to the
current architecture.