### PR TITLE
Renamed jvm flag UseStackBasePointer to PreserveFramePointer

### DIFF
--- a/substratevm/src/com.oracle.svm.core.graal.aarch64/src/com/oracle/svm/core/graal/aarch64/SubstrateAArch64Feature.java
+++ b/substratevm/src/com.oracle.svm.core.graal.aarch64/src/com/oracle/svm/core/graal/aarch64/SubstrateAArch64Feature.java
@@ -53,7 +53,7 @@ class SubstrateAArch64Feature implements Feature {
 
         ImageSingletons.add(SubstrateRegisterConfigFactory.class, new SubstrateRegisterConfigFactory() {
             @Override
-            public RegisterConfig newRegisterFactory(ConfigKind config, MetaAccessProvider metaAccess, TargetDescription target, Boolean useStackBasePointer) {
+            public RegisterConfig newRegisterFactory(ConfigKind config, MetaAccessProvider metaAccess, TargetDescription target, Boolean preserveFramePointer) {
                 return new SubstrateAArch64RegisterConfig(config, metaAccess, target);
             }
         });

--- a/substratevm/src/com.oracle.svm.core.graal.amd64/src/com/oracle/svm/core/graal/amd64/AMD64FarReturnOp.java
+++ b/substratevm/src/com.oracle.svm.core.graal.amd64/src/com/oracle/svm/core/graal/amd64/AMD64FarReturnOp.java
@@ -60,7 +60,7 @@ public final class AMD64FarReturnOp extends AMD64BlockEndOp {
 
     @Override
     public void emitCode(CompilationResultBuilder crb, AMD64MacroAssembler masm) {
-        if (SubstrateOptions.UseStackBasePointer.getValue()) {
+        if (SubstrateOptions.PreserveFramePointer.getValue()) {
             /*
              * We need to properly restore RBP to the value that matches the frame of the new stack
              * pointer. Two options: 1) When RSP is not changing, we are jumping within the same

--- a/substratevm/src/com.oracle.svm.core.graal.amd64/src/com/oracle/svm/core/graal/amd64/SubstrateAMD64Feature.java
+++ b/substratevm/src/com.oracle.svm.core.graal.amd64/src/com/oracle/svm/core/graal/amd64/SubstrateAMD64Feature.java
@@ -54,8 +54,8 @@ class SubstrateAMD64Feature implements Feature {
 
         ImageSingletons.add(SubstrateRegisterConfigFactory.class, new SubstrateRegisterConfigFactory() {
             @Override
-            public RegisterConfig newRegisterFactory(ConfigKind config, MetaAccessProvider metaAccess, TargetDescription target, Boolean useStackBasePointer) {
-                return new SubstrateAMD64RegisterConfig(config, metaAccess, target, useStackBasePointer);
+            public RegisterConfig newRegisterFactory(ConfigKind config, MetaAccessProvider metaAccess, TargetDescription target, Boolean preserveFramePointer) {
+                return new SubstrateAMD64RegisterConfig(config, metaAccess, target, preserveFramePointer);
             }
         });
 

--- a/substratevm/src/com.oracle.svm.core.graal/src/com/oracle/svm/core/graal/code/SubstrateRegisterConfigFactory.java
+++ b/substratevm/src/com.oracle.svm.core.graal/src/com/oracle/svm/core/graal/code/SubstrateRegisterConfigFactory.java
@@ -31,5 +31,5 @@ import jdk.vm.ci.code.TargetDescription;
 import jdk.vm.ci.meta.MetaAccessProvider;
 
 public interface SubstrateRegisterConfigFactory {
-    RegisterConfig newRegisterFactory(ConfigKind config, MetaAccessProvider metaAccess, TargetDescription target, Boolean useStackBasePointer);
+    RegisterConfig newRegisterFactory(ConfigKind config, MetaAccessProvider metaAccess, TargetDescription target, Boolean preserveFramePointer);
 }

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/SubstrateOptions.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/SubstrateOptions.java
@@ -275,7 +275,7 @@ public class SubstrateOptions {
     public static final HostedOptionKey<Integer> MaxNodesInTrivialLeafMethod = new HostedOptionKey<>(40);
 
     @Option(help = "Saves stack base pointer on the stack on method entry.")//
-    public static final HostedOptionKey<Boolean> UseStackBasePointer = new HostedOptionKey<>(false);
+    public static final HostedOptionKey<Boolean> PreserveFramePointer = new HostedOptionKey<>(false);
 
     @Option(help = "Report error if <typename>[:<UsageKind>{,<UsageKind>}] is discovered during analysis (valid values for UsageKind: InHeap, Allocated, InTypeCheck).", type = OptionType.Debug)//
     public static final HostedOptionKey<String[]> ReportAnalysisForbiddenType = new HostedOptionKey<>(new String[0]);

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/aarch64/AArch64FrameAccess.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/aarch64/AArch64FrameAccess.java
@@ -60,7 +60,7 @@ public class AArch64FrameAccess extends FrameAccess {
     @Fold
     @Override
     public int savedBasePointerSize() {
-        if (SubstrateOptions.UseStackBasePointer.getValue()) {
+        if (SubstrateOptions.PreserveFramePointer.getValue()) {
             return wordSize();
         } else {
             return 0;

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/amd64/AMD64FrameAccess.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/amd64/AMD64FrameAccess.java
@@ -62,7 +62,7 @@ public final class AMD64FrameAccess extends FrameAccess {
     @Fold
     @Override
     public int savedBasePointerSize() {
-        if (SubstrateOptions.UseStackBasePointer.getValue()) {
+        if (SubstrateOptions.PreserveFramePointer.getValue()) {
             return wordSize();
         } else {
             return 0;

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/code/SharedRuntimeConfigurationBuilder.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/code/SharedRuntimeConfigurationBuilder.java
@@ -113,7 +113,7 @@ public abstract class SharedRuntimeConfigurationBuilder {
         EnumMap<ConfigKind, SubstrateBackend> backends = new EnumMap<>(ConfigKind.class);
         for (ConfigKind config : ConfigKind.values()) {
             RegisterConfig registerConfig = ImageSingletons.lookup(SubstrateRegisterConfigFactory.class).newRegisterFactory(config, metaAccess, ConfigurationValues.getTarget(),
-                            SubstrateOptions.UseStackBasePointer.getValue());
+                            SubstrateOptions.PreserveFramePointer.getValue());
             CodeCacheProvider codeCacheProvider = createCodeCacheProvider(registerConfig);
 
             Providers newProviders = createProviders(codeCacheProvider, constantReflection, constantFieldProvider, foreignCalls, lowerer, replacements, stampProvider,

--- a/vm/mx.vm/mx_vm.py
+++ b/vm/mx.vm/mx_vm.py
@@ -962,6 +962,9 @@ class NativePropertiesBuildTask(mx.ProjectBuildTask):
             if any((' ' in arg for arg in build_args)):
                 mx.abort("Unsupported space in launcher build argument: {} in config for {}".format(image_config.build_args, image_config.destination))
 
+            if any(('UseStackBasePointer' in arg for arg in build_args)):
+                mx.warn('UseStackBasePointer has been deprecated, please use PreserveFramePointer instead')
+
             self._contents = u""
 
             def _write_ln(s):

--- a/vm/mx.vm/mx_vm.py
+++ b/vm/mx.vm/mx_vm.py
@@ -962,9 +962,6 @@ class NativePropertiesBuildTask(mx.ProjectBuildTask):
             if any((' ' in arg for arg in build_args)):
                 mx.abort("Unsupported space in launcher build argument: {} in config for {}".format(image_config.build_args, image_config.destination))
 
-            if any(('UseStackBasePointer' in arg for arg in build_args)):
-                mx.warn('UseStackBasePointer has been deprecated, please use PreserveFramePointer instead')
-
             self._contents = u""
 
             def _write_ln(s):

--- a/vm/mx.vm/mx_vm.py
+++ b/vm/mx.vm/mx_vm.py
@@ -904,7 +904,7 @@ class NativePropertiesBuildTask(mx.ProjectBuildTask):
             if graalvm_dist.vm_config_name:
                 build_args += ['-Dorg.graalvm.config={}'.format(graalvm_dist.vm_config_name.upper())]
             if _debug_images():
-                build_args += ['-ea', '-H:-AOTInline', '-H:+UseStackBasePointer']
+                build_args += ['-ea', '-H:-AOTInline', '-H:+PreserveFramePointer']
             if _get_svm_support().is_debug_supported():
                 build_args += ['-g']
 


### PR DESCRIPTION
Renamed jvm UseStackBasePointer to PreserveFramePointer, making it consistent between HotSpot and GraalVM users. One less flag to remember and feeling familiar when using GraalVM/SubstrateVM

On the back of the discussion on issue #1447