### PR TITLE
[native-image][JDK11] Support java.lang.reflect.Proxy for native-image on JDK11

### DIFF
--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/proxy/ProxySubstitutions.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/proxy/ProxySubstitutions.java
@@ -26,6 +26,9 @@ package com.oracle.svm.core.jdk.proxy;
 
 // Checkstyle: allow reflection
 
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Modifier;
 import java.lang.reflect.Proxy;
 
 import org.graalvm.nativeimage.ImageSingletons;
@@ -35,6 +38,7 @@ import com.oracle.svm.core.annotate.Substitute;
 import com.oracle.svm.core.annotate.TargetClass;
 import com.oracle.svm.core.annotate.TargetElement;
 import com.oracle.svm.core.jdk.JDK8OrEarlier;
+import com.oracle.svm.core.jdk.JDK11OrLater;
 
 @TargetClass(java.lang.reflect.Proxy.class)
 final class Target_java_lang_reflect_Proxy {
@@ -50,6 +54,26 @@ final class Target_java_lang_reflect_Proxy {
         return ImageSingletons.lookup(DynamicProxyRegistry.class).getProxyClass(interfaces);
     }
 
+    /** We have our own proxy cache so mark the original one as deleted. */
+    @Delete
+    @TargetElement(onlyWith = JDK11OrLater.class)
+    private static Target_jdk_internal_loader_ClassLoaderValue proxyCache;
+
+    @Substitute
+    @TargetElement(onlyWith = JDK11OrLater.class)
+    private static Constructor<?> getProxyConstructor(Class<?> caller, ClassLoader loader, Class<?>... interfaces) {
+        final Class<?> cl = ImageSingletons.lookup(DynamicProxyRegistry.class).getProxyClass(interfaces);
+        try {
+            final Constructor<?> cons = cl.getConstructor(InvocationHandler.class);
+            if (!Modifier.isPublic(cl.getModifiers())) {
+                cons.setAccessible(true);
+            }
+            return cons;
+        } catch (NoSuchMethodException e) {
+            throw new InternalError(e.toString(), e);
+        }
+    }
+
     @Substitute
     public static boolean isProxyClass(Class<?> cl) {
         return Proxy.class.isAssignableFrom(cl) && ImageSingletons.lookup(DynamicProxyRegistry.class).isProxyClass(cl);
@@ -58,6 +82,10 @@ final class Target_java_lang_reflect_Proxy {
 
 @TargetClass(className = "java.lang.reflect.WeakCache", onlyWith = JDK8OrEarlier.class)
 final class Target_java_lang_reflect_WeakCache {
+}
+
+@TargetClass(className = "jdk.internal.loader.ClassLoaderValue", onlyWith = JDK11OrLater.class)
+final class Target_jdk_internal_loader_ClassLoaderValue {
 }
 
 public class ProxySubstitutions {


### PR DESCRIPTION
Current native-image code is not ready for java.lang.reflect.Proxy, any calls to `Proxy.newProxyInstance` fail with this stacktrace:
```
Exception in thread "main" com.oracle.svm.core.jdk.UnsupportedFeatureError: JDK11OrLater: Target_java_lang_ClassLoader.createOrGetClassLoaderValueMap()
	at com.oracle.svm.core.util.VMError.unsupportedFeature(VMError.java:102)
	at java.lang.ClassLoader.createOrGetClassLoaderValueMap(Target_java_lang_ClassLoader.java:155)
	at java.lang.System$2.createOrGetClassLoaderValueMap(System.java:2120)
	at jdk.internal.loader.AbstractClassLoaderValue.map(AbstractClassLoaderValue.java:266)
	at jdk.internal.loader.AbstractClassLoaderValue.computeIfAbsent(AbstractClassLoaderValue.java:189)
	at java.lang.reflect.Proxy.getProxyConstructor(Proxy.java:413)
	at java.lang.reflect.Proxy.newProxyInstance(Proxy.java:1006)
	at ru.yandex.qe.graal.ProxyWork.main(ProxyWork.java:13)
```

 I added simple substitution for `Proxy.getProxyConstructor()` method and deleted `Proxy.proxyCache` field, so Proxy may work under JDK11 .