### PR TITLE
Infer stamp for the dividend of integer division and remainder.

### DIFF
--- a/compiler/mx.compiler/suite.py
+++ b/compiler/mx.compiler/suite.py
@@ -1215,7 +1215,10 @@ suite = {
     "org.graalvm.compiler.phases.common" : {
       "subDir" : "src",
       "sourceDirs" : ["src"],
-      "dependencies" : ["org.graalvm.compiler.phases"],
+      "dependencies" : [
+        "org.graalvm.compiler.phases",
+        "org.graalvm.compiler.loop",
+      ],
       "annotationProcessors" : [
         "GRAAL_NODEINFO_PROCESSOR",
         "GRAAL_OPTIONS_PROCESSOR"
@@ -1307,8 +1310,7 @@ suite = {
       "subDir" : "src",
       "sourceDirs" : ["src"],
       "dependencies" : [
-     "org.graalvm.compiler.loop",
-     "org.graalvm.compiler.phases.common",
+        "org.graalvm.compiler.phases.common",
        ],
       "annotationProcessors" : ["GRAAL_OPTIONS_PROCESSOR"],
       "checkstyle" : "org.graalvm.compiler.graph",

--- a/compiler/src/org.graalvm.compiler.core/src/org/graalvm/compiler/core/phases/HighTier.java
+++ b/compiler/src/org.graalvm.compiler.core/src/org/graalvm/compiler/core/phases/HighTier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,6 +36,7 @@ import static org.graalvm.compiler.phases.common.DeadCodeEliminationPhase.Option
 
 import org.graalvm.compiler.loop.DefaultLoopPolicies;
 import org.graalvm.compiler.loop.LoopPolicies;
+import org.graalvm.compiler.loop.phases.ConvertDeoptimizeToGuardPhase;
 import org.graalvm.compiler.loop.phases.LoopFullUnrollPhase;
 import org.graalvm.compiler.loop.phases.LoopPeelingPhase;
 import org.graalvm.compiler.loop.phases.LoopUnswitchingPhase;
@@ -46,12 +47,12 @@ import org.graalvm.compiler.options.OptionType;
 import org.graalvm.compiler.options.OptionValues;
 import org.graalvm.compiler.phases.PhaseSuite;
 import org.graalvm.compiler.phases.common.CanonicalizerPhase;
-import org.graalvm.compiler.loop.phases.ConvertDeoptimizeToGuardPhase;
 import org.graalvm.compiler.phases.common.DeadCodeEliminationPhase;
 import org.graalvm.compiler.phases.common.IncrementalCanonicalizerPhase;
 import org.graalvm.compiler.phases.common.IterativeConditionalEliminationPhase;
 import org.graalvm.compiler.phases.common.LoweringPhase;
 import org.graalvm.compiler.phases.common.NodeCounterPhase;
+import org.graalvm.compiler.phases.common.OptimizeDivPhase;
 import org.graalvm.compiler.phases.common.RemoveValueProxyPhase;
 import org.graalvm.compiler.phases.common.inlining.InliningPhase;
 import org.graalvm.compiler.phases.common.inlining.policy.GreedyInliningPolicy;
@@ -70,6 +71,9 @@ public class HighTier extends PhaseSuite<HighTierContext> {
     }
 
     public HighTier(OptionValues options) {
+        // Only infer the stamp of the dividend of integer div/rem.
+        appendPhase(new OptimizeDivPhase(true));
+
         CanonicalizerPhase canonicalizer = new CanonicalizerPhase();
         if (ImmutableCode.getValue(options)) {
             canonicalizer.disableReadCanonicalization();

--- a/compiler/src/org.graalvm.compiler.nodes.test/src/org/graalvm/compiler/nodes/test/IntegerDivRemNodeCanonicalizationTest.java
+++ b/compiler/src/org.graalvm.compiler.nodes.test/src/org/graalvm/compiler/nodes/test/IntegerDivRemNodeCanonicalizationTest.java
@@ -1,0 +1,214 @@
+/*
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Arm Limited. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.graalvm.compiler.nodes.test;
+
+import org.graalvm.compiler.core.common.type.PrimitiveStamp;
+import org.graalvm.compiler.core.test.GraalCompilerTest;
+import org.graalvm.compiler.graph.iterators.NodePredicate;
+import org.graalvm.compiler.nodes.NodeView;
+import org.graalvm.compiler.nodes.StructuredGraph;
+import org.graalvm.compiler.nodes.ValueNode;
+import org.graalvm.compiler.nodes.calc.AndNode;
+import org.graalvm.compiler.nodes.calc.RightShiftNode;
+import org.graalvm.compiler.nodes.calc.UnsignedRightShiftNode;
+import org.graalvm.compiler.phases.common.CanonicalizerPhase;
+import org.graalvm.compiler.phases.common.OptimizeDivPhase;
+import org.graalvm.compiler.phases.tiers.HighTierContext;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class IntegerDivRemNodeCanonicalizationTest extends GraalCompilerTest {
+    // Test positive remainder in increment counted loop.
+    public static int remInCountedLoop1() {
+        int sum = 0;
+        for (int i = 0; i < 1000000; i++) {
+            sum += i % 8;
+        }
+        return sum;
+    }
+
+    @Test
+    public void testRemInCountedLoop1() {
+        testRemainder("remInCountedLoop1", 7);
+    }
+
+    // Test positive remainder in decrement counted loop.
+    public static int remInCountedLoop2() {
+        int sum = 0;
+        int i;
+        for (i = 10000; i >= 0; i--) {
+            sum += i % 4;
+        }
+        sum += i % 8;
+        return sum;
+    }
+
+    @Test
+    public void testRemInCountedLoop2() {
+        test("remInCountedLoop2");
+        StructuredGraph graph = buildGraph("remInCountedLoop2");
+
+        // The remainder inside of the loop should be optimized to "i & 3".
+        assertExist(graph, (node) -> {
+            if (node instanceof AndNode) {
+                ValueNode y = ((AndNode) node).getY();
+                return y.isConstant() && y.asJavaConstant().asLong() == 3;
+            }
+            return false;
+        });
+
+        // The last remainder outside of the loop shouldn't be optimized to "i & 7".
+        assertNotExist(graph, (node) -> {
+            if (node instanceof AndNode) {
+                ValueNode y = ((AndNode) node).getY();
+                return y.isConstant() && y.asJavaConstant().asLong() == 7;
+            }
+            return false;
+        });
+    }
+
+    // Test negative remainder in increment counted loop.
+    public static int remInCountedLoop3() {
+        int sum = 0;
+        for (int i = -100000; i < 0; i++) {
+            sum += i % 16;
+        }
+        return sum;
+    }
+
+    @Test
+    public void testRemInCountedLoop3() {
+        testRemainder("remInCountedLoop3", 15);
+    }
+
+    // Test negative remainder in decrement counted loop.
+    public static int remInCountedLoop4() {
+        int sum = 0;
+        for (int i = 0; i > -1000000; i--) {
+            sum += i % 8;
+        }
+        return sum;
+    }
+
+    @Test
+    public void testRemInCountedLoop4() {
+        testRemainder("remInCountedLoop4", 7);
+    }
+
+    // Test positive remainder in increment counted loop with NE condition.
+    public static int remInCountedLoop5() {
+        int sum = 0;
+        for (int i = 0; i != 10000; i++) {
+            sum += i % 32;
+        }
+        return sum;
+    }
+
+    @Test
+    public void testRemInCountedLoop5() {
+        testRemainder("remInCountedLoop5", 31);
+    }
+
+    // Test negative remainder in decrement counted loop with NE condition.
+    public static int remInCountedLoop6() {
+        int sum = 0;
+        for (int i = -1; i != -10000; i--) {
+            sum += i % 32;
+        }
+        return sum;
+    }
+
+    @Test
+    public void testRemInCountedLoop6() {
+        testRemainder("remInCountedLoop6", 31);
+    }
+
+    // Test positive division in increment counted loop.
+    public static int divInCountedLoop() {
+        int sum = 0;
+        for (int i = 0; i < 1000000; i++) {
+            sum += i / 8;
+        }
+        return sum;
+    }
+
+    @Test
+    public void testDivInCountedLoop() {
+        testDivision("divInCountedLoop", 3);
+    }
+
+    // Test function for integer remainder.
+    private void testRemainder(String methodName, int num) {
+        test(methodName);
+        StructuredGraph graph = buildGraph(methodName);
+        NodePredicate predicate = (node) -> {
+            if (node instanceof AndNode) {
+                ValueNode y = ((AndNode) node).getY();
+                return y.isConstant() && y.asJavaConstant().asLong() == num;
+            }
+            return false;
+        };
+        assertExist(graph, predicate);
+    }
+
+    // Test function for integer division.
+    private void testDivision(String methodName, int log2) {
+        test(methodName);
+        StructuredGraph graph = buildGraph(methodName);
+        NodePredicate predicate = (node) -> {
+            if (node instanceof UnsignedRightShiftNode) {
+                ValueNode x = ((UnsignedRightShiftNode) node).getX();
+                ValueNode y = ((UnsignedRightShiftNode) node).getY();
+                int bits = PrimitiveStamp.getBits(x.stamp(NodeView.DEFAULT));
+                if (y.isConstant() && y.asJavaConstant().asLong() == (bits - log2)) {
+                    if (x instanceof RightShiftNode) {
+                        ValueNode shift = ((RightShiftNode) x).getY();
+                        return shift.isConstant() && shift.asJavaConstant().asLong() == bits - 1;
+                    }
+                }
+            }
+            return false;
+        };
+        assertNotExist(graph, predicate);
+    }
+
+    private StructuredGraph buildGraph(String methodName) {
+        StructuredGraph graph = parseEager(methodName, StructuredGraph.AllowAssumptions.YES);
+        HighTierContext context = getDefaultHighTierContext();
+        OptimizeDivPhase optimizeDiv = new OptimizeDivPhase(true);
+        optimizeDiv.apply(graph, context);
+        new CanonicalizerPhase().apply(graph, context);
+        return graph;
+    }
+
+    private static void assertExist(StructuredGraph graph, NodePredicate predicate) {
+        Assert.assertNotEquals(0, graph.getNodes().filter(predicate).count());
+    }
+
+    private static void assertNotExist(StructuredGraph graph, NodePredicate predicate) {
+        Assert.assertEquals(0, graph.getNodes().filter(predicate).count());
+    }
+}

--- a/compiler/src/org.graalvm.compiler.nodes/src/org/graalvm/compiler/nodes/calc/IntegerDivRemNode.java
+++ b/compiler/src/org.graalvm.compiler.nodes/src/org/graalvm/compiler/nodes/calc/IntegerDivRemNode.java
@@ -58,6 +58,7 @@ public abstract class IntegerDivRemNode extends FixedBinaryNode implements Lower
     private final Op op;
     private final Type type;
     private final boolean canDeopt;
+    protected IntegerStamp incomingStampX;
 
     protected IntegerDivRemNode(NodeClass<? extends IntegerDivRemNode> c, Stamp stamp, Op op, Type type, ValueNode x, ValueNode y, GuardingNode zeroCheck) {
         super(c, stamp, x, y);
@@ -91,5 +92,13 @@ public abstract class IntegerDivRemNode extends FixedBinaryNode implements Lower
     @Override
     public boolean canDeoptimize() {
         return canDeopt;
+    }
+
+    public void setIncomingStampX(IntegerStamp stamp) {
+        incomingStampX = stamp;
+    }
+
+    public IntegerStamp getIncomingStampX() {
+        return incomingStampX;
     }
 }

--- a/compiler/src/org.graalvm.compiler.nodes/src/org/graalvm/compiler/nodes/calc/SignedRemNode.java
+++ b/compiler/src/org.graalvm.compiler.nodes/src/org/graalvm/compiler/nodes/calc/SignedRemNode.java
@@ -94,6 +94,9 @@ public class SignedRemNode extends IntegerDivRemNode implements LIRLowerable {
                     // x % y == 0 <=> (x & (y-1)) == 0
                     return new AndNode(forX, ConstantNode.forIntegerStamp(yStamp, constY - 1));
                 } else {
+                    if (self != null && self.incomingStampX != null) {
+                        xStamp = self.incomingStampX;
+                    }
                     if (xStamp.isPositive()) {
                         // x & (y - 1)
                         return new AndNode(forX, ConstantNode.forIntegerStamp(stamp, constY - 1));


### PR DESCRIPTION
This patch creates more opportunities to the following optimizations inside
a counted loop when "d" is a power-of-2 constant:

    "x / d"  ->  "x >> log2(d)"
    "x % d"  ->  "x & (d - 1)"

The above optmization can be applied only if the dividend("x") is known to be
positive. Currently the graal compiler supports this canonicalization. But the
type of the dividend is unrestricted, which means it is not bounded. So most
of the integer divisions and remainders still cannot be canonicalized although
the dividend is positive. So if the compiler can compute the boundary of the
type of the dividend, it can be known as positive, negative or others.

This patch will compute a bounded stamp for the loop variable of a counted loop.
If the variable is used as the dividend of the division or remainder inside of
the loop, the bounded stamp will be used as the real stamp of the dividend.

Directly changing the stamp of the loop variable may generate some issues, for
example it may make a loop endless, or it may influence other loop optimizations.
So this patch just adds a new stamp named "loopStamp" for the counted loop which
represents the stamp of the loop variable only when it is used inside of the loop.
And as I mentioned above, the "loopStamp" will be treated as the new stamp for the
dividend. This operation is applied before the first CanonicalizerPhase, so that
the division and remainder can be optimized as early as possible.

Change-Id: Ia87221897ad67a0ee08bdf4562f357943612426e