### PR TITLE
Allow Class.getPackage() to work on Java 11

### DIFF
--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/JavaLangSubstitutions.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/JavaLangSubstitutions.java
@@ -35,10 +35,12 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.locks.ReentrantLock;
@@ -715,6 +717,55 @@ final class Target_java_lang_Package {
             return SubstrateUtil.cast(pkg, Package.class);
         } else {
             return null;
+        }
+    }
+}
+
+@TargetClass(className = "jdk.internal.loader.BootLoader", onlyWith = JDK11OrLater.class)
+final class Target_jdk_internal_loader_BootLoader {
+    @Substitute
+    static String[] getSystemPackageNames() {
+        return BootLoaderStaticUtils.packageNames.toArray(new String[BootLoaderStaticUtils.packageNames.size()]);
+    }
+
+    @Substitute
+    static Package getDefinedPackage(String name) {
+        if (BootLoaderStaticUtils.packageNames.contains(name.replace('.', '/'))) {
+            Target_java_lang_Package pkg = new Target_java_lang_Package(name, null, null, null,
+                            null, null, null, null, null);
+            return SubstrateUtil.cast(pkg, Package.class);
+        } else {
+            return null;
+        }
+    }
+}
+
+final class BootLoaderStaticUtils {
+    static final Set<String> packageNames;
+
+    static {
+        final Package[] packages = new Helper().getPackages();
+        Set<String> set = new HashSet<>();
+        for (Package pkg : packages) {
+            set.add(pkg.getName());
+        }
+        packageNames = set;
+    }
+
+    static final class Helper extends ClassLoader {
+        @Override
+        protected Package[] getPackages() {
+            return super.getPackages();
+        }
+    }
+}
+
+@AutomaticFeature
+class JavaLangSubstituteFeature11 implements Feature {
+    @Override
+    public void duringSetup(final DuringSetupAccess access) {
+        if (JavaVersionUtil.JAVA_SPEC >= 11) {
+            ImageSingletons.lookup(RuntimeClassInitializationSupport.class).initializeAtBuildTime(BootLoaderStaticUtils.class, "Needed for getPackage() to work");
         }
     }
 }

--- a/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/GetPackageTest.java
+++ b/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/GetPackageTest.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2019, 2019, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package com.oracle.svm.test;
+
+import java.util.ArrayList;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public final class GetPackageTest {
+    @Test
+    public void testGetPackage() {
+        try {
+            ArrayList.class.getPackage();
+        } catch (Throwable t) {
+            Assert.fail("Unexpected exception: " + t);
+        }
+    }
+}


### PR DESCRIPTION
Fixes #1428