### PR TITLE
Limit thread scaling and promptly shutdown pool

### DIFF
--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/ImageClassLoader.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/ImageClassLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -76,6 +76,7 @@ public final class ImageClassLoader {
 
     private static final String CLASS_EXTENSION = ".class";
     private static final int CLASS_EXTENSION_LENGTH = CLASS_EXTENSION.length();
+    private static final int CLASS_LOADING_MAX_SCALING = 8;
     private static final int CLASS_LOADING_TIMEOUT_IN_MINUTES = 10;
 
     static {
@@ -136,7 +137,7 @@ public final class ImageClassLoader {
     }
 
     private void initAllClasses() {
-        final ForkJoinPool executor = new ForkJoinPool(Runtime.getRuntime().availableProcessors());
+        final ForkJoinPool executor = new ForkJoinPool(Math.min(Runtime.getRuntime().availableProcessors(), CLASS_LOADING_MAX_SCALING));
 
         if (JavaVersionUtil.JAVA_SPEC > 8) {
             Set<String> modules = new HashSet<>();
@@ -167,7 +168,11 @@ public final class ImageClassLoader {
                                         .collect(Collectors.toList()));
         uniquePaths.parallelStream().forEach(path -> loadClassesFromPath(executor, path));
 
-        executor.awaitQuiescence(CLASS_LOADING_TIMEOUT_IN_MINUTES, TimeUnit.MINUTES);
+        boolean completed = executor.awaitQuiescence(CLASS_LOADING_TIMEOUT_IN_MINUTES, TimeUnit.MINUTES);
+        if (!completed) {
+            throw shouldNotReachHere("timed out while initializing classes");
+        }
+        executor.shutdownNow();
     }
 
     static Stream<Path> toClassPathEntries(String classPathEntry) {


### PR DESCRIPTION
When running on a large number of cores, within the native image class
loader many threads were being created. Futhermore, these threads were
not being shutdown until the end of execution.

Creating too many threads can cause the process to hang. This is because
each thread makes a call to read /dev/random to get a random seed.
However, it is possible for the system to run out of entropy if too many
threads are created in a short period of time, causing the read of
/dev/random to hang.

To resolve this, I limit the number of threads created by the native
image class loader and also ensure its ForkJoinPool is shutdown
promptly.

Change-Id: I225ba57ab89fee3b7aafcca9913f4ca676aec6bd