### PR TITLE
Fix for #1417 - Invalid Class-Path entries.

### DIFF
--- a/substratevm/src/com.oracle.svm.driver/src/com/oracle/svm/driver/NativeImage.java
+++ b/substratevm/src/com.oracle.svm.driver/src/com/oracle/svm/driver/NativeImage.java
@@ -804,11 +804,17 @@ public class NativeImage {
                 }
 
                 for (Path jarFile : jarFileMatches) {
+                    String fileName = jarFile.getFileName().toString().toLowerCase();
+                    if (!(fileName.endsWith(".jar") || fileName.endsWith(".zip"))) {
+                        // not a .jar or .zip
+                        continue;
+                    }
                     URI jarFileURI = URI.create("jar:" + jarFile.toUri());
                     try (FileSystem jarFS = FileSystems.newFileSystem(jarFileURI, Collections.emptyMap())) {
                         Path nativeImageMetaInfBase = jarFS.getPath("/" + nativeImageMetaInf);
                         processNativeImageMetaInf(jarFile, nativeImageMetaInfBase, metaInfProcessor);
                     }
+
                 }
             }
         } catch (IOException | FileSystemNotFoundException e) {
@@ -865,6 +871,11 @@ public class NativeImage {
 
     static boolean processManifestMainAttributes(Path jarFilePath, BiConsumer<Path, Attributes> manifestConsumer) {
         if (Files.isDirectory(jarFilePath)) {
+            return false;
+        }
+        String fileName = jarFilePath.getFileName().toString().toLowerCase();
+        if (!(fileName.endsWith(".jar") || fileName.endsWith(".zip"))) {
+            // not a .jar or .zip
             return false;
         }
         try (JarFile jarFile = new JarFile(jarFilePath.toFile())) {

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/ImageClassLoader.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/ImageClassLoader.java
@@ -44,6 +44,7 @@ import java.nio.file.FileVisitor;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.nio.file.ProviderNotFoundException;
 import java.nio.file.SimpleFileVisitor;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.ArrayList;
@@ -163,6 +164,11 @@ public final class ImageClassLoader {
         if (Files.exists(path)) {
             if (Files.isRegularFile(path)) {
                 try {
+                    String fileName = path.getFileName().toString().toLowerCase();
+                    if (!(fileName.endsWith(".jar") || fileName.endsWith(".zip"))) {
+                        // ignore entries that aren't .jar or .zip
+                        return;
+                    }
                     URI jarURI = new URI("jar:" + path.toAbsolutePath().toUri());
                     FileSystem probeJarFileSystem;
                     try {


### PR DESCRIPTION
Fixes #1417. Be more defensive for MANIFEST.MF Class-Path entries
which sometimes includes non-jar/zip entries, because
Maven is goofy at times.