### PR TITLE
Fix CodeGenTest issue for AArch64

### DIFF
--- a/compiler/src/org.graalvm.compiler.asm.aarch64.test/src/org/graalvm/compiler/asm/aarch64/test/AArch64BitCountAssemblerTest.java
+++ b/compiler/src/org.graalvm.compiler.asm.aarch64.test/src/org/graalvm/compiler/asm/aarch64/test/AArch64BitCountAssemblerTest.java
@@ -75,6 +75,9 @@ public class AArch64BitCountAssemblerTest extends AssemblerTest {
                 AArch64MacroAssembler masm = new AArch64MacroAssembler(target);
                 Register dst = registerConfig.getReturnRegister(JavaKind.Int);
                 Register src = asRegister(cc.getArgument(0));
+                // Generate a nop first as AArch64 Hotspot requires instruction at nmethod verified
+                // entry to be a jump or nop. (See https://github.com/oracle/graal/issues/1439)
+                masm.nop();
                 RegisterArray registers = registerConfig.filterAllocatableRegisters(AArch64Kind.V64_BYTE, registerConfig.getAllocatableRegisters());
                 masm.popcnt(size, dst, src, registers.get(registers.size() - 1));
                 masm.ret(AArch64.lr);


### PR DESCRIPTION
This fixes issue #1439

For Graal CodeGenTest cases, assembly code generated by assembler or macro assembler is installed into HotSpot as an nmethod. But AArch64 requires the instruction at nmethod verifed entry to be a jump or nop for method invalidation in sweeper thread. To meet the requirement, we patch the generated test code by inserting a nop at the beginning.