### PR TITLE
[checkstyle] Move LineLengthCheck outside of TreeWalker

### DIFF
--- a/compiler/src/org.graalvm.compiler.graph/.checkstyle_checks.xml
+++ b/compiler/src/org.graalvm.compiler.graph/.checkstyle_checks.xml
@@ -32,9 +32,6 @@
     </module>
     <module name="RedundantImport"/>
     <module name="UnusedImports"/>
-    <module name="LineLength">
-      <property name="max" value="250"/>
-    </module>
     <module name="MethodParamPad"/>
     <module name="NoWhitespaceAfter">
       <property name="tokens" value="ARRAY_INIT,BNOT,DEC,DOT,INC,LNOT,UNARY_MINUS,UNARY_PLUS"/>
@@ -233,6 +230,9 @@
       <property name="illegalPattern" value="true"/>
       <property name="message" value="Single year shouldn't be duplicated"/>
     </module>
+  </module>
+  <module name="LineLength">
+    <property name="max" value="250"/>
   </module>
   <module name="RegexpHeader">
     <property name="header" value="/\*\n \* Copyright \(c\) (20[0-9][0-9], )?20[0-9][0-9], Oracle and/or its affiliates\. All rights reserved\.\n \* Copyright \(c\) (20[0-9][0-9], )?20[0-9][0-9], .*\. All rights reserved\.\n \* Intel Math Library \(LIBM\) Source Code\n \* DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER\.\n \*\n \* This code is free software; you can redistribute it and/or modify it\n \* under the terms of the GNU General Public License version 2 only, as\n \* published by the Free Software Foundation\.  Oracle designates this\n \* particular file as subject to the &quot;Classpath&quot; exception as provided\n \* by Oracle in the LICENSE file that accompanied this code.\n \*\n \* This code is distributed in the hope that it will be useful, but WITHOUT\n \* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or\n \* FITNESS FOR A PARTICULAR PURPOSE\.  See the GNU General Public License\n \* version 2 for more details \(a copy is included in the LICENSE file that\n \* accompanied this code\)\.\n \*\n \* You should have received a copy of the GNU General Public License version\n \* 2 along with this work; if not, write to the Free Software Foundation,\n \* Inc\., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA\.\n \*\n \* Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA\n \* or visit www\.oracle\.com if you need additional information or have any\n \* questions\.\n \*/\n"/>

--- a/regex/src/com.oracle.truffle.regex/.checkstyle_checks.xml
+++ b/regex/src/com.oracle.truffle.regex/.checkstyle_checks.xml
@@ -30,9 +30,6 @@
     </module>
     <module name="RedundantImport"/>
     <module name="UnusedImports"/>
-    <module name="LineLength">
-      <property name="max" value="250"/>
-    </module>
     <module name="MethodParamPad"/>
     <module name="NoWhitespaceAfter">
       <property name="tokens" value="ARRAY_INIT,BNOT,DEC,DOT,INC,LNOT,UNARY_MINUS,UNARY_PLUS"/>
@@ -179,6 +176,9 @@
       <property name="onCommentFormat" value="CheckStyle: stop generated"/>
       <property name="checkFormat" value=".*Name|.*LineLength|.*Header"/>
     </module>
+  </module>
+  <module name="LineLength">
+    <property name="max" value="250"/>
   </module>
   <module name="RegexpHeader">
     <property name="header" value="/\*\n \* Copyright \(c\) (?:(20[0-9][0-9]), )?(20[0-9][0-9]), Oracle and/or its affiliates\. All rights reserved\.\n \* DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER\.\n \*\n \* The Universal Permissive License \(UPL\), Version 1\.0\n \*\n \* Subject to the condition set forth below, permission is hereby granted to any\n \* person obtaining a copy of this software, associated documentation and/or\n \* data \(collectively the &quot;Software&quot;\), free of charge and under any and all\n \* copyright rights in the Software, and any and all patent rights owned or\n \* freely licensable by each licensor hereunder covering either \(i\) the\n \* unmodified Software as contributed to or provided by such licensor, or \(ii\)\n \* the Larger Works \(as defined below\), to deal in both\n \*\n \* \(a\) the Software, and\n \*\n \* \(b\) any piece of software and/or hardware listed in the lrgrwrks\.txt file if\n \* one is included with the Software each a &quot;Larger Work&quot; to which the Software\n \* is contributed by such licensors\),\n \*\n \* without restriction, including without limitation the rights to copy, create\n \* derivative works of, display, perform, and distribute the Software and make,\n \* use, sell, offer for sale, import, export, have made, and have sold the\n \* Software and the Larger Work\(s\), and to sublicense the foregoing rights on\n \* either these or other terms\.\n \*\n \* This license is subject to the following condition:\n \*\n \* The above copyright notice and either this complete permission notice or at a\n \* minimum a reference to the UPL must be included in all copies or substantial\n \* portions of the Software\.\n \*\n \* THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR\n \* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,\n \* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT\. IN NO EVENT SHALL THE\n \* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER\n \* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,\n \* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE\n \* SOFTWARE\.\n \*/\n"/>

--- a/sdk/src/org.graalvm.word/.checkstyle_checks.xml
+++ b/sdk/src/org.graalvm.word/.checkstyle_checks.xml
@@ -32,9 +32,6 @@
     </module>
     <module name="RedundantImport"/>
     <module name="UnusedImports"/>
-    <module name="LineLength">
-      <property name="max" value="250"/>
-    </module>
     <module name="MethodParamPad"/>
     <module name="NoWhitespaceAfter">
       <property name="tokens" value="ARRAY_INIT,BNOT,DEC,DOT,INC,LNOT,UNARY_MINUS,UNARY_PLUS"/>
@@ -229,6 +226,9 @@
       <property name="illegalPattern" value="true"/>
       <property name="message" value="Single year shouldn't be duplicated"/>
     </module>
+  </module>
+  <module name="LineLength">
+    <property name="max" value="250"/>
   </module>
   <module name="RegexpHeader">
     <property name="header" value="/\*\n \* Copyright \(c\) (?:(20[0-9][0-9]), )?(20[0-9][0-9]), Oracle and/or its affiliates\. All rights reserved\.\n \* DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER\.\n \*\n \* The Universal Permissive License \(UPL\), Version 1\.0\n \*\n \* Subject to the condition set forth below, permission is hereby granted to any\n \* person obtaining a copy of this software, associated documentation and/or\n \* data \(collectively the &quot;Software&quot;\), free of charge and under any and all\n \* copyright rights in the Software, and any and all patent rights owned or\n \* freely licensable by each licensor hereunder covering either \(i\) the\n \* unmodified Software as contributed to or provided by such licensor, or \(ii\)\n \* the Larger Works \(as defined below\), to deal in both\n \*\n \* \(a\) the Software, and\n \*\n \* \(b\) any piece of software and/or hardware listed in the lrgrwrks\.txt file if\n \* one is included with the Software each a &quot;Larger Work&quot; to which the Software\n \* is contributed by such licensors\),\n \*\n \* without restriction, including without limitation the rights to copy, create\n \* derivative works of, display, perform, and distribute the Software and make,\n \* use, sell, offer for sale, import, export, have made, and have sold the\n \* Software and the Larger Work\(s\), and to sublicense the foregoing rights on\n \* either these or other terms\.\n \*\n \* This license is subject to the following condition:\n \*\n \* The above copyright notice and either this complete permission notice or at a\n \* minimum a reference to the UPL must be included in all copies or substantial\n \* portions of the Software\.\n \*\n \* THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR\n \* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,\n \* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT\. IN NO EVENT SHALL THE\n \* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER\n \* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,\n \* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE\n \* SOFTWARE\.\n \*/\n"/>

--- a/substratevm/src/com.oracle.graal.pointsto/.checkstyle_checks.xml
+++ b/substratevm/src/com.oracle.graal.pointsto/.checkstyle_checks.xml
@@ -51,9 +51,6 @@
     </module>
     <module name="RedundantImport"/>
     <module name="UnusedImports"/>
-    <module name="LineLength">
-      <property name="max" value="250"/>
-    </module>
     <module name="MethodParamPad"/>
     <module name="NoWhitespaceAfter">
       <property name="tokens" value="ARRAY_INIT,BNOT,DEC,DOT,INC,LNOT,UNARY_MINUS,UNARY_PLUS"/>
@@ -225,6 +222,9 @@
       <property name="onCommentFormat" value="Checkstyle: disallow synchronization"/>
       <property name="checkFormat" value="IllegalToken"/>
     </module>
+  </module>
+  <module name="LineLength">
+    <property name="max" value="250"/>
   </module>
   <module name="RegexpHeader">
     <property name="header" value="/\*\n \* Copyright \(c\) 20[0-9][0-9], 20[0-9][0-9], Oracle and/or its affiliates\. All rights reserved\.\n \* DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER\.\n \*\n \* This code is free software; you can redistribute it and/or modify it\n \* under the terms of the GNU General Public License version 2 only, as\n \* published by the Free Software Foundation\.  Oracle designates this\n \* particular file as subject to the &quot;Classpath&quot; exception as provided\n \* by Oracle in the LICENSE file that accompanied this code.\n \*\n \* This code is distributed in the hope that it will be useful, but WITHOUT\n \* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or\n \* FITNESS FOR A PARTICULAR PURPOSE\.  See the GNU General Public License\n \* version 2 for more details \(a copy is included in the LICENSE file that\n \* accompanied this code\)\.\n \*\n \* You should have received a copy of the GNU General Public License version\n \* 2 along with this work; if not, write to the Free Software Foundation,\n \* Inc\., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA\.\n \*\n \* Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA\n \* or visit www\.oracle\.com if you need additional information or have any\n \* questions\.\n \*/\n"/>

--- a/substratevm/src/com.oracle.svm.core/.checkstyle_checks.xml
+++ b/substratevm/src/com.oracle.svm.core/.checkstyle_checks.xml
@@ -52,9 +52,6 @@
     </module>
     <module name="RedundantImport"/>
     <module name="UnusedImports"/>
-    <module name="LineLength">
-      <property name="max" value="250"/>
-    </module>
     <module name="MethodParamPad"/>
     <module name="NoWhitespaceAfter">
       <property name="tokens" value="ARRAY_INIT,BNOT,DEC,DOT,INC,LNOT,UNARY_MINUS,UNARY_PLUS"/>
@@ -264,6 +261,9 @@
       <property name="onCommentFormat" value="Checkstyle: disallow synchronization"/>
       <property name="checkFormat" value="IllegalToken"/>
     </module>
+  </module>
+  <module name="LineLength">
+    <property name="max" value="250"/>
   </module>
   <module name="RegexpHeader">
     <property name="header" value="/\*\n \* Copyright \(c\) 20[0-9][0-9], 20[0-9][0-9], Oracle and/or its affiliates\. All rights reserved\.\n \* DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER\.\n \*\n \* This code is free software; you can redistribute it and/or modify it\n \* under the terms of the GNU General Public License version 2 only, as\n \* published by the Free Software Foundation\.  Oracle designates this\n \* particular file as subject to the &quot;Classpath&quot; exception as provided\n \* by Oracle in the LICENSE file that accompanied this code.\n \*\n \* This code is distributed in the hope that it will be useful, but WITHOUT\n \* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or\n \* FITNESS FOR A PARTICULAR PURPOSE\.  See the GNU General Public License\n \* version 2 for more details \(a copy is included in the LICENSE file that\n \* accompanied this code\)\.\n \*\n \* You should have received a copy of the GNU General Public License version\n \* 2 along with this work; if not, write to the Free Software Foundation,\n \* Inc\., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA\.\n \*\n \* Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA\n \* or visit www\.oracle\.com if you need additional information or have any\n \* questions\.\n \*/\n"/>

--- a/substratevm/src/com.oracle.svm.driver/.checkstyle_checks.xml
+++ b/substratevm/src/com.oracle.svm.driver/.checkstyle_checks.xml
@@ -32,9 +32,6 @@
     </module>
     <module name="RedundantImport"/>
     <module name="UnusedImports"/>
-    <module name="LineLength">
-      <property name="max" value="250"/>
-    </module>
     <module name="MethodParamPad"/>
     <module name="NoWhitespaceAfter">
       <property name="tokens" value="ARRAY_INIT,BNOT,DEC,DOT,INC,LNOT,UNARY_MINUS,UNARY_PLUS"/>
@@ -206,6 +203,9 @@
       <property name="onCommentFormat" value="Checkstyle: disallow synchronization"/>
       <property name="checkFormat" value="IllegalToken"/>
     </module>
+  </module>
+  <module name="LineLength">
+    <property name="max" value="250"/>
   </module>
   <module name="RegexpHeader">
     <property name="header" value="/\*\n \* Copyright \(c\) 20[0-9][0-9], 20[0-9][0-9], Oracle and/or its affiliates\. All rights reserved\.\n \* DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER\.\n \*\n \* This code is free software; you can redistribute it and/or modify it\n \* under the terms of the GNU General Public License version 2 only, as\n \* published by the Free Software Foundation\.  Oracle designates this\n \* particular file as subject to the &quot;Classpath&quot; exception as provided\n \* by Oracle in the LICENSE file that accompanied this code.\n \*\n \* This code is distributed in the hope that it will be useful, but WITHOUT\n \* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or\n \* FITNESS FOR A PARTICULAR PURPOSE\.  See the GNU General Public License\n \* version 2 for more details \(a copy is included in the LICENSE file that\n \* accompanied this code\)\.\n \*\n \* You should have received a copy of the GNU General Public License version\n \* 2 along with this work; if not, write to the Free Software Foundation,\n \* Inc\., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA\.\n \*\n \* Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA\n \* or visit www\.oracle\.com if you need additional information or have any\n \* questions\.\n \*/\n"/>

--- a/substratevm/src/com.oracle.svm.hosted/.checkstyle_checks.xml
+++ b/substratevm/src/com.oracle.svm.hosted/.checkstyle_checks.xml
@@ -32,9 +32,6 @@
     </module>
     <module name="RedundantImport"/>
     <module name="UnusedImports"/>
-    <module name="LineLength">
-      <property name="max" value="250"/>
-    </module>
     <module name="MethodParamPad"/>
     <module name="NoWhitespaceAfter">
       <property name="tokens" value="ARRAY_INIT,BNOT,DEC,DOT,INC,LNOT,UNARY_MINUS,UNARY_PLUS"/>
@@ -206,6 +203,9 @@
       <property name="onCommentFormat" value="Checkstyle: disallow synchronization"/>
       <property name="checkFormat" value="IllegalToken"/>
     </module>
+  </module>
+  <module name="LineLength">
+    <property name="max" value="250"/>
   </module>
   <module name="RegexpHeader">
     <property name="header" value="/\*\n \* Copyright \(c\) 20[0-9][0-9], 20[0-9][0-9], Oracle and/or its affiliates\. All rights reserved\.\n \* DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER\.\n \*\n \* This code is free software; you can redistribute it and/or modify it\n \* under the terms of the GNU General Public License version 2 only, as\n \* published by the Free Software Foundation\.  Oracle designates this\n \* particular file as subject to the &quot;Classpath&quot; exception as provided\n \* by Oracle in the LICENSE file that accompanied this code.\n \*\n \* This code is distributed in the hope that it will be useful, but WITHOUT\n \* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or\n \* FITNESS FOR A PARTICULAR PURPOSE\.  See the GNU General Public License\n \* version 2 for more details \(a copy is included in the LICENSE file that\n \* accompanied this code\)\.\n \*\n \* You should have received a copy of the GNU General Public License version\n \* 2 along with this work; if not, write to the Free Software Foundation,\n \* Inc\., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA\.\n \*\n \* Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA\n \* or visit www\.oracle\.com if you need additional information or have any\n \* questions\.\n \*/\n"/>

--- a/substratevm/src/com.oracle.svm.truffle/.checkstyle_checks.xml
+++ b/substratevm/src/com.oracle.svm.truffle/.checkstyle_checks.xml
@@ -32,9 +32,6 @@
     </module>
     <module name="RedundantImport"/>
     <module name="UnusedImports"/>
-    <module name="LineLength">
-      <property name="max" value="250"/>
-    </module>
     <module name="MethodParamPad"/>
     <module name="NoWhitespaceAfter">
       <property name="tokens" value="ARRAY_INIT,BNOT,DEC,DOT,INC,LNOT,UNARY_MINUS,UNARY_PLUS"/>
@@ -230,6 +227,9 @@
       <property name="onCommentFormat" value="Checkstyle: disallow synchronization"/>
       <property name="checkFormat" value="IllegalToken"/>
     </module>
+  </module>
+  <module name="LineLength">
+    <property name="max" value="250"/>
   </module>
   <module name="RegexpHeader">
     <property name="header" value="/\*\n \* Copyright \(c\) 20[0-9][0-9], 20[0-9][0-9], Oracle and/or its affiliates\. All rights reserved\.\n \* DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER\.\n \*\n \* This code is free software; you can redistribute it and/or modify it\n \* under the terms of the GNU General Public License version 2 only, as\n \* published by the Free Software Foundation\.  Oracle designates this\n \* particular file as subject to the &quot;Classpath&quot; exception as provided\n \* by Oracle in the LICENSE file that accompanied this code.\n \*\n \* This code is distributed in the hope that it will be useful, but WITHOUT\n \* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or\n \* FITNESS FOR A PARTICULAR PURPOSE\.  See the GNU General Public License\n \* version 2 for more details \(a copy is included in the LICENSE file that\n \* accompanied this code\)\.\n \*\n \* You should have received a copy of the GNU General Public License version\n \* 2 along with this work; if not, write to the Free Software Foundation,\n \* Inc\., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA\.\n \*\n \* Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA\n \* or visit www\.oracle\.com if you need additional information or have any\n \* questions\.\n \*/\n"/>

--- a/substratevm/src/org.graalvm.polyglot.nativeapi/.checkstyle_checks.xml
+++ b/substratevm/src/org.graalvm.polyglot.nativeapi/.checkstyle_checks.xml
@@ -30,9 +30,6 @@
     </module>
     <module name="RedundantImport"/>
     <module name="UnusedImports"/>
-    <module name="LineLength">
-      <property name="max" value="250"/>
-    </module>
     <module name="MethodParamPad"/>
     <module name="NoWhitespaceAfter">
       <property name="tokens" value="ARRAY_INIT,BNOT,DEC,DOT,INC,LNOT,UNARY_MINUS,UNARY_PLUS"/>
@@ -242,6 +239,9 @@
       <property name="onCommentFormat" value="Checkstyle: disallow synchronization"/>
       <property name="checkFormat" value="IllegalToken"/>
     </module>
+  </module>
+  <module name="LineLength">
+    <property name="max" value="250"/>
   </module>
   <module name="RegexpHeader">
     <property name="header" value="/\*\n \* Copyright \(c\) 20[0-9][0-9], 20[0-9][0-9], Oracle and/or its affiliates\. All rights reserved\.\n \* DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER\.\n \*\n \* This code is free software; you can redistribute it and/or modify it\n \* under the terms of the GNU General Public License version 2 only, as\n \* published by the Free Software Foundation\.  Oracle designates this\n \* particular file as subject to the &quot;Classpath&quot; exception as provided\n \* by Oracle in the LICENSE file that accompanied this code.\n \*\n \* This code is distributed in the hope that it will be useful, but WITHOUT\n \* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or\n \* FITNESS FOR A PARTICULAR PURPOSE\.  See the GNU General Public License\n \* version 2 for more details \(a copy is included in the LICENSE file that\n \* accompanied this code\)\.\n \*\n \* You should have received a copy of the GNU General Public License version\n \* 2 along with this work; if not, write to the Free Software Foundation,\n \* Inc\., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA\.\n \*\n \* Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA\n \* or visit www\.oracle\.com if you need additional information or have any\n \* questions\.\n \*/\n"/>

--- a/sulong/projects/com.oracle.truffle.llvm.runtime/.checkstyle_checks.xml
+++ b/sulong/projects/com.oracle.truffle.llvm.runtime/.checkstyle_checks.xml
@@ -42,9 +42,6 @@
     </module>
     <module name="RedundantImport"/>
     <module name="UnusedImports"/>
-    <module name="LineLength">
-      <property name="max" value="250"/>
-    </module>
     <module name="MethodParamPad"/>
     <module name="NoWhitespaceAfter">
       <property name="tokens" value="ARRAY_INIT,BNOT,DEC,DOT,INC,LNOT,UNARY_MINUS,UNARY_PLUS"/>
@@ -200,6 +197,9 @@
       <property name="onCommentFormat" value="CheckStyle: stop generated"/>
       <property name="checkFormat" value=".*Name|.*LineLength|.*Header"/>
     </module>
+  </module>
+  <module name="LineLength">
+    <property name="max" value="250"/>
   </module>
   <module name="RegexpHeader">
     <property name="header" value="/\*\n \* Copyright \(c\) (20[1-9][0-9], )?20[1-9][0-9], Oracle and/or its affiliates\.\n \*\n \* All rights reserved\.\n \*\n \* Redistribution and use in source and binary forms, with or without modification, are\n \* permitted provided that the following conditions are met:\n \*\n \* 1\. Redistributions of source code must retain the above copyright notice, this list of\n \* conditions and the following disclaimer\.\n \*\n \* 2\. Redistributions in binary form must reproduce the above copyright notice, this list of\n \* conditions and the following disclaimer in the documentation and/or other materials provided\n \* with the distribution\.\n \*\n \* 3\. Neither the name of the copyright holder nor the names of its contributors may be used to\n \* endorse or promote products derived from this software without specific prior written\n \* permission\.\n \*\n \* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS &quot;AS IS&quot; AND ANY EXPRESS\n \* OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF\n \* MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED\. IN NO EVENT SHALL THE\n \* COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,\n \* EXEMPLARY, OR CONSEQUENTIAL DAMAGES \(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE\n \* GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION\) HOWEVER CAUSED\n \* AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT \(INCLUDING\n \* NEGLIGENCE OR OTHERWISE\) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED\n \* OF THE POSSIBILITY OF SUCH DAMAGE\.\n \*/"/>

--- a/tools/src/com.oracle.truffle.tools.chromeinspector/.checkstyle_checks.xml
+++ b/tools/src/com.oracle.truffle.tools.chromeinspector/.checkstyle_checks.xml
@@ -34,9 +34,6 @@
     </module>
     <module name="RedundantImport"/>
     <module name="UnusedImports"/>
-    <module name="LineLength">
-      <property name="max" value="250"/>
-    </module>
     <module name="MethodParamPad"/>
     <module name="NoWhitespaceAfter">
       <property name="tokens" value="ARRAY_INIT,BNOT,DEC,DOT,INC,LNOT,UNARY_MINUS,UNARY_PLUS"/>
@@ -198,6 +195,9 @@
       <property name="onCommentFormat" value="CheckStyle: stop generated"/>
       <property name="checkFormat" value=".*Name|.*LineLength|.*Header"/>
     </module>
+  </module>
+  <module name="LineLength">
+    <property name="max" value="250"/>
   </module>
   <module name="RegexpHeader">
     <property name="header" value="/\*\n \* Copyright \(c\) (20[0-9][0-9], )?20[0-9][0-9], Oracle and/or its affiliates. All rights reserved.\n \* DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.\n \*\n \* This code is free software; you can redistribute it and/or modify it\n \* under the terms of the GNU General Public License version 2 only, as\n \* published by the Free Software Foundation.  Oracle designates this\n \* particular file as subject to the &quot;Classpath&quot; exception as provided\n \* by Oracle in the LICENSE file that accompanied this code.\n \*\n \* This code is distributed in the hope that it will be useful, but WITHOUT\n \* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or\n \* FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License\n \* version 2 for more details \(a copy is included in the LICENSE file that\n \* accompanied this code\).\n \*\n \* You should have received a copy of the GNU General Public License version\n \* 2 along with this work; if not, write to the Free Software Foundation,\n \* Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.\n \*\n \* Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA\n \* or visit www.oracle.com if you need additional information or have any\n \* questions.\n \*/\n"/>

--- a/truffle/src/com.oracle.truffle.api/.checkstyle_checks.xml
+++ b/truffle/src/com.oracle.truffle.api/.checkstyle_checks.xml
@@ -38,9 +38,6 @@
     </module>
     <module name="RedundantImport"/>
     <module name="UnusedImports"/>
-    <module name="LineLength">
-      <property name="max" value="250"/>
-    </module>
     <module name="MethodParamPad"/>
     <module name="NoWhitespaceAfter">
       <property name="tokens" value="ARRAY_INIT,BNOT,DEC,DOT,INC,LNOT,UNARY_MINUS,UNARY_PLUS"/>
@@ -197,6 +194,9 @@
       <property name="onCommentFormat" value="CheckStyle: stop generated"/>
       <property name="checkFormat" value=".*Name|.*LineLength|.*Header"/>
     </module>
+  </module>
+  <module name="LineLength">
+    <property name="max" value="250"/>
   </module>
   <module name="RegexpHeader">
     <property name="header" value="/\*\n \* Copyright \(c\) (?:(20[0-9][0-9]), )?(20[0-9][0-9]), Oracle and/or its affiliates\. All rights reserved\.\n \* DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER\.\n \*\n \* The Universal Permissive License \(UPL\), Version 1\.0\n \*\n \* Subject to the condition set forth below, permission is hereby granted to any\n \* person obtaining a copy of this software, associated documentation and/or\n \* data \(collectively the &quot;Software&quot;\), free of charge and under any and all\n \* copyright rights in the Software, and any and all patent rights owned or\n \* freely licensable by each licensor hereunder covering either \(i\) the\n \* unmodified Software as contributed to or provided by such licensor, or \(ii\)\n \* the Larger Works \(as defined below\), to deal in both\n \*\n \* \(a\) the Software, and\n \*\n \* \(b\) any piece of software and/or hardware listed in the lrgrwrks\.txt file if\n \* one is included with the Software each a &quot;Larger Work&quot; to which the Software\n \* is contributed by such licensors\),\n \*\n \* without restriction, including without limitation the rights to copy, create\n \* derivative works of, display, perform, and distribute the Software and make,\n \* use, sell, offer for sale, import, export, have made, and have sold the\n \* Software and the Larger Work\(s\), and to sublicense the foregoing rights on\n \* either these or other terms\.\n \*\n \* This license is subject to the following condition:\n \*\n \* The above copyright notice and either this complete permission notice or at a\n \* minimum a reference to the UPL must be included in all copies or substantial\n \* portions of the Software\.\n \*\n \* THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR\n \* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,\n \* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT\. IN NO EVENT SHALL THE\n \* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER\n \* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,\n \* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE\n \* SOFTWARE\.\n \*/\n"/>

--- a/truffle/src/com.oracle.truffle.dsl.processor/.checkstyle_checks.xml
+++ b/truffle/src/com.oracle.truffle.dsl.processor/.checkstyle_checks.xml
@@ -36,9 +36,6 @@
     </module>
     <module name="RedundantImport"/>
     <module name="UnusedImports"/>
-    <module name="LineLength">
-      <property name="max" value="250"/>
-    </module>
     <module name="MethodParamPad"/>
     <module name="NoWhitespaceAfter">
       <property name="tokens" value="ARRAY_INIT,BNOT,DEC,DOT,INC,LNOT,UNARY_MINUS,UNARY_PLUS"/>
@@ -194,6 +191,9 @@
       <property name="onCommentFormat" value="CheckStyle: stop generated"/>
       <property name="checkFormat" value=".*Name|.*LineLength|.*Header"/>
     </module>
+  </module>
+  <module name="LineLength">
+    <property name="max" value="250"/>
   </module>
   <module name="RegexpHeader">
     <property name="header" value="/\*\n \* Copyright \(c\) (?:(20[0-9][0-9]), )?(20[0-9][0-9]), Oracle and/or its affiliates\. All rights reserved\.\n \* DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER\.\n \*\n \* The Universal Permissive License \(UPL\), Version 1\.0\n \*\n \* Subject to the condition set forth below, permission is hereby granted to any\n \* person obtaining a copy of this software, associated documentation and/or\n \* data \(collectively the &quot;Software&quot;\), free of charge and under any and all\n \* copyright rights in the Software, and any and all patent rights owned or\n \* freely licensable by each licensor hereunder covering either \(i\) the\n \* unmodified Software as contributed to or provided by such licensor, or \(ii\)\n \* the Larger Works \(as defined below\), to deal in both\n \*\n \* \(a\) the Software, and\n \*\n \* \(b\) any piece of software and/or hardware listed in the lrgrwrks\.txt file if\n \* one is included with the Software each a &quot;Larger Work&quot; to which the Software\n \* is contributed by such licensors\),\n \*\n \* without restriction, including without limitation the rights to copy, create\n \* derivative works of, display, perform, and distribute the Software and make,\n \* use, sell, offer for sale, import, export, have made, and have sold the\n \* Software and the Larger Work\(s\), and to sublicense the foregoing rights on\n \* either these or other terms\.\n \*\n \* This license is subject to the following condition:\n \*\n \* The above copyright notice and either this complete permission notice or at a\n \* minimum a reference to the UPL must be included in all copies or substantial\n \* portions of the Software\.\n \*\n \* THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR\n \* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,\n \* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT\. IN NO EVENT SHALL THE\n \* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER\n \* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,\n \* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE\n \* SOFTWARE\.\n \*/\n"/>

--- a/truffle/src/com.oracle.truffle.sl/.checkstyle_checks.xml
+++ b/truffle/src/com.oracle.truffle.sl/.checkstyle_checks.xml
@@ -36,9 +36,6 @@
     </module>
     <module name="RedundantImport"/>
     <module name="UnusedImports"/>
-    <module name="LineLength">
-      <property name="max" value="250"/>
-    </module>
     <module name="MethodParamPad"/>
     <module name="NoWhitespaceAfter">
       <property name="tokens" value="ARRAY_INIT,BNOT,DEC,DOT,INC,LNOT,UNARY_MINUS,UNARY_PLUS"/>
@@ -196,6 +193,9 @@
       <property name="onCommentFormat" value="CheckStyle: stop generated"/>
       <property name="checkFormat" value=".*Name|.*LineLength|.*Header"/>
     </module>
+  </module>
+  <module name="LineLength">
+    <property name="max" value="250"/>
   </module>
   <module name="RegexpHeader">
     <property name="header" value="/\*\n \* Copyright \(c\) (?:(20[0-9][0-9]), )?(20[0-9][0-9]), Oracle and/or its affiliates\. All rights reserved\.\n \* DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER\.\n \*\n \* The Universal Permissive License \(UPL\), Version 1\.0\n \*\n \* Subject to the condition set forth below, permission is hereby granted to any\n \* person obtaining a copy of this software, associated documentation and/or\n \* data \(collectively the &quot;Software&quot;\), free of charge and under any and all\n \* copyright rights in the Software, and any and all patent rights owned or\n \* freely licensable by each licensor hereunder covering either \(i\) the\n \* unmodified Software as contributed to or provided by such licensor, or \(ii\)\n \* the Larger Works \(as defined below\), to deal in both\n \*\n \* \(a\) the Software, and\n \*\n \* \(b\) any piece of software and/or hardware listed in the lrgrwrks\.txt file if\n \* one is included with the Software each a &quot;Larger Work&quot; to which the Software\n \* is contributed by such licensors\),\n \*\n \* without restriction, including without limitation the rights to copy, create\n \* derivative works of, display, perform, and distribute the Software and make,\n \* use, sell, offer for sale, import, export, have made, and have sold the\n \* Software and the Larger Work\(s\), and to sublicense the foregoing rights on\n \* either these or other terms\.\n \*\n \* This license is subject to the following condition:\n \*\n \* The above copyright notice and either this complete permission notice or at a\n \* minimum a reference to the UPL must be included in all copies or substantial\n \* portions of the Software\.\n \*\n \* THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR\n \* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,\n \* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT\. IN NO EVENT SHALL THE\n \* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER\n \* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,\n \* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE\n \* SOFTWARE\.\n \*/\n"/>

--- a/truffle/src/com.oracle.truffle.st.test/.checkstyle_checks.xml
+++ b/truffle/src/com.oracle.truffle.st.test/.checkstyle_checks.xml
@@ -36,9 +36,6 @@
     </module>
     <module name="RedundantImport"/>
     <module name="UnusedImports"/>
-    <module name="LineLength">
-      <property name="max" value="250"/>
-    </module>
     <module name="MethodParamPad"/>
     <module name="NoWhitespaceAfter">
       <property name="tokens" value="ARRAY_INIT,BNOT,DEC,DOT,INC,LNOT,UNARY_MINUS,UNARY_PLUS"/>
@@ -196,6 +193,9 @@
       <property name="onCommentFormat" value="CheckStyle: stop generated"/>
       <property name="checkFormat" value=".*Name|.*LineLength|.*Header"/>
     </module>
+  </module>
+  <module name="LineLength">
+    <property name="max" value="250"/>
   </module>
   <module name="RegexpHeader">
     <property name="header" value="/\*\n \* Copyright \(c\) (?:(20[0-9][0-9]), )?(20[0-9][0-9]), Oracle and/or its affiliates\. All rights reserved\.\n \* DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER\.\n \*\n \* The Universal Permissive License \(UPL\), Version 1\.0\n \*\n \* Subject to the condition set forth below, permission is hereby granted to any\n \* person obtaining a copy of this software, associated documentation and/or\n \* data \(collectively the &quot;Software&quot;\), free of charge and under any and all\n \* copyright rights in the Software, and any and all patent rights owned or\n \* freely licensable by each licensor hereunder covering either \(i\) the\n \* unmodified Software as contributed to or provided by such licensor, or \(ii\)\n \* the Larger Works \(as defined below\), to deal in both\n \*\n \* \(a\) the Software, and\n \*\n \* \(b\) any piece of software and/or hardware listed in the lrgrwrks\.txt file if\n \* one is included with the Software each a &quot;Larger Work&quot; to which the Software\n \* is contributed by such licensors\),\n \*\n \* without restriction, including without limitation the rights to copy, create\n \* derivative works of, display, perform, and distribute the Software and make,\n \* use, sell, offer for sale, import, export, have made, and have sold the\n \* Software and the Larger Work\(s\), and to sublicense the foregoing rights on\n \* either these or other terms\.\n \*\n \* This license is subject to the following condition:\n \*\n \* The above copyright notice and either this complete permission notice or at a\n \* minimum a reference to the UPL must be included in all copies or substantial\n \* portions of the Software\.\n \*\n \* THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR\n \* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,\n \* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT\. IN NO EVENT SHALL THE\n \* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER\n \* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,\n \* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE\n \* SOFTWARE\.\n \*/\n"/>

--- a/truffle/src/com.oracle.truffle.st/.checkstyle_checks.xml
+++ b/truffle/src/com.oracle.truffle.st/.checkstyle_checks.xml
@@ -36,9 +36,6 @@
     </module>
     <module name="RedundantImport"/>
     <module name="UnusedImports"/>
-    <module name="LineLength">
-      <property name="max" value="250"/>
-    </module>
     <module name="MethodParamPad"/>
     <module name="NoWhitespaceAfter">
       <property name="tokens" value="ARRAY_INIT,BNOT,DEC,DOT,INC,LNOT,UNARY_MINUS,UNARY_PLUS"/>
@@ -196,6 +193,9 @@
       <property name="onCommentFormat" value="CheckStyle: stop generated"/>
       <property name="checkFormat" value=".*Name|.*LineLength|.*Header"/>
     </module>
+  </module>
+  <module name="LineLength">
+    <property name="max" value="250"/>
   </module>
   <module name="RegexpHeader">
     <property name="header" value="/\*\n \* Copyright \(c\) (?:(20[0-9][0-9]), )?(20[0-9][0-9]), Oracle and/or its affiliates\. All rights reserved\.\n \* DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER\.\n \*\n \* The Universal Permissive License \(UPL\), Version 1\.0\n \*\n \* Subject to the condition set forth below, permission is hereby granted to any\n \* person obtaining a copy of this software, associated documentation and/or\n \* data \(collectively the &quot;Software&quot;\), free of charge and under any and all\n \* copyright rights in the Software, and any and all patent rights owned or\n \* freely licensable by each licensor hereunder covering either \(i\) the\n \* unmodified Software as contributed to or provided by such licensor, or \(ii\)\n \* the Larger Works \(as defined below\), to deal in both\n \*\n \* \(a\) the Software, and\n \*\n \* \(b\) any piece of software and/or hardware listed in the lrgrwrks\.txt file if\n \* one is included with the Software each a &quot;Larger Work&quot; to which the Software\n \* is contributed by such licensors\),\n \*\n \* without restriction, including without limitation the rights to copy, create\n \* derivative works of, display, perform, and distribute the Software and make,\n \* use, sell, offer for sale, import, export, have made, and have sold the\n \* Software and the Larger Work\(s\), and to sublicense the foregoing rights on\n \* either these or other terms\.\n \*\n \* This license is subject to the following condition:\n \*\n \* The above copyright notice and either this complete permission notice or at a\n \* minimum a reference to the UPL must be included in all copies or substantial\n \* portions of the Software\.\n \*\n \* THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR\n \* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,\n \* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT\. IN NO EVENT SHALL THE\n \* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER\n \* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,\n \* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE\n \* SOFTWARE\.\n \*/\n"/>

--- a/vm/src/org.graalvm.component.installer/.checkstyle_checks.xml
+++ b/vm/src/org.graalvm.component.installer/.checkstyle_checks.xml
@@ -32,9 +32,6 @@
     </module>
     <module name="RedundantImport"/>
     <module name="UnusedImports"/>
-    <module name="LineLength">
-      <property name="max" value="250"/>
-    </module>
     <module name="MethodParamPad"/>
     <module name="NoWhitespaceAfter">
       <property name="tokens" value="ARRAY_INIT,BNOT,DEC,DOT,INC,LNOT,UNARY_MINUS,UNARY_PLUS"/>
@@ -194,6 +191,9 @@
       <property name="onCommentFormat" value="CheckStyle: stop generated"/>
       <property name="checkFormat" value=".*Name|.*LineLength|.*Header"/>
     </module>
+  </module>
+  <module name="LineLength">
+    <property name="max" value="250"/>
   </module>
   <module name="RegexpHeader">
     <property name="header" value="/\*\n \* Copyright \(c\) (20[0-9][0-9], )?20[0-9][0-9], Oracle and/or its affiliates. All rights reserved.\n \* DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.\n \*\n \* This code is free software; you can redistribute it and/or modify it\n \* under the terms of the GNU General Public License version 2 only, as\n \* published by the Free Software Foundation.  Oracle designates this\n \* particular file as subject to the &quot;Classpath&quot; exception as provided\n \* by Oracle in the LICENSE file that accompanied this code.\n \*\n \* This code is distributed in the hope that it will be useful, but WITHOUT\n \* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or\n \* FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License\n \* version 2 for more details \(a copy is included in the LICENSE file that\n \* accompanied this code\).\n \*\n \* You should have received a copy of the GNU General Public License version\n \* 2 along with this work; if not, write to the Free Software Foundation,\n \* Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.\n \*\n \* Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA\n \* or visit www.oracle.com if you need additional information or have any\n \* questions.\n \*/\n"/>


### PR DESCRIPTION
This is required to make all .checkstyle_checks.xml files compatible with checkstyle 8.24 and later.

See https://checkstyle.sourceforge.io/releasenotes.html#Release_8.24 and https://github.com/checkstyle/checkstyle/issues/2116