### PR TITLE
Disable isolates and multithreading by default in the LLVM backend.

### DIFF
--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/SubstrateOptions.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/SubstrateOptions.java
@@ -284,8 +284,20 @@ public class SubstrateOptions {
     public static final HostedOptionKey<String> CompilerBackend = new HostedOptionKey<String>("lir") {
         @Override
         protected void onValueUpdate(EconomicMap<OptionKey<?>, Object> values, String oldValue, String newValue) {
-            if ("llvm".equals(newValue) && JavaVersionUtil.JAVA_SPEC > 8) {
-                EmitStringEncodingSubstitutions.update(values, false);
+            if ("llvm".equals(newValue)) {
+                if (JavaVersionUtil.JAVA_SPEC > 8) {
+                    EmitStringEncodingSubstitutions.update(values, false);
+                }
+
+                if ((Boolean) values.get(SpawnIsolates)) {
+                    System.out.println("Warning: Isolates are currently not supported by the LLVM backend. The build will continue with isolates disabled.");
+                    SpawnIsolates.update(values, false);
+                }
+
+                if ((Boolean) values.get(MultiThreaded)) {
+                    System.out.println("Warning: Multithreading is currently not supported by the LLVM backend. The build will continue with multithreading disabled.");
+                    MultiThreaded.update(values, false);
+                }
             }
         }
     };


### PR DESCRIPTION
Disables unsupported features in the LLVM backend with an error message instead of crashing further down the pipeline.