### PR TITLE
Merge two consecutive ldr/str to ldp/stp for AArch64.

### DIFF
--- a/compiler/src/org.graalvm.compiler.asm.aarch64.test/src/org/graalvm/compiler/asm/aarch64/test/AArch64LoadStoreMergingAssemblerTest.java
+++ b/compiler/src/org.graalvm.compiler.asm.aarch64.test/src/org/graalvm/compiler/asm/aarch64/test/AArch64LoadStoreMergingAssemblerTest.java
@@ -1,0 +1,311 @@
+/*
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Arm Limited. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.graalvm.compiler.asm.aarch64.test;
+
+import jdk.vm.ci.aarch64.AArch64;
+import jdk.vm.ci.code.Register;
+import jdk.vm.ci.code.TargetDescription;
+import jdk.vm.ci.runtime.JVMCI;
+import org.graalvm.compiler.asm.aarch64.AArch64Address;
+import org.graalvm.compiler.asm.aarch64.AArch64MacroAssembler;
+import org.graalvm.compiler.test.GraalTest;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assume.assumeTrue;
+
+public class AArch64LoadStoreMergingAssemblerTest extends GraalTest {
+    private Register base;
+    private Register rt1;
+    private Register rt2;
+
+    @Before
+    public void checkAArch64() {
+        TargetDescription target = JVMCI.getRuntime().getHostJVMCIBackend().getTarget();
+        assumeTrue("skipping non AArch64 specific test", target.arch instanceof AArch64);
+    }
+
+    @Before
+    public void setupEnvironment() {
+        base = AArch64.sp;
+        rt1 = AArch64.r1;
+        rt2 = AArch64.r2;
+    }
+
+    private abstract static class AArch64LoadStoreCodeGen {
+        protected AArch64MacroAssembler masm1;
+        protected AArch64MacroAssembler masm2;
+
+        AArch64LoadStoreCodeGen() {
+            TargetDescription target = JVMCI.getRuntime().getHostJVMCIBackend().getTarget();
+            masm1 = new AArch64MacroAssembler(target);
+            masm2 = new AArch64MacroAssembler(target);
+        }
+
+        void emitScaledImmLdr(int size, Register rt, Register base, int imm12) {
+            AArch64Address address = AArch64Address.createScaledImmediateAddress(base, imm12);
+            masm2.ldr(size, rt, address);
+        }
+
+        void emitUnscaledImmLdr(int size, Register rt, Register base, int imm9) {
+            AArch64Address address1 = AArch64Address.createUnscaledImmediateAddress(base, imm9);
+            masm2.ldr(size, rt, address1);
+        }
+
+        void emitScaledImmStr(int size, Register rt, Register base, int imm12) {
+            AArch64Address address = AArch64Address.createScaledImmediateAddress(base, imm12);
+            masm2.str(size, rt, address);
+        }
+
+        void emitUnscaledImmStr(int size, Register rt, Register base, int imm9) {
+            AArch64Address address1 = AArch64Address.createUnscaledImmediateAddress(base, imm9);
+            masm2.str(size, rt, address1);
+        }
+
+        void emitScaledLdp(int size, Register rt1, Register rt2, Register base, int imm7) {
+            AArch64Address mergeAddress = AArch64Address.createScaledImmediateAddress(base, imm7);
+            masm1.ldp(size, rt1, rt2, mergeAddress);
+        }
+
+        void emitScaledStp(int size, Register rt1, Register rt2, Register base, int imm7) {
+            AArch64Address mergeAddress = AArch64Address.createScaledImmediateAddress(base, imm7);
+            masm1.stp(size, rt1, rt2, mergeAddress);
+        }
+
+        void emitUnscaledLdp(int size, Register rt1, Register rt2, Register base, int imm) {
+            AArch64Address mergeAddress = AArch64Address.createUnscaledImmediateAddress(base, imm);
+            masm1.ldp(size, rt1, rt2, mergeAddress);
+        }
+
+        void emitUnscaledStp(int size, Register rt1, Register rt2, Register base, int imm) {
+            AArch64Address mergeAddress = AArch64Address.createUnscaledImmediateAddress(base, imm);
+            masm1.stp(size, rt1, rt2, mergeAddress);
+        }
+
+        abstract void checkAssembly();
+    }
+
+    private static class AArch64LoadStoreMergingCodeGen extends AArch64LoadStoreCodeGen {
+        AArch64LoadStoreMergingCodeGen() {
+            super();
+        }
+
+        @Override
+        void checkAssembly() {
+            byte[] expected = masm1.close(false);
+            byte[] actual = masm2.close(false);
+            assertArrayEquals(expected, actual);
+        }
+    }
+
+    @Test
+    public void testLoad64BitsScaledImmAddress() {
+        AArch64LoadStoreMergingCodeGen codeGen = new AArch64LoadStoreMergingCodeGen();
+        codeGen.emitScaledImmLdr(64, rt1, base, 4);
+        codeGen.emitScaledImmLdr(64, rt2, base, 5);
+        codeGen.emitScaledLdp(64, rt1, rt2, base, 4);
+        codeGen.checkAssembly();
+    }
+
+    @Test
+    public void testLoad32BitsScaledImmAddress() {
+        AArch64LoadStoreMergingCodeGen codeGen = new AArch64LoadStoreMergingCodeGen();
+        codeGen.emitScaledImmLdr(32, rt1, base, 5);
+        codeGen.emitScaledImmLdr(32, rt2, base, 4);
+        codeGen.emitScaledLdp(32, rt2, rt1, base, 4);
+        codeGen.checkAssembly();
+    }
+
+    @Test
+    public void testStore64BitsScaledImmAddress() {
+        AArch64LoadStoreMergingCodeGen codeGen = new AArch64LoadStoreMergingCodeGen();
+        codeGen.emitScaledImmStr(64, rt1, base, 4);
+        codeGen.emitScaledImmStr(64, rt2, base, 5);
+        codeGen.emitScaledStp(64, rt1, rt2, base, 4);
+        codeGen.checkAssembly();
+    }
+
+    @Test
+    public void testStore32BitsScaledImmAddress() {
+        AArch64LoadStoreMergingCodeGen codeGen = new AArch64LoadStoreMergingCodeGen();
+        codeGen.emitScaledImmStr(32, rt1, base, 4);
+        codeGen.emitScaledImmStr(32, rt2, base, 5);
+        codeGen.emitScaledStp(32, rt1, rt2, base, 4);
+        codeGen.checkAssembly();
+    }
+
+    @Test
+    public void testLoad64BitsUnscaledImmAddress() {
+        AArch64LoadStoreMergingCodeGen codeGen = new AArch64LoadStoreMergingCodeGen();
+        codeGen.emitUnscaledImmLdr(64, rt1, base, -32);
+        codeGen.emitUnscaledImmLdr(64, rt2, base, -24);
+        codeGen.emitUnscaledLdp(64, rt1, rt2, base, -32);
+        codeGen.checkAssembly();
+    }
+
+    @Test
+    public void testLoad32BitsUnscaledImmAddress() {
+        AArch64LoadStoreMergingCodeGen codeGen = new AArch64LoadStoreMergingCodeGen();
+        codeGen.emitUnscaledImmLdr(32, rt1, base, 248);
+        codeGen.emitUnscaledImmLdr(32, rt2, base, 252);
+        codeGen.emitUnscaledLdp(32, rt1, rt2, base, 248);
+        codeGen.checkAssembly();
+    }
+
+    @Test
+    public void testStore64BitsUnscaledImmAddress() {
+        AArch64LoadStoreMergingCodeGen codeGen = new AArch64LoadStoreMergingCodeGen();
+        codeGen.emitUnscaledImmStr(64, rt1, base, 32);
+        codeGen.emitUnscaledImmStr(64, rt2, base, 40);
+        codeGen.emitUnscaledStp(64, rt1, rt2, base, 32);
+        codeGen.checkAssembly();
+    }
+
+    @Test
+    public void testStore32BitsUnscaledImmAddress() {
+        AArch64LoadStoreMergingCodeGen codeGen = new AArch64LoadStoreMergingCodeGen();
+        codeGen.emitUnscaledImmStr(32, rt1, base, 32);
+        codeGen.emitUnscaledImmStr(32, rt2, base, 36);
+        codeGen.emitUnscaledStp(32, rt1, rt2, base, 32);
+        codeGen.checkAssembly();
+    }
+
+    @Test
+    public void testLoadUnscaledScaledImmAddress() {
+        AArch64LoadStoreMergingCodeGen codeGen = new AArch64LoadStoreMergingCodeGen();
+        codeGen.emitUnscaledImmLdr(32, rt1, base, 48);
+        codeGen.emitScaledImmLdr(32, rt2, base, 13);
+        codeGen.emitScaledLdp(32, rt1, rt2, base, 12);
+        codeGen.checkAssembly();
+    }
+
+    @Test
+    public void testLoadScaledUnscaledImmAddress() {
+        AArch64LoadStoreMergingCodeGen codeGen = new AArch64LoadStoreMergingCodeGen();
+        codeGen.emitScaledImmLdr(32, rt1, base, 13);
+        codeGen.emitUnscaledImmLdr(32, rt2, base, 48);
+        codeGen.emitUnscaledLdp(32, rt2, rt1, base, 48);
+        codeGen.checkAssembly();
+    }
+
+    @Test
+    public void testLoadMaxAlignedOffset() {
+        AArch64LoadStoreMergingCodeGen codeGen = new AArch64LoadStoreMergingCodeGen();
+        codeGen.emitScaledImmLdr(64, rt1, base, 62);
+        codeGen.emitScaledImmLdr(64, rt2, base, 63);
+        codeGen.emitScaledLdp(64, rt1, rt2, base, 62);
+        codeGen.checkAssembly();
+    }
+
+    @Test
+    public void testStoreMinAlignedOffest() {
+        AArch64LoadStoreMergingCodeGen codeGen = new AArch64LoadStoreMergingCodeGen();
+        codeGen.emitUnscaledImmStr(32, rt1, base, -256);
+        codeGen.emitUnscaledImmStr(32, rt2, base, -252);
+        codeGen.emitUnscaledStp(32, rt1, rt2, base, -256);
+        codeGen.checkAssembly();
+    }
+
+    // All the following tests are the negative ones that ldr/str will not be merged to ldp/stp.
+    private static class AArch64LoadStoreNotMergingCodeGen extends AArch64LoadStoreCodeGen {
+        AArch64LoadStoreNotMergingCodeGen() {
+            super();
+        }
+
+        @Override
+        void checkAssembly() {
+            boolean isMerged = masm2.isImmLoadStoreMerged();
+            masm2.close(false);
+            Assert.assertFalse(isMerged);
+        }
+    }
+
+    @Test
+    public void testDifferentBase() {
+        AArch64LoadStoreNotMergingCodeGen codeGen = new AArch64LoadStoreNotMergingCodeGen();
+        codeGen.emitScaledImmLdr(32, rt1, base, 4);
+        codeGen.emitScaledImmLdr(32, rt2, AArch64.r3, 5);
+        codeGen.checkAssembly();
+    }
+
+    @Test
+    public void testDifferentSize() {
+        AArch64LoadStoreNotMergingCodeGen codeGen = new AArch64LoadStoreNotMergingCodeGen();
+        codeGen.emitScaledImmLdr(32, rt1, base, 4);
+        codeGen.emitScaledImmLdr(64, rt2, base, 5);
+        codeGen.checkAssembly();
+    }
+
+    @Test
+    public void testSameRt() {
+        AArch64LoadStoreNotMergingCodeGen codeGen = new AArch64LoadStoreNotMergingCodeGen();
+        codeGen.emitScaledImmLdr(32, rt1, base, 4);
+        codeGen.emitScaledImmLdr(32, rt1, base, 5);
+        codeGen.checkAssembly();
+    }
+
+    @Test
+    public void testDependencyLdrs() {
+        AArch64LoadStoreNotMergingCodeGen codeGen = new AArch64LoadStoreNotMergingCodeGen();
+        codeGen.emitScaledImmLdr(32, rt1, rt1, 4);
+        codeGen.emitScaledImmLdr(32, rt2, rt1, 5);
+        codeGen.checkAssembly();
+    }
+
+    @Test
+    public void testUnalignedOffset() {
+        AArch64LoadStoreNotMergingCodeGen codeGen = new AArch64LoadStoreNotMergingCodeGen();
+        codeGen.emitUnscaledImmLdr(32, rt1, base, 34);
+        codeGen.emitUnscaledImmLdr(32, rt2, base, 38);
+        codeGen.checkAssembly();
+    }
+
+    @Test
+    public void testUncontinuousOffset() {
+        AArch64LoadStoreNotMergingCodeGen codeGen = new AArch64LoadStoreNotMergingCodeGen();
+        codeGen.emitScaledImmLdr(32, rt1, base, 4);
+        codeGen.emitScaledImmLdr(32, rt2, base, 6);
+        codeGen.checkAssembly();
+    }
+
+    @Test
+    public void testGreaterThanMaxOffset() {
+        AArch64LoadStoreNotMergingCodeGen codeGen = new AArch64LoadStoreNotMergingCodeGen();
+        codeGen.emitScaledImmLdr(32, rt1, base, 66);
+        codeGen.emitScaledImmLdr(32, rt2, base, 67);
+        codeGen.checkAssembly();
+    }
+
+    @Test
+    public void testLdrStr() {
+        AArch64LoadStoreNotMergingCodeGen codeGen = new AArch64LoadStoreNotMergingCodeGen();
+        codeGen.emitScaledImmLdr(32, rt1, base, 4);
+        codeGen.emitScaledImmStr(32, rt2, base, 5);
+        codeGen.checkAssembly();
+    }
+}

--- a/compiler/src/org.graalvm.compiler.asm.aarch64/src/org/graalvm/compiler/asm/aarch64/AArch64Assembler.java
+++ b/compiler/src/org.graalvm.compiler.asm.aarch64/src/org/graalvm/compiler/asm/aarch64/AArch64Assembler.java
@@ -1281,13 +1281,23 @@ public abstract class AArch64Assembler extends Assembler {
     }
 
     /**
+     * Insert ldp/stp at the specified position.
+     */
+    protected void insertLdpStp(int size, Instruction instr, Register rt, Register rt2, Register base, int offset, int position) {
+        InstructionType type = generalFromSize(size);
+        int scaledOffset = maskField(7, offset);
+        int memop = type.encoding | instr.encoding | scaledOffset << LoadStorePairImm7Offset | rt2(rt2) | rn(base) | rt(rt);
+        emitInt(memop | LoadStorePairOp | (0b010 << 23), position);
+    }
+
+    /**
      * Load Pair of Registers calculates an address from a base register value and an immediate
      * offset, and stores two 32-bit words or two 64-bit doublewords to the calculated address, from
      * two registers.
      */
     public void ldp(int size, Register rt, Register rt2, AArch64Address address) {
         assert size == 32 || size == 64;
-        loadStorePairInstruction(LDP, rt, rt2, address, generalFromSize(size));
+        loadStorePairInstruction(size, LDP, rt, rt2, address);
     }
 
     /**
@@ -1297,15 +1307,24 @@ public abstract class AArch64Assembler extends Assembler {
      */
     public void stp(int size, Register rt, Register rt2, AArch64Address address) {
         assert size == 32 || size == 64;
-        loadStorePairInstruction(STP, rt, rt2, address, generalFromSize(size));
+        loadStorePairInstruction(size, STP, rt, rt2, address);
     }
 
-    private void loadStorePairInstruction(Instruction instr, Register rt, Register rt2, AArch64Address address, InstructionType type) {
-        int scaledOffset = maskField(7, address.getImmediateRaw());  // LDP/STP use a 7-bit scaled
-                                                                     // offset
+    private void loadStorePairInstruction(int size, Instruction instr, Register rt, Register rt2, AArch64Address address) {
+        InstructionType type = generalFromSize(size);
+        // LDP/STP uses a 7-bit scaled offset
+        int offset = address.getImmediateRaw();
+        if (address.getAddressingMode() == AddressingMode.IMMEDIATE_UNSCALED) {
+            int sizeInBytes = size / Byte.SIZE;
+            long mask = sizeInBytes - 1;
+            assert (offset & mask) == 0 : "LDP/STP only supports aligned offset.";
+            offset = offset / sizeInBytes;
+        }
+        int scaledOffset = maskField(7, offset);
         int memop = type.encoding | instr.encoding | scaledOffset << LoadStorePairImm7Offset | rt2(rt2) | rn(address.getBase()) | rt(rt);
         switch (address.getAddressingMode()) {
             case IMMEDIATE_SCALED:
+            case IMMEDIATE_UNSCALED:
                 emitInt(memop | LoadStorePairOp | (0b010 << 23));
                 break;
             case IMMEDIATE_POST_INDEXED:

--- a/compiler/src/org.graalvm.compiler.asm.aarch64/src/org/graalvm/compiler/asm/aarch64/AArch64MacroAssembler.java
+++ b/compiler/src/org.graalvm.compiler.asm.aarch64/src/org/graalvm/compiler/asm/aarch64/AArch64MacroAssembler.java
@@ -30,6 +30,8 @@ import static org.graalvm.compiler.asm.aarch64.AArch64Address.AddressingMode.EXT
 import static org.graalvm.compiler.asm.aarch64.AArch64Address.AddressingMode.IMMEDIATE_SCALED;
 import static org.graalvm.compiler.asm.aarch64.AArch64Address.AddressingMode.IMMEDIATE_UNSCALED;
 import static org.graalvm.compiler.asm.aarch64.AArch64Address.AddressingMode.REGISTER_OFFSET;
+import static org.graalvm.compiler.asm.aarch64.AArch64Assembler.Instruction.LDP;
+import static org.graalvm.compiler.asm.aarch64.AArch64Assembler.Instruction.STP;
 import static org.graalvm.compiler.asm.aarch64.AArch64MacroAssembler.AddressGenerationPlan.WorkPlan.ADD_TO_BASE;
 import static org.graalvm.compiler.asm.aarch64.AArch64MacroAssembler.AddressGenerationPlan.WorkPlan.ADD_TO_INDEX;
 import static org.graalvm.compiler.asm.aarch64.AArch64MacroAssembler.AddressGenerationPlan.WorkPlan.NO_WORK;
@@ -57,6 +59,10 @@ public class AArch64MacroAssembler extends AArch64Assembler {
     // Points to the next free scratch register
     private int nextFreeScratchRegister = 0;
 
+    // Last immediate ldr/str instruction, which is a candidate to be merged.
+    private AArch64MemoryEncoding lastImmLoadStoreEncoding;
+    private boolean isImmLoadStoreMerged = false;
+
     public AArch64MacroAssembler(TargetDescription target) {
         super(target);
     }
@@ -81,6 +87,43 @@ public class AArch64MacroAssembler extends AArch64Assembler {
 
     public ScratchRegister getScratchRegister() {
         return scratchRegister[nextFreeScratchRegister++];
+    }
+
+    @Override
+    public void bind(Label l) {
+        super.bind(l);
+        // Clear last ldr/str instruction to prevent the labeled ldr/str being merged.
+        lastImmLoadStoreEncoding = null;
+    }
+
+    private static class AArch64MemoryEncoding {
+        private AArch64Address address;
+        private Register result;
+        private int sizeInBytes;
+        private int position;
+        private boolean isStore;
+
+        AArch64MemoryEncoding(int sizeInBytes, Register result, AArch64Address address, boolean isStore, int position) {
+            this.sizeInBytes = sizeInBytes;
+            this.result = result;
+            this.address = address;
+            this.isStore = isStore;
+            this.position = position;
+            AArch64Address.AddressingMode addressingMode = address.getAddressingMode();
+            assert addressingMode == IMMEDIATE_SCALED || addressingMode == IMMEDIATE_UNSCALED : "Invalid address mode" +
+                            "to merge: " + addressingMode;
+        }
+
+        Register getBase() {
+            return address.getBase();
+        }
+
+        int getOffset() {
+            if (address.getAddressingMode() == IMMEDIATE_UNSCALED) {
+                return address.getImmediateRaw();
+            }
+            return address.getImmediate() * sizeInBytes;
+        }
     }
 
     /**
@@ -323,6 +366,132 @@ public class AArch64MacroAssembler extends AArch64Assembler {
         }
     }
 
+    private boolean tryMerge(int sizeInBytes, Register rt, AArch64Address address, boolean isStore) {
+        isImmLoadStoreMerged = false;
+        if (lastImmLoadStoreEncoding == null) {
+            return false;
+        }
+
+        // Only immediate scaled/unscaled address can be merged.
+        // Pre-index and post-index mode can't be merged.
+        AArch64Address.AddressingMode addressMode = address.getAddressingMode();
+        if (addressMode != IMMEDIATE_SCALED && addressMode != IMMEDIATE_UNSCALED) {
+            return false;
+        }
+
+        // Only the two adjacent ldrs/strs can be merged.
+        int lastPosition = position() - 4;
+        if (lastPosition < 0 || lastPosition != lastImmLoadStoreEncoding.position) {
+            return false;
+        }
+
+        if (isStore != lastImmLoadStoreEncoding.isStore) {
+            return false;
+        }
+
+        // Only merge ldr/str with the same size of 32bits or 64bits.
+        if (sizeInBytes != lastImmLoadStoreEncoding.sizeInBytes || (sizeInBytes != 4 && sizeInBytes != 8)) {
+            return false;
+        }
+
+        // Base register must be the same one.
+        Register curBase = address.getBase();
+        Register preBase = lastImmLoadStoreEncoding.getBase();
+        if (!curBase.equals(preBase)) {
+            return false;
+        }
+
+        // If the two ldrs have the same rt register, they can't be merged.
+        // If the two ldrs have dependence, they can't be merged.
+        Register curRt = rt;
+        Register preRt = lastImmLoadStoreEncoding.result;
+        if (!isStore && (curRt.equals(preRt) || preRt.equals(curBase))) {
+            return false;
+        }
+
+        // Offset checking. Offsets of the two ldrs/strs must be continuous.
+        int curOffset = address.getImmediateRaw();
+        if (addressMode == IMMEDIATE_SCALED) {
+            curOffset = curOffset * sizeInBytes;
+        }
+        int preOffset = lastImmLoadStoreEncoding.getOffset();
+        if (Math.abs(curOffset - preOffset) != sizeInBytes) {
+            return false;
+        }
+
+        // Offset must be in ldp/stp instruction's range.
+        int offset = curOffset > preOffset ? preOffset : curOffset;
+        int minOffset = -64 * sizeInBytes;
+        int maxOffset = 63 * sizeInBytes;
+        if (offset < minOffset || offset > maxOffset) {
+            return false;
+        }
+
+        // Alignment checking.
+        if (isFlagSet(AArch64.Flag.AvoidUnalignedAccesses)) {
+            // AArch64 sp is 16-bytes aligned.
+            if (curBase.equals(sp)) {
+                long pairMask = sizeInBytes * 2 - 1;
+                if ((offset & pairMask) != 0) {
+                    return false;
+                }
+            } else {
+                // If base is not sp, we can't guarantee the access is aligned.
+                return false;
+            }
+        } else {
+            // ldp/stp only supports sizeInBytes aligned offset.
+            long mask = sizeInBytes - 1;
+            if ((curOffset & mask) != 0 || (preOffset & mask) != 0) {
+                return false;
+            }
+        }
+
+        // Merge two ldrs/strs to ldp/stp.
+        Register rt1 = preRt;
+        Register rt2 = curRt;
+        if (curOffset < preOffset) {
+            rt1 = curRt;
+            rt2 = preRt;
+        }
+        int immediate = offset / sizeInBytes;
+        Instruction instruction = isStore ? STP : LDP;
+        int size = sizeInBytes * Byte.SIZE;
+        insertLdpStp(size, instruction, rt1, rt2, curBase, immediate, lastPosition);
+        lastImmLoadStoreEncoding = null;
+        isImmLoadStoreMerged = true;
+        return true;
+    }
+
+    /**
+     * Try to merge two continuous ldr/str to one ldp/stp. If this current ldr/str is not merged,
+     * save it as the last ldr/str.
+     */
+    private boolean tryMergeLoadStore(int srcSize, Register rt, AArch64Address address, boolean isStore) {
+        int sizeInBytes = srcSize / Byte.SIZE;
+        if (tryMerge(sizeInBytes, rt, address, isStore)) {
+            return true;
+        }
+
+        // Save last ldr/str if it is not merged.
+        AArch64Address.AddressingMode addressMode = address.getAddressingMode();
+        if (addressMode == IMMEDIATE_SCALED || addressMode == IMMEDIATE_UNSCALED) {
+            if (addressMode == IMMEDIATE_UNSCALED) {
+                long mask = sizeInBytes - 1;
+                int offset = address.getImmediateRaw();
+                if ((offset & mask) != 0) {
+                    return false;
+                }
+            }
+            lastImmLoadStoreEncoding = new AArch64MemoryEncoding(sizeInBytes, rt, address, isStore, position());
+        }
+        return false;
+    }
+
+    public boolean isImmLoadStoreMerged() {
+        return isImmLoadStoreMerged;
+    }
+
     public void movx(Register dst, Register src) {
         mov(64, dst, src);
     }
@@ -504,7 +673,7 @@ public class AArch64MacroAssembler extends AArch64Assembler {
         assert targetSize == 32 || targetSize == 64;
         assert srcSize <= targetSize;
         if (targetSize == srcSize) {
-            super.ldr(srcSize, rt, address);
+            ldr(srcSize, rt, address);
         } else {
             super.ldrs(targetSize, srcSize, rt, address);
         }
@@ -520,7 +689,25 @@ public class AArch64MacroAssembler extends AArch64Assembler {
      */
     @Override
     public void ldr(int srcSize, Register rt, AArch64Address address) {
-        super.ldr(srcSize, rt, address);
+        // Try to merge two adjacent loads into one ldp.
+        if (!tryMergeLoadStore(srcSize, rt, address, false)) {
+            super.ldr(srcSize, rt, address);
+        }
+    }
+
+    /**
+     * Stores register rt into memory pointed by address.
+     *
+     * @param destSize number of bits written to memory. Must be 8, 16, 32 or 64.
+     * @param rt general purpose register. May not be null or stackpointer.
+     * @param address all addressing modes allowed. May not be null.
+     */
+    @Override
+    public void str(int destSize, Register rt, AArch64Address address) {
+        // Try to merge two adjacent stores into one stp.
+        if (!tryMergeLoadStore(destSize, rt, address, true)) {
+            super.str(destSize, rt, address);
+        }
     }
 
     /**

--- a/compiler/src/org.graalvm.compiler.core.aarch64.test/src/org/graalvm/compiler/core/aarch64/test/AArch64PairLoadStoreTest.java
+++ b/compiler/src/org.graalvm.compiler.core.aarch64.test/src/org/graalvm/compiler/core/aarch64/test/AArch64PairLoadStoreTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Arm Limited and affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package org.graalvm.compiler.core.aarch64.test;
+
+import jdk.vm.ci.aarch64.AArch64;
+import jdk.vm.ci.runtime.JVMCI;
+import org.graalvm.compiler.core.test.GraalCompilerTest;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assume.assumeTrue;
+
+public class AArch64PairLoadStoreTest extends GraalCompilerTest {
+
+    @Before
+    public void checkAArch64() {
+        assumeTrue("skipping AArch64 specific test", JVMCI.getRuntime().getHostJVMCIBackend().getTarget().arch instanceof AArch64);
+    }
+
+    public static long parameterSpill(long v1, long v2, long v3, long v4, long v5, long v6, long v7, long v8, long v9, long v10) {
+        long value0 = v1 + v2 + v3 + v4 + v5 + v6 + v7 + v8;
+        long value1 = v9 + v10;
+        return value0 + value1;
+    }
+
+    @Test
+    public void testParameterSpill() {
+        test("parameterSpill", 1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L, 9L, 10L);
+    }
+
+    static class A {
+        static String a = "adsaf";
+
+        static String b = "asfgsfd";
+
+        static int c;
+
+        static int d;
+    }
+
+    public static int pairLoadStaticFields() {
+        if (A.a == null || A.a != A.b) {
+            return A.b.length();
+        }
+        return A.a.length();
+    }
+
+    @Test
+    public void testPairLoadStaticFields() {
+        test("pairLoadStaticFields");
+    }
+
+    public static int pairStoreStaticFields(int m, int n) {
+        A.c = m;
+        A.d = n;
+        return A.c + A.d;
+    }
+
+    @Test
+    public void testPairStoreStaticFields() {
+        test("pairStoreStaticFields", 1, 2);
+    }
+}

--- a/compiler/src/org.graalvm.compiler.lir.aarch64/src/org/graalvm/compiler/lir/aarch64/AArch64Move.java
+++ b/compiler/src/org.graalvm.compiler.lir.aarch64/src/org/graalvm/compiler/lir/aarch64/AArch64Move.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -255,10 +255,19 @@ public class AArch64Move {
 
         @Override
         public void emitCode(CompilationResultBuilder crb, AArch64MacroAssembler masm) {
-            if (state != null) {
-                crb.recordImplicitException(masm.position(), state);
-            }
+            int prePosition = masm.position();
             emitMemAccess(crb, masm);
+            if (state != null) {
+                int implicitExceptionPosition = prePosition;
+                // Adjust implicit exception position if this ldr/str has been merged to ldp/stp.
+                if (kind.isInteger() && prePosition == masm.position() && masm.isImmLoadStoreMerged()) {
+                    implicitExceptionPosition = prePosition - 4;
+                    if (crb.isImplicitExceptionExist(implicitExceptionPosition)) {
+                        return;
+                    }
+                }
+                crb.recordImplicitException(implicitExceptionPosition, state);
+            }
         }
 
         @Override
@@ -346,8 +355,17 @@ public class AArch64Move {
 
         @Override
         public void emitCode(CompilationResultBuilder crb, AArch64MacroAssembler masm) {
-            crb.recordImplicitException(masm.position(), state);
+            int prePosition = masm.position();
             masm.ldr(64, zr, address.toAddress());
+            int implicitExceptionPosition = prePosition;
+            // Adjust implicit exception position if this ldr has been merged to ldp.
+            if (prePosition == masm.position() && masm.isImmLoadStoreMerged()) {
+                implicitExceptionPosition = prePosition - 4;
+                if (crb.isImplicitExceptionExist(implicitExceptionPosition)) {
+                    return;
+                }
+            }
+            crb.recordImplicitException(implicitExceptionPosition, state);
         }
 
         @Override

--- a/compiler/src/org.graalvm.compiler.lir.aarch64/src/org/graalvm/compiler/lir/aarch64/AArch64Unary.java
+++ b/compiler/src/org.graalvm.compiler.lir.aarch64/src/org/graalvm/compiler/lir/aarch64/AArch64Unary.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -72,15 +72,25 @@ public class AArch64Unary {
 
         @Override
         public void emitCode(CompilationResultBuilder crb, AArch64MacroAssembler masm) {
-            if (state != null) {
-                crb.recordImplicitException(masm.position(), state);
-            }
+            int prePosition = masm.position();
             AArch64Address address = input.toAddress();
             Register dst = asRegister(result);
             if (isSigned) {
                 masm.ldrs(targetSize, srcSize, dst, address);
             } else {
                 masm.ldr(srcSize, dst, address);
+            }
+
+            if (state != null) {
+                int implicitExceptionPosition = prePosition;
+                // Adjust implicit exception position if this ldr/str has been merged to ldp/stp.
+                if (prePosition == masm.position() && masm.isImmLoadStoreMerged()) {
+                    implicitExceptionPosition = prePosition - 4;
+                    if (crb.isImplicitExceptionExist(implicitExceptionPosition)) {
+                        return;
+                    }
+                }
+                crb.recordImplicitException(implicitExceptionPosition, state);
             }
         }
 

--- a/compiler/src/org.graalvm.compiler.lir/src/org/graalvm/compiler/lir/asm/CompilationResultBuilder.java
+++ b/compiler/src/org.graalvm.compiler.lir/src/org/graalvm/compiler/lir/asm/CompilationResultBuilder.java
@@ -69,6 +69,7 @@ import jdk.vm.ci.code.StackSlot;
 import jdk.vm.ci.code.TargetDescription;
 import jdk.vm.ci.code.site.ConstantReference;
 import jdk.vm.ci.code.site.DataSectionReference;
+import jdk.vm.ci.code.site.Infopoint;
 import jdk.vm.ci.code.site.InfopointReason;
 import jdk.vm.ci.code.site.Mark;
 import jdk.vm.ci.meta.Constant;
@@ -253,6 +254,16 @@ public class CompilationResultBuilder {
     public void recordImplicitException(int pcOffset, LIRFrameState info) {
         compilationResult.recordInfopoint(pcOffset, info.debugInfo(), InfopointReason.IMPLICIT_EXCEPTION);
         assert info.exceptionEdge == null;
+    }
+
+    public boolean isImplicitExceptionExist(int pcOffset) {
+        List<Infopoint> infopoints = compilationResult.getInfopoints();
+        for (Infopoint infopoint : infopoints) {
+            if (infopoint.pcOffset == pcOffset && infopoint.reason == InfopointReason.IMPLICIT_EXCEPTION) {
+                return true;
+            }
+        }
+        return false;
     }
 
     public void recordDirectCall(int posBefore, int posAfter, InvokeTarget callTarget, LIRFrameState info) {


### PR DESCRIPTION
This patch will merge two ldr/str to one ldp/stp, like:

```
    str x1, [sp, #128]
    str x2, [sp, #120]
```

will be merged to:

```
    stp x2, x1, [sp, #120]
```

The same to the load operation.

We have to begin this optimization after register allocation,
so that some loads/stores generated for spilling can also be optimized.
Besides we should take care of the following tips:
1. The second ldr/str is not bound to a label.
2. We need to update the Infopoint list when an ImplicitException is
recorded at the second ldr/str position. In this patch, I updated its
position to the first ldr/str position.
3. Some basic ldr/str instruction form checkings when merging to ldp/stp.
More details can be found in my patch.

Here are two jmh cases for this patch:

```
private static int pairLoad() {
    int ret = 0;
    for (int i = 0; i < 10000000; i++) {
        A aa = arr[i];
        ret += aa.a + aa.b;
    }
    return ret;
}

@Benchmark
public int jmhPairLoad() {
    return pairLoad();
}

private static int pairStore(int m, int n) {
    int ret = 0;
    int factor = m + n;
    for (int i = 0; i < 100000; i++) {
        A.c = i;
        A.d = i;
        ret += factor * (A.c + A.d);
    }
    return ret;
}

@Benchmark
public int jmhPairStore() {
    return pairStore(5, 6);
}
```


Add the results:

```
                                            Without this patch
Benchmark                 Mode    Cnt       Score           Error         Units
LdStMerging.jmhPairLoad       avgt     15    120222.590  ? 5719.105    us/op
LdStMerging.jmhPairStore      avgt     15      114.279    ?  0.055     us/op

                                               With this patch
Benchmark                 Mode    Cnt       Score           Error         Units
LdStMerging.jmhPairLoad       avgt     15     116779.081  ? 2964.116   us/op
LdStMerging.jmhPairStore      avgt     15       83.901     ?  1.324      us/op
```


Change-Id: I6c1e3f54e7a1152c41499e9d7aeb50aa7bc62514