### PR TITLE
AArch64 - Read return address correctly.

### DIFF
--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/aarch64/AArch64FrameAccess.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/aarch64/AArch64FrameAccess.java
@@ -48,13 +48,13 @@ class AMD64FrameAccessFeature implements Feature {
 public class AArch64FrameAccess extends FrameAccess {
     @Override
     public CodePointer readReturnAddress(Pointer sourceSp) {
-        /* Read the return address, which is stored one word below the stack pointer. */
-        return (CodePointer) sourceSp.readWord(-returnAddressSize() - wordSize());
+        /* Read the return address, which is stored immediately below the stack pointer. */
+        return (CodePointer) sourceSp.readWord(-returnAddressSize());
     }
 
     @Override
     public void writeReturnAddress(Pointer sourceSp, CodePointer newReturnAddress) {
-        sourceSp.writeWord(-returnAddressSize() - wordSize(), newReturnAddress);
+        sourceSp.writeWord(-returnAddressSize(), newReturnAddress);
     }
 
     @Fold


### PR DESCRIPTION
Since the FrameContext uses `stp fp, lr, ...` to store the
`fp` and `lr` as the first two words in the frame,
the layout is actually:

--------- frame start ---------
lr (word)
fp (word)
--------- rest of frame -------
...

Therefore, when walking the stack, to read the return value
of a given frame with an effective frame-start address, the
immediately first word is the `lr`. Reading the second results
in reading the `fp` which ultimately results in a bus error
on AArch64.