### PR TITLE
Generate complete stack trace string

### DIFF
--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/classinitialization/ConfigurableClassInitialization.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/classinitialization/ConfigurableClassInitialization.java
@@ -340,7 +340,7 @@ public class ConfigurableClassInitialization implements ClassInitializationSuppo
     private static String getTraceString(StackTraceElement[] trace) {
         StringBuilder b = new StringBuilder();
 
-        for (int i = START_OF_THE_TRACE; i < trace.length; i++) {
+        for (int i = 0; i < trace.length; i++) {
             StackTraceElement stackTraceElement = trace[i];
             b.append("\tat ").append(stackTraceElement.toString()).append("\n");
         }


### PR DESCRIPTION
This pull request tries to fix a bug during generate stack traces as a string. 

A stack trace during class initialization has been pruned in the method `ConfigurableClassInitialization.relevantStackTrace()`, where the top `START_OF_THE_TRACE `, i.e., the beginning four irrelevant stack frames are skipped. Therefore, in the method `getTraceString()`, where a stack trace is transformed into a string, it is unnecessary to skip the beginning four frames, since those have already been removed. 

In this pull request, the trace string is generated from the first element of a stack trace. 