### PR TITLE
Print heap size during Native Image compilation

### DIFF
--- a/substratevm/src/com.oracle.graal.pointsto/src/com/oracle/graal/pointsto/util/Timer.java
+++ b/substratevm/src/com.oracle.graal.pointsto/src/com/oracle/graal/pointsto/util/Timer.java
@@ -75,13 +75,16 @@ public class Timer {
     }
 
     private void print(long time) {
+        final String concurrentPrefix;
         if (prefix != null) {
             // Add the PID to further disambiguate concurrent builds of images with the same name
             String pid = GraalServices.getExecutionID();
-            System.out.format("[%s:%s] %12s: %,10.2f ms\n", prefix, pid, name, time / 1000000d);
+            concurrentPrefix = String.format("[%s:%s] ", prefix, pid);
         } else {
-            System.out.format("%12s: %,10.2f ms\n", name, time / 1000000d);
+            concurrentPrefix = "";
         }
+        final double heap = Runtime.getRuntime().totalMemory() / 1024.0 / 1024.0 / 1024.0;
+        System.out.format("%s%12s: %,10.2f ms, %,5.2f GB%n", concurrentPrefix, name, time / 1000000d, heap);
     }
 
     public void print() {


### PR DESCRIPTION
As a user of Native Image I'd like to be able to see how much heap the Native Image process is using, in order to be able to understand how much I'm using the capacity of my CI instance in order to check it's an appropriate size, and also to monitor if the compilation is using more memory than expected, similar to how the number of methods for runtime compilation is printed.

The alignment formatting will break a little if the process uses 100 GB or more, but harmlessly. We obviously can't calculate maximum column length ahead of time.

Example output:

```
[libjvmcicompiler:29812]    classlist:   3,769.93 ms,  1.21 GB
[libjvmcicompiler:29812]        (cap):   1,068.88 ms,  1.21 GB
[libjvmcicompiler:29812]        setup:   2,416.79 ms,  1.21 GB
[libjvmcicompiler:29812]   (typeflow):  31,246.89 ms,  2.61 GB
[libjvmcicompiler:29812]    (objects):  24,958.29 ms,  2.61 GB
[libjvmcicompiler:29812]   (features):   1,958.19 ms,  2.61 GB
[libjvmcicompiler:29812]     analysis:  61,865.63 ms,  2.61 GB
[libjvmcicompiler:29812]     (clinit):   1,919.01 ms,  2.61 GB
0 method(s) included for runtime compilation
[libjvmcicompiler:29812]     universe:   5,308.07 ms,  2.61 GB
[libjvmcicompiler:29812]      (parse):   6,293.68 ms,  2.63 GB
[libjvmcicompiler:29812]     (inline):  14,466.40 ms,  4.19 GB
[libjvmcicompiler:29812]    (compile):  45,002.12 ms,  4.91 GB
[libjvmcicompiler:29812]      compile:  68,968.67 ms,  4.91 GB
[libjvmcicompiler:29812]        image:   3,768.86 ms,  4.91 GB
[libjvmcicompiler:29812]        write:     704.04 ms,  4.91 GB
[libjvmcicompiler:29812]      [total]: 148,093.91 ms,  4.91 GB
```

https://github.com/Shopify/truffleruby/issues/1