### PR TITLE
Make native linker for LLVM compilation customisable

### DIFF
--- a/substratevm/src/com.oracle.svm.core.graal.llvm/src/com/oracle/svm/core/graal/llvm/LLVMNativeImageCodeCache.java
+++ b/substratevm/src/com.oracle.svm.core.graal.llvm/src/com/oracle/svm/core/graal/llvm/LLVMNativeImageCodeCache.java
@@ -564,7 +564,7 @@ public class LLVMNativeImageCodeCache extends NativeImageCodeCache {
     private void nativeLink(DebugContext debug, String outputPath, List<String> inputPaths) {
         try {
             List<String> cmd = new ArrayList<>();
-            cmd.add("ld");
+            cmd.add((LLVMOptions.CustomLD.hasBeenSet()) ? LLVMOptions.CustomLD.getValue() : "ld");
             cmd.add("-r");
             cmd.add("-o");
             cmd.add(outputPath);

--- a/substratevm/src/com.oracle.svm.core.graal.llvm/src/com/oracle/svm/core/graal/llvm/LLVMOptions.java
+++ b/substratevm/src/com.oracle.svm.core.graal.llvm/src/com/oracle/svm/core/graal/llvm/LLVMOptions.java
@@ -44,4 +44,7 @@ public class LLVMOptions {
 
     @Option(help = "Path to a custom llc binary for LLVM compilation")//
     public static final HostedOptionKey<String> CustomLLC = new HostedOptionKey<>("");
+
+    @Option(help = "Path to a custom ld binary for LLVM linking")//
+    public static final HostedOptionKey<String> CustomLD = new HostedOptionKey<>("");
 }


### PR DESCRIPTION
This fixes #1777 
One might argue that the native linker should not be an option that is only set in LLVM, but in order to keep the symmetry with CustomLLC, I put it there.