### PR TITLE
Multithreading support for the LLVM backend

### DIFF
--- a/compiler/src/org.graalvm.compiler.core.llvm/src/org/graalvm/compiler/core/llvm/LLVMUtils.java
+++ b/compiler/src/org.graalvm.compiler.core.llvm/src/org/graalvm/compiler/core/llvm/LLVMUtils.java
@@ -40,6 +40,7 @@ import org.graalvm.compiler.core.common.spi.LIRKindTool;
 import org.graalvm.compiler.lir.ConstantValue;
 import org.graalvm.compiler.lir.Variable;
 import org.graalvm.compiler.lir.VirtualStackSlot;
+import org.graalvm.nativeimage.ImageSingletons;
 
 import jdk.vm.ci.meta.Constant;
 import jdk.vm.ci.meta.PlatformKind;
@@ -53,12 +54,33 @@ public class LLVMUtils {
     static final int UNTRACKED_POINTER_ADDRESS_SPACE = 0;
     static final int TRACKED_POINTER_ADDRESS_SPACE = 1;
     public static final long DEFAULT_PATCHPOINT_ID = 0xABCDEF00L;
+    public static final String GC_REGISTER_FUNCTION_NAME = "__llvm_gc_register";
+    public static final String JNI_WRAPPER_PREFIX = "__llvm_jni_wrapper_";
 
     public static final class DebugLevel {
         public static final int NONE = 0;
         public static final int FUNCTION = 1;
         public static final int BLOCK = 2;
         public static final int NODE = 3;
+    }
+
+    /**
+     * LLVM target-specific inline assembly snippets.
+     */
+    public abstract static class TargetSpecific {
+        public static TargetSpecific get() {
+            return ImageSingletons.lookup(TargetSpecific.class);
+        }
+
+        /**
+         * Snippet that gets the value of an arbitrary register.
+         */
+        public abstract String getRegisterInlineAsm(String register);
+
+        /**
+         * Snippet that jumps to a runtime-computed address.
+         */
+        public abstract String getJumpInlineAsm();
     }
 
     static int getLLVMIntCond(Condition cond) {

--- a/compiler/src/org.graalvm.compiler.core.llvm/src/org/graalvm/compiler/core/llvm/NodeLLVMBuilder.java
+++ b/compiler/src/org.graalvm.compiler.core.llvm/src/org/graalvm/compiler/core/llvm/NodeLLVMBuilder.java
@@ -38,7 +38,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.BiFunction;
 
-import org.bytedeco.javacpp.LLVM;
 import org.bytedeco.javacpp.LLVM.LLVMBasicBlockRef;
 import org.bytedeco.javacpp.LLVM.LLVMTypeRef;
 import org.bytedeco.javacpp.LLVM.LLVMValueRef;
@@ -97,12 +96,13 @@ import org.graalvm.compiler.nodes.spi.NodeValueMap;
 import jdk.vm.ci.code.CallingConvention;
 import jdk.vm.ci.code.DebugInfo;
 import jdk.vm.ci.code.Register;
+import jdk.vm.ci.code.RegisterValue;
 import jdk.vm.ci.meta.JavaConstant;
 import jdk.vm.ci.meta.JavaKind;
 import jdk.vm.ci.meta.ResolvedJavaMethod;
 import jdk.vm.ci.meta.Value;
 
-public class NodeLLVMBuilder implements NodeLIRBuilderTool {
+public abstract class NodeLLVMBuilder implements NodeLIRBuilderTool {
     protected final LLVMGenerator gen;
     protected final LLVMIRBuilder builder;
     private final DebugInfoBuilder debugInfoBuilder;
@@ -144,9 +144,11 @@ public class NodeLLVMBuilder implements NodeLIRBuilderTool {
             builder.buildStackmap(builder.constantLong(startPatchpointID));
 
             for (ParameterNode param : graph.getNodes(ParameterNode.TYPE)) {
-                LLVMValueRef paramValue = builder.getParam(param.index());
+                LLVMValueRef paramValue = builder.getParam(getParamIndex(param.index()));
                 setResult(param, paramValue);
             }
+
+            gen.allocateRegisterSlots();
 
             if (gen.getDebugLevel() >= DebugLevel.FUNCTION) {
                 gen.indent();
@@ -240,6 +242,8 @@ public class NodeLLVMBuilder implements NodeLIRBuilderTool {
         gen.getLLVMResult().setProcessed(block);
     }
 
+    protected abstract int getParamIndex(int index);
+
     @Override
     public void matchBlock(Block b, StructuredGraph graph, StructuredGraph.ScheduleResult blockMap) {
 
@@ -285,7 +289,7 @@ public class NodeLLVMBuilder implements NodeLIRBuilderTool {
         return (int) (probability * Integer.MAX_VALUE);
     }
 
-    private LLVMValueRef emitCondition(LogicNode condition) {
+    protected LLVMValueRef emitCondition(LogicNode condition) {
         if (condition instanceof IsNullNode) {
             return builder.buildIsNull(llvmOperand(((IsNullNode) condition).getValue()));
         }
@@ -384,7 +388,7 @@ public class NodeLLVMBuilder implements NodeLIRBuilderTool {
 
         LLVMValueRef callee;
         LLVMValueRef[] args;
-        args = arguments.stream().map(this::llvmOperand).toArray(LLVMValueRef[]::new);
+        args = getCallArguments(arguments, callTarget.callType(), targetMethod);
 
         LIRFrameState state = state(i);
         state.initDebugInfo(null, false);
@@ -423,6 +427,14 @@ public class NodeLLVMBuilder implements NodeLIRBuilderTool {
             throw shouldNotReachHere();
         }
 
+        LLVMValueRef call = emitCall(i, callTarget, callee, patchpointId, args);
+
+        if (!isVoid) {
+            setResult(i.asNode(), call);
+        }
+    }
+
+    protected LLVMValueRef emitCall(Invoke i, LoweredCallTargetNode callTarget, LLVMValueRef callee, long patchpointId, LLVMValueRef... args) {
         LLVMValueRef call;
         if (i instanceof InvokeWithExceptionNode) {
             InvokeWithExceptionNode invokeWithExceptionNode = (InvokeWithExceptionNode) i;
@@ -434,9 +446,11 @@ public class NodeLLVMBuilder implements NodeLIRBuilderTool {
             call = builder.buildCall(callee, patchpointId, args);
         }
 
-        if (!isVoid) {
-            setResult(i.asNode(), call);
-        }
+        return call;
+    }
+
+    protected LLVMValueRef[] getCallArguments(NodeInputList<ValueNode> arguments, CallingConvention.Type callType, ResolvedJavaMethod targetMethod) {
+        return arguments.stream().map(this::llvmOperand).toArray(LLVMValueRef[]::new);
     }
 
     @Override
@@ -444,13 +458,8 @@ public class NodeLLVMBuilder implements NodeLIRBuilderTool {
         builder.buildLandingPad();
 
         Register exceptionRegister = gen.getRegisterConfig().getReturnRegister(JavaKind.Object);
-        LLVMTypeRef asmType = builder.functionType(builder.longType());
-        LLVMValueRef inlineAsm = builder.buildInlineAsm(asmType, "movq %" + exceptionRegister.name + ", $0", "={" + exceptionRegister.name + "}", false, false);
-
-        LLVMValueRef exception = builder.buildCall(inlineAsm);
-        builder.setCallSiteAttribute(exception, LLVM.LLVMAttributeFunctionIndex, "gc-leaf-function");
-
-        setResult(node, builder.buildRegisterObject(builder.buildIntToPtr(exception, builder.rawPointerType())));
+        LLVMValueRef exception = builder.buildInlineGetRegister(exceptionRegister.name);
+        setResult(node, builder.buildRegisterObject(exception));
     }
 
     @Override
@@ -538,7 +547,7 @@ public class NodeLLVMBuilder implements NodeLIRBuilderTool {
         return (Value) valueMap.get(node);
     }
 
-    private LLVMValueRef llvmOperand(Node node) {
+    protected LLVMValueRef llvmOperand(Node node) {
         assert valueMap.containsKey(node);
         return valueMap.get(node).get();
     }
@@ -583,6 +592,9 @@ public class NodeLLVMBuilder implements NodeLIRBuilderTool {
             }
 
             llvmOperand = new LLVMVariable(intermediate);
+        } else if (operand instanceof RegisterValue) {
+            RegisterValue registerValue = (RegisterValue) operand;
+            llvmOperand = (LLVMVariable) gen.emitReadRegister(registerValue.getRegister(), registerValue.getValueKind());
         } else {
             throw shouldNotReachHere("unknown operand: " + operand.toString());
         }

--- a/compiler/src/org.graalvm.compiler.lir/src/org/graalvm/compiler/lir/gen/LIRGenerator.java
+++ b/compiler/src/org.graalvm.compiler.lir/src/org/graalvm/compiler/lir/gen/LIRGenerator.java
@@ -230,6 +230,16 @@ public abstract class LIRGenerator implements LIRGeneratorTool {
     }
 
     @Override
+    public Variable emitReadRegister(Register register, ValueKind<?> kind) {
+        return emitMove(register.asValue(kind));
+    }
+
+    @Override
+    public void emitWriteRegister(Register dst, Value src, ValueKind<?> kind) {
+        emitMove(dst.asValue(kind), src);
+    }
+
+    @Override
     public void emitMoveConstant(AllocatableValue dst, Constant src) {
         append(moveFactory.createLoad(dst, src));
     }

--- a/compiler/src/org.graalvm.compiler.lir/src/org/graalvm/compiler/lir/gen/LIRGeneratorTool.java
+++ b/compiler/src/org.graalvm.compiler.lir/src/org/graalvm/compiler/lir/gen/LIRGeneratorTool.java
@@ -204,6 +204,10 @@ public interface LIRGeneratorTool extends DiagnosticLIRGeneratorTool, ValueKindF
 
     void emitMove(AllocatableValue dst, Value src);
 
+    Variable emitReadRegister(Register register, ValueKind<?> kind);
+
+    void emitWriteRegister(Register dst, Value src, ValueKind<?> wordStamp);
+
     void emitMoveConstant(AllocatableValue dst, Constant src);
 
     Variable emitAddress(AllocatableValue stackslot);

--- a/compiler/src/org.graalvm.compiler.replacements/src/org/graalvm/compiler/replacements/nodes/ReadRegisterNode.java
+++ b/compiler/src/org.graalvm.compiler.replacements/src/org/graalvm/compiler/replacements/nodes/ReadRegisterNode.java
@@ -91,7 +91,7 @@ public final class ReadRegisterNode extends FixedWithNextNode implements LIRLowe
             generator.getLIRGeneratorTool().emitIncomingValues(new Value[]{result});
         }
         if (!directUse) {
-            result = generator.getLIRGeneratorTool().emitMove(result);
+            result = generator.getLIRGeneratorTool().emitReadRegister(register, kind);
         }
         generator.setResult(this, result);
     }

--- a/compiler/src/org.graalvm.compiler.replacements/src/org/graalvm/compiler/replacements/nodes/WriteRegisterNode.java
+++ b/compiler/src/org.graalvm.compiler.replacements/src/org/graalvm/compiler/replacements/nodes/WriteRegisterNode.java
@@ -65,7 +65,7 @@ public final class WriteRegisterNode extends FixedWithNextNode implements LIRLow
     @Override
     public void generate(NodeLIRBuilderTool generator) {
         Value val = generator.operand(value);
-        generator.getLIRGeneratorTool().emitMove(register.asValue(val.getValueKind()), val);
+        generator.getLIRGeneratorTool().emitWriteRegister(register, val, val.getValueKind());
     }
 
     @Override

--- a/substratevm/src/com.oracle.svm.core.graal.llvm/src/com/oracle/svm/core/graal/llvm/SubstrateLLVMGenerator.java
+++ b/substratevm/src/com.oracle.svm.core.graal.llvm/src/com/oracle/svm/core/graal/llvm/SubstrateLLVMGenerator.java
@@ -24,36 +24,96 @@
  */
 package com.oracle.svm.core.graal.llvm;
 
+import static com.oracle.svm.core.util.VMError.shouldNotReachHere;
 import static com.oracle.svm.core.util.VMError.unimplemented;
+import static org.graalvm.compiler.core.llvm.LLVMUtils.getVal;
 
+import org.bytedeco.javacpp.LLVM;
 import org.bytedeco.javacpp.LLVM.LLVMContextRef;
+import org.bytedeco.javacpp.LLVM.LLVMValueRef;
 import org.graalvm.compiler.core.common.spi.ForeignCallDescriptor;
 import org.graalvm.compiler.core.llvm.LLVMGenerationResult;
 import org.graalvm.compiler.core.llvm.LLVMGenerator;
 import org.graalvm.compiler.core.llvm.LLVMUtils.LLVMKindTool;
+import org.graalvm.compiler.core.llvm.LLVMUtils.LLVMVariable;
+import org.graalvm.compiler.lir.Variable;
 import org.graalvm.compiler.phases.util.Providers;
 import org.graalvm.util.GuardedAnnotationAccess;
 
 import com.oracle.svm.core.SubstrateUtil;
 import com.oracle.svm.core.annotate.Uninterruptible;
+import com.oracle.svm.core.c.function.CEntryPointBuiltins;
+import com.oracle.svm.core.c.function.CEntryPointNativeFunctions;
+import com.oracle.svm.core.graal.code.SubstrateCallingConvention;
+import com.oracle.svm.core.graal.code.SubstrateCallingConventionType;
 import com.oracle.svm.core.graal.code.SubstrateLIRGenerator;
+import com.oracle.svm.core.graal.meta.SubstrateRegisterConfig;
+import com.oracle.svm.core.graal.snippets.CEntryPointSnippets;
 import com.oracle.svm.core.snippets.SnippetRuntime;
+import com.oracle.svm.hosted.meta.HostedMethod;
 import com.oracle.svm.hosted.meta.HostedType;
 
+import jdk.vm.ci.code.CallingConvention;
+import jdk.vm.ci.code.Register;
 import jdk.vm.ci.meta.AllocatableValue;
 import jdk.vm.ci.meta.JavaKind;
 import jdk.vm.ci.meta.ResolvedJavaMethod;
 import jdk.vm.ci.meta.ResolvedJavaType;
 import jdk.vm.ci.meta.Value;
+import jdk.vm.ci.meta.ValueKind;
 
 public class SubstrateLLVMGenerator extends LLVMGenerator implements SubstrateLIRGenerator {
+    /*
+     * Special registers (thread pointer and heap base) are implemented in the LLVM backend by
+     * passing them as arguments to functions. As these registers can be modified in entry point
+     * methods, these hold the values of these registers in stack slots, which get passed to callees
+     * that can potentially modify them and hold the updated version of the "register" upon return.
+     */
+    private LLVMValueRef[] registerStackSlots = new LLVMValueRef[LLVMFeature.SPECIAL_REGISTER_COUNT];
+
+    private final boolean isEntryPoint;
+    private final boolean canModifySpecialRegisters;
+
     SubstrateLLVMGenerator(Providers providers, LLVMGenerationResult generationResult, ResolvedJavaMethod method, LLVMContextRef context, int debugLevel) {
         super(providers, generationResult, method, new SubstrateLLVMIRBuilder(SubstrateUtil.uniqueShortName(method), context, shouldTrackPointers(method)),
                         new LLVMKindTool(context), debugLevel);
+        this.isEntryPoint = isEntryPoint(method);
+        this.canModifySpecialRegisters = canModifySpecialRegisters(method);
+    }
+
+    boolean isEntryPoint() {
+        return isEntryPoint;
     }
 
     private static boolean shouldTrackPointers(ResolvedJavaMethod method) {
         return !GuardedAnnotationAccess.isAnnotationPresent(method, Uninterruptible.class);
+    }
+
+    private static boolean isEntryPoint(ResolvedJavaMethod method) {
+        return ((HostedMethod) method).isEntryPoint();
+    }
+
+    private boolean canModifySpecialRegisters(ResolvedJavaMethod method) {
+        return (method.getDeclaringClass().equals(getMetaAccess().lookupJavaType(CEntryPointSnippets.class)) ||
+                        method.getDeclaringClass().equals(getMetaAccess().lookupJavaType(CEntryPointNativeFunctions.class)) ||
+                        method.getDeclaringClass().equals(getMetaAccess().lookupJavaType(CEntryPointBuiltins.class)));
+    }
+
+    @Override
+    public SubstrateRegisterConfig getRegisterConfig() {
+        return (SubstrateRegisterConfig) super.getRegisterConfig();
+    }
+
+    @Override
+    public void allocateRegisterSlots() {
+        if (!isEntryPoint) {
+            /* Non-entry point methods get the stack slots of their caller as argument. */
+            return;
+        }
+
+        for (int i = 0; i < registerStackSlots.length; ++i) {
+            registerStackSlots[i] = builder.buildArrayAlloca(1);
+        }
     }
 
     @Override
@@ -88,5 +148,103 @@ public class SubstrateLLVMGenerator extends LLVMGenerator implements SubstrateLI
     @Override
     protected JavaKind getTypeKind(ResolvedJavaType type) {
         return ((HostedType) type).getStorageKind();
+    }
+
+    @Override
+    protected LLVM.LLVMTypeRef[] getLLVMFunctionArgTypes(ResolvedJavaMethod method) {
+        LLVM.LLVMTypeRef[] parameterTypes = super.getLLVMFunctionArgTypes(method);
+        LLVM.LLVMTypeRef[] newParameterTypes = parameterTypes;
+        if (!isEntryPoint(method) && registerStackSlots.length > 0) {
+            newParameterTypes = new LLVM.LLVMTypeRef[registerStackSlots.length + parameterTypes.length];
+            for (int i = 0; i < registerStackSlots.length; ++i) {
+                newParameterTypes[i] = canModifySpecialRegisters(method) ? builder.rawPointerType() : builder.longType();
+            }
+            System.arraycopy(parameterTypes, 0, newParameterTypes, LLVMFeature.SPECIAL_REGISTER_COUNT, parameterTypes.length);
+        }
+        return newParameterTypes;
+    }
+
+    @Override
+    public Variable emitReadRegister(Register register, ValueKind<?> kind) {
+        LLVMValueRef value;
+        if (register.equals(getRegisterConfig().getThreadRegister())) {
+            value = getSpecialRegister(LLVMFeature.THREAD_POINTER_INDEX);
+        } else if (register.equals(getRegisterConfig().getHeapBaseRegister())) {
+            value = getSpecialRegister(LLVMFeature.HEAP_BASE_INDEX);
+        } else if (register.equals(getRegisterConfig().getFrameRegister())) {
+            value = builder.buildReadRegister(builder.register(getRegisterConfig().getFrameRegister().name));
+        } else {
+            throw shouldNotReachHere();
+        }
+        return new LLVMVariable(value);
+    }
+
+    @Override
+    public void emitWriteRegister(Register dst, Value src, ValueKind<?> kind) {
+        if (dst.equals(getRegisterConfig().getThreadRegister())) {
+            assert isEntryPoint || canModifySpecialRegisters;
+            builder.buildStore(getVal(src), getSpecialRegisterPointer(LLVMFeature.THREAD_POINTER_INDEX));
+            return;
+        } else if (dst.equals(getRegisterConfig().getHeapBaseRegister())) {
+            assert isEntryPoint || canModifySpecialRegisters;
+            builder.buildStore(getVal(src), getSpecialRegisterPointer(LLVMFeature.HEAP_BASE_INDEX));
+            return;
+        }
+        throw shouldNotReachHere();
+    }
+
+    private LLVMValueRef getSpecialRegisterPointer(int index) {
+        if (isEntryPoint) {
+            return registerStackSlots[index];
+        } else if (canModifySpecialRegisters) {
+            return builder.getParam(index);
+        } else {
+            throw shouldNotReachHere();
+        }
+    }
+
+    LLVMValueRef getSpecialRegister(int index) {
+        LLVMValueRef specialRegister;
+        if (isEntryPoint || canModifySpecialRegisters) {
+            LLVMValueRef specialRegisterPointer = getSpecialRegisterPointer(index);
+            specialRegister = builder.buildLoad(specialRegisterPointer, builder.longType());
+        } else {
+            specialRegister = builder.getParam(index);
+        }
+        return specialRegister;
+    }
+
+    private LLVMValueRef getSpecialRegisterArgument(int index, ResolvedJavaMethod targetMethod) {
+        LLVMValueRef specialRegisterArg;
+        if (canModifySpecialRegisters(targetMethod)) {
+            assert (isEntryPoint || canModifySpecialRegisters);
+            specialRegisterArg = builder.buildBitcast(getSpecialRegisterPointer(index), builder.rawPointerType());
+        } else {
+            if (isEntryPoint || canModifySpecialRegisters) {
+                specialRegisterArg = builder.buildLoad(getSpecialRegisterPointer(index), builder.longType());
+            } else {
+                specialRegisterArg = getSpecialRegister(index);
+            }
+        }
+        return specialRegisterArg;
+    }
+
+    @Override
+    public LLVMValueRef[] getCallArguments(LLVMValueRef[] args, CallingConvention.Type callType, ResolvedJavaMethod targetMethod) {
+        LLVMValueRef[] newArgs = args;
+
+        if (targetMethod != null && !((SubstrateCallingConventionType) callType).nativeABI && registerStackSlots.length > 0) {
+            newArgs = new LLVMValueRef[registerStackSlots.length + args.length];
+            for (int i = 0; i < registerStackSlots.length; ++i) {
+                newArgs[i] = getSpecialRegisterArgument(i, targetMethod);
+            }
+            System.arraycopy(args, 0, newArgs, LLVMFeature.SPECIAL_REGISTER_COUNT, args.length);
+        }
+        return newArgs;
+    }
+
+    @Override
+    protected CallingConvention.Type getCallingConventionType(CallingConvention callingConvention) {
+        return ((SubstrateCallingConvention) callingConvention).getType();
     }
 }

--- a/substratevm/src/com.oracle.svm.core.graal.llvm/src/com/oracle/svm/core/graal/llvm/SubstrateNodeLLVMBuilder.java
+++ b/substratevm/src/com.oracle.svm.core.graal.llvm/src/com/oracle/svm/core/graal/llvm/SubstrateNodeLLVMBuilder.java
@@ -24,24 +24,50 @@
  */
 package com.oracle.svm.core.graal.llvm;
 
-import org.bytedeco.javacpp.LLVM.LLVMValueRef;
-import org.graalvm.compiler.core.llvm.LLVMGenerator;
-import org.graalvm.compiler.core.llvm.LLVMUtils;
-import org.graalvm.compiler.core.llvm.NodeLLVMBuilder;
-import org.graalvm.compiler.lir.Variable;
-import org.graalvm.compiler.nodes.StructuredGraph;
+import static com.oracle.svm.core.graal.code.SubstrateBackend.getJavaFrameAnchor;
+import static com.oracle.svm.core.graal.code.SubstrateBackend.hasJavaFrameAnchor;
+import static org.graalvm.compiler.core.llvm.LLVMIRBuilder.typeOf;
 
+import org.bytedeco.javacpp.LLVM.LLVMBasicBlockRef;
+import org.bytedeco.javacpp.LLVM.LLVMTypeRef;
+import org.bytedeco.javacpp.LLVM.LLVMValueRef;
+import org.bytedeco.javacpp.LLVM;
+import org.graalvm.compiler.core.llvm.LLVMGenerator;
+import org.graalvm.compiler.core.llvm.LLVMIRBuilder;
+import org.graalvm.compiler.core.llvm.LLVMUtils;
+import org.graalvm.compiler.core.llvm.LLVMUtils.LLVMVariable;
+import org.graalvm.compiler.core.llvm.NodeLLVMBuilder;
+import org.graalvm.compiler.graph.NodeInputList;
+import org.graalvm.compiler.lir.Variable;
+import org.graalvm.compiler.nodes.Invoke;
+import org.graalvm.compiler.nodes.LogicNode;
+import org.graalvm.compiler.nodes.LoweredCallTargetNode;
+import org.graalvm.compiler.nodes.StructuredGraph;
+import org.graalvm.compiler.nodes.ValueNode;
+import org.graalvm.compiler.nodes.cfg.Block;
+
+import com.oracle.svm.core.SubstrateOptions;
 import com.oracle.svm.core.graal.code.CGlobalDataInfo;
 import com.oracle.svm.core.graal.code.CGlobalDataReference;
 import com.oracle.svm.core.graal.code.SubstrateDebugInfoBuilder;
 import com.oracle.svm.core.graal.code.SubstrateNodeLIRBuilder;
+import com.oracle.svm.core.graal.meta.RuntimeConfiguration;
 import com.oracle.svm.core.graal.nodes.CGlobalDataLoadAddressNode;
+import com.oracle.svm.core.nodes.SafepointCheckNode;
+import com.oracle.svm.core.thread.Safepoint;
+import com.oracle.svm.core.thread.VMThreads;
+
+import jdk.vm.ci.code.CallingConvention;
+import jdk.vm.ci.code.Register;
+import jdk.vm.ci.meta.ResolvedJavaMethod;
 
 public class SubstrateNodeLLVMBuilder extends NodeLLVMBuilder implements SubstrateNodeLIRBuilder {
     private long nextCGlobalId = 0L;
+    private final RuntimeConfiguration runtimeConfiguration;
 
-    protected SubstrateNodeLLVMBuilder(StructuredGraph graph, LLVMGenerator gen) {
+    protected SubstrateNodeLLVMBuilder(StructuredGraph graph, LLVMGenerator gen, RuntimeConfiguration runtimeConfiguration) {
         super(graph, gen, SubstrateDebugInfoBuilder::new);
+        this.runtimeConfiguration = runtimeConfiguration;
 
         gen.getBuilder().setPersonalityFunction(gen.getFunction(LLVMFeature.getPersonalityStub()));
     }
@@ -59,6 +85,102 @@ public class SubstrateNodeLLVMBuilder extends NodeLLVMBuilder implements Substra
     @Override
     public Variable emitReadReturnAddress() {
         LLVMValueRef returnAddress = getLIRGeneratorTool().getBuilder().buildReturnAddress(getLIRGeneratorTool().getBuilder().constantInt(0));
-        return new LLVMUtils.LLVMVariable(returnAddress);
+        return new LLVMVariable(returnAddress);
+    }
+
+    private SubstrateLLVMGenerator getGenerator() {
+        return (SubstrateLLVMGenerator) gen;
+    }
+
+    @Override
+    protected int getParamIndex(int index) {
+        int offset = (getGenerator().isEntryPoint() ? 0 : LLVMFeature.SPECIAL_REGISTER_COUNT);
+        return offset + index;
+    }
+
+    @Override
+    protected LLVMValueRef[] getCallArguments(NodeInputList<ValueNode> arguments, CallingConvention.Type callType, ResolvedJavaMethod targetMethod) {
+        LLVMValueRef[] args = super.getCallArguments(arguments, callType, targetMethod);
+        return gen.getCallArguments(args, callType, targetMethod);
+    }
+
+    protected LLVMValueRef emitCondition(LogicNode condition) {
+        if (condition instanceof SafepointCheckNode) {
+            LLVMValueRef threadData = getGenerator().getSpecialRegister(LLVMFeature.THREAD_POINTER_INDEX);
+            threadData = gen.getBuilder().buildIntToPtr(threadData, gen.getBuilder().rawPointerType());
+            LLVMValueRef safepointCounterAddr = gen.getBuilder().buildGEP(threadData, gen.getBuilder().constantInt(Math.toIntExact(Safepoint.getThreadLocalSafepointRequestedOffset())));
+            LLVMValueRef safepointCount = gen.getBuilder().buildAtomicSub(safepointCounterAddr, gen.getBuilder().constantInt(1));
+            return gen.getBuilder().buildIsNull(safepointCount);
+        }
+        return super.emitCondition(condition);
+    }
+
+    @Override
+    protected LLVMValueRef emitCall(Invoke i, LoweredCallTargetNode callTarget, LLVMValueRef callee, long patchpointId, LLVMValueRef... args) {
+        if (!hasJavaFrameAnchor(callTarget)) {
+            return super.emitCall(i, callTarget, callee, patchpointId, args);
+        }
+
+        LLVMValueRef anchor = llvmOperand(getJavaFrameAnchor(callTarget));
+        anchor = builder.buildIntToPtr(anchor, builder.rawPointerType());
+
+        LLVMValueRef lastSPAddr = builder.buildGEP(anchor, builder.constantInt(runtimeConfiguration.getJavaFrameAnchorLastSPOffset()));
+        Register stackPointer = gen.getRegisterConfig().getFrameRegister();
+        builder.buildStore(builder.buildReadRegister(builder.register(stackPointer.name)), lastSPAddr);
+
+        if (SubstrateOptions.MultiThreaded.getValue()) {
+            LLVMValueRef threadLocalArea = getGenerator().getSpecialRegister(LLVMFeature.THREAD_POINTER_INDEX);
+            LLVMValueRef statusIndex = builder.constantInt(runtimeConfiguration.getVMThreadStatusOffset());
+            LLVMValueRef statusAddress = builder.buildGEP(builder.buildIntToPtr(threadLocalArea, builder.rawPointerType()), statusIndex);
+            builder.buildStore(builder.constantInt(VMThreads.StatusSupport.STATUS_IN_NATIVE), statusAddress);
+        }
+
+        LLVMValueRef wrapper = createJNIWrapper(callee, args.length, runtimeConfiguration.getJavaFrameAnchorLastIPOffset(), (Block) gen.getCurrentBlock());
+
+        LLVMValueRef[] newArgs = new LLVMValueRef[args.length + 2];
+        newArgs[0] = anchor;
+        newArgs[1] = callee;
+        System.arraycopy(args, 0, newArgs, 2, args.length);
+        return super.emitCall(i, callTarget, wrapper, patchpointId, newArgs);
+    }
+
+    /*
+     * Calling a native function from Java code requires filling the JavaFrameAnchor with the return
+     * address of the call. This wrapper allows this by creating an intermediary call frame from
+     * which the return address can be accessed. The parameters to this wrapper are the anchor, the
+     * native callee, and the arguments to the callee.
+     */
+    public LLVMValueRef createJNIWrapper(LLVMValueRef callee, int numArgs, int anchorIPOffset, Block currentBlock) {
+        LLVMTypeRef calleeType = LLVMIRBuilder.getElementType(typeOf(callee));
+        LLVMTypeRef wrapperType = builder.prependArguments(calleeType, builder.rawPointerType(), typeOf(callee));
+        LLVMValueRef transitionWrapper = builder.addFunction(LLVMUtils.JNI_WRAPPER_PREFIX + LLVMIRBuilder.intrinsicType(calleeType), wrapperType);
+        LLVM.LLVMSetLinkage(transitionWrapper, LLVM.LLVMLinkOnceAnyLinkage);
+        builder.setAttribute(transitionWrapper, LLVM.LLVMAttributeFunctionIndex, "gc-leaf-function");
+        builder.setAttribute(transitionWrapper, LLVM.LLVMAttributeFunctionIndex, "noinline");
+
+        LLVMBasicBlockRef block = builder.appendBasicBlock("main", transitionWrapper);
+        builder.positionAtEnd(block);
+
+        /* Fill in the JavaFrameAnchor */
+        LLVMValueRef anchor = LLVMIRBuilder.getParam(transitionWrapper, 0);
+        LLVMValueRef lastIPAddr = builder.buildGEP(anchor, builder.constantInt(anchorIPOffset));
+        LLVMValueRef callIP = builder.buildReturnAddress(builder.constantInt(0));
+        builder.buildStore(callIP, lastIPAddr);
+
+        LLVMValueRef[] args = new LLVMValueRef[numArgs];
+        for (int i = 0; i < numArgs; ++i) {
+            args[i] = LLVMIRBuilder.getParam(transitionWrapper, i + 2);
+        }
+        LLVMValueRef target = LLVMIRBuilder.getParam(transitionWrapper, 1);
+        LLVMValueRef ret = builder.buildCall(target, args);
+
+        if (LLVMIRBuilder.isVoidType(LLVMIRBuilder.getReturnType(calleeType))) {
+            builder.buildRetVoid();
+        } else {
+            builder.buildRet(ret);
+        }
+
+        builder.positionAtEnd(gen.getBlockEnd(currentBlock));
+        return transitionWrapper;
     }
 }

--- a/substratevm/src/com.oracle.svm.core.graal/src/com/oracle/svm/core/graal/nodes/ReadRegisterFixedNode.java
+++ b/substratevm/src/com.oracle.svm.core.graal/src/com/oracle/svm/core/graal/nodes/ReadRegisterFixedNode.java
@@ -40,7 +40,6 @@ import com.oracle.svm.core.FrameAccess;
 import com.oracle.svm.core.graal.meta.SubstrateRegisterConfig;
 
 import jdk.vm.ci.code.Register;
-import jdk.vm.ci.code.RegisterValue;
 
 /**
  * Reads the value of a specific register.
@@ -75,7 +74,7 @@ public class ReadRegisterFixedNode extends FixedWithNextNode implements LIRLower
         LIRGeneratorTool tool = gen.getLIRGeneratorTool();
         SubstrateRegisterConfig registerConfig = (SubstrateRegisterConfig) tool.getRegisterConfig();
         LIRKind lirKind = tool.getLIRKind(FrameAccess.getWordStamp());
-        RegisterValue value = registerSupplier.apply(registerConfig).asValue(lirKind);
-        gen.setResult(this, tool.emitMove(value));
+        Register register = registerSupplier.apply(registerConfig);
+        gen.setResult(this, tool.emitReadRegister(register, lirKind));
     }
 }

--- a/substratevm/src/com.oracle.svm.core.graal/src/com/oracle/svm/core/graal/nodes/ReadStackPointerNode.java
+++ b/substratevm/src/com.oracle.svm.core.graal/src/com/oracle/svm/core/graal/nodes/ReadStackPointerNode.java
@@ -24,6 +24,7 @@
  */
 package com.oracle.svm.core.graal.nodes;
 
+import jdk.vm.ci.code.Register;
 import org.graalvm.compiler.graph.NodeClass;
 import org.graalvm.compiler.lir.gen.LIRGeneratorTool;
 import org.graalvm.compiler.nodeinfo.NodeCycles;
@@ -34,8 +35,6 @@ import org.graalvm.compiler.nodes.spi.LIRLowerable;
 import org.graalvm.compiler.nodes.spi.NodeLIRBuilderTool;
 
 import com.oracle.svm.core.FrameAccess;
-
-import jdk.vm.ci.code.RegisterValue;
 
 @NodeInfo(cycles = NodeCycles.CYCLES_1, size = NodeSize.SIZE_1)
 public final class ReadStackPointerNode extends FixedWithNextNode implements LIRLowerable {
@@ -48,7 +47,7 @@ public final class ReadStackPointerNode extends FixedWithNextNode implements LIR
     @Override
     public void generate(NodeLIRBuilderTool gen) {
         LIRGeneratorTool tool = gen.getLIRGeneratorTool();
-        RegisterValue input = tool.getRegisterConfig().getFrameRegister().asValue(tool.getLIRKind(FrameAccess.getWordStamp()));
-        gen.setResult(this, tool.emitMove(input));
+        Register register = tool.getRegisterConfig().getFrameRegister();
+        gen.setResult(this, tool.emitReadRegister(register, tool.getLIRKind(FrameAccess.getWordStamp())));
     }
 }

--- a/substratevm/src/com.oracle.svm.core.graal/src/com/oracle/svm/core/graal/nodes/WriteCurrentVMThreadNode.java
+++ b/substratevm/src/com.oracle.svm.core.graal/src/com/oracle/svm/core/graal/nodes/WriteCurrentVMThreadNode.java
@@ -54,7 +54,7 @@ public class WriteCurrentVMThreadNode extends FixedWithNextNode implements LIRLo
     public void generate(NodeLIRBuilderTool gen) {
         LIRGeneratorTool tool = gen.getLIRGeneratorTool();
         SubstrateRegisterConfig registerConfig = (SubstrateRegisterConfig) tool.getRegisterConfig();
-        gen.getLIRGeneratorTool().emitMove(registerConfig.getThreadRegister().asValue(tool.getLIRKind(FrameAccess.getWordStamp())), gen.operand(value));
+        gen.getLIRGeneratorTool().emitWriteRegister(registerConfig.getThreadRegister(), gen.operand(value), tool.getLIRKind(FrameAccess.getWordStamp()));
     }
 
     @NodeIntrinsic

--- a/substratevm/src/com.oracle.svm.core.graal/src/com/oracle/svm/core/graal/nodes/WriteHeapBaseNode.java
+++ b/substratevm/src/com.oracle.svm.core.graal/src/com/oracle/svm/core/graal/nodes/WriteHeapBaseNode.java
@@ -52,7 +52,7 @@ public class WriteHeapBaseNode extends FixedWithNextNode implements LIRLowerable
     @Override
     public void generate(NodeLIRBuilderTool gen) {
         LIRGeneratorTool tool = gen.getLIRGeneratorTool();
-        tool.emitMove(((SubstrateRegisterConfig) tool.getResult().getRegisterConfig()).getHeapBaseRegister().asValue(tool.getLIRKind(FrameAccess.getWordStamp())), gen.operand(value));
+        tool.emitWriteRegister(((SubstrateRegisterConfig) tool.getResult().getRegisterConfig()).getHeapBaseRegister(), gen.operand(value), tool.getLIRKind(FrameAccess.getWordStamp()));
     }
 
     @NodeIntrinsic

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/annotate/ForceFixedRegisterReads.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/annotate/ForceFixedRegisterReads.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2019, 2019, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package com.oracle.svm.core.annotate;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Used to force reads of register values to be implemented using a {@link ReadRegisterFixedNode}
+ * instead of a {@link ReadRegisterFloatingNode} to prevent instances where a register read would be
+ * hoisted above the point where the register is written to.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface ForceFixedRegisterReads {
+}

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/thread/VMThreads.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/thread/VMThreads.java
@@ -33,6 +33,7 @@ import org.graalvm.nativeimage.c.type.CCharPointer;
 import org.graalvm.word.ComparableWord;
 import org.graalvm.word.WordFactory;
 
+import com.oracle.svm.core.annotate.ForceFixedRegisterReads;
 import com.oracle.svm.core.annotate.Uninterruptible;
 import com.oracle.svm.core.jdk.UninterruptibleUtils;
 import com.oracle.svm.core.locks.VMCondition;
@@ -395,6 +396,7 @@ public abstract class VMThreads {
 
         /** A guarded transition from native to Java. */
         @Uninterruptible(reason = "Called from uninterruptible code.")
+        @ForceFixedRegisterReads
         public static boolean compareAndSetNativeToJava() {
             return statusTL.compareAndSet(STATUS_IN_NATIVE, STATUS_IN_JAVA);
         }


### PR DESCRIPTION
This PR allows multithreading for the LLVM backend by implementing support for the fixed register values of Native Image (thread pointer and heap base pointer) by passing them as arguments to functions.