### PR TITLE
compiler: fix getClass bug

### DIFF
--- a/compiler/src/org.graalvm.compiler.replacements/src/org/graalvm/compiler/replacements/StandardGraphBuilderPlugins.java
+++ b/compiler/src/org.graalvm.compiler.replacements/src/org/graalvm/compiler/replacements/StandardGraphBuilderPlugins.java
@@ -116,7 +116,6 @@ import org.graalvm.compiler.nodes.java.UnsafeCompareAndSwapNode;
 import org.graalvm.compiler.nodes.memory.HeapAccess;
 import org.graalvm.compiler.nodes.memory.address.IndexAddressNode;
 import org.graalvm.compiler.nodes.type.StampTool;
-import org.graalvm.compiler.nodes.util.GraphUtil;
 import org.graalvm.compiler.nodes.virtual.EnsureVirtualizedNode;
 import org.graalvm.compiler.replacements.nodes.ProfileBooleanNode;
 import org.graalvm.compiler.replacements.nodes.ReverseBytesNode;
@@ -835,13 +834,8 @@ public class StandardGraphBuilderPlugins {
             @Override
             public boolean apply(GraphBuilderContext b, ResolvedJavaMethod targetMethod, Receiver receiver) {
                 ValueNode object = receiver.get();
-                ValueNode folded = GetClassNode.tryFold(b.getMetaAccess(), b.getConstantReflection(), NodeView.DEFAULT, GraphUtil.originalValue(object));
-                if (folded != null) {
-                    b.addPush(JavaKind.Object, folded);
-                } else {
-                    Stamp stamp = StampFactory.objectNonNull(TypeReference.createTrusted(b.getAssumptions(), b.getMetaAccess().lookupJavaType(Class.class)));
-                    b.addPush(JavaKind.Object, new GetClassNode(stamp, object));
-                }
+                Stamp stamp = StampFactory.objectNonNull(TypeReference.createTrusted(b.getAssumptions(), b.getMetaAccess().lookupJavaType(Class.class)));
+                b.addPush(JavaKind.Object, new GetClassNode(stamp, object));
                 return true;
             }
         });


### PR DESCRIPTION
[case.zip](https://github.com/oracle/graal/files/3624372/case.zip)

The attached file is test case. I verified the failure with GraalVM 19.2.0.1
```bash
./run.sh
==Before assignment==
class test.next.Son
class test.next.Father
class test.next.FatherCousin
==After assignment==
class test.next.Son
class test.next.Father
class test.next.FatherCousin
1:class test.next.Son
1:class test.next.Father
1:class test.next.FatherCousin
-------------- graal compilation -------------
CompilerOracle: compileonly test/next/Son.doSomething
==Before assignment==
class test.next.Son
class test.next.Father
class test.next.FatherCousin
==After assignment==
class test.next.Son
class test.next.Father
class test.next.FatherCousin
    297    1    b        test.next.Son::doSomething (33 bytes)
[Use -Dgraal.LogFile=<path> to redirect Graal log output to a file.]
HotSpotCompilation-1           Ltest/next/Son;                                                        doSomething                                   ()V                                                 |   19ms    66B   300B
1:class test.next.Son
1:class test.next.Son
1:class test.next.Son
```

Normal execution can list all class name. But graal compiled code just output the same class name.

The root cause is graal try to optimize GetClassNode during graph build phase. It will check phi node to see if there's only single value for phi. But the whole graph is not completed, the phi has only 1 input value. 

My fix is removing the optimization. GetClassNode will do the same fold in canonical method. So I think it will not cause performance issue.

Thanks,
Kuai Wei