### PR TITLE
rework handling of volatile accesses on aarch64

### DIFF
--- a/compiler/src/org.graalvm.compiler.asm.aarch64.test/src/org/graalvm/compiler/asm/aarch64/test/TestProtectedAssembler.java
+++ b/compiler/src/org.graalvm.compiler.asm.aarch64.test/src/org/graalvm/compiler/asm/aarch64/test/TestProtectedAssembler.java
@@ -133,16 +133,6 @@ class TestProtectedAssembler extends AArch64Assembler {
     }
 
     @Override
-    protected void ldar(int size, Register rt, Register rn) {
-        super.ldar(size, rt, rn);
-    }
-
-    @Override
-    protected void stlr(int size, Register rt, Register rn) {
-        super.stlr(size, rt, rn);
-    }
-
-    @Override
     public void ldaxr(int size, Register rt, Register rn) {
         super.ldaxr(size, rt, rn);
     }

--- a/compiler/src/org.graalvm.compiler.asm.aarch64/src/org/graalvm/compiler/asm/aarch64/AArch64Assembler.java
+++ b/compiler/src/org.graalvm.compiler.asm.aarch64/src/org/graalvm/compiler/asm/aarch64/AArch64Assembler.java
@@ -1402,7 +1402,7 @@ public abstract class AArch64Assembler extends Assembler {
      * @param rt general purpose register. May not be null or stackpointer.
      * @param rn general purpose register.
      */
-    protected void ldar(int size, Register rt, Register rn) {
+    public void ldar(int size, Register rt, Register rn) {
         assert size == 8 || size == 16 || size == 32 || size == 64;
         int transferSize = NumUtil.log2Ceil(size / 8);
         exclusiveLoadInstruction(LDAR, rt, rn, transferSize);
@@ -1415,7 +1415,7 @@ public abstract class AArch64Assembler extends Assembler {
      * @param rt general purpose register. May not be null or stackpointer.
      * @param rn general purpose register.
      */
-    protected void stlr(int size, Register rt, Register rn) {
+    public void stlr(int size, Register rt, Register rn) {
         assert size == 8 || size == 16 || size == 32 || size == 64;
         int transferSize = NumUtil.log2Ceil(size / 8);
         // Hack: Passing the zero-register means it is ignored when building the encoding.
@@ -1471,7 +1471,7 @@ public abstract class AArch64Assembler extends Assembler {
      */
     private void exclusiveStoreInstruction(Instruction instr, Register rs, Register rt, Register rn, int log2TransferSize) {
         assert log2TransferSize >= 0 && log2TransferSize < 4;
-        assert rt.getRegisterCategory().equals(CPU) && rs.getRegisterCategory().equals(CPU) && !rs.equals(rt);
+        assert rt.getRegisterCategory().equals(CPU) && rs.getRegisterCategory().equals(CPU) && (instr == STLR || !rs.equals(rt));
         int transferSizeEncoding = log2TransferSize << LoadStoreTransferSizeOffset;
         emitInt(transferSizeEncoding | instr.encoding | rs2(rs) | rn(rn) | rt(rt));
     }

--- a/compiler/src/org.graalvm.compiler.core.aarch64.test/src/org/graalvm/compiler/core/aarch64/test/AArch64VolatileAccessesTest.java
+++ b/compiler/src/org.graalvm.compiler.core.aarch64.test/src/org/graalvm/compiler/core/aarch64/test/AArch64VolatileAccessesTest.java
@@ -1,0 +1,194 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, Red Hat Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package org.graalvm.compiler.core.aarch64.test;
+
+import jdk.vm.ci.aarch64.AArch64;
+import jdk.vm.ci.aarch64.AArch64Kind;
+import org.graalvm.compiler.core.test.MatchRuleTest;
+import org.graalvm.compiler.lir.LIRInstruction;
+import org.graalvm.compiler.lir.aarch64.AArch64Move;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.function.Predicate;
+
+import static org.junit.Assume.assumeTrue;
+
+public class AArch64VolatileAccessesTest extends MatchRuleTest {
+    private static volatile byte volatileByteField;
+    private static volatile short volatileShortField;
+    private static volatile int volatileIntField;
+    private static volatile long volatileLongField;
+    private static volatile float volatileFloatField;
+    private static volatile double volatileDoubleField;
+
+    private static Predicate<LIRInstruction> storePredicate(AArch64Kind kind) {
+        return op -> (op instanceof AArch64Move.VolatileStoreOp && ((AArch64Move.VolatileStoreOp) op).getKind() == kind);
+    }
+
+    private static Predicate<LIRInstruction> loadPredicate(AArch64Kind kind) {
+        return op -> (op instanceof AArch64Move.VolatileLoadOp && ((AArch64Move.VolatileLoadOp) op).getKind() == kind);
+    }
+
+    @Before
+    public void checkAArch64() {
+        assumeTrue("skipping AArch64 specific test", getTarget().arch instanceof AArch64);
+    }
+
+    public static byte volatileByteFieldLoad() {
+        return volatileByteField;
+    }
+
+    @Test
+    public void test01() {
+        checkLIR("volatileByteFieldLoad", loadPredicate(AArch64Kind.BYTE), 1);
+        volatileByteField = 42;
+        test("volatileByteFieldLoad");
+    }
+
+    public static short volatileShortFieldLoad() {
+        return volatileShortField;
+    }
+
+    @Test
+    public void test02() {
+        checkLIR("volatileShortFieldLoad", loadPredicate(AArch64Kind.WORD), 1);
+        volatileShortField = 42;
+        test("volatileShortFieldLoad");
+    }
+
+    public static int volatileIntFieldLoad() {
+        return volatileIntField;
+    }
+
+    @Test
+    public void test03() {
+        checkLIR("volatileIntFieldLoad", loadPredicate(AArch64Kind.DWORD), 1);
+        volatileIntField = 42;
+        test("volatileIntFieldLoad");
+    }
+
+    public static long volatileLongFieldLoad() {
+        return volatileLongField;
+    }
+
+    @Test
+    public void test04() {
+        checkLIR("volatileLongFieldLoad", loadPredicate(AArch64Kind.QWORD), 1);
+        volatileLongField = 42;
+        test("volatileLongFieldLoad");
+    }
+
+    public static float volatileFloatFieldLoad() {
+        return volatileFloatField;
+    }
+
+    @Test
+    public void test05() {
+        checkLIR("volatileFloatFieldLoad", loadPredicate(AArch64Kind.SINGLE), 1);
+        volatileFloatField = 42;
+        test("volatileFloatFieldLoad");
+    }
+
+    public static double volatileDoubleFieldLoad() {
+        return volatileDoubleField;
+    }
+
+    @Test
+    public void test06() {
+        checkLIR("volatileDoubleFieldLoad", loadPredicate(AArch64Kind.DOUBLE), 1);
+        volatileDoubleField = 42;
+        test("volatileDoubleFieldLoad");
+    }
+
+    public static void volatileByteFieldStore(byte v) {
+        volatileByteField = v;
+    }
+
+    @Test
+    public void test07() {
+        checkLIR("volatileByteFieldStore", storePredicate(AArch64Kind.BYTE), 1);
+        executeActual(getResolvedJavaMethod("volatileByteFieldStore"), (byte) 0x42);
+        Assert.assertEquals(volatileByteField, 0x42);
+    }
+
+    public static void volatileShortFieldStore(short v) {
+        volatileShortField = v;
+    }
+
+    @Test
+    public void test08() {
+        checkLIR("volatileShortFieldStore", storePredicate(AArch64Kind.WORD), 1);
+        executeActual(getResolvedJavaMethod("volatileShortFieldStore"), (short) 0x42);
+        Assert.assertEquals(volatileShortField, 0x42);
+    }
+
+    public static void volatileIntFieldStore(int v) {
+        volatileIntField = v;
+    }
+
+    @Test
+    public void test09() {
+        checkLIR("volatileIntFieldStore", storePredicate(AArch64Kind.DWORD), 1);
+        executeActual(getResolvedJavaMethod("volatileIntFieldStore"), 0x42);
+        Assert.assertEquals(volatileIntField, 0x42);
+    }
+
+    public static void volatileLongFieldStore(int v) {
+        volatileLongField = v;
+    }
+
+    @Test
+    public void test10() {
+        checkLIR("volatileLongFieldStore", storePredicate(AArch64Kind.QWORD), 1);
+        executeActual(getResolvedJavaMethod("volatileLongFieldStore"), 0x42);
+        Assert.assertEquals(volatileLongField, 0x42);
+    }
+
+    public static void volatileFloatFieldStore(float v) {
+        volatileFloatField = v;
+    }
+
+    @Test
+    public void test11() {
+        checkLIR("volatileFloatFieldStore", storePredicate(AArch64Kind.SINGLE), 1);
+        executeActual(getResolvedJavaMethod("volatileFloatFieldStore"), (float) 0x42);
+        Assert.assertEquals(volatileFloatField, 0x42, 0);
+    }
+
+    public static void volatileDoubleFieldStore(double v) {
+        volatileDoubleField = v;
+    }
+
+    @Test
+    public void test12() {
+        checkLIR("volatileDoubleFieldStore", storePredicate(AArch64Kind.DOUBLE), 1);
+        executeActual(getResolvedJavaMethod("volatileDoubleFieldStore"), (double) 0x42);
+        Assert.assertEquals(volatileDoubleField, 0x42, 0);
+    }
+}

--- a/compiler/src/org.graalvm.compiler.core.aarch64/src/org/graalvm/compiler/core/aarch64/AArch64ArithmeticLIRGenerator.java
+++ b/compiler/src/org.graalvm.compiler.core.aarch64/src/org/graalvm/compiler/core/aarch64/AArch64ArithmeticLIRGenerator.java
@@ -46,6 +46,7 @@ import org.graalvm.compiler.lir.aarch64.AArch64AddressValue;
 import org.graalvm.compiler.lir.aarch64.AArch64ArithmeticLIRGeneratorTool;
 import org.graalvm.compiler.lir.aarch64.AArch64ArithmeticOp;
 import org.graalvm.compiler.lir.aarch64.AArch64BitManipulationOp;
+import org.graalvm.compiler.lir.aarch64.AArch64Move;
 import org.graalvm.compiler.lir.aarch64.AArch64Move.LoadOp;
 import org.graalvm.compiler.lir.aarch64.AArch64Move.StoreConstantOp;
 import org.graalvm.compiler.lir.aarch64.AArch64Move.StoreOp;
@@ -507,6 +508,14 @@ public class AArch64ArithmeticLIRGenerator extends ArithmeticLIRGenerator implem
     }
 
     @Override
+    public Variable emitVolatileLoad(LIRKind kind, Value address, LIRFrameState state) {
+        AllocatableValue loadAddress = asAllocatable(address);
+        Variable result = getLIRGen().newVariable(getLIRGen().toRegisterKind(kind));
+        getLIRGen().append(new AArch64Move.VolatileLoadOp((AArch64Kind) kind.getPlatformKind(), result, loadAddress, state));
+        return result;
+    }
+
+    @Override
     public void emitStore(ValueKind<?> lirKind, Value address, Value inputVal, LIRFrameState state) {
         AArch64AddressValue storeAddress = getLIRGen().asAddressValue(address);
         AArch64Kind kind = (AArch64Kind) lirKind.getPlatformKind();
@@ -521,6 +530,14 @@ public class AArch64ArithmeticLIRGenerator extends ArithmeticLIRGenerator implem
         }
         AllocatableValue input = asAllocatable(inputVal);
         getLIRGen().append(new StoreOp(kind, storeAddress, input, state));
+    }
+
+    @Override
+    public void emitVolatileStore(ValueKind<?> lirKind, Value addressVal, Value inputVal, LIRFrameState state) {
+        AArch64Kind kind = (AArch64Kind) lirKind.getPlatformKind();
+        AllocatableValue input = asAllocatable(inputVal);
+        AllocatableValue address = asAllocatable(addressVal);
+        getLIRGen().append(new AArch64Move.VolatileStoreOp(kind, address, input, state));
     }
 
     @Override

--- a/compiler/src/org.graalvm.compiler.core.aarch64/src/org/graalvm/compiler/core/aarch64/AArch64ReadReplacementPhase.java
+++ b/compiler/src/org.graalvm.compiler.core.aarch64/src/org/graalvm/compiler/core/aarch64/AArch64ReadReplacementPhase.java
@@ -31,6 +31,7 @@ import org.graalvm.compiler.nodes.StructuredGraph;
 import org.graalvm.compiler.nodes.calc.SignExtendNode;
 import org.graalvm.compiler.nodes.calc.ZeroExtendNode;
 import org.graalvm.compiler.nodes.memory.ReadNode;
+import org.graalvm.compiler.nodes.memory.VolatileReadNode;
 import org.graalvm.compiler.phases.Phase;
 
 /**
@@ -46,7 +47,7 @@ public class AArch64ReadReplacementPhase extends Phase {
             if (node instanceof AArch64ReadNode) {
                 continue;
             }
-            if (node instanceof ReadNode) {
+            if (node instanceof ReadNode && !(node instanceof VolatileReadNode)) {
                 ReadNode readNode = (ReadNode) node;
                 if (readNode.hasExactlyOneUsage()) {
                     Node usage = readNode.usages().first();

--- a/compiler/src/org.graalvm.compiler.core.amd64/src/org/graalvm/compiler/core/amd64/AMD64ArithmeticLIRGenerator.java
+++ b/compiler/src/org.graalvm.compiler.core.amd64/src/org/graalvm/compiler/core/amd64/AMD64ArithmeticLIRGenerator.java
@@ -1177,6 +1177,16 @@ public class AMD64ArithmeticLIRGenerator extends ArithmeticLIRGenerator implemen
         return result;
     }
 
+    @Override
+    public Variable emitVolatileLoad(LIRKind kind, Value address, LIRFrameState state) {
+        throw GraalError.shouldNotReachHere();
+    }
+
+    @Override
+    public void emitVolatileStore(ValueKind<?> kind, Value address, Value input, LIRFrameState state) {
+        throw GraalError.shouldNotReachHere();
+    }
+
     protected void emitStoreConst(AMD64Kind kind, AMD64AddressValue address, ConstantValue value, LIRFrameState state) {
         Constant c = value.getConstant();
         if (JavaConstant.isNull(c)) {

--- a/compiler/src/org.graalvm.compiler.core.sparc/src/org/graalvm/compiler/core/sparc/SPARCArithmeticLIRGenerator.java
+++ b/compiler/src/org.graalvm.compiler.core.sparc/src/org/graalvm/compiler/core/sparc/SPARCArithmeticLIRGenerator.java
@@ -663,6 +663,16 @@ public class SPARCArithmeticLIRGenerator extends ArithmeticLIRGenerator {
     }
 
     @Override
+    public Variable emitVolatileLoad(LIRKind kind, Value address, LIRFrameState state) {
+        throw GraalError.shouldNotReachHere();
+    }
+
+    @Override
+    public void emitVolatileStore(ValueKind<?> kind, Value address, Value input, LIRFrameState state) {
+        throw GraalError.shouldNotReachHere();
+    }
+
+    @Override
     public void emitStore(ValueKind<?> kind, Value address, Value inputVal, LIRFrameState state) {
         SPARCAddressValue storeAddress = getLIRGen().asAddressValue(address);
         if (isJavaConstant(inputVal)) {

--- a/compiler/src/org.graalvm.compiler.hotspot.aarch64/src/org/graalvm/compiler/hotspot/aarch64/AArch64HotSpotLoweringProvider.java
+++ b/compiler/src/org.graalvm.compiler.hotspot.aarch64/src/org/graalvm/compiler/hotspot/aarch64/AArch64HotSpotLoweringProvider.java
@@ -37,6 +37,8 @@ import org.graalvm.compiler.hotspot.meta.HotSpotRegistersProvider;
 import org.graalvm.compiler.nodes.calc.FloatConvertNode;
 import org.graalvm.compiler.nodes.calc.IntegerDivRemNode;
 import org.graalvm.compiler.nodes.calc.RemNode;
+import org.graalvm.compiler.nodes.memory.VolatileReadNode;
+import org.graalvm.compiler.nodes.memory.VolatileWriteNode;
 import org.graalvm.compiler.nodes.spi.LoweringTool;
 import org.graalvm.compiler.nodes.spi.PlatformConfigurationProvider;
 import org.graalvm.compiler.options.OptionValues;
@@ -73,6 +75,9 @@ public class AArch64HotSpotLoweringProvider extends DefaultHotSpotLoweringProvid
         } else if (n instanceof FloatConvertNode) {
             // AMD64 has custom lowerings for ConvertNodes, HotSpotLoweringProvider does not expect
             // to see a ConvertNode and throws an error, just do nothing here.
+        } else if (n instanceof VolatileReadNode || n instanceof VolatileWriteNode) {
+            // AArch64 emits its own code sequence for volatile accesses. We don't want it lowered
+            // to memory barriers + a regular access.
         } else {
             super.lower(n, tool);
         }

--- a/compiler/src/org.graalvm.compiler.lir.aarch64/src/org/graalvm/compiler/lir/aarch64/AArch64Move.java
+++ b/compiler/src/org.graalvm.compiler.lir.aarch64/src/org/graalvm/compiler/lir/aarch64/AArch64Move.java
@@ -307,6 +307,45 @@ public class AArch64Move {
         }
     }
 
+    public static final class VolatileLoadOp extends AArch64LIRInstruction {
+        public static final LIRInstructionClass<VolatileLoadOp> TYPE = LIRInstructionClass.create(VolatileLoadOp.class);
+        protected final AArch64Kind kind;
+        @State protected LIRFrameState state;
+        @Def protected AllocatableValue result;
+        @Use protected AllocatableValue address;
+
+        public VolatileLoadOp(AArch64Kind kind, AllocatableValue result, AllocatableValue address, LIRFrameState state) {
+            super(TYPE);
+            this.kind = kind;
+            this.result = result;
+            this.address = address;
+            this.state = state;
+            if (state != null) {
+                throw GraalError.shouldNotReachHere("Can't handle implicit null check");
+            }
+        }
+
+        @Override
+        protected void emitCode(CompilationResultBuilder crb, AArch64MacroAssembler masm) {
+            int srcSize = kind.getSizeInBytes() * Byte.SIZE;
+            int destSize = result.getPlatformKind().getSizeInBytes() * Byte.SIZE;
+            if (kind.isInteger()) {
+                masm.ldar(srcSize, asRegister(result), asRegister(address));
+            } else {
+                assert srcSize == destSize;
+                try (ScratchRegister r1 = masm.getScratchRegister()) {
+                    Register rscratch1 = r1.getRegister();
+                    masm.ldar(srcSize, rscratch1, asRegister(address));
+                    masm.fmov(destSize, asRegister(result), rscratch1);
+                }
+            }
+        }
+
+        public AArch64Kind getKind() {
+            return kind;
+        }
+    }
+
     public static class StoreOp extends MemOp {
         public static final LIRInstructionClass<StoreOp> TYPE = LIRInstructionClass.create(StoreOp.class);
         @Use protected AllocatableValue input;
@@ -338,6 +377,43 @@ public class AArch64Move {
         @Override
         public void emitMemAccess(CompilationResultBuilder crb, AArch64MacroAssembler masm) {
             emitStore(crb, masm, kind, addressValue.toAddress(), zr.asValue(LIRKind.combine(addressValue)));
+        }
+    }
+
+    public static class VolatileStoreOp extends AArch64LIRInstruction {
+        public static final LIRInstructionClass<VolatileStoreOp> TYPE = LIRInstructionClass.create(VolatileStoreOp.class);
+        protected final AArch64Kind kind;
+        @State protected LIRFrameState state;
+        @Use protected AllocatableValue input;
+        @Use protected AllocatableValue address;
+
+        public VolatileStoreOp(AArch64Kind kind, AllocatableValue address, AllocatableValue input, LIRFrameState state) {
+            super(TYPE);
+            this.kind = kind;
+            this.address = address;
+            this.input = input;
+            this.state = state;
+            if (state != null) {
+                throw GraalError.shouldNotReachHere("Can't handle implicit null check");
+            }
+        }
+
+        @Override
+        protected void emitCode(CompilationResultBuilder crb, AArch64MacroAssembler masm) {
+            int destSize = kind.getSizeInBytes() * Byte.SIZE;
+            if (kind.isInteger()) {
+                masm.stlr(destSize, asRegister(input), asRegister(address));
+            } else {
+                try (ScratchRegister r1 = masm.getScratchRegister()) {
+                    Register rscratch1 = r1.getRegister();
+                    masm.fmov(destSize, rscratch1, asRegister(input));
+                    masm.stlr(destSize, rscratch1, asRegister(address));
+                }
+            }
+        }
+
+        public AArch64Kind getKind() {
+            return kind;
         }
     }
 

--- a/compiler/src/org.graalvm.compiler.lir/src/org/graalvm/compiler/lir/gen/ArithmeticLIRGeneratorTool.java
+++ b/compiler/src/org.graalvm.compiler.lir/src/org/graalvm/compiler/lir/gen/ArithmeticLIRGeneratorTool.java
@@ -100,7 +100,11 @@ public interface ArithmeticLIRGeneratorTool {
 
     Variable emitLoad(LIRKind kind, Value address, LIRFrameState state);
 
+    Variable emitVolatileLoad(LIRKind kind, Value address, LIRFrameState state);
+
     void emitStore(ValueKind<?> kind, Value address, Value input, LIRFrameState state);
+
+    void emitVolatileStore(ValueKind<?> kind, Value address, Value input, LIRFrameState state);
 
     @SuppressWarnings("unused")
     default Value emitFusedMultiplyAdd(Value a, Value b, Value c) {

--- a/compiler/src/org.graalvm.compiler.nodes/src/org/graalvm/compiler/nodes/memory/VolatileReadNode.java
+++ b/compiler/src/org.graalvm.compiler.nodes/src/org/graalvm/compiler/nodes/memory/VolatileReadNode.java
@@ -26,12 +26,13 @@
 
 package org.graalvm.compiler.nodes.memory;
 
+import org.graalvm.compiler.core.common.LIRKind;
 import org.graalvm.compiler.core.common.type.Stamp;
-import org.graalvm.compiler.debug.GraalError;
 import org.graalvm.compiler.graph.NodeClass;
 import org.graalvm.compiler.graph.spi.Simplifiable;
 import org.graalvm.compiler.graph.spi.SimplifierTool;
 import org.graalvm.compiler.nodeinfo.NodeInfo;
+import org.graalvm.compiler.nodes.NodeView;
 import org.graalvm.compiler.nodes.memory.address.AddressNode;
 import org.graalvm.compiler.nodes.spi.Lowerable;
 import org.graalvm.compiler.nodes.spi.LoweringTool;
@@ -51,17 +52,18 @@ public class VolatileReadNode extends ReadNode implements SingleMemoryKill, Lowe
     }
 
     @Override
-    public void generate(NodeLIRBuilderTool gen) {
-        throw new GraalError("Shouldn't be generated");
-    }
-
-    @Override
     public void simplify(SimplifierTool tool) {
         if (lastLocationAccess != null && hasOnlyUsagesOfType(Memory)) {
             replaceAtUsages(lastLocationAccess.asNode(), Memory);
             assert hasNoUsages();
             graph().removeFixed(this);
         }
+    }
+
+    @Override
+    public void generate(NodeLIRBuilderTool gen) {
+        LIRKind readKind = gen.getLIRGeneratorTool().getLIRKind(getAccessStamp(NodeView.DEFAULT));
+        gen.setResult(this, gen.getLIRGeneratorTool().getArithmetic().emitVolatileLoad(readKind, gen.operand(address), gen.state(this)));
     }
 
     @SuppressWarnings("try")

--- a/compiler/src/org.graalvm.compiler.nodes/src/org/graalvm/compiler/nodes/memory/VolatileWriteNode.java
+++ b/compiler/src/org.graalvm.compiler.nodes/src/org/graalvm/compiler/nodes/memory/VolatileWriteNode.java
@@ -26,11 +26,12 @@
 
 package org.graalvm.compiler.nodes.memory;
 
-import org.graalvm.compiler.debug.GraalError;
+import org.graalvm.compiler.core.common.LIRKind;
 import org.graalvm.compiler.graph.Node;
 import org.graalvm.compiler.graph.NodeClass;
 import org.graalvm.compiler.graph.spi.CanonicalizerTool;
 import org.graalvm.compiler.nodeinfo.NodeInfo;
+import org.graalvm.compiler.nodes.NodeView;
 import org.graalvm.compiler.nodes.ValueNode;
 import org.graalvm.compiler.nodes.memory.address.AddressNode;
 import org.graalvm.compiler.nodes.spi.Lowerable;
@@ -48,7 +49,8 @@ public class VolatileWriteNode extends WriteNode implements Lowerable {
 
     @Override
     public void generate(NodeLIRBuilderTool gen) {
-        throw new GraalError("Shouldn't be generated");
+        LIRKind writeKind = gen.getLIRGeneratorTool().getLIRKind(value().stamp(NodeView.DEFAULT));
+        gen.getLIRGeneratorTool().getArithmetic().emitVolatileStore(writeKind, gen.operand(address), gen.operand(value()), gen.state(this));
     }
 
     @Override

--- a/compiler/src/org.graalvm.compiler.replacements.jdk9.test/src/org/graalvm/compiler/replacements/jdk9/test/VarHandleTest.java
+++ b/compiler/src/org.graalvm.compiler.replacements.jdk9.test/src/org/graalvm/compiler/replacements/jdk9/test/VarHandleTest.java
@@ -27,6 +27,7 @@ package org.graalvm.compiler.replacements.jdk9.test;
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.VarHandle;
 
+import jdk.vm.ci.aarch64.AArch64;
 import org.graalvm.compiler.core.test.GraalCompilerTest;
 import org.graalvm.compiler.debug.GraalError;
 import org.graalvm.compiler.graph.Node;
@@ -115,6 +116,18 @@ public class VarHandleTest extends GraalCompilerTest {
         Assert.assertEquals(expectedAnyKill, countAnyKill(graph));
     }
 
+    private boolean volatileAccessLowered() {
+        return !(getTarget().arch instanceof AArch64);
+    }
+
+    private int numberOfExpectedMembars() {
+        return volatileAccessLowered() ? 2 : 0;
+    }
+
+    private int numberOfExpectedKills() {
+        return volatileAccessLowered() ? 2 : 1;
+    }
+
     @Test
     public void testRead1() {
         testAccess("testRead1Snippet", 1, 0, 0, 0);
@@ -122,7 +135,7 @@ public class VarHandleTest extends GraalCompilerTest {
 
     @Test
     public void testRead2() {
-        testAccess("testRead2Snippet", 1, 0, 2, 2);
+        testAccess("testRead2Snippet", 1, 0, numberOfExpectedMembars(), numberOfExpectedKills());
     }
 
     @Test
@@ -132,7 +145,7 @@ public class VarHandleTest extends GraalCompilerTest {
 
     @Test
     public void testRead4() {
-        testAccess("testRead4Snippet", 1, 0, 2, 2);
+        testAccess("testRead4Snippet", 1, 0, numberOfExpectedMembars(), numberOfExpectedKills());
     }
 
     @Test
@@ -142,7 +155,7 @@ public class VarHandleTest extends GraalCompilerTest {
 
     @Test
     public void testWrite2() {
-        testAccess("testWrite2Snippet", 0, 1, 2, 2);
+        testAccess("testWrite2Snippet", 0, 1, numberOfExpectedMembars(), numberOfExpectedKills());
     }
 
     @Test
@@ -152,7 +165,7 @@ public class VarHandleTest extends GraalCompilerTest {
 
     @Test
     public void testWrite4() {
-        testAccess("testWrite4Snippet", 0, 1, 2, 2);
+        testAccess("testWrite4Snippet", 0, 1, numberOfExpectedMembars(), numberOfExpectedKills());
     }
 
     private static int countAnyKill(StructuredGraph graph) {

--- a/substratevm/src/com.oracle.svm.core.graal.aarch64/src/com/oracle/svm/core/graal/aarch64/SubstrateAArch64LoweringProvider.java
+++ b/substratevm/src/com.oracle.svm.core.graal.aarch64/src/com/oracle/svm/core/graal/aarch64/SubstrateAArch64LoweringProvider.java
@@ -30,6 +30,8 @@ import org.graalvm.compiler.debug.DebugCloseable;
 import org.graalvm.compiler.graph.Node;
 import org.graalvm.compiler.nodes.StructuredGraph;
 import org.graalvm.compiler.nodes.calc.FloatConvertNode;
+import org.graalvm.compiler.nodes.memory.VolatileReadNode;
+import org.graalvm.compiler.nodes.memory.VolatileWriteNode;
 import org.graalvm.compiler.nodes.spi.LoweringTool;
 import org.graalvm.compiler.nodes.spi.PlatformConfigurationProvider;
 
@@ -59,6 +61,9 @@ public class SubstrateAArch64LoweringProvider extends SubstrateBasicLoweringProv
             // expect to see a ConvertNode and throws an error, just do nothing here.
         } else if (n instanceof CodeSynchronizationNode) {
             lowerCodeSynchronizationNode((CodeSynchronizationNode) n);
+        } else if (n instanceof VolatileReadNode || n instanceof VolatileWriteNode) {
+            // AArch64 emits its own code sequence for volatile accesses. We don't want it lowered
+            // to memory barriers + a regular access.
         } else {
             super.lower(n, tool);
         }

--- a/substratevm/src/com.oracle.svm.core.graal.llvm/src/com/oracle/svm/core/graal/llvm/LLVMGenerator.java
+++ b/substratevm/src/com.oracle.svm.core.graal.llvm/src/com/oracle/svm/core/graal/llvm/LLVMGenerator.java
@@ -54,6 +54,7 @@ import org.graalvm.compiler.core.common.spi.LIRKindTool;
 import org.graalvm.compiler.core.common.type.RawPointerStamp;
 import org.graalvm.compiler.core.common.type.Stamp;
 import org.graalvm.compiler.core.common.type.StampFactory;
+import org.graalvm.compiler.debug.GraalError;
 import org.graalvm.compiler.lir.LIRFrameState;
 import org.graalvm.compiler.lir.LIRInstruction;
 import org.graalvm.compiler.lir.LabelRef;
@@ -1740,6 +1741,16 @@ public class LLVMGenerator implements LIRGeneratorTool, SubstrateLIRGenerator {
             }
             LLVMValueRef castedAddress = builder.buildBitcast(address, builder.pointerType(valueType, LLVMIRBuilder.isObjectType(addressType), false));
             builder.buildStore(castedValue, castedAddress);
+        }
+
+        @Override
+        public Variable emitVolatileLoad(LIRKind kind, Value address, LIRFrameState state) {
+            throw GraalError.shouldNotReachHere();
+        }
+
+        @Override
+        public void emitVolatileStore(ValueKind<?> kind, Value address, Value input, LIRFrameState state) {
+            throw GraalError.shouldNotReachHere();
         }
     }
 


### PR DESCRIPTION
This builds on top of https://github.com/oracle/graal/pull/1642 and implements volatile field accesses on aarch64 without explicit membar instructions.