### PR TITLE
Reworked LLVM exception handling

### DIFF
--- a/compiler/src/org.graalvm.compiler.core.llvm/src/org/graalvm/compiler/core/llvm/LLVMGenerator.java
+++ b/compiler/src/org.graalvm.compiler.core.llvm/src/org/graalvm/compiler/core/llvm/LLVMGenerator.java
@@ -25,6 +25,7 @@
 package org.graalvm.compiler.core.llvm;
 
 import static org.graalvm.compiler.core.llvm.LLVMIRBuilder.isObject;
+import static org.graalvm.compiler.core.llvm.LLVMIRBuilder.isVoidType;
 import static org.graalvm.compiler.core.llvm.LLVMIRBuilder.typeOf;
 import static org.graalvm.compiler.core.llvm.LLVMUtils.dumpTypes;
 import static org.graalvm.compiler.core.llvm.LLVMUtils.dumpValues;
@@ -178,7 +179,7 @@ public class LLVMGenerator implements LIRGeneratorTool {
         throw unimplemented();
     }
 
-    LLVMValueRef getFunction(ResolvedJavaMethod method) {
+    public LLVMValueRef getFunction(ResolvedJavaMethod method) {
         LLVMTypeRef functionType = getLLVMFunctionType(method);
         return builder.getFunction(getFunctionName(method), functionType);
     }
@@ -187,7 +188,7 @@ public class LLVMGenerator implements LIRGeneratorTool {
         return method.getName();
     }
 
-    private LLVMTypeRef getLLVMFunctionReturnType(ResolvedJavaMethod method) {
+    LLVMTypeRef getLLVMFunctionReturnType(ResolvedJavaMethod method) {
         ResolvedJavaType returnType = method.getSignature().getReturnType(null).resolve(null);
         return builder.getLLVMStackType(getTypeKind(returnType));
     }
@@ -451,7 +452,7 @@ public class LLVMGenerator implements LIRGeneratorTool {
         LLVMValueRef[] arguments = Arrays.stream(args).map(LLVMUtils::getVal).toArray(LLVMValueRef[]::new);
 
         LLVMValueRef call = builder.buildCall(callee, patchpointId, arguments);
-        return new LLVMVariable(call);
+        return (isVoidType(getLLVMFunctionReturnType(targetMethod))) ? null : new LLVMVariable(call);
     }
 
     protected ResolvedJavaMethod findForeignCallTarget(@SuppressWarnings("unused") ForeignCallDescriptor descriptor) {

--- a/compiler/src/org.graalvm.compiler.core.llvm/src/org/graalvm/compiler/core/llvm/LLVMIRBuilder.java
+++ b/compiler/src/org.graalvm.compiler.core.llvm/src/org/graalvm/compiler/core/llvm/LLVMIRBuilder.java
@@ -143,6 +143,14 @@ public class LLVMIRBuilder {
         LLVM.LLVMAddCallSiteAttribute(call, (int) index, attr);
     }
 
+    void setPersonalityFunction(LLVMValueRef function, LLVMValueRef personality) {
+        LLVM.LLVMSetPersonalityFn(function, personality);
+    }
+
+    public void setPersonalityFunction(LLVMValueRef personality) {
+        setPersonalityFunction(getMainFunction(), personality);
+    }
+
     LLVMBasicBlockRef appendBasicBlock(String name, LLVMValueRef func) {
         return LLVM.LLVMAppendBasicBlockInContext(context, func, name);
     }
@@ -331,6 +339,10 @@ public class LLVMIRBuilder {
 
     private static boolean isTracked(LLVMTypeRef pointerType) {
         return LLVM.LLVMGetPointerAddressSpace(pointerType) == LLVMUtils.TRACKED_POINTER_ADDRESS_SPACE;
+    }
+
+    private static LLVMTypeRef getElementType(LLVMTypeRef pointerType) {
+        return LLVM.LLVMGetElementType(pointerType);
     }
 
     static boolean isObject(LLVMTypeRef type) {
@@ -548,28 +560,64 @@ public class LLVMIRBuilder {
             result = buildCall(callee, args);
             addCallSiteAttribute(result, "statepoint-id", Long.toString(statepointId));
         } else {
-
             LLVMTypeRef calleeType = typeOf(callee);
-            LLVMTypeRef statepointType = functionType(tokenType(), true, longType(), intType(), calleeType, intType(), intType());
+            LLVMValueRef token = buildCall(getStatepointIntrinsic(calleeType), getStatepointArgs(statepointId, callee, args));
 
-            LLVMValueRef[] statepointArgs = new LLVMValueRef[args.length + 7];
-            statepointArgs[0] = constantLong(statepointId);
-            statepointArgs[1] = constantInt(0); /* numPatchBytes */
-            statepointArgs[2] = callee;
-            statepointArgs[3] = constantInt(args.length);
-            statepointArgs[4] = constantInt(0); /* flags */
-            System.arraycopy(args, 0, statepointArgs, 5, args.length);
-            statepointArgs[5 + args.length] = constantLong(0L); /* numTransitionArgs */
-            statepointArgs[6 + args.length] = constantLong(0L); /* numDeoptArgs */
-
-            LLVMValueRef token = buildIntrinsicCall("llvm.experimental.gc.statepoint." + intrinsicType(calleeType), statepointType, statepointArgs);
-
-            LLVMTypeRef resultType = getReturnType(LLVM.LLVMGetElementType(calleeType));
-            LLVMTypeRef gcResultType = functionType(resultType, tokenType());
-            result = buildIntrinsicCall("llvm.experimental.gc.result." + intrinsicType(resultType), gcResultType, token);
-
+            LLVMTypeRef resultType = getReturnType(getElementType(calleeType));
+            if (isVoidType(resultType)) {
+                result = token;
+            } else {
+                LLVMTypeRef gcResultType = functionType(resultType, tokenType());
+                result = buildIntrinsicCall("llvm.experimental.gc.result." + intrinsicType(resultType), gcResultType, token);
+            }
         }
         return result;
+    }
+
+    private LLVMValueRef buildInvoke(LLVMValueRef callee, LLVMBasicBlockRef successor, LLVMBasicBlockRef handler, LLVMValueRef... args) {
+        return LLVM.LLVMBuildInvoke(builder, callee, new PointerPointer<>(args), args.length, successor, handler, DEFAULT_INSTR_NAME);
+    }
+
+    LLVMValueRef buildInvoke(LLVMValueRef callee, LLVMBasicBlockRef successor, LLVMBasicBlockRef handler, long statepointId, LLVMValueRef... args) {
+        LLVMValueRef result;
+        if (trackPointers) {
+            result = buildInvoke(callee, successor, handler, args);
+            addCallSiteAttribute(result, "statepoint-id", Long.toString(statepointId));
+        } else {
+            LLVMTypeRef calleeType = typeOf(callee);
+            LLVMValueRef token = buildInvoke(getStatepointIntrinsic(calleeType), successor, handler, getStatepointArgs(statepointId, callee, args));
+            LLVMTypeRef resultType = getReturnType(getElementType(calleeType));
+            if (isVoidType(resultType)) {
+                result = token;
+            } else {
+                positionAtEnd(successor);
+                LLVMTypeRef gcResultType = functionType(resultType, tokenType());
+                result = buildIntrinsicCall("llvm.experimental.gc.result." + intrinsicType(resultType), gcResultType, token);
+                /* No need to set the builder back as invoke is a terminator instruction */
+            }
+        }
+
+        return result;
+    }
+
+    private LLVMValueRef getStatepointIntrinsic(LLVMTypeRef calleeType) {
+        LLVMTypeRef statepointType = functionType(tokenType(), true, longType(), intType(), calleeType, intType(), intType());
+        return getFunction("llvm.experimental.gc.statepoint." + intrinsicType(calleeType), statepointType);
+    }
+
+    private LLVMValueRef[] getStatepointArgs(long statepointId, LLVMValueRef callee, LLVMValueRef... args) {
+        LLVMValueRef[] statepointArgs = new LLVMValueRef[args.length + 7];
+
+        statepointArgs[0] = constantLong(statepointId);
+        statepointArgs[1] = constantInt(0); /* numPatchBytes */
+        statepointArgs[2] = callee;
+        statepointArgs[3] = constantInt(args.length);
+        statepointArgs[4] = constantInt(0); /* flags */
+        System.arraycopy(args, 0, statepointArgs, 5, args.length);
+        statepointArgs[5 + args.length] = constantLong(0L); /* numTransitionArgs */
+        statepointArgs[6 + args.length] = constantLong(0L); /* numDeoptArgs */
+
+        return statepointArgs;
     }
 
     private void addCallSiteAttribute(LLVMValueRef call, String key, String value) {
@@ -608,18 +656,14 @@ public class LLVMIRBuilder {
         return switchVal;
     }
 
+    public LLVMValueRef buildLandingPad() {
+        LLVMValueRef landingPad = LLVM.LLVMBuildLandingPad(builder, tokenType(), null, 1, DEFAULT_INSTR_NAME);
+        LLVM.LLVMAddClause(landingPad, constantNull(rawPointerType()));
+        return landingPad;
+    }
+
     public void buildUnreachable() {
         LLVM.LLVMBuildUnreachable(builder);
-    }
-
-    LLVMValueRef buildSetjmp(LLVMValueRef buffer) {
-        LLVMTypeRef setjmpType = functionType(intType(), rawPointerType());
-        return buildIntrinsicCall("llvm.eh.sjlj.setjmp", setjmpType, buffer);
-    }
-
-    public void buildLongjmp(LLVMValueRef buffer) {
-        LLVMTypeRef longjmpType = functionType(voidType(), rawPointerType());
-        buildIntrinsicCall("llvm.eh.sjlj.longjmp", longjmpType, buffer);
     }
 
     public void buildStackmap(LLVMValueRef patchpointId, LLVMValueRef... liveValues) {
@@ -635,6 +679,10 @@ public class LLVMIRBuilder {
 
     public void buildDebugtrap() {
         buildIntrinsicCall("llvm.debugtrap", functionType(voidType()));
+    }
+
+    LLVMValueRef buildInlineAsm(LLVMTypeRef functionType, String asm, String constraints, boolean hasSideEffects, boolean alignStack) {
+        return LLVM.LLVMConstInlineAsm(functionType, asm, constraints, hasSideEffects ? TRUE : FALSE, alignStack ? TRUE : FALSE);
     }
 
     public LLVMValueRef functionEntryCount(LLVMValueRef count) {

--- a/substratevm/src/com.oracle.svm.core.graal.llvm/src/com/oracle/svm/core/graal/llvm/GCCExceptionTable.java
+++ b/substratevm/src/com.oracle.svm.core.graal.llvm/src/com/oracle/svm/core/graal/llvm/GCCExceptionTable.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright (c) 2019, 2019, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package com.oracle.svm.core.graal.llvm;
+
+import static com.oracle.svm.core.util.VMError.shouldNotReachHere;
+
+import java.util.Arrays;
+
+import org.graalvm.nativeimage.StackValue;
+import org.graalvm.nativeimage.c.type.CIntPointer;
+import org.graalvm.word.Pointer;
+
+import com.oracle.svm.core.log.Log;
+
+public class GCCExceptionTable {
+
+    enum Encoding {
+        ULEB128((byte) 0x1),
+        UDATA2((byte) 0x2),
+        UDATA4((byte) 0x3),
+        UDATA8((byte) 0x4),
+        SLEB128((byte) 0x9),
+        SDATA2((byte) 0xA),
+        SDATA4((byte) 0xB),
+        SDATA8((byte) 0xC);
+
+        byte encoding;
+        static Encoding[] lookupTable = new Encoding[16];
+
+        static {
+            Arrays.stream(values()).forEach(value -> lookupTable[value.encoding] = value);
+        }
+
+        Encoding(byte encoding) {
+            this.encoding = encoding;
+        }
+
+        static Encoding parse(int encodingEncoding) {
+            if (encodingEncoding < 0 || encodingEncoding >= lookupTable.length) {
+                return null;
+            }
+            Encoding encoding = lookupTable[encodingEncoding];
+            if (encoding == null) {
+                return null;
+            }
+            return encoding;
+        }
+    }
+
+    public static Long getHandlerOffset(Pointer buffer, long pcOffset) {
+        Log log = Log.noopLog();
+
+        CIntPointer offset = StackValue.get(Integer.BYTES);
+        offset.write(0);
+
+        int header = Byte.toUnsignedInt(buffer.readByte(offset.read()));
+        offset.write(offset.read() + Byte.BYTES);
+        log.string("header: ").hex(header).newline();
+        assert header == 255;
+
+        int typeEncodingEncoding = Byte.toUnsignedInt(buffer.readByte(offset.read()));
+        offset.write(offset.read() + Byte.BYTES);
+        log.string("typeEncodingEncoding: ").hex(typeEncodingEncoding).newline();
+        assert typeEncodingEncoding == 155;
+
+        long typeBaseOffset = getULSB(buffer, offset);
+        long typeEnd = typeBaseOffset + offset.read();
+        log.string("typeBaseOffset: ").unsigned(typeBaseOffset).string(", typeEnd: ").unsigned(typeEnd).newline();
+
+        int siteEncodingEncoding = Byte.toUnsignedInt(buffer.readByte(offset.read()));
+        offset.write(offset.read() + Byte.BYTES);
+        log.string("siteEncodingEncoding: ").hex(siteEncodingEncoding).newline();
+        Encoding siteEncoding = Encoding.parse(siteEncodingEncoding);
+
+        long siteTableLength = getULSB(buffer, offset);
+        log.string("siteTableLength: ").signed(siteTableLength).newline();
+        assert siteTableLength % 13 == 0;
+
+        long siteTableEnd = offset.read() + siteTableLength;
+        log.string("siteTableEnd: ").signed(siteTableEnd).newline();
+        while (offset.read() < siteTableEnd) {
+
+            long startOffset = get(buffer, siteEncoding, offset);
+            long size = get(buffer, siteEncoding, offset);
+            long handlerOffset = get(buffer, siteEncoding, offset);
+            log.string("start: ").unsigned(startOffset).string(", size: ").unsigned(size).string(", handlerOffset: ").unsigned(handlerOffset).newline();
+
+            if (startOffset <= pcOffset && startOffset + size >= pcOffset) {
+                return handlerOffset;
+            }
+            int action = Byte.toUnsignedInt(buffer.readByte(offset.read()));
+            offset.write(offset.read() + Byte.BYTES);
+            log.string("action: ").unsigned(action).newline();
+            if (action != 0) {
+                assert action == 1;
+            }
+        }
+
+        return null;
+    }
+
+    private static long getULSB(Pointer buffer, CIntPointer offset) {
+        int read;
+        long result = 0;
+        int shift = 0;
+        do {
+            read = buffer.readByte(offset.read());
+            offset.write(offset.read() + Byte.BYTES);
+            result |= (read & Byte.MAX_VALUE) << shift;
+            shift += 7;
+        } while ((read & 0x80) != 0);
+
+        return result;
+    }
+
+    private static long get(Pointer buffer, Encoding encoding, CIntPointer offset) {
+        switch (encoding) {
+            case ULEB128:
+                return getULSB(buffer, offset);
+            case UDATA4:
+                int result = buffer.readInt(offset.read());
+                offset.write(offset.read() + Integer.BYTES);
+                return result;
+            default:
+                throw shouldNotReachHere();
+        }
+    }
+}

--- a/substratevm/src/com.oracle.svm.core.graal.llvm/src/com/oracle/svm/core/graal/llvm/LLVMDirectives.java
+++ b/substratevm/src/com.oracle.svm.core.graal.llvm/src/com/oracle/svm/core/graal/llvm/LLVMDirectives.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2019, 2019, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package com.oracle.svm.core.graal.llvm;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.graalvm.nativeimage.c.CContext;
+
+import com.oracle.svm.core.SubstrateOptions;
+
+public class LLVMDirectives implements CContext.Directives {
+    @Override
+    public boolean isInConfiguration() {
+        return SubstrateOptions.CompilerBackend.getValue().equals("llvm");
+    }
+
+    @Override
+    public List<String> getHeaderFiles() {
+        return Collections.singletonList("<unwind.h>");
+    }
+}

--- a/substratevm/src/com.oracle.svm.core.graal.llvm/src/com/oracle/svm/core/graal/llvm/LLVMFeature.java
+++ b/substratevm/src/com.oracle.svm.core.graal.llvm/src/com/oracle/svm/core/graal/llvm/LLVMFeature.java
@@ -32,38 +32,60 @@ import java.io.OutputStream;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 
+import org.graalvm.compiler.api.replacements.SnippetReflectionProvider;
+import org.graalvm.compiler.core.common.type.StampFactory;
+import org.graalvm.compiler.debug.DebugHandlersFactory;
+import org.graalvm.compiler.graph.Node;
+import org.graalvm.compiler.nodes.FixedWithNextNode;
+import org.graalvm.compiler.nodes.FrameState;
+import org.graalvm.compiler.nodes.StructuredGraph;
+import org.graalvm.compiler.nodes.java.LoadExceptionObjectNode;
+import org.graalvm.compiler.nodes.spi.LoweringTool;
+import org.graalvm.compiler.options.OptionValues;
 import org.graalvm.compiler.phases.util.Providers;
-import org.graalvm.compiler.replacements.Snippets;
-import org.graalvm.nativeimage.hosted.Feature;
 import org.graalvm.nativeimage.ImageSingletons;
 import org.graalvm.nativeimage.Platform;
 import org.graalvm.nativeimage.Platforms;
 import org.graalvm.nativeimage.c.function.CLibrary;
 import org.graalvm.nativeimage.c.function.CodePointer;
+import org.graalvm.nativeimage.hosted.Feature;
 import org.graalvm.word.Pointer;
-import org.graalvm.word.WordFactory;
 
 import com.oracle.svm.core.annotate.AutomaticFeature;
 import com.oracle.svm.core.graal.GraalFeature;
 import com.oracle.svm.core.graal.code.SubstrateBackend;
 import com.oracle.svm.core.graal.code.SubstrateBackendFactory;
+import com.oracle.svm.core.graal.meta.RuntimeConfiguration;
+import com.oracle.svm.core.graal.nodes.ExceptionStateNode;
+import com.oracle.svm.core.graal.nodes.ReadExceptionObjectNode;
+import com.oracle.svm.core.graal.snippets.NodeLoweringProvider;
+import com.oracle.svm.core.nodes.CFunctionEpilogueNode;
 import com.oracle.svm.core.snippets.SnippetRuntime;
 import com.oracle.svm.core.util.UserError;
+import com.oracle.svm.hosted.FeatureImpl;
 import com.oracle.svm.hosted.c.util.FileUtils;
 import com.oracle.svm.hosted.code.CompileQueue;
 import com.oracle.svm.hosted.image.NativeImageCodeCache;
 import com.oracle.svm.hosted.image.NativeImageCodeCacheFactory;
 import com.oracle.svm.hosted.image.NativeImageHeap;
+import com.oracle.svm.hosted.meta.HostedMethod;
 
 @AutomaticFeature
 @CLibrary("m")
 @Platforms({Platform.LINUX.class, Platform.DARWIN.class})
-public class LLVMFeature implements Feature, GraalFeature, Snippets {
+public class LLVMFeature implements Feature, GraalFeature {
+
+    private static HostedMethod personalityStub;
 
     @Override
     public boolean isInConfiguration(IsInConfigurationAccess access) {
         return CompilerBackend.getValue().equals("llvm");
+    }
+
+    public static HostedMethod getPersonalityStub() {
+        return personalityStub;
     }
 
     @Override
@@ -82,21 +104,49 @@ public class LLVMFeature implements Feature, GraalFeature, Snippets {
                 return new LLVMNativeImageCodeCache(compileQueue.getCompilations(), heap, platform);
             }
         });
-        ImageSingletons.add(SnippetRuntime.ExceptionStackFrameVisitor.class, new SnippetRuntime.ExceptionStackFrameVisitor() {
+        ImageSingletons.add(SnippetRuntime.ExceptionUnwind.class, new SnippetRuntime.ExceptionUnwind() {
             @Override
-            public CodePointer getExceptionHandlerPointer(CodePointer ip, Pointer sp, long handlerOffset) {
-                /*
-                 * LLVM uses a setjmp/longjmp mechanism for exception handling, with the unwind
-                 * information held in a buffer on the stack of the caller. As such, the value
-                 * returned by lookupExceptionOffset is not the offset of the exception handling
-                 * code relative to the call IP, but the offset of the setjmp buffer relative to the
-                 * caller's stack pointer. Furthermore, this offset is stored as itself + 1, because
-                 * it is legal (and frequent) to have an offset of 0 for the buffer, which would be
-                 * considered as the absence of the exception handler.
-                 */
-                return (CodePointer) sp.add(WordFactory.unsigned(handlerOffset - 1));
+            public void unwindException(Pointer callerSP, CodePointer callerIP) {
+                LLVMPersonalityFunction.raiseException();
             }
         });
+    }
+
+    @Override
+    public void beforeCompilation(BeforeCompilationAccess access) {
+        FeatureImpl.BeforeCompilationAccessImpl accessImpl = (FeatureImpl.BeforeCompilationAccessImpl) access;
+        personalityStub = accessImpl.getUniverse().lookup(LLVMPersonalityFunction.getPersonalityStub());
+    }
+
+    @Override
+    public void registerLowerings(RuntimeConfiguration runtimeConfig, OptionValues options, Iterable<DebugHandlersFactory> factories, Providers providers, SnippetReflectionProvider snippetReflection,
+                    Map<Class<? extends Node>, NodeLoweringProvider<?>> lowerings, boolean hosted) {
+        lowerings.put(LoadExceptionObjectNode.class, new LLVMLoadExceptionObjectLowering());
+    }
+
+    private static class LLVMLoadExceptionObjectLowering implements NodeLoweringProvider<LoadExceptionObjectNode> {
+
+        @Override
+        public void lower(LoadExceptionObjectNode node, LoweringTool tool) {
+            FrameState exceptionState = node.stateAfter();
+            assert exceptionState != null;
+
+            StructuredGraph graph = node.graph();
+            FixedWithNextNode readRegNode = graph.add(new ReadExceptionObjectNode(StampFactory.objectNonNull()));
+            graph.replaceFixedWithFixed(node, readRegNode);
+
+            /*
+             * When libunwind has found an exception handler, it jumps directly to it from native
+             * code. We therefore need the CFunctionEpilogueNode to restore the Java state before we
+             * handle the exception.
+             */
+            CFunctionEpilogueNode cFunctionEpilogueNode = new CFunctionEpilogueNode();
+            graph.add(cFunctionEpilogueNode);
+            graph.addAfterFixed(readRegNode, cFunctionEpilogueNode);
+            cFunctionEpilogueNode.lower(tool);
+
+            graph.addAfterFixed(readRegNode, graph.add(new ExceptionStateNode(exceptionState)));
+        }
     }
 
     private static void checkLLVMVersion() {

--- a/substratevm/src/com.oracle.svm.core.graal.llvm/src/com/oracle/svm/core/graal/llvm/LLVMPersonalityFunction.java
+++ b/substratevm/src/com.oracle.svm.core.graal.llvm/src/com/oracle/svm/core/graal/llvm/LLVMPersonalityFunction.java
@@ -1,0 +1,227 @@
+/*
+ * Copyright (c) 2019, 2019, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package com.oracle.svm.core.graal.llvm;
+
+import static com.oracle.svm.core.util.VMError.shouldNotReachHere;
+
+import com.oracle.svm.core.SubstrateOptions;
+import org.graalvm.compiler.core.common.NumUtil;
+import org.graalvm.compiler.word.Word;
+import org.graalvm.nativeimage.CurrentIsolate;
+import org.graalvm.nativeimage.IsolateThread;
+import org.graalvm.nativeimage.StackValue;
+import org.graalvm.nativeimage.c.CContext;
+import org.graalvm.nativeimage.c.constant.CConstant;
+import org.graalvm.nativeimage.c.function.CEntryPoint;
+import org.graalvm.nativeimage.c.function.CFunction;
+import org.graalvm.nativeimage.c.struct.CField;
+import org.graalvm.nativeimage.c.struct.CStruct;
+import org.graalvm.nativeimage.c.struct.SizeOf;
+import org.graalvm.word.Pointer;
+import org.graalvm.word.PointerBase;
+import org.graalvm.word.WordFactory;
+
+import com.oracle.graal.pointsto.meta.AnalysisMethod;
+import com.oracle.svm.core.c.function.CEntryPointOptions;
+import com.oracle.svm.core.snippets.SnippetRuntime;
+import com.oracle.svm.core.stack.StackOverflowCheck;
+import com.oracle.svm.hosted.code.CEntryPointCallStubSupport;
+
+import java.util.function.BooleanSupplier;
+
+@CContext(LLVMDirectives.class)
+public class LLVMPersonalityFunction {
+
+    /*
+     * Exception handling using libunwind happens using the following steps:
+     *
+     * 1. The exception is raised using _Unwind_RaiseException
+     *
+     * 2. libunwind walks the stack twice, and for each Java call frame calls the personality
+     * function below
+     *
+     * 3. During the first stack walk (UA_SEARCH_PHASE), the personality function tells whether it
+     * has a registered handler able to handle the exception (URC_HANDLER_FOUND).
+     *
+     * 4. During the second stack walk (UA_CLEANUP_PHASE), the frame that accepted the exception
+     * prepares the context to jump to the handler (URC_INSTALL_CONTEXT).
+     *
+     * In order for the personality function to function normally, it needs the context from the
+     * thread which threw the exception to be restored when the function is called. This is done
+     * through the thread argument which is passed to libunwind in place of the exception object
+     * (see raiseException()). Libunwind then passes the value back as the third argument to the
+     * personality function. The actual exception is then retrieved from the thread-local variable
+     * SnippetRuntime.currentException.
+     *
+     * When preparing to jump to the handler, the exception object is placed in the return register,
+     * from which it will get extracted after the landingpad instruction (see
+     * NodeLLVMBuilder.emitReadExceptionObject).
+     */
+    @CEntryPoint
+    @CEntryPointOptions(include = IncludeForLLVMOnly.class)
+    @SuppressWarnings("unused")
+    public static int personality(int version, int action, IsolateThread thread, _Unwind_Exception unwindException, _Unwind_Context context) {
+        Pointer ip = getIP(context);
+        Pointer functionStart = getRegionStart(context);
+        int pcOffset = NumUtil.safeToInt(ip.rawValue() - functionStart.rawValue());
+
+        Pointer lsda = getLanguageSpecificData(context);
+        Long handlerOffset = GCCExceptionTable.getHandlerOffset(lsda, pcOffset);
+
+        if (handlerOffset == null || handlerOffset == 0) {
+            return _URC_CONTINUE_UNWIND();
+        }
+
+        if ((action & _UA_SEARCH_PHASE()) != 0) {
+            return _URC_HANDLER_FOUND();
+        } else if ((action & _UA_CLEANUP_PHASE()) != 0) {
+            Throwable exception = SnippetRuntime.currentException.get();
+            SnippetRuntime.currentException.set(null);
+
+            int exceptionRegister = 0; // builtinEHReturnDataRegno(0);
+            int typeRegister = 1; // builtinEHReturnDataRegno(1);
+
+            setGR(context, exceptionRegister, Word.objectToTrackedPointer(exception).rawValue());
+            setGR(context, typeRegister, 1);
+            setIP(context, functionStart.add(handlerOffset.intValue()));
+
+            StackOverflowCheck.singleton().protectYellowZone();
+            return _URC_INSTALL_CONTEXT();
+        } else {
+            return _URC_FATAL_PHASE1_ERROR();
+        }
+    }
+
+    private static class IncludeForLLVMOnly implements BooleanSupplier {
+        @Override
+        public boolean getAsBoolean() {
+            return SubstrateOptions.CompilerBackend.getValue().equals("llvm");
+        }
+    }
+
+    static AnalysisMethod getPersonalityStub() {
+        try {
+            return CEntryPointCallStubSupport.singleton()
+                            .getStubForMethod(LLVMPersonalityFunction.class.getMethod("personality", int.class, int.class, IsolateThread.class, _Unwind_Exception.class, _Unwind_Context.class));
+        } catch (NoSuchMethodException e) {
+            throw shouldNotReachHere();
+        }
+    }
+
+    public static void raiseException() {
+        _Unwind_Exception exceptionStructure = StackValue.get(SizeOf.get(_Unwind_Exception.class));
+        exceptionStructure.set_exception_class(CurrentIsolate.getCurrentThread());
+        exceptionStructure.set_exception_cleanup(WordFactory.nullPointer());
+        raiseException(exceptionStructure);
+    }
+
+    // Allow methods with non-standard names: Checkstyle: stop
+
+    /* _Unwind_Reason_Code */
+    @CConstant
+    private static native int _URC_NO_REASON();
+
+    @CConstant
+    private static native int _URC_FOREIGN_EXCEPTION_CAUGHT();
+
+    @CConstant
+    private static native int _URC_FATAL_PHASE2_ERROR();
+
+    @CConstant
+    private static native int _URC_FATAL_PHASE1_ERROR();
+
+    @CConstant
+    private static native int _URC_NORMAL_STOP();
+
+    @CConstant
+    private static native int _URC_END_OF_STACK();
+
+    @CConstant
+    private static native int _URC_HANDLER_FOUND();
+
+    @CConstant
+    private static native int _URC_INSTALL_CONTEXT();
+
+    @CConstant
+    private static native int _URC_CONTINUE_UNWIND();
+
+    /* _Unwind_Action */
+    @CConstant
+    private static native int _UA_SEARCH_PHASE();
+
+    @CConstant
+    private static native int _UA_CLEANUP_PHASE();
+
+    @CConstant
+    private static native int _UA_HANDLER_FRAME();
+
+    @CConstant
+    private static native int _UA_FORCE_UNWIND();
+
+    @CConstant
+    private static native int _UA_END_OF_STACK();
+
+    @CStruct(addStructKeyword = true)
+    private interface _Unwind_Exception extends PointerBase {
+        @CField
+        PointerBase exception_class();
+
+        @CField
+        void set_exception_class(PointerBase value);
+
+        @CField
+        PointerBase exception_cleanup();
+
+        @CField
+        void set_exception_cleanup(PointerBase value);
+    }
+
+    @CStruct(addStructKeyword = true, isIncomplete = true)
+    private interface _Unwind_Context extends PointerBase {
+    }
+
+    @CFunction(value = "_Unwind_RaiseException")
+    public static native int raiseException(_Unwind_Exception exception);
+
+    @CFunction(value = "_Unwind_GetIP")
+    public static native Pointer getIP(_Unwind_Context context);
+
+    @CFunction(value = "_Unwind_SetIP")
+    public static native Pointer setIP(_Unwind_Context context, Pointer ip);
+
+    @CFunction(value = "_Unwind_SetGR")
+    public static native Pointer setGR(_Unwind_Context context, int reg, long value);
+
+    @CFunction(value = "_Unwind_GetRegionStart")
+    public static native Pointer getRegionStart(_Unwind_Context context);
+
+    @CFunction(value = "_Unwind_GetLanguageSpecificData")
+    public static native Pointer getLanguageSpecificData(_Unwind_Context context);
+
+    @CFunction(value = "__builtin_eh_return_data_regno")
+    public static native int builtinEHReturnDataRegno(int id);
+}
+
+// Checkstyle: resume

--- a/substratevm/src/com.oracle.svm.core.graal.llvm/src/com/oracle/svm/core/graal/llvm/SubstrateLLVMGenerator.java
+++ b/substratevm/src/com.oracle.svm.core.graal.llvm/src/com/oracle/svm/core/graal/llvm/SubstrateLLVMGenerator.java
@@ -24,10 +24,9 @@
  */
 package com.oracle.svm.core.graal.llvm;
 
-import static org.graalvm.compiler.core.llvm.LLVMUtils.getVal;
+import static com.oracle.svm.core.util.VMError.unimplemented;
 
 import org.bytedeco.javacpp.LLVM.LLVMContextRef;
-import org.bytedeco.javacpp.LLVM.LLVMValueRef;
 import org.graalvm.compiler.core.common.spi.ForeignCallDescriptor;
 import org.graalvm.compiler.core.llvm.LLVMGenerationResult;
 import org.graalvm.compiler.core.llvm.LLVMGenerator;
@@ -66,17 +65,8 @@ public class SubstrateLLVMGenerator extends LLVMGenerator implements SubstrateLI
 
     @Override
     public void emitFarReturn(AllocatableValue result, Value sp, Value setjmpBuffer) {
-        LLVMValueRef exceptionHolder = builder.getUniqueGlobal("__svm_exception_object", builder.objectType(), true);
-        LLVMValueRef exceptionObject = getVal(result);
-        builder.buildStore(exceptionObject, exceptionHolder);
-
-        LLVMValueRef buffer = builder.buildIntToPtr(getVal(setjmpBuffer), builder.pointerType(builder.arrayType(builder.longType(), 5), false));
-
-        LLVMValueRef spAddr = builder.buildGEP(buffer, builder.constantInt(0), builder.constantInt(2));
-        builder.buildStore(getVal(sp), spAddr);
-
-        builder.buildLongjmp(builder.buildBitcast(buffer, builder.rawPointerType()));
-        builder.buildUnreachable();
+        /* Exception unwinding is handled by libunwind */
+        throw unimplemented();
     }
 
     @Override

--- a/substratevm/src/com.oracle.svm.core.graal.llvm/src/com/oracle/svm/core/graal/llvm/SubstrateNodeLLVMBuilder.java
+++ b/substratevm/src/com.oracle.svm.core.graal.llvm/src/com/oracle/svm/core/graal/llvm/SubstrateNodeLLVMBuilder.java
@@ -42,6 +42,8 @@ public class SubstrateNodeLLVMBuilder extends NodeLLVMBuilder implements Substra
 
     protected SubstrateNodeLLVMBuilder(StructuredGraph graph, LLVMGenerator gen) {
         super(graph, gen, SubstrateDebugInfoBuilder::new);
+
+        gen.getBuilder().setPersonalityFunction(gen.getFunction(LLVMFeature.getPersonalityStub()));
     }
 
     @Override

--- a/substratevm/src/com.oracle.svm.core.graal/src/com/oracle/svm/core/graal/nodes/ExceptionStateNode.java
+++ b/substratevm/src/com.oracle.svm.core.graal/src/com/oracle/svm/core/graal/nodes/ExceptionStateNode.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2019, 2019, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package com.oracle.svm.core.graal.nodes;
+
+import org.graalvm.compiler.core.common.type.StampFactory;
+import org.graalvm.compiler.graph.Node;
+import org.graalvm.compiler.graph.NodeClass;
+import org.graalvm.compiler.graph.spi.Canonicalizable;
+import org.graalvm.compiler.graph.spi.CanonicalizerTool;
+import org.graalvm.compiler.nodeinfo.NodeCycles;
+import org.graalvm.compiler.nodeinfo.NodeInfo;
+import org.graalvm.compiler.nodeinfo.NodeSize;
+import org.graalvm.compiler.nodes.AbstractStateSplit;
+import org.graalvm.compiler.nodes.FrameState;
+
+@NodeInfo(cycles = NodeCycles.CYCLES_0, size = NodeSize.SIZE_0)
+public final class ExceptionStateNode extends AbstractStateSplit implements Canonicalizable {
+    public static final NodeClass<ExceptionStateNode> TYPE = NodeClass.create(ExceptionStateNode.class);
+
+    public ExceptionStateNode(FrameState stateAfter) {
+        super(TYPE, StampFactory.forVoid(), stateAfter);
+        assert stateAfter != null;
+    }
+
+    @Override
+    public Node canonical(CanonicalizerTool tool) {
+        if (stateAfter == null) {
+            /* After the FrameStateAssignmentPhase, the node is unnecessary. */
+            return null;
+        }
+        return this;
+    }
+}

--- a/substratevm/src/com.oracle.svm.core.graal/src/com/oracle/svm/core/graal/nodes/ReadExceptionObjectNode.java
+++ b/substratevm/src/com.oracle.svm.core.graal/src/com/oracle/svm/core/graal/nodes/ReadExceptionObjectNode.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2019, 2019, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package com.oracle.svm.core.graal.nodes;
+
+import jdk.vm.ci.meta.JavaKind;
+import org.graalvm.compiler.core.common.type.Stamp;
+import org.graalvm.compiler.core.common.type.StampFactory;
+import org.graalvm.compiler.graph.NodeClass;
+import org.graalvm.compiler.nodeinfo.NodeCycles;
+import org.graalvm.compiler.nodeinfo.NodeInfo;
+import org.graalvm.compiler.nodeinfo.NodeSize;
+import org.graalvm.compiler.nodes.FixedWithNextNode;
+import org.graalvm.compiler.nodes.spi.LIRLowerable;
+import org.graalvm.compiler.nodes.spi.NodeLIRBuilderTool;
+
+import java.util.concurrent.atomic.AtomicLong;
+
+@NodeInfo(cycles = NodeCycles.CYCLES_1, size = NodeSize.SIZE_1)
+public final class ReadExceptionObjectNode extends FixedWithNextNode implements LIRLowerable {
+    public static final NodeClass<ReadExceptionObjectNode> TYPE = NodeClass.create(ReadExceptionObjectNode.class);
+
+    /*
+     * Make every node unique to prevent de-duplication. The node reads a fixed register, so it
+     * needs to remain the first node immediately after the InvokeWithExceptionNode.
+     */
+    @SuppressWarnings("unused")//
+    private final long uniqueId;
+    private static final AtomicLong nextUniqueId = new AtomicLong();
+
+    public ReadExceptionObjectNode(Stamp stamp) {
+        super(TYPE, stamp);
+        uniqueId = nextUniqueId.getAndIncrement();
+    }
+
+    public ReadExceptionObjectNode(JavaKind kind) {
+        this(StampFactory.forKind(kind));
+    }
+
+    @Override
+    public void generate(NodeLIRBuilderTool gen) {
+        gen.emitReadExceptionObject(this);
+    }
+}

--- a/substratevm/src/com.oracle.svm.core.graal/src/com/oracle/svm/core/graal/snippets/ExceptionSnippets.java
+++ b/substratevm/src/com.oracle.svm.core.graal/src/com/oracle/svm/core/graal/snippets/ExceptionSnippets.java
@@ -31,29 +31,18 @@ import static com.oracle.svm.core.snippets.KnownIntrinsics.readReturnAddress;
 import static com.oracle.svm.core.snippets.SnippetRuntime.UNWIND_EXCEPTION;
 
 import java.util.Map;
-import java.util.concurrent.atomic.AtomicLong;
 
 import org.graalvm.compiler.api.replacements.Snippet;
 import org.graalvm.compiler.api.replacements.SnippetReflectionProvider;
-import org.graalvm.compiler.core.common.type.Stamp;
 import org.graalvm.compiler.core.common.type.StampFactory;
 import org.graalvm.compiler.debug.DebugHandlersFactory;
 import org.graalvm.compiler.graph.Node;
-import org.graalvm.compiler.graph.NodeClass;
-import org.graalvm.compiler.graph.spi.Canonicalizable;
-import org.graalvm.compiler.graph.spi.CanonicalizerTool;
-import org.graalvm.compiler.nodeinfo.NodeCycles;
-import org.graalvm.compiler.nodeinfo.NodeInfo;
-import org.graalvm.compiler.nodeinfo.NodeSize;
-import org.graalvm.compiler.nodes.AbstractStateSplit;
 import org.graalvm.compiler.nodes.FixedWithNextNode;
 import org.graalvm.compiler.nodes.FrameState;
 import org.graalvm.compiler.nodes.StructuredGraph;
 import org.graalvm.compiler.nodes.UnwindNode;
 import org.graalvm.compiler.nodes.java.LoadExceptionObjectNode;
-import org.graalvm.compiler.nodes.spi.LIRLowerable;
 import org.graalvm.compiler.nodes.spi.LoweringTool;
-import org.graalvm.compiler.nodes.spi.NodeLIRBuilderTool;
 import org.graalvm.compiler.options.OptionValues;
 import org.graalvm.compiler.phases.util.Providers;
 import org.graalvm.compiler.replacements.SnippetTemplate;
@@ -64,8 +53,8 @@ import org.graalvm.nativeimage.c.function.CodePointer;
 import org.graalvm.word.Pointer;
 
 import com.oracle.svm.core.annotate.NeverInline;
-
-import jdk.vm.ci.meta.JavaKind;
+import com.oracle.svm.core.graal.nodes.ExceptionStateNode;
+import com.oracle.svm.core.graal.nodes.ReadExceptionObjectNode;
 
 public final class ExceptionSnippets extends SubstrateTemplates implements Snippets {
 
@@ -91,7 +80,6 @@ public final class ExceptionSnippets extends SubstrateTemplates implements Snipp
         super(options, factories, providers, snippetReflection);
 
         lowerings.put(UnwindNode.class, new UnwindLowering());
-        lowerings.put(LoadExceptionObjectNode.class, new LoadExceptionObjectLowering());
     }
 
     protected class UnwindLowering implements NodeLoweringProvider<UnwindNode> {
@@ -106,7 +94,7 @@ public final class ExceptionSnippets extends SubstrateTemplates implements Snipp
         }
     }
 
-    protected class LoadExceptionObjectLowering implements NodeLoweringProvider<LoadExceptionObjectNode> {
+    public static class LoadExceptionObjectLowering implements NodeLoweringProvider<LoadExceptionObjectNode> {
 
         @Override
         public void lower(LoadExceptionObjectNode node, LoweringTool tool) {
@@ -119,51 +107,5 @@ public final class ExceptionSnippets extends SubstrateTemplates implements Snipp
 
             graph.addAfterFixed(readRegNode, graph.add(new ExceptionStateNode(exceptionState)));
         }
-    }
-}
-
-@NodeInfo(cycles = NodeCycles.CYCLES_1, size = NodeSize.SIZE_1)
-final class ReadExceptionObjectNode extends FixedWithNextNode implements LIRLowerable {
-    public static final NodeClass<ReadExceptionObjectNode> TYPE = NodeClass.create(ReadExceptionObjectNode.class);
-
-    /*
-     * Make every node unique to prevent de-duplication. The node reads a fixed register, so it
-     * needs to remain the first node immediately after the InvokeWithExceptionNode.
-     */
-    @SuppressWarnings("unused")//
-    private final long uniqueId;
-    private static final AtomicLong nextUniqueId = new AtomicLong();
-
-    protected ReadExceptionObjectNode(Stamp stamp) {
-        super(TYPE, stamp);
-        uniqueId = nextUniqueId.getAndIncrement();
-    }
-
-    protected ReadExceptionObjectNode(JavaKind kind) {
-        this(StampFactory.forKind(kind));
-    }
-
-    @Override
-    public void generate(NodeLIRBuilderTool gen) {
-        gen.emitReadExceptionObject(this);
-    }
-}
-
-@NodeInfo(cycles = NodeCycles.CYCLES_0, size = NodeSize.SIZE_0)
-final class ExceptionStateNode extends AbstractStateSplit implements Canonicalizable {
-    public static final NodeClass<ExceptionStateNode> TYPE = NodeClass.create(ExceptionStateNode.class);
-
-    protected ExceptionStateNode(FrameState stateAfter) {
-        super(TYPE, StampFactory.forVoid(), stateAfter);
-        assert stateAfter != null;
-    }
-
-    @Override
-    public Node canonical(CanonicalizerTool tool) {
-        if (stateAfter == null) {
-            /* After the FrameStateAssignmentPhase, the node is unnecessary. */
-            return null;
-        }
-        return this;
     }
 }

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/SubstrateOptions.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/SubstrateOptions.java
@@ -282,8 +282,15 @@ public class SubstrateOptions {
     public static final HostedOptionKey<String> CompilerBackend = new HostedOptionKey<String>("lir") {
         @Override
         protected void onValueUpdate(EconomicMap<OptionKey<?>, Object> values, String oldValue, String newValue) {
-            if ("llvm".equals(newValue) && JavaVersionUtil.JAVA_SPEC > 8) {
-                EmitStringEncodingSubstitutions.update(values, false);
+            if ("llvm".equals(newValue)) {
+                if (JavaVersionUtil.JAVA_SPEC > 8) {
+                    EmitStringEncodingSubstitutions.update(values, false);
+                }
+                /*
+                 * The code information is filled before linking, which means that stripping dead
+                 * functions makes it incoherent with the executable.
+                 */
+                RemoveUnusedSymbols.update(values, false);
             }
         }
     };

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/code/SubstrateLIRBackendFeature.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/code/SubstrateLIRBackendFeature.java
@@ -26,19 +26,31 @@ package com.oracle.svm.hosted.code;
 
 import static com.oracle.svm.core.SubstrateOptions.CompilerBackend;
 
-import org.graalvm.nativeimage.hosted.Feature;
+import java.util.Map;
+
+import org.graalvm.compiler.api.replacements.SnippetReflectionProvider;
+import org.graalvm.compiler.debug.DebugHandlersFactory;
+import org.graalvm.compiler.graph.Node;
+import org.graalvm.compiler.nodes.java.LoadExceptionObjectNode;
+import org.graalvm.compiler.options.OptionValues;
+import org.graalvm.compiler.phases.util.Providers;
 import org.graalvm.nativeimage.ImageSingletons;
+import org.graalvm.nativeimage.Platform;
+import org.graalvm.nativeimage.hosted.Feature;
 
 import com.oracle.svm.core.annotate.AutomaticFeature;
+import com.oracle.svm.core.graal.GraalFeature;
+import com.oracle.svm.core.graal.meta.RuntimeConfiguration;
+import com.oracle.svm.core.graal.snippets.ExceptionSnippets;
+import com.oracle.svm.core.graal.snippets.NodeLoweringProvider;
 import com.oracle.svm.core.snippets.SnippetRuntime;
 import com.oracle.svm.hosted.image.LIRNativeImageCodeCache;
 import com.oracle.svm.hosted.image.NativeImageCodeCache;
 import com.oracle.svm.hosted.image.NativeImageCodeCacheFactory;
 import com.oracle.svm.hosted.image.NativeImageHeap;
-import org.graalvm.nativeimage.Platform;
 
 @AutomaticFeature
-class SubstrateLIRBackendFeature implements Feature {
+class SubstrateLIRBackendFeature implements Feature, GraalFeature {
     @Override
     public boolean isInConfiguration(IsInConfigurationAccess access) {
         return CompilerBackend.getValue().equals("lir");
@@ -52,6 +64,12 @@ class SubstrateLIRBackendFeature implements Feature {
                 return new LIRNativeImageCodeCache(compileQueue.getCompilations(), heap);
             }
         });
-        ImageSingletons.add(SnippetRuntime.ExceptionStackFrameVisitor.class, new SnippetRuntime.ExceptionStackFrameVisitor());
+        ImageSingletons.add(SnippetRuntime.ExceptionUnwind.class, new SnippetRuntime.ExceptionUnwind());
+    }
+
+    @Override
+    public void registerLowerings(RuntimeConfiguration runtimeConfig, OptionValues options, Iterable<DebugHandlersFactory> factories, Providers providers, SnippetReflectionProvider snippetReflection,
+                    Map<Class<? extends Node>, NodeLoweringProvider<?>> lowerings, boolean hosted) {
+        lowerings.put(LoadExceptionObjectNode.class, new ExceptionSnippets.LoadExceptionObjectLowering());
     }
 }


### PR DESCRIPTION
Replace the setjmp/longjmp mechanism used by the LLVM backend to use the preferred way of delegating stack walking to libunwind. This simplifies the code in several places and is less buggy when targeting new architectures.