### PR TITLE
Implicitly support auto-reflection for usages of cls.getDeclaredFields()

### DIFF
--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/snippets/ReflectionPlugins.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/snippets/ReflectionPlugins.java
@@ -460,8 +460,8 @@ public class ReflectionPlugins {
             Class<?> clazz = snippetReflection.asObject(Class.class, receiver.get().asJavaConstant());
             String target = clazz.getTypeName() + ( declared ? ".getDeclaredConstructors()" : ".getConstructors()");
             try {
-                Constructor[] constructors = declared ? clazz.getDeclaredConstructors() : clazz.getConstructors();
-                Constructor[] intrinsic = getIntrinsicArray(analysis, hosted, b, constructors);
+                Constructor<?>[] constructors = declared ? clazz.getDeclaredConstructors() : clazz.getConstructors();
+                Constructor<?>[] intrinsic = getIntrinsicArray(analysis, hosted, b, constructors);
                 if (intrinsic == null) {
                     return false;
                 }

--- a/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/GetConstructorsTest.java
+++ b/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/GetConstructorsTest.java
@@ -1,0 +1,62 @@
+package com.oracle.svm.test;
+
+import java.lang.reflect.Constructor;
+import java.util.Arrays;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class GetConstructorsTest {
+
+    @Test
+    public void testGetConstructors() {
+
+        Constructor<?>[] constructors = Foo.class.getConstructors();
+
+        assertHasConstructor(constructors);
+        assertHasConstructor(constructors, String.class);
+        assertHasNotConstructor(constructors, boolean.class);
+    }
+
+    private void assertHasConstructor(Constructor<?>[] constructors, Class<?>... expectedParamTypes) {
+        boolean found = false;
+        for (Constructor<?> constructor : constructors) {
+            Class<?>[] paramTypes = constructor.getParameterTypes();
+            if (!Arrays.equals(paramTypes, expectedParamTypes)) {
+                continue;
+            }
+            found = true;
+        }
+
+        Assert.assertTrue("Expected to find constructor matching " + Arrays.asList(expectedParamTypes), found);
+    }
+
+    private void assertHasNotConstructor(Constructor<?>[] constructors, Class<?>... expectedParamTypes) {
+        boolean found = false;
+        for (Constructor<?> constructor : constructors) {
+            Class<?>[] paramTypes = constructor.getParameterTypes();
+            if (!Arrays.equals(paramTypes, expectedParamTypes)) {
+                continue;
+            }
+            found = true;
+        }
+
+        Assert.assertFalse("Expected to not find constructor matching " + Arrays.asList(expectedParamTypes), found);
+    }
+
+    static class Foo {
+
+        public Foo() {
+
+        }
+
+        public Foo(String name) {
+
+        }
+
+        private Foo(boolean truthiness) {
+
+        }
+
+    }
+}

--- a/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/GetDeclaredConstructorsTest.java
+++ b/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/GetDeclaredConstructorsTest.java
@@ -1,0 +1,49 @@
+package com.oracle.svm.test;
+
+import java.lang.reflect.Constructor;
+import java.util.Arrays;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class GetDeclaredConstructorsTest {
+
+    @Test
+    public void testGetConstructors() {
+
+        Constructor<?>[] constructors = Foo.class.getDeclaredConstructors();
+
+        assertHasConstructor(constructors);
+        assertHasConstructor(constructors, String.class);
+        assertHasConstructor(constructors, boolean.class);
+    }
+
+    private void assertHasConstructor(Constructor<?>[] constructors, Class<?>... expectedParamTypes) {
+        boolean found = false;
+        for (Constructor<?> constructor : constructors) {
+            Class<?>[] paramTypes = constructor.getParameterTypes();
+            if (!Arrays.equals(paramTypes, expectedParamTypes)) {
+                continue;
+            }
+            found = true;
+        }
+
+        Assert.assertTrue("Expected to find constructor matching " + Arrays.asList(expectedParamTypes), found);
+    }
+
+    static class Foo {
+
+        public Foo() {
+
+        }
+
+        public Foo(String name) {
+
+        }
+
+        private Foo(boolean truthiness) {
+
+        }
+
+    }
+}

--- a/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/GetDeclaredFieldsTest.java
+++ b/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/GetDeclaredFieldsTest.java
@@ -1,0 +1,73 @@
+package com.oracle.svm.test;
+
+import java.lang.reflect.Field;
+import java.util.Arrays;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class GetDeclaredFieldsTest {
+
+    @Test
+    public void testGetFields() {
+        Field[] fields = null;
+
+        fields = ClassOne.class.getDeclaredFields();
+
+        assertHasExactlyFields(fields,
+                               "privateOne1",
+                               "privateOne2",
+                               "publicOne3");
+
+        fields = ClassTwo.class.getDeclaredFields();
+        assertHasExactlyFields(fields,
+                               "privateTwo1",
+                               "publicTwo2");
+
+        fields = ClassThree.class.getDeclaredFields();
+
+        assertHasExactlyFields(fields,
+                               "privateThree1",
+                               "publicThree2");
+    }
+
+    private static void assertHasField(Field[] fields, String name) {
+        boolean found = false;
+
+        for (Field field : fields) {
+            if (field.getName().equals(name)) {
+                found = true;
+                break;
+            }
+        }
+
+        Assert.assertTrue("Expected field: " + name + " in " + Arrays.asList(fields), found);
+    }
+
+    private static void assertHasExactlyFields(Field[] fields, String... names) {
+        Assert.assertTrue("Expected " + names.length + " fields in " + Arrays.asList(fields), fields.length == names.length);
+        for (String name : names) {
+            assertHasField(fields, name);
+        }
+    }
+
+    static class ClassOne {
+        private String privateOne1;
+
+        private int privateOne2;
+
+        public boolean publicOne3;
+    }
+
+    static class ClassTwo extends ClassOne {
+        boolean privateTwo1;
+
+        public boolean publicTwo2;
+    }
+
+    static class ClassThree extends ClassTwo {
+        private boolean privateThree1;
+
+        public String publicThree2;
+    }
+}

--- a/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/GetDeclaredMethodsTest.java
+++ b/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/GetDeclaredMethodsTest.java
@@ -1,0 +1,72 @@
+package com.oracle.svm.test;
+
+import java.lang.reflect.Method;
+import java.util.Arrays;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class GetDeclaredMethodsTest {
+
+    @Test
+    public void testGetMethods() {
+        Method[] methods = null;
+
+        methods = Child.class.getDeclaredMethods();
+        assertHasExactlyMethods(methods,
+                        "childDoSomething",
+                        "childDoSomethingPrivate");
+    }
+
+    private void assertHasExactlyMethods(Method[] methods, String... names) {
+        for (Method method : methods) {
+            boolean found = false;
+            for (String name : names) {
+                if (method.getName().equals(name)) {
+                    found = true;
+                    break;
+                }
+            }
+            Assert.assertTrue("Method with name " + method.getName() + " not expected in " + Arrays.asList(names), found);
+        }
+        for (String name : names) {
+            assertHasMethod(methods, name);
+        }
+    }
+
+    private void assertHasMethod(Method[] methods, String name) {
+        boolean found = false;
+
+        for (Method method : methods) {
+            if (method.getName().equals(name)) {
+                found = true;
+                break;
+            }
+        }
+
+        Assert.assertTrue("Expected method " + name + " in " + Arrays.asList(methods), found);
+    }
+
+    class Parent {
+
+        public void parentDoSomething() {
+
+        }
+
+        private void parentDoSomethingPrivate() {
+
+        }
+    }
+
+    class Child extends Parent {
+
+        public void childDoSomething() {
+
+        }
+
+        private void childDoSomethingPrivate() {
+
+        }
+
+    }
+}

--- a/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/GetFieldsTest.java
+++ b/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/GetFieldsTest.java
@@ -1,0 +1,69 @@
+package com.oracle.svm.test;
+
+import java.lang.reflect.Field;
+import java.util.Arrays;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class GetFieldsTest {
+
+    @Test
+    public void testGetFields() {
+        Field[] fields = null;
+
+        fields = ClassOne.class.getFields();
+
+        assertHasExactlyFields(fields,
+                        "publicOne3");
+
+        fields = ClassTwo.class.getFields();
+
+        assertHasExactlyFields(fields,
+                        "publicOne3",
+                        "publicTwo2");
+
+        fields = ClassThree.class.getFields();
+
+        assertHasExactlyFields(fields,
+                        "publicOne3",
+                        "publicTwo2",
+                        "publicThree2");
+    }
+
+    private static void assertHasField(Field[] fields, String name) {
+        boolean found = false;
+
+        for (Field field : fields) {
+            if (field.getName().equals(name)) {
+                found = true;
+                break;
+            }
+        }
+
+        Assert.assertTrue("Expected field: " + name + " in " + Arrays.asList(fields), found);
+    }
+
+    private static void assertHasExactlyFields(Field[] fields, String... names) {
+        Assert.assertTrue("Expected " + names.length + " fields in " + Arrays.asList(fields), fields.length == names.length);
+        for (String name : names) {
+            assertHasField(fields, name);
+        }
+    }
+
+    static class ClassOne {
+        private String privateOne1;
+        private int privateOne2;
+        public boolean publicOne3;
+    }
+
+    static class ClassTwo extends ClassOne {
+        boolean privateTwo1;
+        public boolean publicTwo2;
+    }
+
+    static class ClassThree extends ClassTwo {
+        private boolean privateThree1;
+        public String publicThree2;
+    }
+}

--- a/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/GetMethodsTest.java
+++ b/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/GetMethodsTest.java
@@ -1,0 +1,79 @@
+package com.oracle.svm.test;
+
+import java.lang.reflect.Method;
+import java.util.Arrays;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class GetMethodsTest {
+
+    @Test
+    public void testGetMethods() {
+        Method[] methods = null;
+
+        methods = Child.class.getMethods();
+        assertHasExactlyMethods(methods,
+                        "equals",
+                        "toString",
+                        "hashCode",
+                        "notify",
+                        "notifyAll",
+                        "wait",
+                        "getClass",
+                        "parentDoSomething",
+                        "childDoSomething");
+    }
+
+    private void assertHasExactlyMethods(Method[] methods, String... names) {
+        for (Method method : methods) {
+            boolean found = false;
+            for (String name : names) {
+                if (method.getName().equals(name)) {
+                    found = true;
+                    break;
+                }
+            }
+            Assert.assertTrue("Method with name " + method.getName() + " not expected in " + Arrays.asList(names), found);
+        }
+        for (String name : names) {
+            assertHasMethod(methods, name);
+        }
+    }
+
+    private void assertHasMethod(Method[] methods, String name) {
+        boolean found = false;
+
+        for (Method method : methods) {
+            if (method.getName().equals(name)) {
+                found = true;
+                break;
+            }
+        }
+
+        Assert.assertTrue("Expected method " + name + " in " + Arrays.asList(methods), found);
+    }
+
+    class Parent {
+
+        public void parentDoSomething() {
+
+        }
+
+        private void parentDoSomethingPrivate() {
+
+        }
+    }
+
+    class Child extends Parent {
+
+        public void childDoSomething() {
+
+        }
+
+        private void childDoSomethingPrivate() {
+
+        }
+
+    }
+}


### PR DESCRIPTION
Fixes #1470

If a user invokes getDeclaredFields(), chances are they might want all declared
fields, and this usage will automatically add *all* declared fields to the
reflection data.