### PR TITLE
Adding missing debug context to BasePhase

### DIFF
--- a/compiler/src/org.graalvm.compiler.phases/src/org/graalvm/compiler/phases/BasePhase.java
+++ b/compiler/src/org.graalvm.compiler.phases/src/org/graalvm/compiler/phases/BasePhase.java
@@ -179,7 +179,8 @@ public abstract class BasePhase<C> implements PhaseSizeContract {
     protected final void apply(final StructuredGraph graph, final C context, final boolean dumpGraph) {
         graph.checkCancellation();
         DebugContext debug = graph.getDebug();
-        try (DebugCloseable a = timer.start(debug); DebugContext.Scope s = debug.scope(getClass(), this); DebugCloseable c = memUseTracker.start(debug)) {
+
+        try (DebugCloseable a = timer.start(debug); DebugContext.Scope s = debug.scope(getClass(), graph, this); DebugCloseable c = memUseTracker.start(debug)) {
             int sizeBefore = 0;
             Mark before = null;
             OptionValues options = graph.getOptions();


### PR DESCRIPTION
This PR allows allows compilation phases that go through BasePhase to be correctly dumped. The problem was that no context was being passed to the debug scope creation.