### PR TITLE
[native-image][JDK11] Fix error in JavaUtilZipSubstitutions.doInflate

### DIFF
--- a/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/JavaUtilZipSubstitutions.java
+++ b/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/JavaUtilZipSubstitutions.java
@@ -682,10 +682,10 @@ final class Util_java_util_zip_Inflater_JDK11OrLater {
 
         if (ret == ZLib.Z_STREAM_END() || ret == ZLib.Z_OK()) {
             if (ret == ZLib.Z_STREAM_END()) {
-                finished = 1;
-                inputUsed = inputLen - strm.avail_in();
-                outputUsed = outputLen - strm.avail_out();
+                finished = 1; 
             }
+            inputUsed = inputLen - strm.avail_in();
+            outputUsed = outputLen - strm.avail_out();
         } else if (ret == ZLib.Z_NEED_DICT()) {
             needDict = 1;
             inputUsed = inputLen - strm.avail_in();


### PR DESCRIPTION
In this PR I fixed small mistake in `JavaUtilZipSubstitutions.doInflate` method that caused different exceptions related to Inflater on JDK11. In fact, I only synchronized Java and C implementations (see https://github.com/AdoptOpenJDK/openjdk-jdk11/blob/19fb8f93c59dfd791f62d41f332db9e306bc1422/src/java.base/share/native/libzip/Inflater.c#L143 )

Minimal example:
```
import java.io.BufferedReader;
import java.io.IOException;
import java.io.InputStreamReader;

import java.util.zip.GZIPInputStream;

import java.net.URL;
import java.net.URLConnection;

public class GzipExample {
  public static void main(String[] args) throws Exception {
    final URL url = new URL("https://google.com");
    final URLConnection urlConnection = url.openConnection();
    urlConnection.setRequestProperty("Accept-Encoding", "gzip");

    try (final BufferedReader reader = new BufferedReader(new InputStreamReader(new GZIPInputStream(urlConnection.getInputStream())))) {
      System.out.println(reader.readLine());
    } catch (IOException e) {
      e.printStackTrace();
    }
  }
}
```

Without this PR it fails with:
```
java.util.zip.ZipException: invalid literal/lengths set
	at java.util.zip.InflaterInputStream.read(InflaterInputStream.java:165)
	at java.util.zip.GZIPInputStream.read(GZIPInputStream.java:118)
	at sun.nio.cs.StreamDecoder.readBytes(StreamDecoder.java:284)
	at sun.nio.cs.StreamDecoder.implRead(StreamDecoder.java:326)
	at sun.nio.cs.StreamDecoder.read(StreamDecoder.java:178)
	at java.io.InputStreamReader.read(InputStreamReader.java:185)
	at java.io.BufferedReader.fill(BufferedReader.java:161)
	at java.io.BufferedReader.readLine(BufferedReader.java:326)
	at java.io.BufferedReader.readLine(BufferedReader.java:392)
	at scratch_34.main(scratch_34.java:17)
```