### PR TITLE
Fix CheckGraalIntrinsics failure with latest jdk11u

### DIFF
--- a/compiler/src/org.graalvm.compiler.hotspot.test/src/org/graalvm/compiler/hotspot/test/CheckGraalIntrinsics.java
+++ b/compiler/src/org.graalvm.compiler.hotspot.test/src/org/graalvm/compiler/hotspot/test/CheckGraalIntrinsics.java
@@ -386,19 +386,15 @@ public class CheckGraalIntrinsics extends GraalTest {
         if (isJDK11OrHigher()) {
             // Relevant for Java flight recorder
             add(toBeInvestigated,
+                            "java/lang/CharacterDataLatin1.isDigit(I)Z",
+                            "java/lang/CharacterDataLatin1.isLowerCase(I)Z",
+                            "java/lang/CharacterDataLatin1.isUpperCase(I)Z",
+                            "java/lang/CharacterDataLatin1.isWhitespace(I)Z",
                             "jdk/jfr/internal/JVM.getEventWriter()Ljava/lang/Object;");
             if (!config.useBase64Intrinsics()) {
                 add(ignore,
                                 "java/util/Base64$Encoder.encodeBlock([BII[BIZ)V");
             }
-        }
-
-        if (isJDK12OrHigher()) {
-            add(toBeInvestigated,
-                            "java/lang/CharacterDataLatin1.isDigit(I)Z",
-                            "java/lang/CharacterDataLatin1.isLowerCase(I)Z",
-                            "java/lang/CharacterDataLatin1.isUpperCase(I)Z",
-                            "java/lang/CharacterDataLatin1.isWhitespace(I)Z");
         }
 
         if (isJDK13OrHigher()) {


### PR DESCRIPTION
HotSpot intrinsics isDigit/isLowerCase/isUpperCase/isWhitespace are added into the toBeInvestigated set with the condition that jdk version is 12 or higher. But now these intrinsics are backported to jdk11u[1]. We should change the condition to isJDK11OrHigher.

[1] http://hg.openjdk.java.net/jdk-updates/jdk11u/rev/d8c737fcf612