### PR TITLE
Support latest Windows SDK

### DIFF
--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/image/NativeBootImageViaCC.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/image/NativeBootImageViaCC.java
@@ -221,6 +221,7 @@ public abstract class NativeBootImageViaCC extends NativeBootImage {
             cmd.add("ws2_32.lib");
             cmd.add("secur32.lib");
             cmd.add("iphlpapi.lib");
+            cmd.add("legacy_stdio_definitions.lib");
 
             return cmd;
         }


### PR DESCRIPTION
This one line change "should" allow substrateVM to build on latest Windows SDK.
The legacy_stdio_definitions.lib includes old names for stdio.
See bug#948 for more info.