### PR TITLE
Issue 1598

### DIFF
--- a/substratevm/src/com.oracle.graal.pointsto/src/com/oracle/graal/pointsto/meta/AnalysisType.java
+++ b/substratevm/src/com.oracle.graal.pointsto/src/com/oracle/graal/pointsto/meta/AnalysisType.java
@@ -40,6 +40,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
+import java.util.function.Predicate;
 
 import org.graalvm.compiler.debug.GraalError;
 import org.graalvm.compiler.graph.Node;
@@ -886,6 +887,14 @@ public class AnalysisType implements WrappedJavaType, OriginalClassProvider, Com
     @Override
     public AnalysisField[] getStaticFields() {
         return convertFields(wrapped.getStaticFields(), new ArrayList<>(), false);
+    }
+
+    public AnalysisField[] getStaticFields(final Predicate<? super ResolvedJavaField> fieldToAnalisis) {
+        ResolvedJavaField[] fields = Arrays.stream(wrapped.getStaticFields())
+                        .filter(fieldToAnalisis)
+                        .toArray(ResolvedJavaField[]::new);
+
+        return convertFields(fields, new ArrayList<>(), false);
     }
 
     @Override

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/analysis/Inflation.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/analysis/Inflation.java
@@ -197,21 +197,9 @@ public class Inflation extends BigBang {
                      * value is via a reflective field access, and we even have to guess the field
                      * name.
                      */
-                    AnalysisField found = null;
-                    for (AnalysisField f : type.getStaticFields()) {
-                        if (f.getName().endsWith("$VALUES")) {
-                            if (found != null) {
-                                /*
-                                 * Enumeration has more than one static field with enumeration
-                                 * values. Bailout and use Class.getEnumConstants() to get the value
-                                 * instead.
-                                 */
-                                found = null;
-                                break;
-                            }
-                            found = f;
-                        }
-                    }
+                    AnalysisField[] foundFields = type.getStaticFields(f -> f.getName().endsWith("$VALUES"));
+                    AnalysisField found = foundFields.length != 1 ? null : foundFields[0];
+
                     Enum<?>[] enumConstants;
                     if (found == null) {
                         /*


### PR DESCRIPTION
I think the initialization of enum's static fields for analysinc is redundant, because we need only $VALUES field; as an alternative we can get by invoke `(Enum<?>[]) type.getJavaClass().getEnumConstants()`. If we remove the initialization of all the fields thet we don't need, in this case the issue would not be reproduce.
The rest of the static fields will be added by `BytecodeParser` if this fields will be read.

I'm new in Graal project, so I am not sure this opinion is 100% correct, please review it.