### PR TITLE
Fixes #1426 - IOUtil.write1() unimplemented.

### DIFF
--- a/substratevm/src/com.oracle.svm.core.posix.jdk11/src/com/oracle/svm/core/posix/jdk11/PosixJavaNIOSubstitutions.java
+++ b/substratevm/src/com.oracle.svm.core.posix.jdk11/src/com/oracle/svm/core/posix/jdk11/PosixJavaNIOSubstitutions.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2019, 2019, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package com.oracle.svm.core.posix.jdk11;
+
+import static com.oracle.svm.core.posix.PosixJavaNIOSubstitutions.convertReturnVal;
+import static com.oracle.svm.core.posix.headers.Unistd.write;
+
+import java.io.IOException;
+
+import org.graalvm.nativeimage.Platform;
+import org.graalvm.nativeimage.Platforms;
+import org.graalvm.nativeimage.StackValue;
+import org.graalvm.nativeimage.c.type.CCharPointer;
+import org.graalvm.word.WordFactory;
+
+import com.oracle.svm.core.annotate.Substitute;
+import com.oracle.svm.core.annotate.TargetClass;
+import com.oracle.svm.core.jdk.JDK11OrLater;
+
+@Platforms({Platform.LINUX.class, Platform.DARWIN.class})
+public class PosixJavaNIOSubstitutions {
+
+    @TargetClass(className = "sun.nio.ch.IOUtil", onlyWith = JDK11OrLater.class)
+    @Platforms({Platform.LINUX.class, Platform.DARWIN.class})
+    static final class Target_sun_nio_ch_IOUtil {
+        // ported from {jdk11}/src/java.base/unix/native/libnio/ch/IOUtil.c
+        //   107  JNIEXPORT jint JNICALL
+        //   108  Java_sun_nio_ch_IOUtil_write1(JNIEnv *env, jclass cl, jint fd, jbyte b)
+        @Substitute
+        static int write1(int fd, byte b) throws IOException {
+            //   110      char c = (char)b;
+            CCharPointer c = StackValue.get(CCharPointer.class);
+            c.write(b);
+            //   111      return convertReturnVal(env, write(fd, &c, 1), JNI_FALSE);
+            return convertReturnVal(write(fd, c, WordFactory.unsigned(1)), false);
+        }
+    }
+}
+

--- a/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/PosixJavaNIOSubstitutions.java
+++ b/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/PosixJavaNIOSubstitutions.java
@@ -325,7 +325,7 @@ public final class PosixJavaNIOSubstitutions {
         throw PosixUtils.newIOExceptionWithLastError(msg);
     }
 
-    protected static int convertReturnVal(WordBase n, boolean reading) throws IOException {
+    public static int convertReturnVal(WordBase n, boolean reading) throws IOException {
         return convertReturnVal((int) n.rawValue(), reading);
     }
 


### PR DESCRIPTION
Fixeds #1426 

* Create a posix.jdk11 package for additive API extensions.
* Implement IOUtil.write1().
* Open up helper methods from core implementation.

--

Instead of creating `FooJDK11OrLater` to avoid trampling, which also may make it more difficult to align JDK8 to JDK11 implementations, and could accidentally result in the JDK11 class entirely shadowing the JDK8 variant if someone forgets the `JDK11OrLater` suffix, I've created a `jdk11` sub-package to hold an _identically-named_ version of the class.

I have _not_ wholesale re-organized the package, but if not met with opposition, will do so in a subsequent PR.