### PR TITLE
AArch64: Better implementation for float sqrt.

### DIFF
--- a/compiler/src/org.graalvm.compiler.core.aarch64.test/src/org/graalvm/compiler/core/aarch64/test/AArch64FloatSqrtTest.java
+++ b/compiler/src/org.graalvm.compiler.core.aarch64.test/src/org/graalvm/compiler/core/aarch64/test/AArch64FloatSqrtTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Arm Limited. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.graalvm.compiler.core.aarch64.test;
+
+import org.graalvm.compiler.lir.LIRInstruction;
+import org.junit.Test;
+
+import java.util.function.Predicate;
+
+public class AArch64FloatSqrtTest extends AArch64MatchRuleTest {
+
+    private static final Predicate<LIRInstruction> p1 = op -> op.name().equals("SQRT");
+    private static final Predicate<LIRInstruction> p2 = op -> op.name().equals("AArch64FloatConvert");
+
+    public float floatSqrt(float f) {
+        return (float) Math.sqrt(f);
+    }
+
+    private float[] input = {-1, 0f, -0f, Float.MAX_VALUE, Float.MIN_NORMAL, Float.MIN_VALUE, Float.NaN, Float.NEGATIVE_INFINITY, Float.POSITIVE_INFINITY};
+
+    @Test
+    public void testFloatSqrt() {
+        for (float f : input) {
+            test("floatSqrt", f);
+            checkLIR("floatSqrt", p1, 1);
+            checkLIR("floatSqrt", p2, 0);
+        }
+    }
+}

--- a/compiler/src/org.graalvm.compiler.core.aarch64/src/org/graalvm/compiler/core/aarch64/AArch64ArithmeticLIRGenerator.java
+++ b/compiler/src/org.graalvm.compiler.core.aarch64/src/org/graalvm/compiler/core/aarch64/AArch64ArithmeticLIRGenerator.java
@@ -436,7 +436,8 @@ public class AArch64ArithmeticLIRGenerator extends ArithmeticLIRGenerator implem
 
     @Override
     public Value emitMathSqrt(Value input) {
-        assert input.getPlatformKind() == AArch64Kind.DOUBLE;
+        assert input.getPlatformKind() == AArch64Kind.DOUBLE ||
+                        input.getPlatformKind() == AArch64Kind.SINGLE;
         return emitUnary(AArch64ArithmeticOp.SQRT, input);
     }
 

--- a/compiler/src/org.graalvm.compiler.core/src/org/graalvm/compiler/core/gen/NodeMatchRules.java
+++ b/compiler/src/org.graalvm.compiler.core/src/org/graalvm/compiler/core/gen/NodeMatchRules.java
@@ -55,6 +55,7 @@ import org.graalvm.compiler.nodes.calc.PointerEqualsNode;
 import org.graalvm.compiler.nodes.calc.ReinterpretNode;
 import org.graalvm.compiler.nodes.calc.RightShiftNode;
 import org.graalvm.compiler.nodes.calc.SignExtendNode;
+import org.graalvm.compiler.nodes.calc.SqrtNode;
 import org.graalvm.compiler.nodes.calc.SubNode;
 import org.graalvm.compiler.nodes.calc.UnsignedRightShiftNode;
 import org.graalvm.compiler.nodes.calc.XorNode;
@@ -101,6 +102,7 @@ import jdk.vm.ci.meta.Value;
 @MatchableNode(nodeClass = LogicCompareAndSwapNode.class, inputs = {"address", "expectedValue", "newValue"})
 @MatchableNode(nodeClass = ValueCompareAndSwapNode.class, inputs = {"address", "expectedValue", "newValue"})
 @MatchableNode(nodeClass = RightShiftNode.class, inputs = {"x", "y"}, ignoresSideEffects = true)
+@MatchableNode(nodeClass = SqrtNode.class, inputs = {"value"}, ignoresSideEffects = true)
 public abstract class NodeMatchRules {
 
     NodeLIRBuilder lirBuilder;


### PR DESCRIPTION
We can optimize the implementation for float sqrt by adding match rule
like C2:
        match(Set dst (ConvD2F (SqrtD (ConvF2D src))))

        fcvt    d0, s0
        fsqrt   d0, d0
        fcvt    s0, d0

After this patch, generated assembly above can be optimized to below:

        fsqrt   s0, s0