### PR TITLE
No-op module reflection modifications.

### DIFF
--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/Target_java_lang_Module.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/Target_java_lang_Module.java
@@ -28,6 +28,7 @@ import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.util.List;
 
+import com.oracle.svm.core.annotate.Delete;
 import com.oracle.svm.core.annotate.Substitute;
 import com.oracle.svm.core.annotate.TargetClass;
 import com.oracle.svm.core.annotate.TargetElement;
@@ -41,4 +42,53 @@ public final class Target_java_lang_Module {
         List<byte[]> arr = Resources.get(name);
         return arr == null ? null : new ByteArrayInputStream(arr.get(0));
     }
+
+    /*
+     * All implementations of these stubs are completely empty no-op.
+     * This seems appropriate as DynamicHub only references a singleton
+     * Module implementation anyhow, effectively neutering the module system
+     * within JDK11.
+     */
+
+    @SuppressWarnings({"unused", "static-method"})
+    @Substitute
+    public boolean isReflectivelyExportedOrOpen(String pn, Target_java_lang_Module other, boolean open) {
+        return true;
+    }
+
+    @SuppressWarnings({"unused", "static-method"})
+    @Substitute
+    private void implAddReads(Target_java_lang_Module other, boolean syncVM) {
+    }
+
+    @SuppressWarnings({"unused", "static-method"})
+    @Substitute
+    private void implAddExportsOrOpens(String pn,
+                    Target_java_lang_Module other,
+                    boolean open,
+                    boolean syncVM) {
+    }
+
+    @SuppressWarnings({"unused", "static-method"})
+    @Substitute
+    void implAddUses(Class<?> service) {
+    }
+
+    @SuppressWarnings({"unused", "static-method"})
+    @Substitute
+    public boolean canUse(Class<?> service) {
+        return true;
+    }
+
+    @SuppressWarnings({"unused", "static-method"})
+    @Substitute
+    public boolean canRead(Target_java_lang_Module other) {
+        return true;
+    }
+
+    @Delete
+    @TargetClass(className = "java.lang.Module", innerClass = "ReflectionData", onlyWith = JDK11OrLater.class)
+    public static final class ReflectionData {
+    }
+
 }


### PR DESCRIPTION
The WeakPairMap inside Module$ReflectionData was changing,
sometimes, during heap generation of native-image.

Delete the class and no-op the relevant methods that used it.

Might be a sub-optimal solution, but avoids spurious native-image
failures at this point when using JDK11+.