### PR TITLE
Prevent NullPointerException in SecurityServicesFeature

### DIFF
--- a/substratevm/mx.substratevm/mx_substratevm.py
+++ b/substratevm/mx.substratevm/mx_substratevm.py
@@ -426,7 +426,7 @@ def native_image_context(common_args=None, hosted_assertions=True, native_image_
             mx.log(timestr() + 'Shutting down completed')
 
 native_image_context.hosted_assertions = ['-J-ea', '-J-esa']
-_native_unittest_features = '--features=com.oracle.svm.test.ImageInfoTest$TestFeature,com.oracle.svm.test.ServiceLoaderTest$TestFeature'
+_native_unittest_features = '--features=com.oracle.svm.test.ImageInfoTest$TestFeature,com.oracle.svm.test.ServiceLoaderTest$TestFeature,com.oracle.svm.test.SecurityServiceTest$TestFeature'
 
 
 def svm_gate_body(args, tasks):
@@ -456,7 +456,8 @@ def svm_gate_body(args, tasks):
                         blacklist.flush()
                         blacklist_args = ['--blacklist', blacklist.name]
 
-                    native_unittest(['--build-args', _native_unittest_features] + blacklist_args)
+                    # We need the -H:+EnableAllSecurityServices for com.oracle.svm.test.SecurityServiceTest
+                    native_unittest(['--build-args', _native_unittest_features, '-H:+EnableAllSecurityServices'] + blacklist_args)
 
         with Task('Run Truffle NFI unittests with SVM image', tasks, tags=["svmjunit"]) as t:
             if t:

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/SecurityServicesFeature.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/SecurityServicesFeature.java
@@ -278,11 +278,20 @@ public class SecurityServicesFeature extends JNIRegistrationUtil implements Feat
             try {
                 /*
                  * Access the Provider.knownEngines map and extract the EngineDescription
-                 * corresponding to the serviceType. From the EngineDescription object extract the
-                 * value of the constructorParameterClassName field then, if the class name is not
-                 * null, get the corresponding Class<?> object and return it.
+                 * corresponding to the serviceType. Note that the map holds EngineDescription(s) of
+                 * only those service types that are shipped in the JDK. From the EngineDescription
+                 * object extract the value of the constructorParameterClassName field then, if the
+                 * class name is not null, get the corresponding Class<?> object and return it.
                  */
                 /* EngineDescription */Object engineDescription = knownEngines.get(serviceType);
+                /*
+                 * This isn't an engine known to the Provider (which actually means that it isn't
+                 * one that's shipped in the JDK), so we don't have the predetermined knowledge of
+                 * the constructor param class.
+                 */
+                if (engineDescription == null) {
+                    return null;
+                }
                 String constrParamClassName = (String) consParamClassNameField.get(engineDescription);
                 if (constrParamClassName != null) {
                     return access.findClassByName(constrParamClassName);

--- a/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/SecurityServiceTest.java
+++ b/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/SecurityServiceTest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2019, 2019, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package com.oracle.svm.test;
+
+import java.security.Provider;
+import java.security.Security;
+
+import org.graalvm.nativeimage.hosted.Feature;
+import org.graalvm.nativeimage.hosted.RuntimeClassInitialization;
+import org.hamcrest.CoreMatchers;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Tests the {@code SecurityServicesFeature}.
+ */
+public class SecurityServiceTest {
+    public static class TestFeature implements Feature {
+
+        @Override
+        public void duringSetup(final DuringSetupAccess access) {
+            // we use these (application) classes during Native image build
+            RuntimeClassInitialization.initializeAtBuildTime(NoOpService.class);
+            RuntimeClassInitialization.initializeAtBuildTime(NoOpProvider.class);
+
+            // register the provider
+            Security.addProvider(new NoOpProvider());
+        }
+    }
+
+    /**
+     * Tests that native-image generation doesn't run into an issue (like NPE) if the application
+     * uses a java.security.Provider.Service which isn't part of the services shipped in the JDK.
+     *
+     * @throws Exception
+     * @see <a href="https://github.com/oracle/graal/issues/1883">issue-1883</a>
+     */
+    @Test
+    public void testUnKnownSecurityServices() throws Exception {
+        final Provider registered = Security.getProvider("no-op-provider");
+        Assert.assertNotNull("Service is not registered", registered);
+        // make Provider.Service#newInstance(...) "reachable" for native-image to trigger
+        // certain (auto) reflection registrations through the SecurityServicesFeature
+        final Object impl = registered.getService("NoOp", "no-op-algo").newInstance(null);
+        Assert.assertNotNull("No service instance was created", impl);
+        Assert.assertThat("Unexpected service implementation class", impl, CoreMatchers.instanceOf(NoOpImpl.class));
+    }
+
+    private static final class NoOpProvider extends Provider {
+
+        static final long serialVersionUID = 1234L;
+
+        protected NoOpProvider() {
+            super("no-op-provider", 1.0, "No-op provider used in " + SecurityServiceTest.class.getName());
+            putService(new NoOpService(this));
+        }
+    }
+
+    private static final class NoOpService extends Provider.Service {
+        NoOpService(final Provider provider) {
+            super(provider, "NoOp", "no-op-algo", NoOpImpl.class.getName(), null, null);
+        }
+    }
+
+    public static final class NoOpImpl {
+        public NoOpImpl() {
+
+        }
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/oracle/graal/issues/1883

The `SecurityServicesFeature` adds an (internal) callback to register certain `java.security.Provider.Service` related classes for reflection. This callback is triggered if/when the `Provider.Service#newInstance` method is reachable in the application. When this callback gets triggered, it uses the `java.util.Provider#knownEngines` (internal) private field to get hold of certain details. This `knownEngines` will only contain details of services that are shipped within the JDK. As a result, if the application uses non-JDK related services, this `knownEngines` will not have information for such service types. The code, which tries to do the reflection registration, however doesn't check for `null` in such cases and that results in the reported NPE.

The commit here adds a `null` check for such cases. This PR also includes a test case which reproduces this issue and verifies the fix. The test case was run locally as follows:

```
mx build
mx native-unittest com.oracle.svm.test.SecurityServiceTest --build-args -H:+EnableAllSecurityServices --features=com.oracle.svm.test.SecurityServiceTest\$TestFeature
```
Note: The `EnableAllSecurityServices` is necessary to trigger this issue.

I haven't added this test's `TestFeature` to the `gate` features (https://github.com/oracle/graal/blob/master/substratevm/mx.substratevm/mx_substratevm.py#L429) since I don't know if that's expected to be done for any new test cases.