### PR TITLE
Prevent duplicated static initialization at runtime

### DIFF
--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/hub/DynamicHub.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/hub/DynamicHub.java
@@ -320,6 +320,11 @@ public final class DynamicHub implements JavaKind.FormatWithToString, AnnotatedE
     }
 
     @Platforms(Platform.HOSTED_ONLY.class)
+    public void setClassInitializationInfo(ClassInitializationInfo classInitializationInfo) {
+        this.classInitializationInfo = classInitializationInfo;
+    }
+
+    @Platforms(Platform.HOSTED_ONLY.class)
     public void setData(int layoutEncoding, int typeID, int monitorOffset, int hashCodeOffset, int[] assignableFromMatches, BitSet instanceOfBits,
                     CFunctionPointer[] vtable, long referenceMapIndex, boolean isInstantiated) {
         this.layoutEncoding = layoutEncoding;

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/classinitialization/ClassInitializationFeature.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/classinitialization/ClassInitializationFeature.java
@@ -61,6 +61,7 @@ import com.oracle.svm.hosted.FeatureImpl;
 import com.oracle.svm.hosted.analysis.Inflation;
 import com.oracle.svm.hosted.meta.MethodPointer;
 import com.oracle.svm.hosted.phases.SubstrateClassInitializationPlugin;
+import com.oracle.svm.hosted.SVMHost;
 
 import jdk.vm.ci.meta.ResolvedJavaMethod;
 import jdk.vm.ci.meta.ResolvedJavaType;
@@ -288,6 +289,7 @@ public class ClassInitializationFeature implements Feature {
                                  */
                                 if (!classInitializationSupport.shouldInitializeAtRuntime(c)) {
                                     provenSafe.add(type);
+                                    ((SVMHost) universe.hostVM()).dynamicHub(type).setClassInitializationInfo(ClassInitializationInfo.INITIALIZED_INFO_SINGLETON);
                                 }
                             }
                         });


### PR DESCRIPTION
When a class is firstly recoganzied to initialize at RUN_TIME and later proven safe to initialize at BUILD_TIME, it misses the chance to set its DynamicHub.classInitializationInfo to INITIALIZED_INFO_SINGLETON, resulting duplicated initialization at runtime. 
The following test case can reproduce the issue, and it can be fixed by this PR.

```
package test.init;

import java.util.HashMap;
import java.util.Map;

/**
 * java -cp bin -agentlib:native-image-agent=config-output-dir=TestDupInitConfig/META-INF/native-image test.init.TestDupInit
 * $native_image -cp bin:TestDupInitConfig test.init.TestDupInit
 * @author cengfeng.lzy@alibaba-inc.com
 *
 */
public class TestDupInit {
    
    static {
        //Make sure Letter get initialized at runtime 
        System.out.println(Letter.getMappings().size());
    }
    
    public static void main(String[] args) throws ClassNotFoundException, InstantiationException, IllegalAccessException {
        testShouldNotDupInit();
    }

    private static void testShouldNotDupInit() throws ClassNotFoundException {
        Singleton t = Singleton.instance;
        //Prevent optimization
        exe("test.init.Singleton",true);
        Singleton t2 = Singleton.instance;
        if(t2 != t) {
            throw new RuntimeException("Enum field has been changed");
        }
        System.out.println("testShouldNotDupInit Good");
    }

    private static void exe(String type, boolean init) throws ClassNotFoundException {
        //forName triggers clinit at runtime
        Class c = Class.forName(type,init,Thread.currentThread().getContextClassLoader());
        System.out.println(c.getCanonicalName());
    }
}

/**
 * This enum shall be initialized at buildtime
 * @author cengfeng.lzy@alibaba-inc.com
 *
 */
enum Singleton {
    instance;
}

/**
 * This enum shall be initialized at runtime
 * @author cengfeng.lzy@alibaba-inc.com
 *
 */
enum Letter {
    A, B, C, D;

    private static final Map<String, Letter> mappings = new HashMap<>(16);
    static {
        for (Letter l : Letter.values()) {
            mappings.put(l.name(), l);
        }
    }
    
    public static Map<String, Letter> getMappings(){
        return mappings;
    }
}
```