### PR TITLE
`isCloningAllowed` should not be @CompilationFinal

### DIFF
--- a/truffle/src/com.oracle.truffle.sl/src/com/oracle/truffle/sl/nodes/SLRootNode.java
+++ b/truffle/src/com.oracle.truffle.sl/src/com/oracle/truffle/sl/nodes/SLRootNode.java
@@ -64,7 +64,7 @@ public class SLRootNode extends RootNode {
     /** The name of the function, for printing purposes only. */
     private final String name;
 
-    @CompilationFinal private boolean isCloningAllowed;
+    private boolean isCloningAllowed;
 
     private final SourceSection sourceSection;
 


### PR DESCRIPTION
`isCloningAllowed` can be set via `setCloningAllowed(boolean)` and "escapes" the node in `isCloningAllowed()`. To be able to use `@CompilationFinal`, an assumption is needed (see https://github.com/oracle/graal/pull/1458). However, it might be good enough to remove `@CompilationFinal` from `isCloningAllowed`, at least it's correct.

/cc @chumer 