### PR TITLE
Workaround NPEs in coverage

### DIFF
--- a/tools/src/com.oracle.truffle.tools.coverage/src/com/oracle/truffle/tools/coverage/CoverageTracker.java
+++ b/tools/src/com.oracle.truffle.tools.coverage/src/com/oracle/truffle/tools/coverage/CoverageTracker.java
@@ -192,7 +192,9 @@ public final class CoverageTracker implements AutoCloseable {
             final RootNode rootNode = node.getRootNode();
             final Map<SourceSection, RootData> perRootData = sourceCoverage.computeIfAbsent(source, s -> new HashMap<>());
             final RootData rootData = perRootData.get(rootNode.getSourceSection());
-            rootData.loadedStatements.add(section);
+            if (rootData != null) {
+                rootData.loadedStatements.add(section);
+            }
         }
     }
 
@@ -227,7 +229,9 @@ public final class CoverageTracker implements AutoCloseable {
                 continue;
             }
             if (coverageNode.isStatement) {
-                rootData.coveredStatements.put(section, count);
+                if (rootData != null) {
+                    rootData.coveredStatements.put(section, count);
+                }
                 continue;
             }
             throw new IllegalStateException("Found a node without adequate tag.");

--- a/tools/src/com.oracle.truffle.tools.coverage/src/com/oracle/truffle/tools/coverage/impl/LineCoverage.java
+++ b/tools/src/com.oracle.truffle.tools.coverage/src/com/oracle/truffle/tools/coverage/impl/LineCoverage.java
@@ -47,6 +47,9 @@ final class LineCoverage {
     }
 
     private static Map<Integer, LineState> makeLines(SourceCoverage coverage, boolean strictLines) {
+        if (!coverage.getSource().hasCharacters()) {
+            return Collections.emptyMap();
+        }
         final int lineCount = coverage.getSource().getLineCount();
         final HashMap<Integer, List<SectionCoverage>> lineContent = new HashMap<>(lineCount);
         for (RootCoverage rootCoverage : coverage.getRoots()) {


### PR DESCRIPTION
This is more of an issue than a PR. I have to use these workarounds to avoid NPEs when running coverage on simple Ruby programs like this:

```ruby
require 'chunky_png'

a = ChunkyPNG::Image.from_file('a.png')
b = ChunkyPNG::Image.from_file('b.png')
c = a.compose(b, 0, 0)
c.save('c.png')
```

I don't really understand it enough to be able to fix the underlying problem.