### PR TITLE
Fix rounding conditions for SignedDivNode when canonicalized.

### DIFF
--- a/compiler/src/org.graalvm.compiler.nodes/src/org/graalvm/compiler/nodes/calc/SignedDivNode.java
+++ b/compiler/src/org.graalvm.compiler.nodes/src/org/graalvm/compiler/nodes/calc/SignedDivNode.java
@@ -122,7 +122,7 @@ public class SignedDivNode extends IntegerDivRemNode implements LIRLowerable {
             ValueNode dividend = forX;
             int log2 = CodeUtil.log2(abs);
             // no rounding if dividend is positive or if its low bits are always 0
-            if (stampX.canBeNegative() || (stampX.upMask() & (abs - 1)) != 0) {
+            if (stampX.canBeNegative() && (stampX.upMask() & (abs - 1)) != 0) {
                 int bits = PrimitiveStamp.getBits(forX.stamp(view));
                 RightShiftNode sign = new RightShiftNode(forX, ConstantNode.forInt(bits - 1));
                 UnsignedRightShiftNode round = new UnsignedRightShiftNode(sign, ConstantNode.forInt(bits - log2));


### PR DESCRIPTION
The conditions that a division can be replaced by one shift
instruction are:
1. The divisor is power-of-2.
2. The dividend is positive, or its low bits are always 0.
Otherwise, the dividend needs to be rounded if we still want to
replace the division by shift when the divisor is power-of-2.

But the conditions to round the dividend in Graal is:
"if (stampX.canBeNegative() || (stampX.upMask() & (abs - 1)) != 0)"
So if stampX is positive, and its low bits are not always 0, it will
also be rounded. This will also generate the rounding instructions,
which is redundant.

This patch modifies the conditions to make sure that any positive
dividend is not rounded.

Change-Id: I3bf4eceb11f50d3aa6e0bc606f7927f20259a477