### PR TITLE
Fix NPE in coverage when a source has no path

### DIFF
--- a/tools/src/com.oracle.truffle.tools.coverage/src/com/oracle/truffle/tools/coverage/SourceCoverage.java
+++ b/tools/src/com.oracle.truffle.tools.coverage/src/com/oracle/truffle/tools/coverage/SourceCoverage.java
@@ -61,4 +61,12 @@ public final class SourceCoverage {
     public RootCoverage[] getRoots() {
         return roots;
     }
+
+    public String getName() {
+      if (source.getPath() == null) {
+        return source.getName();
+      } else {
+        return source.getPath();
+      }
+    }
 }

--- a/tools/src/com.oracle.truffle.tools.coverage/src/com/oracle/truffle/tools/coverage/impl/CoverageCLI.java
+++ b/tools/src/com.oracle.truffle.tools.coverage/src/com/oracle/truffle/tools/coverage/impl/CoverageCLI.java
@@ -53,14 +53,12 @@ final class CoverageCLI {
     }
 
     private static String getHistogramLineFormat(SourceCoverage[] coverage) {
-        int maxPathLength = 10;
+        int maxNameLength = 10;
         for (SourceCoverage source : coverage) {
-            final String path = source.getSource().getPath();
-            if (path != null) {
-                maxPathLength = Math.max(maxPathLength, path.length());
-            }
+            final String name = source.getName();
+            maxNameLength = Math.max(maxNameLength, name.length());
         }
-        return " %-" + maxPathLength + "s |  %10s |  %7s |  %7s ";
+        return " %-" + maxNameLength + "s |  %10s |  %7s |  %7s ";
     }
 
     private static String percentFormat(double val) {
@@ -100,11 +98,11 @@ final class CoverageCLI {
         printLine();
         printLinesLegend();
         for (SourceCoverage sourceCoverage : coverage) {
-            final String path = sourceCoverage.getSource().getPath();
+            final String name = sourceCoverage.getName();
             printLine();
             printSummaryHeader();
             final LineCoverage lineCoverage = new LineCoverage(sourceCoverage, strictLines);
-            out.println(String.format(format, path, statementCoverage(sourceCoverage), lineCoverage(lineCoverage), rootCoverage(sourceCoverage)));
+            out.println(String.format(format, name, statementCoverage(sourceCoverage), lineCoverage(lineCoverage), rootCoverage(sourceCoverage)));
             out.println();
             printLinesOfSource(sourceCoverage.getSource(), lineCoverage);
         }
@@ -136,8 +134,8 @@ final class CoverageCLI {
         printSummaryHeader();
         printLine();
         for (SourceCoverage sourceCoverage : coverage) {
-            final String path = sourceCoverage.getSource().getPath();
-            final String line = String.format(format, path,
+            final String name = sourceCoverage.getName();
+            final String line = String.format(format, name,
                             statementCoverage(sourceCoverage),
                             lineCoverage(new LineCoverage(sourceCoverage, strictLines)),
                             rootCoverage(sourceCoverage));
@@ -150,7 +148,7 @@ final class CoverageCLI {
         Arrays.sort(coverage, new Comparator<SourceCoverage>() {
             @Override
             public int compare(SourceCoverage o1, SourceCoverage o2) {
-                return o1.getSource().getPath().compareTo(o2.getSource().getPath());
+                return o1.getName().compareTo(o2.getName());
             }
         });
     }

--- a/tools/src/com.oracle.truffle.tools.coverage/src/com/oracle/truffle/tools/coverage/impl/JSONPrinter.java
+++ b/tools/src/com.oracle.truffle.tools.coverage/src/com/oracle/truffle/tools/coverage/impl/JSONPrinter.java
@@ -58,6 +58,7 @@ final class JSONPrinter {
 
     private static JSONObject sourceJSON(SourceCoverage coverage) {
         final JSONObject sourceJson = new JSONObject();
+        sourceJson.put("name", coverage.getSource().getName());
         sourceJson.put("path", coverage.getSource().getPath());
         sourceJson.put("roots", rootsJson(coverage.getRoots()));
         return sourceJson;

--- a/tools/src/com.oracle.truffle.tools.coverage/src/com/oracle/truffle/tools/coverage/impl/LCOVPrinter.java
+++ b/tools/src/com.oracle.truffle.tools.coverage/src/com/oracle/truffle/tools/coverage/impl/LCOVPrinter.java
@@ -36,6 +36,7 @@ class LCOVPrinter {
 
     private static final String END_OF_RECORD = "end_of_record";
     private static final String TEST_NAME = "TN:";
+    private static final String SOURCE_NAME = "SN:";
     private static final String SOURCE_FILE = "SF:";
     private static final String FUNCTION = "FN:";
     private static final String FUNCTION_DATA = "FNDA:";
@@ -111,6 +112,7 @@ class LCOVPrinter {
 
     private void printSourceCoverage(SourceCoverage sourceCoverage) {
         printTestName();
+        printSourceName(sourceCoverage);
         printSourceFile(sourceCoverage);
         printRootData(sourceCoverage);
         printLineData(sourceCoverage);
@@ -167,6 +169,10 @@ class LCOVPrinter {
 
     private void printRoot(RootCoverage root) {
         out.println(FUNCTION + root.getSourceSection().getStartLine() + "," + root.getName());
+    }
+
+    private void printSourceName(SourceCoverage sourceCoverage) {
+        out.println(SOURCE_NAME + sourceCoverage.getSource().getName());
     }
 
     private void printSourceFile(SourceCoverage sourceCoverage) {


### PR DESCRIPTION
Also generally add source name support to coverage.

https://github.com/Shopify/truffleruby/issues/1