### PR TITLE
Memory bulk zeroing for AArch64

### DIFF
--- a/compiler/src/org.graalvm.compiler.asm.aarch64/src/org/graalvm/compiler/asm/aarch64/AArch64Assembler.java
+++ b/compiler/src/org.graalvm.compiler.asm.aarch64/src/org/graalvm/compiler/asm/aarch64/AArch64Assembler.java
@@ -54,6 +54,7 @@ import static org.graalvm.compiler.asm.aarch64.AArch64Assembler.Instruction.CNT;
 import static org.graalvm.compiler.asm.aarch64.AArch64Assembler.Instruction.CSEL;
 import static org.graalvm.compiler.asm.aarch64.AArch64Assembler.Instruction.CSINC;
 import static org.graalvm.compiler.asm.aarch64.AArch64Assembler.Instruction.CSNEG;
+import static org.graalvm.compiler.asm.aarch64.AArch64Assembler.Instruction.DC;
 import static org.graalvm.compiler.asm.aarch64.AArch64Assembler.Instruction.DMB;
 import static org.graalvm.compiler.asm.aarch64.AArch64Assembler.Instruction.EON;
 import static org.graalvm.compiler.asm.aarch64.AArch64Assembler.Instruction.EOR;
@@ -673,6 +674,7 @@ public abstract class AArch64Assembler extends Assembler {
 
         MRS(0xD5300000),
         MSR(0xD5100000),
+        DC(0xD5087000),
 
         BLR_NATIVE(0xc0000000),
 
@@ -705,6 +707,24 @@ public abstract class AArch64Assembler extends Assembler {
         private final int op0;
         private final int op1;
         private final int crn;
+        private final int crm;
+        private final int op2;
+    }
+
+    public enum DataCacheOperationType {
+        ZVA(0b011, 0b0100, 0b001);
+
+        DataCacheOperationType(int op1, int crm, int op2) {
+            this.op1 = op1;
+            this.crm = crm;
+            this.op2 = op2;
+        }
+
+        public int encoding() {
+            return op1 << 16 | crm << 8 | op2 << 5;
+        }
+
+        private final int op1;
         private final int crm;
         private final int op2;
     }
@@ -2959,6 +2979,10 @@ public abstract class AArch64Assembler extends Assembler {
 
     public void msr(SystemRegister systemRegister, Register src) {
         emitInt(MRS.encoding | systemRegister.encoding() | rt(src));
+    }
+
+    public void dc(DataCacheOperationType type, Register src) {
+        emitInt(DC.encoding | type.encoding() | rt(src));
     }
 
     public void annotatePatchingImmediate(int pos, Instruction instruction, int operandSizeBits, int offsetBits, int shift) {

--- a/compiler/src/org.graalvm.compiler.core.aarch64/src/org/graalvm/compiler/core/aarch64/AArch64LIRGenerator.java
+++ b/compiler/src/org.graalvm.compiler.core.aarch64/src/org/graalvm/compiler/core/aarch64/AArch64LIRGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -66,6 +66,7 @@ import org.graalvm.compiler.lir.aarch64.AArch64AtomicMove.AtomicReadAndWriteOp;
 import org.graalvm.compiler.lir.aarch64.AArch64Move.MembarOp;
 import org.graalvm.compiler.lir.aarch64.AArch64PauseOp;
 import org.graalvm.compiler.lir.aarch64.AArch64SpeculativeBarrier;
+import org.graalvm.compiler.lir.aarch64.AArch64ZeroMemoryOp;
 import org.graalvm.compiler.lir.gen.LIRGenerationResult;
 import org.graalvm.compiler.lir.gen.LIRGenerator;
 import org.graalvm.compiler.phases.util.Providers;
@@ -582,5 +583,11 @@ public abstract class AArch64LIRGenerator extends LIRGenerator {
     @Override
     public void emitSpeculationFence() {
         append(new AArch64SpeculativeBarrier());
+    }
+
+    @Override
+    public void emitZeroMemory(Value address, Value length) {
+        // Value address is 8-byte aligned; Value length is multiple of 8.
+        append(new AArch64ZeroMemoryOp(asAllocatable(address), asAllocatable(length), false, -1));
     }
 }

--- a/compiler/src/org.graalvm.compiler.core.aarch64/src/org/graalvm/compiler/core/aarch64/AArch64LoweringProviderMixin.java
+++ b/compiler/src/org.graalvm.compiler.core.aarch64/src/org/graalvm/compiler/core/aarch64/AArch64LoweringProviderMixin.java
@@ -36,6 +36,6 @@ public interface AArch64LoweringProviderMixin extends LoweringProvider {
 
     @Override
     default boolean supportBulkZeroing() {
-        return false;
+        return true;
     }
 }

--- a/compiler/src/org.graalvm.compiler.core.amd64/src/org/graalvm/compiler/core/amd64/AMD64ArithmeticLIRGenerator.java
+++ b/compiler/src/org.graalvm.compiler.core.amd64/src/org/graalvm/compiler/core/amd64/AMD64ArithmeticLIRGenerator.java
@@ -124,7 +124,6 @@ import org.graalvm.compiler.lir.amd64.AMD64ShiftOp;
 import org.graalvm.compiler.lir.amd64.AMD64SignExtendOp;
 import org.graalvm.compiler.lir.amd64.AMD64Ternary;
 import org.graalvm.compiler.lir.amd64.AMD64Unary;
-import org.graalvm.compiler.lir.amd64.AMD64ZeroMemoryOp;
 import org.graalvm.compiler.lir.amd64.vector.AMD64VectorBinary;
 import org.graalvm.compiler.lir.amd64.vector.AMD64VectorBinary.AVXBinaryConstFloatOp;
 import org.graalvm.compiler.lir.amd64.vector.AMD64VectorBinary.AVXBinaryOp;
@@ -1128,12 +1127,6 @@ public class AMD64ArithmeticLIRGenerator extends ArithmeticLIRGenerator implemen
     @Override
     public Value emitMathPow(Value x, Value y) {
         return new AMD64MathPowOp().emitLIRWrapper(getLIRGen(), x, y);
-    }
-
-    @Override
-    public void emitZeroMemory(Value address, Value length) {
-        RegisterValue lengthReg = moveToReg(AMD64.rcx, length);
-        getLIRGen().append(new AMD64ZeroMemoryOp(getAMD64LIRGen().asAddressValue(address), lengthReg));
     }
 
     protected AMD64LIRGenerator getAMD64LIRGen() {

--- a/compiler/src/org.graalvm.compiler.core.amd64/src/org/graalvm/compiler/core/amd64/AMD64LIRGenerator.java
+++ b/compiler/src/org.graalvm.compiler.core.amd64/src/org/graalvm/compiler/core/amd64/AMD64LIRGenerator.java
@@ -94,6 +94,7 @@ import org.graalvm.compiler.lir.amd64.AMD64StringLatin1InflateOp;
 import org.graalvm.compiler.lir.amd64.AMD64StringUTF16CompressOp;
 import org.graalvm.compiler.lir.amd64.AMD64ZapRegistersOp;
 import org.graalvm.compiler.lir.amd64.AMD64ZapStackOp;
+import org.graalvm.compiler.lir.amd64.AMD64ZeroMemoryOp;
 import org.graalvm.compiler.lir.gen.LIRGenerationResult;
 import org.graalvm.compiler.lir.gen.LIRGenerator;
 import org.graalvm.compiler.lir.hashing.Hasher;
@@ -673,5 +674,12 @@ public abstract class AMD64LIRGenerator extends LIRGenerator {
     @Override
     public void emitSpeculationFence() {
         append(new AMD64LFenceOp());
+    }
+
+    @Override
+    public void emitZeroMemory(Value address, Value length) {
+        RegisterValue lengthReg = AMD64.rcx.asValue(length.getValueKind());
+        emitMove(lengthReg, length);
+        append(new AMD64ZeroMemoryOp(asAddressValue(address), lengthReg));
     }
 }

--- a/compiler/src/org.graalvm.compiler.hotspot/src/org/graalvm/compiler/hotspot/GraalHotSpotVMConfig.java
+++ b/compiler/src/org.graalvm.compiler.hotspot/src/org/graalvm/compiler/hotspot/GraalHotSpotVMConfig.java
@@ -624,6 +624,12 @@ public class GraalHotSpotVMConfig extends GraalHotSpotVMConfigBase {
 
     public final boolean tlabStats = getFlag("TLABStats", Boolean.class);
 
+    // We set 0x10 as default value to disable DC ZVA if this field is not present in HotSpot.
+    // ARMv8-A architecture reference manual D12.2.35 Data Cache Zero ID register says:
+    // * BS, bits [3:0] indicate log2 of the DC ZVA block size in (4-byte) words.
+    // * DZP, bit [4] of indicates whether use of DC ZVA instruction is prohibited.
+    public final int psrInfoDczidValue = getFieldValue("VM_Version::_psr_info.dczid_el0", Integer.class, "uint32_t", 0x10);
+
     // FIXME This is only temporary until the GC code is changed.
     public final boolean inlineContiguousAllocationSupported = getFieldValue("CompilerToVM::Data::_supports_inline_contig_alloc", Boolean.class);
     public final long heapEndAddress = getFieldValue("CompilerToVM::Data::_heap_end_addr", Long.class, "HeapWord**");

--- a/compiler/src/org.graalvm.compiler.lir.aarch64/src/org/graalvm/compiler/lir/aarch64/AArch64ZeroMemoryOp.java
+++ b/compiler/src/org.graalvm.compiler.lir.aarch64/src/org/graalvm/compiler/lir/aarch64/AArch64ZeroMemoryOp.java
@@ -1,0 +1,181 @@
+/*
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Arm Limited and affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.graalvm.compiler.lir.aarch64;
+
+import jdk.vm.ci.code.CodeUtil;
+import jdk.vm.ci.code.Register;
+import jdk.vm.ci.meta.AllocatableValue;
+import org.graalvm.compiler.asm.Label;
+import org.graalvm.compiler.asm.aarch64.AArch64Address;
+import org.graalvm.compiler.asm.aarch64.AArch64Assembler;
+import org.graalvm.compiler.asm.aarch64.AArch64MacroAssembler;
+import org.graalvm.compiler.lir.LIRInstructionClass;
+import org.graalvm.compiler.lir.Opcode;
+import org.graalvm.compiler.lir.asm.CompilationResultBuilder;
+
+import static jdk.vm.ci.aarch64.AArch64.zr;
+import static jdk.vm.ci.code.ValueUtil.asRegister;
+import static org.graalvm.compiler.lir.LIRInstruction.OperandFlag.REG;
+
+/**
+ * Zero a chunk of memory on AArch64.
+ */
+@Opcode("ZERO_MEMORY")
+public final class AArch64ZeroMemoryOp extends AArch64LIRInstruction {
+    public static final LIRInstructionClass<AArch64ZeroMemoryOp> TYPE = LIRInstructionClass.create(AArch64ZeroMemoryOp.class);
+
+    @Use({REG}) protected AllocatableValue addressValue;
+    @Use({REG}) protected AllocatableValue lengthValue;
+
+    private final boolean useDcZva;
+    private final int zvaLength;
+
+    /**
+     * Constructor of AArch64ZeroMemoryOp.
+     *
+     * @param address allocatable 8-byte aligned base address of the memory chunk.
+     * @param length allocatable length of the memory chunk, the value must be multiple of 8.
+     * @param useDcZva is DC ZVA instruction is able to use.
+     * @param zvaLength the ZVA length info of current AArch64 CPU, negative value indicates length
+     *            is unknown at compile time.
+     */
+    public AArch64ZeroMemoryOp(AllocatableValue address, AllocatableValue length, boolean useDcZva, int zvaLength) {
+        super(TYPE);
+        this.addressValue = address;
+        this.lengthValue = length;
+        this.useDcZva = useDcZva;
+        this.zvaLength = zvaLength;
+    }
+
+    @Override
+    protected void emitCode(CompilationResultBuilder crb, AArch64MacroAssembler masm) {
+        Register base = asRegister(addressValue);
+        Register size = asRegister(lengthValue);
+        if (useDcZva && zvaLength > 0) {
+            // From ARMv8-A architecture reference manual D12.2.35 Data Cache Zero ID register:
+            // A valid ZVA length should be a power-of-2 value in [4, 2048]
+            assert (CodeUtil.isPowerOf2(zvaLength) && 4 <= zvaLength && zvaLength <= 2048);
+            emitZeroMemoryWithDc(masm, base, size);
+        } else {
+            // Use store pair instructions (STP) to zero memory as a fallback.
+            emitZeroMemoryWithStp(masm, base, size);
+        }
+    }
+
+    /**
+     * Zero a chunk of memory with DC ZVA instructions.
+     *
+     * @param masm the AArch64 macro assembler.
+     * @param base base an 8-byte aligned address of the memory chunk to be zeroed.
+     * @param size size of the memory chunk to be zeroed, in bytes, must be multiple of 8.
+     */
+    private void emitZeroMemoryWithDc(AArch64MacroAssembler masm, Register base, Register size) {
+        Label preLoop = new Label();
+        Label zvaLoop = new Label();
+        Label postLoop = new Label();
+        Label tail = new Label();
+        Label done = new Label();
+
+        try (AArch64MacroAssembler.ScratchRegister sc1 = masm.getScratchRegister()) {
+            Register rscratch1 = sc1.getRegister();
+
+            // Count number of bytes to be pre-zeroed to align base address with ZVA length.
+            masm.neg(64, rscratch1, base);
+            masm.and(64, rscratch1, rscratch1, zvaLength - 1);
+
+            // Is size less than number of bytes to be pre-zeroed? Jump to POST_LOOP if so.
+            masm.cmp(64, size, rscratch1);
+            masm.branchConditionally(AArch64Assembler.ConditionFlag.LE, postLoop);
+            masm.sub(64, size, size, rscratch1);
+
+            // Pre-ZVA loop.
+            masm.bind(preLoop);
+            masm.subs(64, rscratch1, rscratch1, 8);
+            masm.branchConditionally(AArch64Assembler.ConditionFlag.LT, zvaLoop);
+            masm.str(64, zr, AArch64Address.createPostIndexedImmediateAddress(base, 8));
+            masm.jmp(preLoop);
+
+            // ZVA loop.
+            masm.bind(zvaLoop);
+            masm.subs(64, size, size, zvaLength);
+            masm.branchConditionally(AArch64Assembler.ConditionFlag.LT, tail);
+            masm.dc(AArch64Assembler.DataCacheOperationType.ZVA, base);
+            masm.add(64, base, base, zvaLength);
+            masm.jmp(zvaLoop);
+
+            // Handle bytes after ZVA loop.
+            masm.bind(tail);
+            masm.add(64, size, size, zvaLength);
+
+            // Post-ZVA loop.
+            masm.bind(postLoop);
+            masm.subs(64, size, size, 8);
+            masm.branchConditionally(AArch64Assembler.ConditionFlag.LT, done);
+            masm.str(64, zr, AArch64Address.createPostIndexedImmediateAddress(base, 8));
+            masm.jmp(postLoop);
+
+            // Done.
+            masm.bind(done);
+        }
+    }
+
+    /**
+     * Zero a chunk of memory with STP instructions.
+     *
+     * @param masm the AArch64 macro assembler.
+     * @param base base an 8-byte aligned address of the memory chunk to be zeroed.
+     * @param size size of the memory chunk to be zeroed, in bytes, must be multiple of 8.
+     */
+    private void emitZeroMemoryWithStp(AArch64MacroAssembler masm, Register base, Register size) {
+        Label loop = new Label();
+        Label tail = new Label();
+        Label done = new Label();
+
+        // Jump to DONE if size is zero.
+        masm.cbz(64, size, done);
+
+        // Is base address already 16-byte aligned? Jump to LDP loop if so.
+        masm.tbz(base, 3, loop);
+        masm.sub(64, size, size, 8);
+        masm.str(64, zr, AArch64Address.createPostIndexedImmediateAddress(base, 8));
+
+        // The STP loop that zeros 16 bytes in each iteration.
+        masm.bind(loop);
+        masm.subs(64, size, size, 16);
+        masm.branchConditionally(AArch64Assembler.ConditionFlag.LT, tail);
+        masm.stp(64, zr, zr, AArch64Address.createPostIndexedImmediateAddress(base, 2));
+        masm.jmp(loop);
+
+        // We may need to zero the tail 8 bytes of the memory chunk.
+        masm.bind(tail);
+        masm.adds(64, size, size, 16);
+        masm.branchConditionally(AArch64Assembler.ConditionFlag.EQ, done);
+        masm.str(64, zr, AArch64Address.createPostIndexedImmediateAddress(base, 8));
+
+        // Done.
+        masm.bind(done);
+    }
+}

--- a/compiler/src/org.graalvm.compiler.lir.aarch64/src/org/graalvm/compiler/lir/aarch64/AArch64ZeroMemoryOp.java
+++ b/compiler/src/org.graalvm.compiler.lir.aarch64/src/org/graalvm/compiler/lir/aarch64/AArch64ZeroMemoryOp.java
@@ -78,7 +78,7 @@ public final class AArch64ZeroMemoryOp extends AArch64LIRInstruction {
             // From ARMv8-A architecture reference manual D12.2.35 Data Cache Zero ID register:
             // A valid ZVA length should be a power-of-2 value in [4, 2048]
             assert (CodeUtil.isPowerOf2(zvaLength) && 4 <= zvaLength && zvaLength <= 2048);
-            emitZeroMemoryWithDc(masm, base, size);
+            emitZeroMemoryWithDc(masm, base, size, zvaLength);
         } else {
             // Use store pair instructions (STP) to zero memory as a fallback.
             emitZeroMemoryWithStp(masm, base, size);
@@ -91,8 +91,9 @@ public final class AArch64ZeroMemoryOp extends AArch64LIRInstruction {
      * @param masm the AArch64 macro assembler.
      * @param base base an 8-byte aligned address of the memory chunk to be zeroed.
      * @param size size of the memory chunk to be zeroed, in bytes, must be multiple of 8.
+     * @param zvaLength the ZVA length info of current AArch64 CPU.
      */
-    private void emitZeroMemoryWithDc(AArch64MacroAssembler masm, Register base, Register size) {
+    private static void emitZeroMemoryWithDc(AArch64MacroAssembler masm, Register base, Register size, int zvaLength) {
         Label preLoop = new Label();
         Label zvaLoop = new Label();
         Label postLoop = new Label();
@@ -149,7 +150,7 @@ public final class AArch64ZeroMemoryOp extends AArch64LIRInstruction {
      * @param base base an 8-byte aligned address of the memory chunk to be zeroed.
      * @param size size of the memory chunk to be zeroed, in bytes, must be multiple of 8.
      */
-    private void emitZeroMemoryWithStp(AArch64MacroAssembler masm, Register base, Register size) {
+    private static void emitZeroMemoryWithStp(AArch64MacroAssembler masm, Register base, Register size) {
         Label loop = new Label();
         Label tail = new Label();
         Label done = new Label();

--- a/compiler/src/org.graalvm.compiler.lir/src/org/graalvm/compiler/lir/gen/ArithmeticLIRGeneratorTool.java
+++ b/compiler/src/org.graalvm.compiler.lir/src/org/graalvm/compiler/lir/gen/ArithmeticLIRGeneratorTool.java
@@ -137,8 +137,4 @@ public interface ArithmeticLIRGeneratorTool {
         throw GraalError.unimplemented("No specialized implementation available");
     }
 
-    @SuppressWarnings("unused")
-    default void emitZeroMemory(Value address, Value length) {
-        throw GraalError.unimplemented("Bulk zeroing is not supported on this platform");
-    }
 }

--- a/compiler/src/org.graalvm.compiler.lir/src/org/graalvm/compiler/lir/gen/LIRGeneratorTool.java
+++ b/compiler/src/org.graalvm.compiler.lir/src/org/graalvm/compiler/lir/gen/LIRGeneratorTool.java
@@ -353,4 +353,8 @@ public interface LIRGeneratorTool extends DiagnosticLIRGeneratorTool, ValueKindF
     default Value emitReadReturnAddress(Stamp wordStamp, int returnAddressSize) {
         return emitMove(StackSlot.get(getLIRKind(wordStamp), -returnAddressSize, true));
     }
+
+    default void emitZeroMemory(Value address, Value length) {
+        throw GraalError.unimplemented("Bulk zeroing is not implemented on this architecture");
+    }
 }

--- a/compiler/src/org.graalvm.compiler.lir/src/org/graalvm/compiler/lir/gen/LIRGeneratorTool.java
+++ b/compiler/src/org.graalvm.compiler.lir/src/org/graalvm/compiler/lir/gen/LIRGeneratorTool.java
@@ -354,6 +354,7 @@ public interface LIRGeneratorTool extends DiagnosticLIRGeneratorTool, ValueKindF
         return emitMove(StackSlot.get(getLIRKind(wordStamp), -returnAddressSize, true));
     }
 
+    @SuppressWarnings("unused")
     default void emitZeroMemory(Value address, Value length) {
         throw GraalError.unimplemented("Bulk zeroing is not implemented on this architecture");
     }

--- a/compiler/src/org.graalvm.compiler.replacements/src/org/graalvm/compiler/replacements/nodes/ZeroMemoryNode.java
+++ b/compiler/src/org.graalvm.compiler.replacements/src/org/graalvm/compiler/replacements/nodes/ZeroMemoryNode.java
@@ -60,7 +60,7 @@ public class ZeroMemoryNode extends FixedAccessNode implements LIRLowerable {
 
     @Override
     public void generate(NodeLIRBuilderTool gen) {
-        gen.getLIRGeneratorTool().getArithmetic().emitZeroMemory(gen.operand(getAddress()), gen.operand(length));
+        gen.getLIRGeneratorTool().emitZeroMemory(gen.operand(getAddress()), gen.operand(length));
     }
 
     @Override


### PR DESCRIPTION
Current AArch64 Graal generates inefficient STR loops to zero memory of
new arrays/objects in TLAB fast path. To improve the performance of new
array/object allocations, this patch implements memory bulk zeroing with
AArch64 store pair (STP) and cache maintenance (DC ZVA) instructions.

In this implementation, we try to read the pre-loaded value of AArch64
system register DCZID_EL0 from HotSpot field via JVMCI at compile-time,
and generate loops with DC ZVA instruction based on the zva length. In
cases that use of DC ZVA is prohibited, bulk zeroing is disabled by VM
options or the HotSpot field is unable to read, we generate bulk zeroing
code with STP instructions as a fallback.

Performance numbers of JMH case ArrayAllocationBenchmark.java:
```
  (size)        Before         After  Units   Delta
     128  12247939.660  12286886.510  ops/s     ~0%
     256  12779460.750  12744019.880  ops/s     ~0%
     512  11359980.920  11378595.970  ops/s     ~0%
    1024   8612579.648   8605721.524  ops/s     ~0%
    2048   5179105.584   5874018.934  ops/s  +13.4%
    4096   2910263.315   3127318.244  ops/s   +7.5%
    8192   1562452.712   1645597.896  ops/s   +5.3%
   16384    822959.316    848823.521  ops/s   +3.1%
   32768    421660.441    430801.295  ops/s   +2.2%
   65536    215829.630    215310.007  ops/s     ~0%
  131072    108880.555    108901.943  ops/s     ~0%
```
We see performance improved when the allocation size is in [2048, 32768]
in this test since it hits the bulk zeroing path.