### PR TITLE
Fix SLRootNode#setCloningAllowed()

### DIFF
--- a/truffle/src/com.oracle.truffle.sl/src/com/oracle/truffle/sl/nodes/SLRootNode.java
+++ b/truffle/src/com.oracle.truffle.sl/src/com/oracle/truffle/sl/nodes/SLRootNode.java
@@ -40,6 +40,7 @@
  */
 package com.oracle.truffle.sl.nodes;
 
+import com.oracle.truffle.api.CompilerDirectives;
 import com.oracle.truffle.api.CompilerDirectives.CompilationFinal;
 import com.oracle.truffle.api.frame.FrameDescriptor;
 import com.oracle.truffle.api.frame.VirtualFrame;
@@ -96,6 +97,7 @@ public class SLRootNode extends RootNode {
     }
 
     public void setCloningAllowed(boolean isCloningAllowed) {
+        CompilerDirectives.transferToInterpreterAndInvalidate();
         this.isCloningAllowed = isCloningAllowed;
     }
 


### PR DESCRIPTION
Before changing the value of `isCloningAllowed`, a ` CompilerDirectives.transferToInterpreterAndInvalidate()` is needed because it is a `@CompilationFinal` field.