### PR TITLE
Fix for #1267 - NetworkInterface#isLoopback()

### DIFF
--- a/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/JavaNetNetworkInterface.java
+++ b/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/JavaNetNetworkInterface.java
@@ -31,7 +31,9 @@ import java.net.InterfaceAddress;
 import java.net.NetworkInterface;
 import java.net.SocketException;
 
+import com.oracle.svm.core.util.Utf8;
 import org.graalvm.nativeimage.ImageSingletons;
+import org.graalvm.nativeimage.PinnedObject;
 import org.graalvm.nativeimage.Platform;
 import org.graalvm.nativeimage.Platforms;
 import org.graalvm.nativeimage.StackValue;
@@ -904,6 +906,92 @@ public class JavaNetNetworkInterface {
         return ifs;
     }
 
+    //   577  static int getFlags0(JNIEnv *env, jstring name) {
+    @SuppressWarnings({"unused"})
+    static int getFlags0(String name) {
+        final PlatformSupport platformSupport = ImageSingletons.lookup(PlatformSupport.class);
+        //   578      jboolean isCopy;
+        //   579      int ret, sock;
+        int ret, sock;
+        //   580      const char* name_utf;
+        byte[] name_utf;
+        //   581      int flags = 0;
+        CIntPointer flags = StackValue.get(CIntPointer.class);
+
+        //   583      name_utf = (*env)->GetStringUTFChars(env, name, &isCopy);
+        name_utf = Utf8.stringToUtf8(name, true);
+        //   584
+        try (PinnedObject name_utf_Pin = PinnedObject.create(name_utf)) {
+            CCharPointer name_utf_Pointer = name_utf_Pin.addressOfArrayElement(0);
+            //   585      if ((sock = openSocketWithFallback(env, name_utf)) < 0) {
+            if ((sock = openSocketWithFallback(name_utf_Pointer)) < 0) {
+                //   586          (*env)->ReleaseStringUTFChars(env, name, name_utf);
+                //   587          return -1;
+                return -1;
+                //   588      }
+            }
+            //   590      ret = getFlags(sock, name_utf, &flags);
+            ret = platformSupport.getFlags(sock, name_utf_Pointer, flags);
+            //   592      close(sock);
+            Unistd.close(sock);
+            //   593      (*env)->ReleaseStringUTFChars(env, name, name_utf);
+            //   594
+            //   595      if (ret < 0) {
+            if (ret < 0) {
+                //   596          NET_ThrowByNameWithLastError(env, JNU_JAVANETPKG "SocketException", "IOCTL  SIOCGLIFFLAGS failed");
+                throw new SocketException(PosixUtils.lastErrorString("IOCTL SIOCGLIFFLAGS failed"));
+                //   597          return -1;
+                //   598      }
+                //   599
+            }
+            //   600      return flags;
+            //   601  }
+            return flags.read();
+        } catch (SocketException e) {
+            return -1;
+        }
+    }
+
+    @SuppressWarnings({"unused"})
+    static int openSocketWithFallback(CCharPointer ifname) throws SocketException {
+        //  1050  #ifdef AF_INET6
+        if (JavaNetNetUtil.ipv6_available()) {
+            //  1051  static int openSocketWithFallback(JNIEnv *env, const char *ifname){
+            //  1052      int sock;
+            int sock;
+            //  1053      struct ifreq if2;
+            //  1054
+            //  1055       if ((sock = JVM_Socket(AF_INET, SOCK_DGRAM, 0)) < 0) {
+            if ((sock = VmPrimsJVM.JVM_Socket(Socket.AF_INET(), Socket.SOCK_DGRAM(), 0)) < 0) {
+                //  1056           if (errno == EPROTONOSUPPORT){
+                if (Errno.errno() == Errno.EPROTONOSUPPORT()) {
+                    //  1057                if ( (sock = JVM_Socket(AF_INET6, SOCK_DGRAM, 0)) < 0 ){
+                    if ((sock = VmPrimsJVM.JVM_Socket(Socket.AF_INET6(), Socket.SOCK_DGRAM(), 0)) < 0) {
+                        //  1058                   NET_ThrowByNameWithLastError(env , JNU_JAVANETPKG "SocketException", "IPV6 Socket creation failed");
+                        //  1059                   return -1;
+                        throw new SocketException(PosixUtils.lastErrorString("IPV6 Socket creation failed"));
+                    }
+                } else {
+                    //  1062           else{ // errno is not NOSUPPORT
+                    //  1063               NET_ThrowByNameWithLastError(env , JNU_JAVANETPKG "SocketException", "IPV4 Socket creation failed");
+                    throw new SocketException(PosixUtils.lastErrorString("IPV4 Socket creation failed"));
+                }
+            }
+            //  1068       /* Linux starting from 2.6.? kernel allows ioctl call with either IPv4 or IPv6 socket regardless of type
+            //  1069          of address of an interface */
+            //  1070
+            //  1071         return sock;
+            return sock;
+        } else {
+            //  1074  #else
+            //  1075  static int openSocketWithFallback(JNIEnv *env, const char *ifname){
+            //  1076      return openSocket(env,AF_INET);
+            return openSocket(Socket.AF_INET());
+            //  1077  }
+            //  1078  #endif
+        }
+    }
+
     /*
      * Translated from jdk/src/solaris/native/java/net/NetworkInterface.c?v=Java_1.8.0_40_b10
      */
@@ -932,6 +1020,7 @@ public class JavaNetNetworkInterface {
         // 1074     return sock;
         return sock;
     }
+
 
     /**
      * Access to platform-dependent code.

--- a/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/PosixJavaNetSubstitutions.java
+++ b/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/PosixJavaNetSubstitutions.java
@@ -4023,6 +4023,22 @@ final class Target_java_net_NetworkInterface {
         return obj;
     }
 
+    //   477  /*
+    //   478   * Class:     java_net_NetworkInterface
+    //   479   * Method:    isLoopback0
+    //   480   * Signature: (Ljava/lang/String;I)Z
+    //   481   */
+    //   482  JNIEXPORT jboolean JNICALL Java_java_net_NetworkInterface_isLoopback0(JNIEnv *env, jclass cls, jstring name, jint index) {
+    //   483      int ret = getFlags0(env, name);
+    //   484      return (ret & IFF_LOOPBACK) ? JNI_TRUE :  JNI_FALSE;
+    //   485  }
+    @Substitute
+    @SuppressWarnings({"unused"})
+    private static boolean isLoopback0(String name, int index) {
+        int ret = JavaNetNetworkInterface.getFlags0(name);
+        return ((ret & NetIf.IFF_LOOPBACK()) != 0) ? true : false;
+    }
+
     /*
      * Translated from jdk8u/jdk/src/solaris/native/java/net/NetworkInterface.c
      */

--- a/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/NetworkInterfaceTest.java
+++ b/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/NetworkInterfaceTest.java
@@ -1,0 +1,23 @@
+package com.oracle.svm.test;
+
+import java.net.NetworkInterface;
+import java.net.SocketException;
+import java.util.Enumeration;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class NetworkInterfaceTest {
+
+    @Test
+    public void testLoopback() throws SocketException {
+        Enumeration<NetworkInterface> ifaces = NetworkInterface.getNetworkInterfaces();
+        boolean foundLoopback = false;
+        while (ifaces.hasMoreElements()) {
+            NetworkInterface each = ifaces.nextElement();
+            foundLoopback = each.isLoopback() || foundLoopback;
+        }
+
+        Assert.assertTrue("At least one loopback found", foundLoopback);
+    }
+}


### PR DESCRIPTION
Fixes #1267 . Transliterate JDK C to Java as appropriate.
- isLoopback0()
- getFlags0()
- openSocketWithFallback()

    $ ./com.redhat.network.networktest
    name:en5 (en5) ==> false
    name:utun1 (utun1) ==> false
    name:utun0 (utun0) ==> false
    name:awdl0 (awdl0) ==> false
    name:en0 (en0) ==> false
    name:lo0 (lo0) ==> true