### PR TITLE
1537 registernetarrays

### DIFF
--- a/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/PosixJavaNetSubstitutions.java
+++ b/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/PosixJavaNetSubstitutions.java
@@ -126,6 +126,9 @@ class PosixJavaNetSubstitutionsFeature implements Feature {
             JNIRuntimeAccess.register(access.findClassByName("java.lang.Boolean").getDeclaredMethod("getBoolean", String.class));
 
             RuntimeReflection.register(access.findClassByName("java.net.InetAddressImpl"));
+            RuntimeReflection.register(access.findClassByName("[Ljava.net.NetworkInterface;"));
+            RuntimeReflection.register(access.findClassByName("[Ljava.net.InterfaceAddress;"));
+
             RuntimeReflection.register(access.findClassByName("java.net.Inet4AddressImpl"));
             RuntimeReflection.register(access.findClassByName("java.net.Inet6AddressImpl"));
             RuntimeReflection.registerForReflectiveInstantiation(access.findClassByName("java.net.Inet4AddressImpl"));


### PR DESCRIPTION
Register 2 array classes for reflection. They are required by `java.net.NetworkInterface<clinit>`