### PR TITLE
Fix occurrences of occure*

### DIFF
--- a/compiler/docs/Truffle.md
+++ b/compiler/docs/Truffle.md
@@ -84,7 +84,7 @@ mx --jdk jvmci sl -Dgraal.TruffleBackgroundCompilation=false \
 
 This time we get more output, because the method `namesEqual` was inlined at
 multiple sites (each site is represented by its inlining chain). The following output
-fragment first shows us the histogram with the `if`-statement ID and its occurence
+fragment first shows us the histogram with the `if`-statement ID and its occurrence
 count. It then shows the exact call stacks and execution counts for the branches.
 For example, for `[1]`, when `namesEqual` is called from `executeRead`, the `true`
 branch is taken `18018` times. When the `namesEqual` is called from `executeWrite`

--- a/compiler/src/org.graalvm.compiler.hotspot.test/src/org/graalvm/compiler/hotspot/test/CompilationWrapperTest.java
+++ b/compiler/src/org.graalvm.compiler.hotspot.test/src/org/graalvm/compiler/hotspot/test/CompilationWrapperTest.java
@@ -249,7 +249,7 @@ public class CompilationWrapperTest extends GraalCompilerTest {
             for (Probe probe : probes) {
                 String error = probe.test();
                 if (error != null) {
-                    Assert.fail(String.format("Did not find expected occurences of '%s' in output of command: %s%n%s", probe.substring, error, proc));
+                    Assert.fail(String.format("Did not find expected occurrences of '%s' in output of command: %s%n%s", probe.substring, error, proc));
                 }
             }
             String line = diagnosticProbe.lastMatchingLine;

--- a/sdk/src/org.graalvm.launcher/src/org/graalvm/launcher/MultiLanguageShell.java
+++ b/sdk/src/org.graalvm.launcher/src/org/graalvm/launcher/MultiLanguageShell.java
@@ -219,7 +219,7 @@ class MultiLanguageShell {
             } catch (PolyglotException e) {
                 bufferSource = null;
                 if (e.isInternalError()) {
-                    console.println("Internal error occured: " + e.toString());
+                    console.println("Internal error occurred: " + e.toString());
                     if (verboseErrors) {
                         e.printStackTrace(new PrintWriter(console.getOutput()));
                     } else {
@@ -260,7 +260,7 @@ class MultiLanguageShell {
                     }
                 }
             } catch (Throwable e) {
-                console.println("Internal error occured: " + e.toString());
+                console.println("Internal error occurred: " + e.toString());
                 if (verboseErrors) {
                     e.printStackTrace(new PrintWriter(console.getOutput()));
                 } else {

--- a/sdk/src/org.graalvm.nativeimage/src/org/graalvm/nativeimage/hosted/Feature.java
+++ b/sdk/src/org.graalvm.nativeimage/src/org/graalvm/nativeimage/hosted/Feature.java
@@ -477,7 +477,7 @@ public interface Feature {
     }
 
     /**
-     * Handler for code that needs to run after the analysis, even if an error has occured, e.g.,
+     * Handler for code that needs to run after the analysis, even if an error has occurred, e.g.,
      * like reporting code.
      *
      * @param access The supported operations that the feature can perform at this time

--- a/sdk/src/org.graalvm.polyglot/src/org/graalvm/polyglot/Source.java
+++ b/sdk/src/org.graalvm.polyglot/src/org/graalvm/polyglot/Source.java
@@ -911,7 +911,7 @@ public final class Source {
 
         /**
          * Uses configuration of this builder to create new {@link Source} object. The method throws
-         * an {@link IOException} if an error loading the source occured.
+         * an {@link IOException} if an error loading the source occurred.
          *
          * @return the source object
          * @since 19.0

--- a/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/linux/ProcFSSupport.java
+++ b/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/linux/ProcFSSupport.java
@@ -47,7 +47,7 @@ class ProcFSSupport {
      * buffer is dual-purpose and used to return the file's path name if requested via the
      * {@code needName} parameter. As such the buffer should be large enough to accommodate a path.
      * If not enough buffer capacity is available, and needName is true, false will be returned. If
-     * a mapping is not found, or an error has occured, false will be returned.
+     * a mapping is not found, or an error has occurred, false will be returned.
      *
      * @param fd a file descriptor pointing to /proc/self/maps
      * @param buffer a buffer for reading operations, and optionally for returning the path name of

--- a/truffle/src/com.oracle.truffle.api.dsl.test/src/com/oracle/truffle/api/dsl/test/PolymorphicTest.java
+++ b/truffle/src/com.oracle.truffle.api.dsl.test/src/com/oracle/truffle/api/dsl/test/PolymorphicTest.java
@@ -84,7 +84,7 @@ public class PolymorphicTest {
     private static void assertNoDuplicatesRec(Set<Node> ignored, Set<Class<?>> seenClasses, Node current) {
         if (!ignored.contains(current)) {
             if (seenClasses.contains(current.getClass())) {
-                Assert.fail(String.format("Multiple occurences of the same class %s. %nTree: %s", current.getClass().getSimpleName(), NodeUtil.printCompactTreeToString(current.getRootNode())));
+                Assert.fail(String.format("Multiple occurrences of the same class %s. %nTree: %s", current.getClass().getSimpleName(), NodeUtil.printCompactTreeToString(current.getRootNode())));
             } else {
                 seenClasses.add(current.getClass());
             }

--- a/truffle/src/com.oracle.truffle.api.dsl.test/src/com/oracle/truffle/api/dsl/test/TestHelper.java
+++ b/truffle/src/com.oracle.truffle.api.dsl.test/src/com/oracle/truffle/api/dsl/test/TestHelper.java
@@ -219,7 +219,7 @@ class TestHelper {
                 } else {
                     actualResult = executeWith(root, value);
                 }
-                fail(String.format("Exception %s  expected but not occured.", result.getClass()));
+                fail(String.format("Exception %s  expected but not occurred.", result.getClass()));
             } catch (Throwable e) {
                 actualResult = e;
                 if (!e.getClass().isAssignableFrom(((Class<?>) result))) {

--- a/truffle/src/com.oracle.truffle.api/src/com/oracle/truffle/api/source/Source.java
+++ b/truffle/src/com.oracle.truffle.api/src/com/oracle/truffle/api/source/Source.java
@@ -1655,7 +1655,7 @@ public abstract class Source {
 
         /**
          * Uses configuration of this builder to create new {@link Source} object. The method throws
-         * an {@link IOException} if an error loading the source occured.
+         * an {@link IOException} if an error loading the source occurred.
          *
          * @return the source object
          * @throws IOException if an error reading the content occurred

--- a/vm/src/org.graalvm.component.installer/src/org/graalvm/component/installer/Bundle.properties
+++ b/vm/src/org.graalvm.component.installer/src/org/graalvm/component/installer/Bundle.properties
@@ -71,14 +71,14 @@ STORAGE_CorruptedComponentStorage=Component metadata storage is corrupted.
 STORAGE_InvalidReleaseFile=Invalid GraalVM release file.
 
 
-INSTALLER_IOException=I/O error occured: {0}
+INSTALLER_IOException=I/O error occurred: {0}
 INSTALLER_FailError={0}
 INSTALLER_FileDoesNotExist=File does not exist: {0}
 INSTALLER_FileExists=File already exists: {0}
 INSTALLER_DirectoryNotEmpty=Directory is not empty: {0}
 INSTALLER_AccessDenied=Permission denied: {0}
 INSTALLER_InvalidMetadata=Invalid component metadata or corrupted component package
-INSTALLER_InternalError=Internal error occured: {0}
+INSTALLER_InternalError=Internal error occurred: {0}
 
 REGISTRY_ReadingComponentList=Error reading component list: {0}
 REGISTRY_ReadingComponentMetadata=Error reading metadata of component {0}: {1}


### PR DESCRIPTION
This typo surfaced in the polyglot shell (see https://github.com/oracle/truffleruby/issues/1831). Turns out there are some more *occur**r**ences* of 'occure'* in the code base.

See https://www.lexico.com/en/definition/occur