### PR TITLE
Fail truffle+sdk gates if checkcopyrights fails

### DIFF
--- a/sdk/mx.sdk/mx_sdk.py
+++ b/sdk/mx.sdk/mx_sdk.py
@@ -90,7 +90,9 @@ def _sdk_gate_runner(args, tasks):
     with Task('SDK UnitTests', tasks, tags=['test']) as t:
         if t: unittest(['--suite', 'sdk', '--enable-timing', '--verbose', '--fail-fast'])
     with Task('Check Copyrights', tasks) as t:
-        if t: mx.checkcopyrights(['--primary'])
+        if t:
+            if mx.checkcopyrights(['--primary']) != 0:
+                t.abort('Copyright errors found. Please run "mx checkcopyrights --primary -- --fix" to fix them.')
 
 mx_gate.add_gate_runner(_suite, _sdk_gate_runner)
 

--- a/truffle/mx.truffle/mx_truffle.py
+++ b/truffle/mx.truffle/mx_truffle.py
@@ -228,7 +228,9 @@ def _truffle_gate_runner(args, tasks):
     with Task('File name length check', tasks) as t:
         if t: check_filename_length([])
     with Task('Check Copyrights', tasks) as t:
-        if t: mx.checkcopyrights(['--primary'])
+        if t:
+            if mx.checkcopyrights(['--primary']) != 0:
+                t.abort('Copyright errors found. Please run "mx checkcopyrights --primary -- --fix" to fix them.')
 
 mx_gate.add_gate_runner(_suite, _truffle_gate_runner)
 


### PR DESCRIPTION
`mx.checkcopyrights(['--primary'])` does not fail the gate if the check fails, so valid its return value in the same way Sulong does:
https://github.com/oracle/graal/blob/832cee40053360183c4b15a443a552142c15012e/sulong/mx.sulong/mx_sulong.py#L167-L168