### PR TITLE
Add support for SecurityManager.getClassContext()

### DIFF
--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/StackTraceUtils.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/StackTraceUtils.java
@@ -37,16 +37,25 @@ import com.oracle.svm.core.stack.JavaStackWalker;
 
 public class StackTraceUtils {
 
+    private static final Class<?>[] NO_CLASSES = new Class<?>[0];
+    private static final StackTraceElement[] NO_ELEMENTS = new StackTraceElement[0];
+
     public static StackTraceElement[] getStackTrace(boolean filterExceptions, Pointer startSP, CodePointer startIP) {
         BuildStackTraceVisitor visitor = new BuildStackTraceVisitor(filterExceptions);
         JavaStackWalker.walkCurrentThread(startSP, startIP, visitor);
-        return visitor.trace.toArray(new StackTraceElement[0]);
+        return visitor.trace.toArray(NO_ELEMENTS);
     }
 
     public static StackTraceElement[] getStackTrace(boolean filterExceptions, IsolateThread thread) {
         BuildStackTraceVisitor visitor = new BuildStackTraceVisitor(filterExceptions);
         JavaStackWalker.walkThread(thread, visitor);
-        return visitor.trace.toArray(new StackTraceElement[0]);
+        return visitor.trace.toArray(NO_ELEMENTS);
+    }
+
+    public static Class<?>[] getClassContext(int skip, Pointer startSP, CodePointer startIP) {
+        GetClassContextVisitor visitor = new GetClassContextVisitor(skip);
+        JavaStackWalker.walkCurrentThread(startSP, startIP, visitor);
+        return visitor.trace.toArray(NO_CLASSES);
     }
 
     /**
@@ -153,5 +162,25 @@ class GetCallerClassVisitor extends JavaStackFrameVisitor {
             result = frameInfo.getSourceClass();
             return false;
         }
+    }
+}
+
+class GetClassContextVisitor extends JavaStackFrameVisitor {
+    private int skip;
+    final ArrayList<Class<?>> trace;
+
+    GetClassContextVisitor(final int skip) {
+        trace = new ArrayList<>();
+        this.skip = skip;
+    }
+
+    @Override
+    public boolean visitFrame(final FrameInfoQueryResult frameInfo) {
+        if (skip > 0) {
+            skip--;
+        } else if (StackTraceUtils.shouldShowFrame(frameInfo, false, false)) {
+            trace.add(frameInfo.getSourceClass());
+        }
+        return true;
     }
 }

--- a/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/StackTraceTests.java
+++ b/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/StackTraceTests.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2019, 2019, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package com.oracle.svm.test;
+
+import static junit.framework.TestCase.assertTrue;
+import static org.junit.Assert.assertSame;
+
+import org.junit.Test;
+
+/**
+ *
+ */
+public class StackTraceTests {
+
+    static final class Subclass extends SecurityManager {
+        @Override
+        protected Class<?>[] getClassContext() {
+            return super.getClassContext();
+        }
+    }
+
+    @Test
+    public void testGetClassContext() {
+        final Subclass sm = new Subclass();
+        final Class<?>[] classes = sm.getClassContext();
+        assertSame(StackTraceTests.class, classes[0]);
+        assertTrue(classes.length > 1);
+    }
+}


### PR DESCRIPTION
This method is used by some logging frameworks and in a few other places as a poor pre-9 alternative to `StackWalker`.