### PR TITLE
Use memory access stamp of Read/WriteNode to do address lowering.

### DIFF
--- a/compiler/src/org.graalvm.compiler.core.aarch64/src/org/graalvm/compiler/core/aarch64/AArch64ReadNode.java
+++ b/compiler/src/org.graalvm.compiler.core.aarch64/src/org/graalvm/compiler/core/aarch64/AArch64ReadNode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2017, Red Hat Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -70,6 +70,11 @@ public class AArch64ReadNode extends ReadNode {
         AArch64Kind readKind = (AArch64Kind) lirgen.getLIRKind(accessStamp).getPlatformKind();
         int resultBits = ((IntegerStamp) stamp(NodeView.DEFAULT)).getBits();
         gen.setResult(this, arithgen.emitExtendMemory(isSigned, readKind, resultBits, (AArch64AddressValue) gen.operand(getAddress()), gen.state(this)));
+    }
+
+    @Override
+    public Stamp getAccessStamp() {
+        return accessStamp;
     }
 
     /**

--- a/compiler/src/org.graalvm.compiler.phases.common/src/org/graalvm/compiler/phases/common/AddressLoweringByUsePhase.java
+++ b/compiler/src/org.graalvm.compiler.phases.common/src/org/graalvm/compiler/phases/common/AddressLoweringByUsePhase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2017, Red Hat Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -69,7 +69,7 @@ public class AddressLoweringByUsePhase extends Phase {
             AddressNode lowered;
             if (node instanceof ReadNode) {
                 ReadNode readNode = (ReadNode) node;
-                Stamp stamp = readNode.stamp(NodeView.DEFAULT);
+                Stamp stamp = readNode.getAccessStamp();
                 address = readNode.getAddress();
                 lowered = lowering.lower(readNode, stamp, address);
             } else if (node instanceof JavaReadNode) {
@@ -79,12 +79,12 @@ public class AddressLoweringByUsePhase extends Phase {
                 lowered = lowering.lower(javaReadNode, stamp, address);
             } else if (node instanceof FloatingReadNode) {
                 FloatingReadNode floatingReadNode = (FloatingReadNode) node;
-                Stamp stamp = floatingReadNode.stamp(NodeView.DEFAULT);
+                Stamp stamp = floatingReadNode.getAccessStamp();
                 address = floatingReadNode.getAddress();
                 lowered = lowering.lower(floatingReadNode, stamp, address);
             } else if (node instanceof AbstractWriteNode) {
                 AbstractWriteNode abstractWriteNode = (AbstractWriteNode) node;
-                Stamp stamp = abstractWriteNode.value().stamp(NodeView.DEFAULT);
+                Stamp stamp = abstractWriteNode.getAccessStamp();
                 address = abstractWriteNode.getAddress();
                 lowered = lowering.lower(abstractWriteNode, stamp, address);
             } else if (node instanceof PrefetchAllocateNode) {


### PR DESCRIPTION
This patch fixes issue:https://github.com/oracle/graal/issues/1408.

Graal AddressLoweringPhase lowers the general address node to platform
specific address node, like AArch64AddressNode, and together with some
optimizations. It should use the right memory access type to set the
suitable address mode and scaleFactor. But currently it uses the node type.

An AArch64ReadNode is a node merges ZeroExtended/SignedExtended with
ReadNode. If the type of the ReadNode is 32bits. After extending, the
type of the AArch64ReadNode is 64bits, but its access type is still 32bits.
So if the compiler is lowering an AArch64ReadNode and using its node type,
the result address will be wrong.

This patch modifies the stamp of the address to the access stamp.

Change-Id: I0a805134bbff22f9df5626ccdeda95f41ed721e6