### PR TITLE
Fixes 1420 - missing `AbstractPlainSocketImpl.isReusePortAvailable0()`

### DIFF
--- a/substratevm/mx.substratevm/suite.py
+++ b/substratevm/mx.substratevm/suite.py
@@ -457,6 +457,23 @@ suite = {
             "spotbugs": "false",
         },
 
+        "com.oracle.svm.test.jdk11": {
+            "subDir": "src",
+            "sourceDirs": ["src"],
+            "dependencies": [
+                "mx:JUNIT_TOOL",
+                "sdk:GRAAL_SDK",
+            ],
+            "checkstyle": "com.oracle.svm.core",
+            "workingSets": "SVM",
+            "annotationProcessors": [
+                "compiler:GRAAL_OPTIONS_PROCESSOR",
+            ],
+            "javaCompliance": "11+",
+            "spotbugs": "false",
+            "testProject": True,
+        },
+
         "com.oracle.svm.reflect": {
             "subDir": "src",
             "sourceDirs": ["src"],
@@ -918,6 +935,7 @@ suite = {
           "relpath" : True,
           "dependencies" : [
             "com.oracle.svm.test",
+            "com.oracle.svm.test.jdk11",
           ],
           "distDependencies": [
             "mx:JUNIT_TOOL",

--- a/substratevm/src/com.oracle.svm.core.posix.jdk11/src/com/oracle/svm/core/posix/Target_java_net_AbstractPlainSocketImpl_JDK11OrLater.java
+++ b/substratevm/src/com.oracle.svm.core.posix.jdk11/src/com/oracle/svm/core/posix/Target_java_net_AbstractPlainSocketImpl_JDK11OrLater.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2019, 2019, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package com.oracle.svm.core.posix;
+
+import com.oracle.svm.core.annotate.Substitute;
+import com.oracle.svm.core.annotate.TargetClass;
+import com.oracle.svm.core.jdk.JDK11OrLater;
+import org.graalvm.nativeimage.Platform;
+import org.graalvm.nativeimage.Platforms;
+
+@TargetClass(className = "java.net.AbstractPlainSocketImpl", onlyWith = JDK11OrLater.class)
+@Platforms({Platform.LINUX.class, Platform.DARWIN.class})
+final class Target_java_net_AbstractPlainSocketImpl_JDK11OrLater {
+    // This class must not hide the "normal" Posix variant, and should be additive
+
+    /* Do not re-format commented-out code: @formatter:off */
+    // ported from: ./src/java.base/unix/native/libnet/SocketImpl.c
+    //    38  JNIEXPORT jboolean JNICALL
+    //    39  Java_java_net_AbstractPlainDatagramSocketImpl_isReusePortAvailable0(JNIEnv* env, jclass c1)
+    @Substitute
+    static boolean isReusePortAvailable0() {
+        //    41      return (reuseport_available()) ? JNI_TRUE : JNI_FALSE;
+        return JavaNetNetUtil.reuseport_available();
+    }
+    /* Do not re-format commented-out code: @formatter:on */
+}

--- a/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/headers/Socket.java
+++ b/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/headers/Socket.java
@@ -843,9 +843,8 @@ public class Socket {
     @Platforms(Platform.LINUX.class)
     public static native int SO_BSDCOMPAT();
 
-    // [not present on old Linux systems]
-    // @CConstant
-    // public static native int SO_REUSEPORT();
+    @CConstant
+    public static native int SO_REUSEPORT();
 
     @CConstant
     @Platforms(Platform.LINUX.class)

--- a/substratevm/src/com.oracle.svm.test.jdk11/src/com/oracle/svm/test/jdk11/ReusePortAvailableTest.java
+++ b/substratevm/src/com.oracle.svm.test.jdk11/src/com/oracle/svm/test/jdk11/ReusePortAvailableTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2018, 2018, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package com.oracle.svm.test.jdk11;
+
+import java.net.Socket;
+import java.net.SocketOption;
+import java.util.Set;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class ReusePortAvailableTest {
+
+    @Test
+    public void testReusePortAvailable() throws Exception {
+        Socket s = new Socket();
+        try {
+            Set<SocketOption<?>> opts = s.supportedOptions();
+        } catch (Exception e) {
+            Assert.fail("Call to supportedOptions() failed");
+        }
+    }
+}


### PR DESCRIPTION
Fixes #1420

Add appropriate transliterations for JavaNetNetUtil and AbstractPlainSocketImpl
for JDK11 support.

Also creates a JDK11 smoke-test suite and adds a test for the implementation.