### PR TITLE
Fix the error message in DisallowedImageHeapObjectFeature to refer to initialize-at-run-time instead of initialize-at-build-time

### DIFF
--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/image/DisallowedImageHeapObjectFeature.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/image/DisallowedImageHeapObjectFeature.java
@@ -126,7 +126,7 @@ public class DisallowedImageHeapObjectFeature implements Feature {
         throw new UnsupportedFeatureException(msg + " " +
                         "The object was probably created by a class initializer and is reachable from a static field. " +
                         "You can request class initialization at image run time by using the option " +
-                        SubstrateOptionsParser.commandArgument(ClassInitializationFeature.Options.ClassInitialization, "<class-name>", "initialize-at-build-time") + ". " +
+                        SubstrateOptionsParser.commandArgument(ClassInitializationFeature.Options.ClassInitialization, "<class-name>", "initialize-at-run-time") + ". " +
                         "Or you can write your own initialization methods and call them explicitly from your main entry point.");
     }
 


### PR DESCRIPTION
Fixes https://github.com/oracle/graal/issues/1849.

The commit here fixes the error message printed out by `DisallowedImageHeapObjectFeature`.