### PR TITLE
Allow Array.set(objArray, index, null) to not throw NPE.

### DIFF
--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/JavaLangReflectSubstitutions.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/JavaLangReflectSubstitutions.java
@@ -364,7 +364,10 @@ final class Target_java_lang_reflect_Array {
                 return;
             }
         } else if (array instanceof Object[]) {
-            if (array.getClass().getComponentType().isAssignableFrom(value.getClass())) {
+            if (value == null) {
+                ((Object[]) array)[index] = null;
+                return;
+            } else if (array.getClass().getComponentType().isAssignableFrom(value.getClass())) {
                 ((Object[]) array)[index] = value;
                 return;
             }

--- a/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/ArraySetTest.java
+++ b/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/ArraySetTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2019, 2019, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package com.oracle.svm.test;
+
+// Checkstyle: off
+import java.lang.reflect.Array;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class ArraySetTest {
+
+    @Test
+    public void testObjectArraySetWithNull() {
+        String[] array = new String[]{
+                        "a",
+                        "b",
+                        "c",
+                        "d"
+        };
+
+        Array.set(array, 0, null);
+
+        Assert.assertNull(array[0]);
+        Assert.assertEquals("b", array[1]);
+        Assert.assertEquals("c", array[2]);
+        Assert.assertEquals("d", array[3]);
+    }
+
+}


### PR DESCRIPTION
Fixes #1585

Avoid checking assignability of the value to the array
element type if the value is null, and therefore `.getClass()`
is pretty much guaranteed to throw an NPE.

@cstancu I have no idea how to make Checkstyle actually stop uselessly whinging about the import in my test:

`/Users/bob/repos/oracle/graal/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/ArraySetTest.java:28: Illegal import - java.lang.reflect.Array.`

I've attempted a `// Checkstyle: off` but that doesn't seem sufficient.

I also question the need for such stringent checkstyle/linting/formatting in tests. Seems to just cause more non-functional work to make random compiler tools "happy" about code that doesn't even ship to end-users. Sorta discourages testing, in fact.