### PR TITLE
Implement ClassLoader.getPlatformClassLoader()

### DIFF
--- a/substratevm/mx.substratevm/mx_substratevm.py
+++ b/substratevm/mx.substratevm/mx_substratevm.py
@@ -119,6 +119,8 @@ GRAAL_COMPILER_FLAGS_MAP['11'].extend(add_opens_from_packages(jdk_opens_packages
 
 # These packages should be opened at runtime calls to Modules.addOpens, if they are still needed.
 java_base_opens_packages = [
+    # Reflective access to jdk.internal.logger classes
+    'java.base/jdk.internal.logger',
     # Reflective access to jdk.internal.ref.CleanerImpl$PhantomCleanableRef.
     'java.base/jdk.internal.ref',
     # Reflective access to jdk.internal.reflect.MethodAccessor.

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/JavaLangSubstitutions.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/JavaLangSubstitutions.java
@@ -719,6 +719,7 @@ public final class JavaLangSubstitutions {
 
     public static class ClassLoaderSupport {
         public Target_java_lang_ClassLoader systemClassLoader;
+        public Target_java_lang_ClassLoader platformClassLoader;
 
         @Platforms(Platform.HOSTED_ONLY.class) public Map<ClassLoader, Target_java_lang_ClassLoader> classLoaders = Collections.synchronizedMap(new IdentityHashMap<>());
 

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/Target_java_lang_ClassLoader.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/Target_java_lang_ClassLoader.java
@@ -139,7 +139,7 @@ public final class Target_java_lang_ClassLoader {
     @Substitute //
     @TargetElement(onlyWith = JDK9OrLater.class) //
     public static ClassLoader getPlatformClassLoader() {
-        throw VMError.unsupportedFeature("JDK9OrLater: Target_java_lang_ClassLoader.getPlatformClassLoader()");
+        return SubstrateUtil.cast(ClassLoaderSupport.getInstance().platformClassLoader, ClassLoader.class);
     }
 
     @Substitute //

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/ClassLoaderFeature.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/ClassLoaderFeature.java
@@ -41,6 +41,7 @@ public class ClassLoaderFeature implements Feature {
     public void beforeAnalysis(BeforeAnalysisAccess access) {
         ClassLoaderSupport.getInstance().createClassLoaders(ClassLoader.getSystemClassLoader());
         ClassLoaderSupport.getInstance().systemClassLoader = ClassLoaderSupport.getInstance().classLoaders.get(ClassLoader.getSystemClassLoader());
+        ClassLoaderSupport.getInstance().platformClassLoader = ClassLoaderSupport.getInstance().classLoaders.get(ClassLoader.getPlatformClassLoader());
     }
 
     @Override


### PR DESCRIPTION
add add-opens for jdk.internal.logger (used by e.g. Formatter in core JDK classes)

This fixes #1276 