### PR TITLE
Allow to stop building after the relocatable object file is written.

### DIFF
--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/NativeImageGenerator.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/NativeImageGenerator.java
@@ -56,6 +56,7 @@ import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
+import com.oracle.svm.core.LinkerInvocation;
 import org.graalvm.collections.EconomicSet;
 import org.graalvm.collections.Pair;
 import org.graalvm.compiler.api.replacements.Fold;
@@ -657,7 +658,11 @@ public class NativeImageGenerator {
                  * not is an implementation detail of the image.
                  */
                 Path tmpDir = tempDirectory();
-                Path imagePath = image.write(debug, generatedFiles(HostedOptionValues.singleton()), tmpDir, imageName, beforeConfig).getOutputFile();
+                LinkerInvocation inv = image.write(debug, generatedFiles(HostedOptionValues.singleton()), tmpDir, imageName, beforeConfig);
+                if (NativeImageOptions.ExitAfterWrite.getValue()) {
+                    return;
+                }
+                Path imagePath = inv.getOutputFile();
 
                 AfterImageWriteAccessImpl afterConfig = new AfterImageWriteAccessImpl(featureHandler, loader, hUniverse, imagePath, tmpDir, image.getBootImageKind(), debug);
                 featureHandler.forEachFeature(feature -> feature.afterImageWrite(afterConfig));

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/NativeImageOptions.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/NativeImageOptions.java
@@ -160,6 +160,9 @@ public class NativeImageOptions {
     @Option(help = "Exit after analysis")//
     public static final HostedOptionKey<Boolean> ExitAfterAnalysis = new HostedOptionKey<>(false);
 
+    @Option(help = "Exit after writing relocatable file")//
+    public static final HostedOptionKey<Boolean> ExitAfterWrite = new HostedOptionKey<>(false);
+
     @Option(help = "Throw unsafe operation offset errors.)")//
     public static final HostedOptionKey<Boolean> ThrowUnsafeOffsetErrors = new HostedOptionKey<>(true);
 

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/image/NativeBootImageViaCC.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/image/NativeBootImageViaCC.java
@@ -308,6 +308,9 @@ public abstract class NativeBootImageViaCC extends NativeBootImage {
             } else {
                 write(tempDirectory.resolve(imageName + ObjectFile.getFilenameSuffix()));
             }
+            if (NativeImageOptions.ExitAfterWrite.getValue()) {
+                return null;
+            }
             // 2. run a command to make an executable of it
             int status;
             try {


### PR DESCRIPTION
This fixes #1632 