### PR TITLE
AArch64: Fixed some lowering issues.

### DIFF
--- a/substratevm/src/com.oracle.svm.core.graal/src/com/oracle/svm/core/graal/snippets/ArithmeticSnippets.java
+++ b/substratevm/src/com.oracle.svm.core.graal/src/com/oracle/svm/core/graal/snippets/ArithmeticSnippets.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -61,7 +61,7 @@ import jdk.vm.ci.meta.DeoptimizationAction;
 import jdk.vm.ci.meta.DeoptimizationReason;
 import jdk.vm.ci.meta.JavaKind;
 
-public final class ArithmeticSnippets extends SubstrateTemplates implements Snippets {
+public abstract class ArithmeticSnippets extends SubstrateTemplates implements Snippets {
 
     @Snippet
     protected static int idivSnippet(int x, int y, @ConstantParameter boolean needsZeroCheck) {
@@ -179,12 +179,6 @@ public final class ArithmeticSnippets extends SubstrateTemplates implements Snip
 
     private final ObjectLayout layout;
 
-    @SuppressWarnings("unused")
-    public static void registerLowerings(OptionValues options, Iterable<DebugHandlersFactory> factories, Providers providers, SnippetReflectionProvider snippetReflection,
-                    Map<Class<? extends Node>, NodeLoweringProvider<?>> lowerings) {
-        new ArithmeticSnippets(options, factories, providers, snippetReflection, lowerings);
-    }
-
     private final SnippetInfo idiv;
     private final SnippetInfo ldiv;
     private final SnippetInfo irem;
@@ -194,7 +188,7 @@ public final class ArithmeticSnippets extends SubstrateTemplates implements Snip
     private final SnippetInfo uirem;
     private final SnippetInfo ulrem;
 
-    private ArithmeticSnippets(OptionValues options, Iterable<DebugHandlersFactory> factories, Providers providers, SnippetReflectionProvider snippetReflection,
+    protected ArithmeticSnippets(OptionValues options, Iterable<DebugHandlersFactory> factories, Providers providers, SnippetReflectionProvider snippetReflection,
                     Map<Class<? extends Node>, NodeLoweringProvider<?>> lowerings) {
         super(options, factories, providers, snippetReflection);
         this.layout = ConfigurationValues.getObjectLayout();
@@ -245,7 +239,7 @@ public final class ArithmeticSnippets extends SubstrateTemplates implements Snip
         }
     }
 
-    static class IdentityLowering implements NodeLoweringProvider<Node> {
+    public static class IdentityLowering implements NodeLoweringProvider<Node> {
         @Override
         public void lower(Node node, LoweringTool tool) {
             // do nothing and leave node unchanged.

--- a/substratevm/src/com.oracle.svm.core.graal/src/com/oracle/svm/core/graal/snippets/aarch64/AArch64ArithmeticSnippets.java
+++ b/substratevm/src/com.oracle.svm.core.graal/src/com/oracle/svm/core/graal/snippets/aarch64/AArch64ArithmeticSnippets.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright (c) 2019, 2019, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package com.oracle.svm.core.graal.snippets.aarch64;
+
+import java.util.Map;
+
+import org.graalvm.compiler.api.replacements.Snippet;
+import org.graalvm.compiler.api.replacements.SnippetReflectionProvider;
+import org.graalvm.compiler.debug.DebugHandlersFactory;
+import org.graalvm.compiler.graph.Node;
+import org.graalvm.compiler.graph.Node.NodeIntrinsic;
+import org.graalvm.compiler.graph.NodeClass;
+import org.graalvm.compiler.nodeinfo.NodeInfo;
+import org.graalvm.compiler.nodes.NodeView;
+import org.graalvm.compiler.nodes.StructuredGraph;
+import org.graalvm.compiler.nodes.ValueNode;
+import org.graalvm.compiler.nodes.calc.RemNode;
+import org.graalvm.compiler.nodes.spi.LoweringTool;
+import org.graalvm.compiler.options.OptionValues;
+import org.graalvm.compiler.phases.util.Providers;
+import org.graalvm.compiler.replacements.SnippetTemplate;
+import org.graalvm.compiler.replacements.SnippetTemplate.Arguments;
+import org.graalvm.compiler.replacements.SnippetTemplate.SnippetInfo;
+
+import com.oracle.svm.core.graal.snippets.ArithmeticSnippets;
+import com.oracle.svm.core.graal.snippets.NodeLoweringProvider;
+
+import jdk.vm.ci.meta.JavaKind;
+
+/**
+ * AArch64 does not have a remainder operation. We use <code>n % d == n - Truncate(n / d) * d</code>
+ * for it instead. This is not correct for some edge cases, so we have to fix it up using these
+ * snippets.
+ */
+final class AArch64ArithmeticSnippets extends ArithmeticSnippets {
+    @Snippet
+    protected static float fremSnippet(float x, float y) {
+        // JVMS: If either value1' or value2' is NaN, the result is NaN.
+        // JVMS: If the dividend is an infinity or the divisor is a zero or both, the result is NaN.
+        if (Float.isInfinite(x) || y == 0.0f || Float.isNaN(y)) {
+            return Float.NaN;
+        }
+        // JVMS: If the dividend is finite and the divisor is an infinity, the result equals the
+        // dividend.
+        // JVMS: If the dividend is a zero and the divisor is finite, the result equals the
+        // dividend.
+        if (x == 0.0f || Float.isInfinite(y)) {
+            return x;
+        }
+
+        float result = safeRem(x, y);
+
+        // JVMS: If neither value1' nor value2' is NaN, the sign of the result equals the sign of
+        // the dividend.
+        if (result == 0.0f && x < 0.0f) {
+            return -result;
+        }
+        return result;
+    }
+
+    @Snippet
+    protected static double dremSnippet(double x, double y) {
+        // JVMS: If either value1' or value2' is NaN, the result is NaN.
+        // JVMS: If the dividend is an infinity or the divisor is a zero or both, the result is NaN.
+        if (Double.isInfinite(x) || y == 0.0 || Double.isNaN(y)) {
+            return Double.NaN;
+        }
+        // JVMS: If the dividend is finite and the divisor is an infinity, the result equals the
+        // dividend.
+        // JVMS: If the dividend is a zero and the divisor is finite, the result equals the
+        // dividend.
+        if (x == 0.0 || Double.isInfinite(y)) {
+            return x;
+        }
+
+        double result = safeRem(x, y);
+
+        // JVMS: If neither value1' nor value2' is NaN, the sign of the result equals the sign of
+        // the dividend.
+        if (result == 0.0 && x < 0.0) {
+            return -result;
+        }
+        return result;
+    }
+
+    @NodeIntrinsic(SafeFloatRemNode.class)
+    private static native float safeRem(float x, float y);
+
+    @NodeIntrinsic(SafeFloatRemNode.class)
+    private static native double safeRem(double x, double y);
+
+    private final SnippetInfo drem;
+    private final SnippetInfo frem;
+
+    @SuppressWarnings("unused")
+    public static void registerLowerings(OptionValues options, Iterable<DebugHandlersFactory> factories, Providers providers,
+                    SnippetReflectionProvider snippetReflection, Map<Class<? extends Node>, NodeLoweringProvider<?>> lowerings) {
+
+        new AArch64ArithmeticSnippets(options, factories, providers, snippetReflection, lowerings);
+    }
+
+    private AArch64ArithmeticSnippets(OptionValues options, Iterable<DebugHandlersFactory> factories, Providers providers,
+                    SnippetReflectionProvider snippetReflection, Map<Class<? extends Node>, NodeLoweringProvider<?>> lowerings) {
+
+        super(options, factories, providers, snippetReflection, lowerings);
+        frem = snippet(AArch64ArithmeticSnippets.class, "fremSnippet");
+        drem = snippet(AArch64ArithmeticSnippets.class, "dremSnippet");
+
+        lowerings.put(RemNode.class, new AArch64RemLowering());
+        lowerings.put(SafeFloatRemNode.class, new IdentityLowering());
+    }
+
+    protected class AArch64RemLowering implements NodeLoweringProvider<RemNode> {
+        @Override
+        public void lower(RemNode node, LoweringTool tool) {
+            JavaKind kind = node.stamp(NodeView.DEFAULT).getStackKind();
+            assert kind == JavaKind.Float || kind == JavaKind.Double;
+            SnippetTemplate.SnippetInfo snippet = kind == JavaKind.Float ? frem : drem;
+            StructuredGraph graph = node.graph();
+            Arguments args = new Arguments(snippet, graph.getGuardsStage(), tool.getLoweringStage());
+            args.add("x", node.getX());
+            args.add("y", node.getY());
+            template(node, args).instantiate(providers.getMetaAccess(), node, SnippetTemplate.DEFAULT_REPLACER, tool, args);
+        }
+    }
+}
+
+@NodeInfo
+class SafeFloatRemNode extends RemNode {
+    public static final NodeClass<SafeFloatRemNode> TYPE = NodeClass.create(SafeFloatRemNode.class);
+
+    protected SafeFloatRemNode(ValueNode x, ValueNode y) {
+        super(TYPE, x, y);
+    }
+}

--- a/substratevm/src/com.oracle.svm.core.graal/src/com/oracle/svm/core/graal/snippets/aarch64/AArch64NonSnippetLowerings.java
+++ b/substratevm/src/com.oracle.svm.core.graal/src/com/oracle/svm/core/graal/snippets/aarch64/AArch64NonSnippetLowerings.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2019, 2019, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package com.oracle.svm.core.graal.snippets.aarch64;
+
+import java.util.Map;
+import java.util.function.Predicate;
+
+import org.graalvm.compiler.api.replacements.SnippetReflectionProvider;
+import org.graalvm.compiler.debug.DebugHandlersFactory;
+import org.graalvm.compiler.graph.Node;
+import org.graalvm.compiler.options.OptionValues;
+import org.graalvm.compiler.phases.util.Providers;
+
+import com.oracle.svm.core.graal.meta.RuntimeConfiguration;
+import com.oracle.svm.core.graal.snippets.NodeLoweringProvider;
+import com.oracle.svm.core.graal.snippets.NonSnippetLowerings;
+
+import jdk.vm.ci.meta.ResolvedJavaMethod;
+
+final class AArch64NonSnippetLowerings extends NonSnippetLowerings {
+
+    @SuppressWarnings("unused")
+    public static void registerLowerings(RuntimeConfiguration runtimeConfig, Predicate<ResolvedJavaMethod> mustNotAllocatePredicate, OptionValues options, Iterable<DebugHandlersFactory> factories,
+                    Providers providers, SnippetReflectionProvider snippetReflection, Map<Class<? extends Node>, NodeLoweringProvider<?>> lowerings) {
+
+        new AArch64NonSnippetLowerings(runtimeConfig, mustNotAllocatePredicate, options, factories, providers, snippetReflection, lowerings);
+    }
+
+    private AArch64NonSnippetLowerings(RuntimeConfiguration runtimeConfig, Predicate<ResolvedJavaMethod> mustNotAllocatePredicate, OptionValues options, Iterable<DebugHandlersFactory> factories,
+                    Providers providers, SnippetReflectionProvider snippetReflection, Map<Class<? extends Node>, NodeLoweringProvider<?>> lowerings) {
+
+        super(runtimeConfig, mustNotAllocatePredicate, options, factories, providers, snippetReflection, lowerings);
+    }
+}

--- a/substratevm/src/com.oracle.svm.core.graal/src/com/oracle/svm/core/graal/snippets/aarch64/AArch64SnippetsFeature.java
+++ b/substratevm/src/com.oracle.svm.core.graal/src/com/oracle/svm/core/graal/snippets/aarch64/AArch64SnippetsFeature.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2019, 2019, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package com.oracle.svm.core.graal.snippets.aarch64;
+
+import java.util.Map;
+import java.util.function.Predicate;
+
+import org.graalvm.compiler.api.replacements.SnippetReflectionProvider;
+import org.graalvm.compiler.debug.DebugHandlersFactory;
+import org.graalvm.compiler.graph.Node;
+import org.graalvm.compiler.options.OptionValues;
+import org.graalvm.compiler.phases.util.Providers;
+import org.graalvm.nativeimage.ImageSingletons;
+import org.graalvm.nativeimage.Platform;
+import org.graalvm.nativeimage.Platforms;
+
+import com.oracle.svm.core.annotate.AutomaticFeature;
+import com.oracle.svm.core.graal.GraalFeature;
+import com.oracle.svm.core.graal.meta.RuntimeConfiguration;
+import com.oracle.svm.core.graal.snippets.NodeLoweringProvider;
+import com.oracle.svm.core.heap.RestrictHeapAccessCallees;
+
+import jdk.vm.ci.meta.ResolvedJavaMethod;
+
+@AutomaticFeature
+@Platforms(Platform.AARCH64.class)
+class AArch64SnippetsFeature implements GraalFeature {
+
+    @Override
+    public void registerLowerings(RuntimeConfiguration runtimeConfig, OptionValues options, Iterable<DebugHandlersFactory> factories, Providers providers,
+                    SnippetReflectionProvider snippetReflection, Map<Class<? extends Node>, NodeLoweringProvider<?>> lowerings, boolean hosted) {
+
+        Predicate<ResolvedJavaMethod> mustNotAllocatePredicate = null;
+        if (hosted) {
+            mustNotAllocatePredicate = method -> ImageSingletons.lookup(RestrictHeapAccessCallees.class).mustNotAllocate(method);
+        }
+
+        AArch64ArithmeticSnippets.registerLowerings(options, factories, providers, snippetReflection, lowerings);
+        AArch64NonSnippetLowerings.registerLowerings(runtimeConfig, mustNotAllocatePredicate, options, factories, providers, snippetReflection, lowerings);
+        PosixAArch64VaListSnippets.registerLowerings(options, factories, providers, snippetReflection, lowerings);
+    }
+}

--- a/substratevm/src/com.oracle.svm.core.graal/src/com/oracle/svm/core/graal/snippets/amd64/AMD64ArithmeticSnippets.java
+++ b/substratevm/src/com.oracle.svm.core.graal/src/com/oracle/svm/core/graal/snippets/amd64/AMD64ArithmeticSnippets.java
@@ -22,38 +22,31 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
-package com.oracle.svm.core.graal.aarch64;
+package com.oracle.svm.core.graal.snippets.amd64;
 
-import org.graalvm.compiler.core.aarch64.AArch64LoweringProviderMixin;
-import org.graalvm.compiler.core.common.spi.ForeignCallsProvider;
+import java.util.Map;
+
+import org.graalvm.compiler.api.replacements.SnippetReflectionProvider;
+import org.graalvm.compiler.debug.DebugHandlersFactory;
 import org.graalvm.compiler.graph.Node;
-import org.graalvm.compiler.nodes.calc.FloatConvertNode;
-import org.graalvm.compiler.nodes.spi.LoweringTool;
+import org.graalvm.compiler.options.OptionValues;
+import org.graalvm.compiler.phases.util.Providers;
 
-import com.oracle.svm.core.graal.meta.SubstrateBasicLoweringProvider;
+import com.oracle.svm.core.graal.snippets.ArithmeticSnippets;
 import com.oracle.svm.core.graal.snippets.NodeLoweringProvider;
 
-import jdk.vm.ci.code.TargetDescription;
-import jdk.vm.ci.meta.MetaAccessProvider;
+final class AMD64ArithmeticSnippets extends ArithmeticSnippets {
 
-public class SubstrateAArch64LoweringProvider extends SubstrateBasicLoweringProvider implements AArch64LoweringProviderMixin {
+    @SuppressWarnings("unused")
+    public static void registerLowerings(OptionValues options, Iterable<DebugHandlersFactory> factories, Providers providers,
+                    SnippetReflectionProvider snippetReflection, Map<Class<? extends Node>, NodeLoweringProvider<?>> lowerings) {
 
-    public SubstrateAArch64LoweringProvider(MetaAccessProvider metaAccess, ForeignCallsProvider foreignCalls, TargetDescription target) {
-        super(metaAccess, foreignCalls, target);
+        new AMD64ArithmeticSnippets(options, factories, providers, snippetReflection, lowerings);
     }
 
-    @SuppressWarnings("unchecked")
-    @Override
-    public void lower(Node n, LoweringTool tool) {
-        @SuppressWarnings("rawtypes")
-        NodeLoweringProvider lowering = getLowerings().get(n.getClass());
-        if (lowering != null) {
-            lowering.lower(n, tool);
-        } else if (n instanceof FloatConvertNode) {
-            // AMD64 has custom lowerings for ConvertNodes, HotSpotLoweringProvider does not expect
-            // to see a ConvertNode and throws an error, just do nothing here.
-        } else {
-            super.lower(n, tool);
-        }
+    private AMD64ArithmeticSnippets(OptionValues options, Iterable<DebugHandlersFactory> factories, Providers providers,
+                    SnippetReflectionProvider snippetReflection, Map<Class<? extends Node>, NodeLoweringProvider<?>> lowerings) {
+
+        super(options, factories, providers, snippetReflection, lowerings);
     }
 }

--- a/substratevm/src/com.oracle.svm.core.graal/src/com/oracle/svm/core/graal/snippets/amd64/AMD64NonSnippetLowerings.java
+++ b/substratevm/src/com.oracle.svm.core.graal/src/com/oracle/svm/core/graal/snippets/amd64/AMD64NonSnippetLowerings.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2019, 2019, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package com.oracle.svm.core.graal.snippets.amd64;
+
+import java.util.Map;
+import java.util.function.Predicate;
+
+import org.graalvm.compiler.api.replacements.SnippetReflectionProvider;
+import org.graalvm.compiler.debug.DebugHandlersFactory;
+import org.graalvm.compiler.graph.Node;
+import org.graalvm.compiler.nodes.calc.FloatConvertNode;
+import org.graalvm.compiler.nodes.spi.LoweringTool;
+import org.graalvm.compiler.options.OptionValues;
+import org.graalvm.compiler.phases.util.Providers;
+import org.graalvm.compiler.replacements.amd64.AMD64ConvertSnippets;
+
+import com.oracle.svm.core.config.ConfigurationValues;
+import com.oracle.svm.core.graal.meta.RuntimeConfiguration;
+import com.oracle.svm.core.graal.snippets.NodeLoweringProvider;
+import com.oracle.svm.core.graal.snippets.NonSnippetLowerings;
+
+import jdk.vm.ci.code.TargetDescription;
+import jdk.vm.ci.meta.ResolvedJavaMethod;
+
+final class AMD64NonSnippetLowerings extends NonSnippetLowerings {
+
+    @SuppressWarnings("unused")
+    public static void registerLowerings(RuntimeConfiguration runtimeConfig, Predicate<ResolvedJavaMethod> mustNotAllocatePredicate, OptionValues options, Iterable<DebugHandlersFactory> factories,
+                    Providers providers, SnippetReflectionProvider snippetReflection, Map<Class<? extends Node>, NodeLoweringProvider<?>> lowerings) {
+
+        new AMD64NonSnippetLowerings(runtimeConfig, mustNotAllocatePredicate, options, factories, providers, snippetReflection, lowerings);
+    }
+
+    private AMD64NonSnippetLowerings(RuntimeConfiguration runtimeConfig, Predicate<ResolvedJavaMethod> mustNotAllocatePredicate, OptionValues options, Iterable<DebugHandlersFactory> factories,
+                    Providers providers, SnippetReflectionProvider snippetReflection, Map<Class<? extends Node>, NodeLoweringProvider<?>> lowerings) {
+
+        super(runtimeConfig, mustNotAllocatePredicate, options, factories, providers, snippetReflection, lowerings);
+
+        lowerings.put(FloatConvertNode.class, new FloatConvertLowering(options, factories, providers, snippetReflection, ConfigurationValues.getTarget()));
+    }
+
+    private static class FloatConvertLowering implements NodeLoweringProvider<FloatConvertNode> {
+
+        private final AMD64ConvertSnippets.Templates convertSnippets;
+
+        FloatConvertLowering(OptionValues options, Iterable<DebugHandlersFactory> factories, Providers providers, SnippetReflectionProvider snippetReflection, TargetDescription target) {
+            convertSnippets = new AMD64ConvertSnippets.Templates(options, factories, providers, snippetReflection, target);
+        }
+
+        @Override
+        public void lower(FloatConvertNode node, LoweringTool tool) {
+            convertSnippets.lower(node, tool);
+        }
+    }
+}

--- a/substratevm/src/com.oracle.svm.core.graal/src/com/oracle/svm/core/graal/snippets/amd64/AMD64SnippetsFeature.java
+++ b/substratevm/src/com.oracle.svm.core.graal/src/com/oracle/svm/core/graal/snippets/amd64/AMD64SnippetsFeature.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2019, 2019, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package com.oracle.svm.core.graal.snippets.amd64;
+
+import java.util.Map;
+import java.util.function.Predicate;
+
+import org.graalvm.compiler.api.replacements.SnippetReflectionProvider;
+import org.graalvm.compiler.debug.DebugHandlersFactory;
+import org.graalvm.compiler.graph.Node;
+import org.graalvm.compiler.options.OptionValues;
+import org.graalvm.compiler.phases.util.Providers;
+import org.graalvm.nativeimage.ImageSingletons;
+import org.graalvm.nativeimage.Platform;
+import org.graalvm.nativeimage.Platforms;
+
+import com.oracle.svm.core.annotate.AutomaticFeature;
+import com.oracle.svm.core.graal.GraalFeature;
+import com.oracle.svm.core.graal.meta.RuntimeConfiguration;
+import com.oracle.svm.core.graal.snippets.NodeLoweringProvider;
+import com.oracle.svm.core.heap.RestrictHeapAccessCallees;
+
+import jdk.vm.ci.meta.ResolvedJavaMethod;
+
+@AutomaticFeature
+@Platforms(Platform.AMD64.class)
+class AMD64SnippetsFeature implements GraalFeature {
+
+    @Override
+    public void registerLowerings(RuntimeConfiguration runtimeConfig, OptionValues options, Iterable<DebugHandlersFactory> factories, Providers providers,
+                    SnippetReflectionProvider snippetReflection, Map<Class<? extends Node>, NodeLoweringProvider<?>> lowerings, boolean hosted) {
+
+        Predicate<ResolvedJavaMethod> mustNotAllocatePredicate = null;
+        if (hosted) {
+            mustNotAllocatePredicate = method -> ImageSingletons.lookup(RestrictHeapAccessCallees.class).mustNotAllocate(method);
+        }
+
+        AMD64ArithmeticSnippets.registerLowerings(options, factories, providers, snippetReflection, lowerings);
+        AMD64NonSnippetLowerings.registerLowerings(runtimeConfig, mustNotAllocatePredicate, options, factories, providers, snippetReflection, lowerings);
+        PosixAMD64VaListSnippets.registerLowerings(options, factories, providers, snippetReflection, lowerings);
+    }
+}

--- a/substratevm/src/com.oracle.svm.core.graal/src/com/oracle/svm/core/graal/snippets/amd64/PosixAMD64VaListSnippets.java
+++ b/substratevm/src/com.oracle.svm.core.graal/src/com/oracle/svm/core/graal/snippets/amd64/PosixAMD64VaListSnippets.java
@@ -22,7 +22,7 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
-package com.oracle.svm.core.graal.snippets;
+package com.oracle.svm.core.graal.snippets.amd64;
 
 import java.util.Map;
 
@@ -37,34 +37,15 @@ import org.graalvm.compiler.replacements.SnippetTemplate;
 import org.graalvm.compiler.replacements.SnippetTemplate.Arguments;
 import org.graalvm.compiler.replacements.SnippetTemplate.SnippetInfo;
 import org.graalvm.compiler.replacements.Snippets;
-import org.graalvm.nativeimage.Platform;
-import org.graalvm.nativeimage.impl.DeprecatedPlatform;
 import org.graalvm.word.Pointer;
 
-import com.oracle.svm.core.annotate.AutomaticFeature;
-import com.oracle.svm.core.graal.GraalFeature;
-import com.oracle.svm.core.graal.meta.RuntimeConfiguration;
 import com.oracle.svm.core.graal.nodes.VaListNextArgNode;
+import com.oracle.svm.core.graal.snippets.NodeLoweringProvider;
+import com.oracle.svm.core.graal.snippets.SubstrateTemplates;
 import com.oracle.svm.core.util.VMError;
 
-@AutomaticFeature
-class PosixAArch64VaListSnippetsFeature implements GraalFeature {
-    @Override
-    public boolean isInConfiguration(IsInConfigurationAccess access) {
-        return Platform.includedIn(DeprecatedPlatform.LINUX_SUBSTITUTION_AARCH64.class) || Platform.includedIn(DeprecatedPlatform.DARWIN_SUBSTITUTION_AARCH64.class) ||
-                        Platform.includedIn(Platform.LINUX_AARCH64.class) || Platform.includedIn(Platform.DARWIN_AARCH64.class);
-    }
-
-    @Override
-    public void registerLowerings(RuntimeConfiguration runtimeConfig, OptionValues options, Iterable<DebugHandlersFactory> factories, Providers providers,
-                    SnippetReflectionProvider snippetReflection, Map<Class<? extends Node>, NodeLoweringProvider<?>> lowerings, boolean hosted) {
-
-        PosixAArch64VaListSnippets.registerLowerings(options, factories, providers, snippetReflection, lowerings);
-    }
-}
-
 /**
- * Implementation of C {@code va_list} handling for System V systems on AArch64 (Linux, but same
+ * Implementation of C {@code va_list} handling for System V systems on AMD64 (Linux, but same
  * behavior on Darwin). A {@code va_list} is used for passing the arguments of a C varargs function
  * ({@code ...} in the argument list) to another function. Varargs functions use the same calling
  * convention as other functions, which entails passing the first few arguments in registers and the
@@ -73,54 +54,57 @@ class PosixAArch64VaListSnippetsFeature implements GraalFeature {
  * read from the {@code va_list} in another function. The {@code va_list} structure looks like this:
  *
  * <pre>
- *   typedef struct  va_list {
- *     void * stack; // next stack param
- *     void * gr_top; // end of GP arg reg save area
- *     void * vr_top; // end of FP/SIMD arg reg save area
- *     int gr_offs; // offset from  gr_top to next GP register arg
- *     int vr_offs; // offset from  vr_top to next FP/SIMD register arg
- *   } va_list;[1]
+ *   typedef struct {
+ *     unsigned int gp_offset;  // offset of the next general-purpose argument in reg_save_area
+ *     unsigned int fp_offset;  // offset of the next floating-point argument in reg_save_area
+ *     void *overflow_arg_area; // address of the next overflow argument (can be gp or fp)
+ *     void *reg_save_area;     // start address of the register save area
+ *   } va_list[1];
  * </pre>
  *
  * Reading a {@code va_list} requires knowing the types of the arguments. General-purpose values
- * (integers and pointers) are passed in the eight 64-bit registers {@code x0} to {@code x7}, which
- * are saved below {@code gr_top}. Floating-point values are passed in the eight 128-bit registers
- * {@code v0} through {@code v7}, which are saved below {@code vr_top} following the general-purpose
- * registers.
+ * (integers and pointers) are passed in the six 64-bit registers {@code rdi, rsi, rdx, rcx, r8} and
+ * {@code r9}, which are saved to the start of {@code reg_save_area}. Floating-point values are
+ * passed in the eight 128-bit registers {@code xmm0} through {@code xmm7}, which are saved to
+ * {@code reg_save_area} following the general-purpose registers. (Some sources specify that the
+ * sixteen registers {@code xmm0} through {@code xmm15} are used, but this appears to be wrong.)
  * <p>
- * In the case of more than eight general-purpose values or eight floating-point values, further
- * arguments are passed on the stack and can be read from {@code stack} (which is typically a
- * pointer to the arguments on the stack). For passing on the stack, 32-bit {@code float} values are
- * promoted to 64-bit {@code double}, and integer values with less than 32 bits are promoted to
- * 32-bit {@code int}. However, each value in {@code overflow_arg_area} is eight-byte aligned.
+ * In the case of more than six general-purpose values or eight floating-point values, further
+ * arguments are passed on the stack and can be read from {@code overflow_arg_area} (which is
+ * typically a pointer to the arguments on the stack). For passing on the stack, 32-bit
+ * {@code float} values are promoted to 64-bit {@code double}, and integer values with less than 32
+ * bits are promoted to 32-bit {@code int}. However, each value in {@code overflow_arg_area} is
+ * eight-byte aligned.
  * <p>
  * Reading an argument from a {@code va_list} requires checking whether all of the
- * {@code reg_save_area} for the type of argument has been consumed, that is, if <i>gp_offset >=
- * 0</i>, or in case of a floating-point argument, if <i>fp_offset >= 0</i>. If not, the argument is
- * read from {@code gr_top+offset} or {@code vr_top+offset}, and then either {@code gp_offset} is
+ * {@code reg_save_area} for the type of argument has been consumed, that is, if <i>gp_offset == 6 *
+ * 8</i>, or in case of a floating-point argument, if <i>fp_offset == 6 * 8 + 8 * 16</i>. If not,
+ * the argument is read from {@code reg_save_area+offset}, and then either {@code gp_offset} is
  * increased by 8 or {@code fp_offset} is increased by 16. If the {@code reg_save_area} has already
- * been consumed, the argument is read from {@code stack}, and {@code stack} is increased to point
- * to the next eight-byte-aligned value.
+ * been consumed, the argument is read from {@code overflow_arg_area}, and {@code overflow_arg_area}
+ * is increased to point to the next eight-byte-aligned value.
  *
  * <p>
  * References:<br>
- * <cite>Procedure Call Standard for the ARM 64-bit architecture (AArch64): APPENDIX Variable
- * Argument Lists.</cite><br>
+ * <cite>Hubicka, Jaeger, Mitchell: System V Application Binary Interface, AMD64 Architecture
+ * Processor Supplement (Draft, 0.99.7, 2014-11-17): 3.5.7 Variable Argument Lists.</cite><br>
+ * <cite>Agner Fog: Calling conventions for different C++ compilers and operating systems (updated
+ * 2017-05-01): 7. Function calling conventions.</cite>
  */
-final class PosixAArch64VaListSnippets extends SubstrateTemplates implements Snippets {
+final class PosixAMD64VaListSnippets extends SubstrateTemplates implements Snippets {
 
     // (read above)
-    private static final int GP_OFFSET_LOCATION = 24;
-    private static final int MAX_GP_OFFSET = 0;
-    private static final int FP_OFFSET_LOCATION = 28;
-    private static final int MAX_FP_OFFSET = 0;
-    private static final int STACK_AREA_LOCATION = 0;
-    private static final int STACK_AREA_GP_ALIGNMENT = 8;
-    private static final int STACK_AREA_FP_ALIGNMENT = 8;
-    private static final int GP_TOP_LOCATION = 8;
-    private static final int FP_TOP_LOCATION = 16;
+    private static final int GP_OFFSET_LOCATION = 0;
+    private static final int NUM_GP_ARG_REGISTERS = 6;
+    private static final int MAX_GP_OFFSET = NUM_GP_ARG_REGISTERS * 8;
+    private static final int FP_OFFSET_LOCATION = 4;
+    private static final int NUM_FP_ARG_REGISTERS = 8;
+    private static final int MAX_FP_OFFSET = MAX_GP_OFFSET + NUM_FP_ARG_REGISTERS * 16;
+    private static final int OVERFLOW_ARG_AREA_LOCATION = 8;
+    private static final int OVERFLOW_ARG_AREA_ALIGNMENT = 8;
+    private static final int REG_SAVE_AREA_LOCATION = 16;
 
-    private PosixAArch64VaListSnippets(OptionValues options, Iterable<DebugHandlersFactory> factories, Providers providers, SnippetReflectionProvider snippetReflection) {
+    private PosixAMD64VaListSnippets(OptionValues options, Iterable<DebugHandlersFactory> factories, Providers providers, SnippetReflectionProvider snippetReflection) {
         super(options, factories, providers, snippetReflection);
     }
 
@@ -128,14 +112,14 @@ final class PosixAArch64VaListSnippets extends SubstrateTemplates implements Sni
     protected static double vaArgDoubleSnippet(Pointer vaList) {
         int fpOffset = vaList.readInt(FP_OFFSET_LOCATION);
         if (fpOffset < MAX_FP_OFFSET) {
-            Pointer regSaveArea = vaList.readWord(FP_TOP_LOCATION);
+            Pointer regSaveArea = vaList.readWord(REG_SAVE_AREA_LOCATION);
             double v = regSaveArea.readDouble(fpOffset);
-            vaList.writeInt(FP_OFFSET_LOCATION, fpOffset + 16); // 16-byte FP register
+            vaList.writeInt(FP_OFFSET_LOCATION, fpOffset + 16); // 16-byte XMM register
             return v;
         } else {
-            Pointer overflowArgArea = vaList.readWord(STACK_AREA_LOCATION);
+            Pointer overflowArgArea = vaList.readWord(OVERFLOW_ARG_AREA_LOCATION);
             double v = overflowArgArea.readDouble(0);
-            vaList.writeWord(STACK_AREA_LOCATION, overflowArgArea.add(STACK_AREA_FP_ALIGNMENT));
+            vaList.writeWord(OVERFLOW_ARG_AREA_LOCATION, overflowArgArea.add(OVERFLOW_ARG_AREA_ALIGNMENT));
             return v;
         }
     }
@@ -150,14 +134,14 @@ final class PosixAArch64VaListSnippets extends SubstrateTemplates implements Sni
     protected static long vaArgLongSnippet(Pointer vaList) {
         int gpOffset = vaList.readInt(GP_OFFSET_LOCATION);
         if (gpOffset < MAX_GP_OFFSET) {
-            Pointer regSaveArea = vaList.readWord(GP_TOP_LOCATION);
+            Pointer regSaveArea = vaList.readWord(REG_SAVE_AREA_LOCATION);
             long v = regSaveArea.readLong(gpOffset);
             vaList.writeInt(GP_OFFSET_LOCATION, gpOffset + 8);
             return v;
         } else {
-            Pointer overflowArgArea = vaList.readWord(STACK_AREA_LOCATION);
+            Pointer overflowArgArea = vaList.readWord(OVERFLOW_ARG_AREA_LOCATION);
             long v = overflowArgArea.readLong(0);
-            vaList.writeWord(STACK_AREA_LOCATION, overflowArgArea.add(STACK_AREA_GP_ALIGNMENT));
+            vaList.writeWord(OVERFLOW_ARG_AREA_LOCATION, overflowArgArea.add(OVERFLOW_ARG_AREA_ALIGNMENT));
             return v;
         }
     }
@@ -171,10 +155,10 @@ final class PosixAArch64VaListSnippets extends SubstrateTemplates implements Sni
     public static void registerLowerings(OptionValues options, Iterable<DebugHandlersFactory> factories, Providers providers,
                     SnippetReflectionProvider snippetReflection, Map<Class<? extends Node>, NodeLoweringProvider<?>> lowerings) {
 
-        new PosixAArch64VaListSnippets(options, factories, providers, snippetReflection, lowerings);
+        new PosixAMD64VaListSnippets(options, factories, providers, snippetReflection, lowerings);
     }
 
-    private PosixAArch64VaListSnippets(OptionValues options, Iterable<DebugHandlersFactory> factories, Providers providers,
+    private PosixAMD64VaListSnippets(OptionValues options, Iterable<DebugHandlersFactory> factories, Providers providers,
                     SnippetReflectionProvider snippetReflection, Map<Class<? extends Node>, NodeLoweringProvider<?>> lowerings) {
 
         super(options, factories, providers, snippetReflection);
@@ -183,10 +167,10 @@ final class PosixAArch64VaListSnippets extends SubstrateTemplates implements Sni
 
     protected class VaListSnippetsLowering implements NodeLoweringProvider<VaListNextArgNode> {
 
-        private final SnippetInfo vaArgDouble = snippet(PosixAArch64VaListSnippets.class, "vaArgDoubleSnippet");
-        private final SnippetInfo vaArgFloat = snippet(PosixAArch64VaListSnippets.class, "vaArgFloatSnippet");
-        private final SnippetInfo vaArgLong = snippet(PosixAArch64VaListSnippets.class, "vaArgLongSnippet");
-        private final SnippetInfo vaArgInt = snippet(PosixAArch64VaListSnippets.class, "vaArgIntSnippet");
+        private final SnippetInfo vaArgDouble = snippet(PosixAMD64VaListSnippets.class, "vaArgDoubleSnippet");
+        private final SnippetInfo vaArgFloat = snippet(PosixAMD64VaListSnippets.class, "vaArgFloatSnippet");
+        private final SnippetInfo vaArgLong = snippet(PosixAMD64VaListSnippets.class, "vaArgLongSnippet");
+        private final SnippetInfo vaArgInt = snippet(PosixAMD64VaListSnippets.class, "vaArgIntSnippet");
 
         @Override
         public void lower(VaListNextArgNode node, LoweringTool tool) {

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/NativeImageGenerator.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/NativeImageGenerator.java
@@ -51,7 +51,6 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.ForkJoinWorkerThread;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
@@ -174,14 +173,12 @@ import com.oracle.svm.core.graal.phases.MethodSafepointInsertionPhase;
 import com.oracle.svm.core.graal.phases.OptimizeExceptionCallsPhase;
 import com.oracle.svm.core.graal.phases.RemoveUnwindPhase;
 import com.oracle.svm.core.graal.phases.TrustedInterfaceTypePlugin;
-import com.oracle.svm.core.graal.snippets.ArithmeticSnippets;
 import com.oracle.svm.core.graal.snippets.DeoptHostedSnippets;
 import com.oracle.svm.core.graal.snippets.DeoptRuntimeSnippets;
 import com.oracle.svm.core.graal.snippets.DeoptTester;
 import com.oracle.svm.core.graal.snippets.ExceptionSnippets;
 import com.oracle.svm.core.graal.snippets.MonitorSnippets;
 import com.oracle.svm.core.graal.snippets.NodeLoweringProvider;
-import com.oracle.svm.core.graal.snippets.NonSnippetLowerings;
 import com.oracle.svm.core.graal.snippets.TypeSnippets;
 import com.oracle.svm.core.graal.stackvalue.StackValueNode;
 import com.oracle.svm.core.graal.stackvalue.StackValuePhase;
@@ -1191,15 +1188,8 @@ public class NativeImageGenerator {
             SubstrateLoweringProvider lowerer = (SubstrateLoweringProvider) providers.getLowerer();
             Map<Class<? extends Node>, NodeLoweringProvider<?>> lowerings = lowerer.getLowerings();
 
-            Predicate<ResolvedJavaMethod> mustNotAllocatePredicate = null;
-            if (hosted) {
-                mustNotAllocatePredicate = method -> ImageSingletons.lookup(RestrictHeapAccessCallees.class).mustNotAllocate(method);
-            }
-
             Iterable<DebugHandlersFactory> factories = runtimeConfig != null ? runtimeConfig.getDebugHandlersFactories() : Collections.singletonList(new GraalDebugHandlersFactory(snippetReflection));
             lowerer.setConfiguration(runtimeConfig, options, factories, providers, snippetReflection);
-            NonSnippetLowerings.registerLowerings(runtimeConfig, mustNotAllocatePredicate, options, factories, providers, snippetReflection, lowerings);
-            ArithmeticSnippets.registerLowerings(options, factories, providers, snippetReflection, lowerings);
             MonitorSnippets.registerLowerings(options, factories, providers, snippetReflection, lowerings);
             TypeSnippets.registerLowerings(runtimeConfig, options, factories, providers, snippetReflection, lowerings);
             ExceptionSnippets.registerLowerings(options, factories, providers, snippetReflection, lowerings);


### PR DESCRIPTION
Before there was not a proper separation of between AMD64 and AArch64 specific
lowerings.

Refactored architecture-specific functionality into separate classes.
Also added proper AArch64 RemNode lowering support, and removed
AMD64-specific FloatConvertNode and AMD64ArrayIndexOfDispatchNode
lowering from AArch64 path.

Change-Id: I322dc97c8d9ce9fb521c53304400a6e29f5da6fe