### PR TITLE
Relax reflection configuration errors for unresolved types.

### DIFF
--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/configure/ReflectionConfigurationParser.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/configure/ReflectionConfigurationParser.java
@@ -44,9 +44,15 @@ public final class ReflectionConfigurationParser<T> extends ConfigurationParser 
     private static final String CONSTRUCTOR_NAME = "<init>";
 
     private final ReflectionConfigurationParserDelegate<T> delegate;
+    private final boolean allowIncompleteClasspath;
 
     public ReflectionConfigurationParser(ReflectionConfigurationParserDelegate<T> delegate) {
+        this(delegate, false);
+    }
+
+    public ReflectionConfigurationParser(ReflectionConfigurationParserDelegate<T> delegate, boolean allowIncompleteClasspath) {
         this.delegate = delegate;
+        this.allowIncompleteClasspath = allowIncompleteClasspath;
     }
 
     @Override
@@ -75,7 +81,8 @@ public final class ReflectionConfigurationParser<T> extends ConfigurationParser 
 
         T clazz = delegate.resolveType(className);
         if (clazz == null) {
-            throw new JSONParserException("Class " + className + " not found");
+            handleError("Could not resolve " + className + " for reflection configuration.");
+            return;
         }
         delegate.registerType(clazz);
 
@@ -127,7 +134,7 @@ public final class ReflectionConfigurationParser<T> extends ConfigurationParser 
                                     delegate.getTypeName(clazz));
                 }
             } catch (NoClassDefFoundError e) {
-                showWarning("Could not register " + delegate.getTypeName(clazz) + ": " + name + " for reflection. Reason: " + formatError(e) + ".");
+                handleError("Could not register " + delegate.getTypeName(clazz) + ": " + name + " for reflection. Reason: " + formatError(e) + ".");
             }
         }
     }
@@ -162,9 +169,9 @@ public final class ReflectionConfigurationParser<T> extends ConfigurationParser 
         try {
             delegate.registerField(clazz, fieldName, allowWrite, allowUnsafeAccess);
         } catch (NoSuchFieldException e) {
-            throw new JSONParserException("Field " + delegate.getTypeName(clazz) + "." + fieldName + " not found");
+            handleError("Field " + delegate.getTypeName(clazz) + "." + fieldName + " not found.");
         } catch (NoClassDefFoundError e) {
-            showWarning("Could not register field " + delegate.getTypeName(clazz) + "." + fieldName + " for reflection. Reason: " + formatError(e) + ".");
+            handleError("Could not register field " + delegate.getTypeName(clazz) + "." + fieldName + " for reflection. Reason: " + formatError(e) + ".");
         }
     }
 
@@ -202,9 +209,9 @@ public final class ReflectionConfigurationParser<T> extends ConfigurationParser 
                     delegate.registerMethod(clazz, methodName, methodParameterTypes);
                 }
             } catch (NoSuchMethodException e) {
-                throw new JSONParserException("Method " + formatMethod(clazz, methodName, methodParameterTypes) + " not found");
+                handleError("Method " + formatMethod(clazz, methodName, methodParameterTypes) + " not found.");
             } catch (NoClassDefFoundError e) {
-                showWarning("Could not register method " + formatMethod(clazz, methodName, methodParameterTypes) + " for reflection. Reason: " + formatError(e) + ".");
+                handleError("Could not register method " + formatMethod(clazz, methodName, methodParameterTypes) + " for reflection. Reason: " + formatError(e) + ".");
             }
         } else {
             try {
@@ -218,7 +225,7 @@ public final class ReflectionConfigurationParser<T> extends ConfigurationParser 
                     throw new JSONParserException("Method " + delegate.getTypeName(clazz) + "." + methodName + " not found");
                 }
             } catch (NoClassDefFoundError e) {
-                showWarning("Could not register method " + delegate.getTypeName(clazz) + "." + methodName + " for reflection. Reason: " + formatError(e) + ".");
+                handleError("Could not register method " + delegate.getTypeName(clazz) + "." + methodName + " for reflection. Reason: " + formatError(e) + ".");
             }
         }
     }
@@ -245,10 +252,13 @@ public final class ReflectionConfigurationParser<T> extends ConfigurationParser 
         return delegate.getTypeName(clazz) + "." + methodName + "(" + parameterTypeNames + ")";
     }
 
-    private static void showWarning(String message) {
+    private void handleError(String message) {
         // Checkstyle: stop
-        System.out.println("WARNING: " + message);
+        if (this.allowIncompleteClasspath) {
+            System.out.println("WARNING: " + message);
+        } else {
+            throw new JSONParserException(message + " To allow unresolvable reflection configuration, use option -H:+AllowIncompleteClasspath");
+        }
         // Checkstyle: resume
     }
-
 }

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/config/ConfigurationParserUtils.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/config/ConfigurationParserUtils.java
@@ -42,6 +42,7 @@ import java.util.function.Consumer;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
+import com.oracle.svm.hosted.NativeImageOptions;
 import org.graalvm.nativeimage.impl.ReflectionRegistry;
 
 import com.oracle.svm.core.configure.ConfigurationFiles;
@@ -57,7 +58,7 @@ import com.oracle.svm.hosted.ImageClassLoader;
 public final class ConfigurationParserUtils {
 
     public static ReflectionConfigurationParser<Class<?>> create(ReflectionRegistry registry, ImageClassLoader imageClassLoader) {
-        return new ReflectionConfigurationParser<>(new ReflectionRegistryAdapter(registry, imageClassLoader));
+        return new ReflectionConfigurationParser<>(new ReflectionRegistryAdapter(registry, imageClassLoader), NativeImageOptions.AllowIncompleteClasspath.getValue());
     }
 
     /**


### PR DESCRIPTION
Fixes #1548.

Instead of throwing a hard error, display a warning and proceed
parsing the remainder. Useful for framework-type bits.