### PR TITLE
Add a try/finally to ensure the dir stream gets closed.

### DIFF
--- a/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/PosixJavaIOSubstitutions.java
+++ b/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/PosixJavaIOSubstitutions.java
@@ -228,20 +228,22 @@ final class Target_java_io_UnixFileSystem {
             return null;
         }
 
-        List<String> entries = new ArrayList<>();
-        dirent dirent = StackValue.get(SizeOf.get(dirent.class) + PATH_MAX() + 1);
-        direntPointer resultDirent = StackValue.get(direntPointer.class);
+        try {
+            List<String> entries = new ArrayList<>();
+            dirent dirent = StackValue.get(SizeOf.get(dirent.class) + PATH_MAX() + 1);
+            direntPointer resultDirent = StackValue.get(direntPointer.class);
 
-        while (readdir_r(dir, dirent, resultDirent) == 0 && !resultDirent.read().isNull()) {
-            String name = CTypeConversion.toJavaString(dirent.d_name());
-            if (name.equals(".") || name.equals("..")) {
-                continue;
+            while (readdir_r(dir, dirent, resultDirent) == 0 && !resultDirent.read().isNull()) {
+                String name = CTypeConversion.toJavaString(dirent.d_name());
+                if (name.equals(".") || name.equals("..")) {
+                    continue;
+                }
+                entries.add(name);
             }
-            entries.add(name);
+            return entries.toArray(new String[entries.size()]);
+        } finally {
+            closedir(dir);
         }
-
-        closedir(dir);
-        return entries.toArray(new String[entries.size()]);
     }
 
     @Substitute


### PR DESCRIPTION
Relates to, but probably isn't a fix for #1581.

Comparing the code to JDK8, there is missing error-handling which could, I guess, result in a directory stream being left open.