### PR TITLE
add simple implementation for JVM_GetNanoTimeAdjustment()

### DIFF
--- a/substratevm/src/com.oracle.svm.native.jvm.posix/src/JvmFuncs.c
+++ b/substratevm/src/com.oracle.svm.native.jvm.posix/src/JvmFuncs.c
@@ -307,6 +307,15 @@ JNIEXPORT jlong JVM_NanoTime(void *env, void * ignored) {
     return Java_java_lang_System_nanoTime(env, ignored);
 }
 
+JNIEXPORT jlong JVM_GetNanoTimeAdjustment(void *env, void * ignored, jlong offset_secs) {
+    printf("JVM_GetNanoTimeAdjustment called: not implemented, return 0\n");
+    return 0;
+}
+
+JNIEXPORT jlong Java_jdk_internal_misc_VM_getNanoTimeAdjustment(void *env, void * ignored, jlong offset_secs) {
+    return JVM_GetNanoTimeAdjustment(env, ignored, offset_secs);
+}
+
 JNIEXPORT void JVM_Halt(int retcode) {
     _exit(retcode);
 }


### PR DESCRIPTION
This is just a basic implementation that always returns 0.
Most important is that there is an implementation that is not returning -1.

When this PR got accepted, a new issue should be created for writing a proper implementation.

This fixes #1263 