### PR TITLE
Fix condition for memory bulk zeroing

### DIFF
--- a/compiler/src/org.graalvm.compiler.hotspot/src/org/graalvm/compiler/hotspot/replacements/NewObjectSnippets.java
+++ b/compiler/src/org.graalvm.compiler.hotspot/src/org/graalvm/compiler/hotspot/replacements/NewObjectSnippets.java
@@ -605,7 +605,7 @@ public class NewObjectSnippets implements Snippets {
         } else {
             // Use Word instead of int to avoid extension to long in generated code
             Word off = WordFactory.signed(offset);
-            if (useBulkZeroing && probability(SLOW_PATH_PROBABILITY, size >= getMinimalBulkZeroingSize(INJECTED_OPTIONVALUES))) {
+            if (useBulkZeroing && value == 0 && probability(SLOW_PATH_PROBABILITY, (size - offset) >= getMinimalBulkZeroingSize(INJECTED_OPTIONVALUES))) {
                 if (theCounters != null && theCounters.instanceBulkInit != null) {
                     theCounters.instanceBulkInit.inc();
                 }
@@ -624,7 +624,6 @@ public class NewObjectSnippets implements Snippets {
                 for (; off.rawValue() < size; off = off.add(8)) {
                     memory.initializeLong(off, value, LocationIdentity.init());
                 }
-
             }
         }
     }


### PR DESCRIPTION
In the snippet code for allocating new array/object, method fillMemory()
calls ZeroMemoryNode.zero() without checking the value to fill is zero
or not. And, to be more accurate, the value of "size - offset", which is
the actual number of bytes to be zeroed, should be compared against the
value of "MinimalBulkZeroingSize".