### PR TITLE
Fixed AArch64 relocation and patching mistakes in SVM.

### DIFF
--- a/compiler/src/org.graalvm.compiler.asm.aarch64/src/org/graalvm/compiler/asm/aarch64/AArch64Assembler.java
+++ b/compiler/src/org.graalvm.compiler.asm.aarch64/src/org/graalvm/compiler/asm/aarch64/AArch64Assembler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2020, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2018, Red Hat Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -3027,13 +3027,56 @@ public abstract class AArch64Assembler extends Assembler {
         }
     }
 
-    void annotateImmediateMovSequence(int pos, int numInstrs) {
-        if (codePatchingAnnotationConsumer != null) {
-            codePatchingAnnotationConsumer.accept(new MovSequenceAnnotation(pos, numInstrs));
+    public abstract static class PatchableCodeAnnotation extends CodeAnnotation {
+
+        PatchableCodeAnnotation(int instructionStartPosition) {
+            super(instructionStartPosition);
+        }
+
+        abstract void patch(int codePos, int relative, byte[] code);
+    }
+
+    /**
+     * Contains methods used for patching instruction(s) within AArch64.
+     */
+    public static class PatcherUtil {
+        /**
+         * Method to patch a series a bytes within a byte address with a given value.
+         *
+         * @param code the array of bytes in which patch is to be performed
+         * @param codePos where in the array the patch should be performed
+         * @param value the value to be added to the series of bytes
+         * @param bitsUsed the number of bits to patch within each byte
+         * @param offsets where with the bytes the value should be added
+         */
+        public static void writeBitSequence(byte[] code, int codePos, int value, int[] bitsUsed, int[] offsets) {
+            assert bitsUsed.length == offsets.length : "bitsUsed and offsets parameter arrays do not match";
+            int curValue = value;
+            for (int i = 0; i < bitsUsed.length; i++) {
+                int usedBits = bitsUsed[i];
+                if (usedBits == 0) {
+                    continue;
+                }
+
+                int offset = offsets[i];
+                int mask = (1 << usedBits) - 1;
+
+                byte patchTarget = code[codePos + i];
+                byte patch = (byte) (((curValue & mask) << offset) & 0xFF);
+                byte retainedPatchTarget = (byte) (patchTarget & ((~(mask << offset)) & 0xFF));
+                patchTarget = (byte) (retainedPatchTarget | patch);
+                code[codePos + i] = patchTarget;
+                curValue = curValue >> usedBits;
+            }
+        }
+
+        public static int computeRelativePageDifference(int target, int curPos, int pageSize) {
+            int relative = target / pageSize - curPos / pageSize;
+            return relative;
         }
     }
 
-    public static class SingleInstructionAnnotation extends CodeAnnotation {
+    public static class SingleInstructionAnnotation extends PatchableCodeAnnotation {
 
         /**
          * The size of the operand, in bytes.
@@ -3050,18 +3093,44 @@ public abstract class AArch64Assembler extends Assembler {
             this.shift = shift;
             this.instruction = instruction;
         }
-    }
 
-    public static class MovSequenceAnnotation extends CodeAnnotation {
+        @Override
+        public String toString() {
+            return "SINGLE_INSTRUCTION";
+        }
 
-        /**
-         * The size of the operand, in bytes.
-         */
-        public final int numInstrs;
+        @Override
+        public void patch(int codePos, int relative, byte[] code) {
+            int curValue = relative;
+            assert (curValue & ((1 << shift) - 1)) == 0 : "relative offset has incorrect alignment";
+            curValue = curValue >> shift;
 
-        MovSequenceAnnotation(int instructionPosition, int numInstrs) {
-            super(instructionPosition);
-            this.numInstrs = numInstrs;
+            // right this is only BL instructions are being patched here
+            assert instruction == AArch64Assembler.Instruction.BL : "trying to patch an unexpected instruction";
+            GraalError.guarantee(NumUtil.isSignedNbit(operandSizeBits, curValue), "value too large to fit into space");
+
+            // fill in immediate operand of operandSizeBits starting at offsetBits within
+            // instruction
+            int bitsRemaining = operandSizeBits;
+            int offsetRemaining = offsetBits;
+
+            int[] bitsUsed = new int[4];
+            int[] offsets = new int[4];
+
+            for (int i = 0; i < 4; ++i) {
+                if (offsetRemaining >= 8) {
+                    offsetRemaining -= 8;
+                    continue;
+                }
+                offsets[i] = offsetRemaining;
+                // number of bits to be filled within this byte
+                int bits = Math.min(8 - offsetRemaining, bitsRemaining);
+                bitsUsed[i] = bits;
+                bitsRemaining -= bits;
+
+                offsetRemaining = 0;
+            }
+            PatcherUtil.writeBitSequence(code, instructionPosition, curValue, bitsUsed, offsets);
         }
     }
 

--- a/compiler/src/org.graalvm.compiler.asm.aarch64/src/org/graalvm/compiler/asm/aarch64/AArch64MacroAssembler.java
+++ b/compiler/src/org.graalvm.compiler.asm.aarch64/src/org/graalvm/compiler/asm/aarch64/AArch64MacroAssembler.java
@@ -2238,7 +2238,7 @@ public class AArch64MacroAssembler extends AArch64Assembler {
         this.ldr(srcSize, result, a);
     }
 
-    public static class AdrpLdrMacroInstruction extends PatchableCodeAnnotation {
+    public static class AdrpLdrMacroInstruction extends AArch64Assembler.PatchableCodeAnnotation {
         public final int srcSize;
 
         public AdrpLdrMacroInstruction(int position, int srcSize) {
@@ -2279,7 +2279,7 @@ public class AArch64MacroAssembler extends AArch64Assembler {
         }
     }
 
-    public static class AdrpAddMacroInstruction extends PatchableCodeAnnotation {
+    public static class AdrpAddMacroInstruction extends AArch64Assembler.PatchableCodeAnnotation {
         public AdrpAddMacroInstruction(int position) {
             super(position);
         }
@@ -2318,7 +2318,7 @@ public class AArch64MacroAssembler extends AArch64Assembler {
         }
     }
 
-    public static class MovSequenceAnnotation extends PatchableCodeAnnotation {
+    public static class MovSequenceAnnotation extends AArch64Assembler.PatchableCodeAnnotation {
 
         /**
          * An enum to indicate how each 16-bit immediate chunk is represented within a sequence of

--- a/compiler/src/org.graalvm.compiler.asm.aarch64/src/org/graalvm/compiler/asm/aarch64/AArch64MacroAssembler.java
+++ b/compiler/src/org.graalvm.compiler.asm.aarch64/src/org/graalvm/compiler/asm/aarch64/AArch64MacroAssembler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -43,6 +43,7 @@ import static org.graalvm.compiler.asm.aarch64.AArch64MacroAssembler.AddressGene
 
 import org.graalvm.compiler.asm.BranchTargetOutOfBoundsException;
 import org.graalvm.compiler.asm.Label;
+import org.graalvm.compiler.asm.aarch64.AArch64MacroAssembler.MovSequenceAnnotation.MovAction;
 import org.graalvm.compiler.core.common.NumUtil;
 import org.graalvm.compiler.debug.GraalError;
 
@@ -510,7 +511,7 @@ public class AArch64MacroAssembler extends AArch64Assembler {
      * @param needsImmAnnotation Flag denoting if annotation should be added.
      */
     private void mov32(Register dst, int imm, boolean needsImmAnnotation) {
-        int numMovs = 0;
+        MovAction[] includeSet = {MovAction.SKIPPED, MovAction.SKIPPED};
         int pos = position();
 
         // Split 32-bit imm into low16 and high16 parts.
@@ -520,24 +521,25 @@ public class AArch64MacroAssembler extends AArch64Assembler {
         // Generate code sequence with a combination of MOVZ or MOVN with MOVK.
         if (high16 == 0) {
             movz(32, dst, low16, 0);
-            numMovs = 1;
+            includeSet[0] = MovAction.USED;
         } else if (high16 == 0xFFFF) {
             movn(32, dst, low16 ^ 0xFFFF, 0);
-            numMovs = 1;
+            includeSet[0] = MovAction.NEGATED;
         } else if (low16 == 0) {
             movz(32, dst, high16, 16);
-            numMovs = 1;
+            includeSet[1] = MovAction.USED;
         } else if (low16 == 0xFFFF) {
             movn(32, dst, high16 ^ 0xFFFF, 16);
-            numMovs = 1;
+            includeSet[1] = MovAction.NEGATED;
         } else {
             // Neither of the 2 parts is all-0s or all-1s. Generate 2 instructions.
             movz(32, dst, low16, 0);
             movk(32, dst, high16, 16);
-            numMovs = 2;
+            includeSet[0] = MovAction.USED;
+            includeSet[1] = MovAction.USED;
         }
         if (needsImmAnnotation) {
-            annotateImmediateMovSequence(pos, numMovs);
+            annotateImmediateMovSequence(pos, includeSet);
         }
     }
 
@@ -549,7 +551,7 @@ public class AArch64MacroAssembler extends AArch64Assembler {
      * @param needsImmAnnotation Flag denoting if annotation should be added.
      */
     private void mov64(Register dst, long imm, boolean needsImmAnnotation) {
-        int numMovs = 0;
+        MovAction[] includeSet = {MovAction.SKIPPED, MovAction.SKIPPED, MovAction.SKIPPED, MovAction.SKIPPED};
         int pos = position();
         int[] chunks = new int[4];
         int zeroCount = 0;
@@ -570,67 +572,70 @@ public class AArch64MacroAssembler extends AArch64Assembler {
         if (zeroCount == 4) {
             // Generate only one MOVZ.
             movz(64, dst, 0, 0);
-            numMovs = 1;
+            includeSet[0] = MovAction.USED;
         } else if (negCount == 4) {
             // Generate only one MOVN.
             movn(64, dst, 0, 0);
-            numMovs = 1;
+            includeSet[0] = MovAction.NEGATED;
         } else if (zeroCount == 3) {
             // Generate only one MOVZ.
             for (int i = 0; i < 4; i++) {
                 if (chunks[i] != 0) {
                     movz(64, dst, chunks[i], i * 16);
+                    includeSet[i] = MovAction.USED;
                     break;
                 }
             }
-            numMovs = 1;
         } else if (negCount == 3) {
             // Generate only one MOVN.
             for (int i = 0; i < 4; i++) {
                 if (chunks[i] != 0xFFFF) {
                     movn(64, dst, chunks[i] ^ 0xFFFF, i * 16);
+                    includeSet[i] = MovAction.NEGATED;
                     break;
                 }
             }
-            numMovs = 1;
         } else if (zeroCount == 2) {
             // Generate one MOVZ and one MOVK.
             int i;
             for (i = 0; i < 4; i++) {
                 if (chunks[i] != 0) {
                     movz(64, dst, chunks[i], i * 16);
+                    includeSet[i] = MovAction.USED;
                     break;
                 }
             }
             for (int k = i + 1; k < 4; k++) {
                 if (chunks[k] != 0) {
                     movk(64, dst, chunks[k], k * 16);
+                    includeSet[k] = MovAction.USED;
                     break;
                 }
             }
-            numMovs = 2;
         } else if (negCount == 2) {
             // Generate one MOVN and one MOVK.
             int i;
             for (i = 0; i < 4; i++) {
                 if (chunks[i] != 0xFFFF) {
                     movn(64, dst, chunks[i] ^ 0xFFFF, i * 16);
+                    includeSet[i] = MovAction.NEGATED;
                     break;
                 }
             }
             for (int k = i + 1; k < 4; k++) {
                 if (chunks[k] != 0xFFFF) {
                     movk(64, dst, chunks[k], k * 16);
+                    includeSet[k] = MovAction.USED;
                     break;
                 }
             }
-            numMovs = 2;
         } else if (zeroCount == 1) {
             // Generate one MOVZ and two MOVKs.
             int i;
             for (i = 0; i < 4; i++) {
                 if (chunks[i] != 0) {
                     movz(64, dst, chunks[i], i * 16);
+                    includeSet[i] = MovAction.USED;
                     break;
                 }
             }
@@ -638,17 +643,18 @@ public class AArch64MacroAssembler extends AArch64Assembler {
             for (int k = i + 1; k < 4; k++) {
                 if (chunks[k] != 0) {
                     movk(64, dst, chunks[k], k * 16);
+                    includeSet[k] = MovAction.USED;
                     numMovks++;
                 }
             }
             assert numMovks == 2;
-            numMovs = 3;
         } else if (negCount == 1) {
             // Generate one MOVN and two MOVKs.
             int i;
             for (i = 0; i < 4; i++) {
                 if (chunks[i] != 0xFFFF) {
                     movn(64, dst, chunks[i] ^ 0xFFFF, i * 16);
+                    includeSet[i] = MovAction.NEGATED;
                     break;
                 }
             }
@@ -656,21 +662,24 @@ public class AArch64MacroAssembler extends AArch64Assembler {
             for (int k = i + 1; k < 4; k++) {
                 if (chunks[k] != 0xFFFF) {
                     movk(64, dst, chunks[k], k * 16);
+                    includeSet[k] = MovAction.USED;
                     numMovks++;
                 }
             }
             assert numMovks == 2;
-            numMovs = 3;
         } else {
             // Generate one MOVZ and three MOVKs
             movz(64, dst, chunks[0], 0);
             movk(64, dst, chunks[1], 16);
             movk(64, dst, chunks[2], 32);
             movk(64, dst, chunks[3], 48);
-            numMovs = 4;
+            includeSet[0] = MovAction.USED;
+            includeSet[1] = MovAction.USED;
+            includeSet[2] = MovAction.USED;
+            includeSet[3] = MovAction.USED;
         }
         if (needsImmAnnotation) {
-            annotateImmediateMovSequence(pos, numMovs);
+            annotateImmediateMovSequence(pos, includeSet);
         }
     }
 
@@ -776,7 +785,8 @@ public class AArch64MacroAssembler extends AArch64Assembler {
             }
         }
         if (needsImmAnnotation) {
-            annotateImmediateMovSequence(pos, 3);
+            MovAction[] includeSet = {MovAction.USED, MovAction.USED, MovAction.USED};
+            annotateImmediateMovSequence(pos, includeSet);
         }
         assert !firstMove;
     }
@@ -2217,24 +2227,23 @@ public class AArch64MacroAssembler extends AArch64Assembler {
         umov(fixedSize, dst, 0, vreg);
     }
 
-    public interface MacroInstruction {
-        void patch(int codePos, int relative, byte[] code);
-    }
-
     /**
      * Emits elf patchable adrp ldr sequence.
      */
     public void adrpLdr(int srcSize, Register result, AArch64Address a) {
         if (codePatchingAnnotationConsumer != null) {
-            codePatchingAnnotationConsumer.accept(new AdrpLdrMacroInstruction(position()));
+            codePatchingAnnotationConsumer.accept(new AdrpLdrMacroInstruction(position(), srcSize));
         }
         super.adrp(a.getBase());
         this.ldr(srcSize, result, a);
     }
 
-    public static class AdrpLdrMacroInstruction extends CodeAnnotation implements MacroInstruction {
-        public AdrpLdrMacroInstruction(int position) {
+    public static class AdrpLdrMacroInstruction extends PatchableCodeAnnotation {
+        public final int srcSize;
+
+        public AdrpLdrMacroInstruction(int position, int srcSize) {
             super(position);
+            this.srcSize = srcSize;
         }
 
         @Override
@@ -2244,11 +2253,33 @@ public class AArch64MacroAssembler extends AArch64Assembler {
 
         @Override
         public void patch(int codePos, int relative, byte[] code) {
-            throw GraalError.unimplemented();
+            int shiftSize = srcSize == 64 ? 3 : 2; // srcSize is either 64 or 32
+            int pos = instructionPosition;
+
+            int targetAddress = pos + relative;
+            assert (targetAddress & ((1 << shiftSize) - 1)) == 0 : "shift bits must be zero";
+
+            int relativePageDifference = PatcherUtil.computeRelativePageDifference(targetAddress, pos, 1 << 12);
+
+            // adrp imm_hi bits
+            int curValue = (relativePageDifference >> 2) & 0x7FFFF;
+            int[] adrHiBits = {3, 8, 8};
+            int[] adrHiOffsets = {5, 0, 0};
+            PatcherUtil.writeBitSequence(code, pos, curValue, adrHiBits, adrHiOffsets);
+            // adrp imm_lo bits
+            curValue = relativePageDifference & 0x3;
+            int[] adrLoBits = {2};
+            int[] adrLoOffsets = {5};
+            PatcherUtil.writeBitSequence(code, pos + 3, curValue, adrLoBits, adrLoOffsets);
+            // ldr bits
+            curValue = (targetAddress >> shiftSize) & 0x1FF;
+            int[] ldrBits = {6, 6};
+            int[] ldrOffsets = {2, 0};
+            PatcherUtil.writeBitSequence(code, pos + 5, curValue, ldrBits, ldrOffsets);
         }
     }
 
-    public static class AdrpAddMacroInstruction extends CodeAnnotation implements MacroInstruction {
+    public static class AdrpAddMacroInstruction extends PatchableCodeAnnotation {
         public AdrpAddMacroInstruction(int position) {
             super(position);
         }
@@ -2260,7 +2291,94 @@ public class AArch64MacroAssembler extends AArch64Assembler {
 
         @Override
         public void patch(int codePos, int relative, byte[] code) {
-            throw GraalError.unimplemented();
+            int pos = instructionPosition;
+            int targetAddress = pos + relative;
+            int relativePageDifference = PatcherUtil.computeRelativePageDifference(targetAddress, pos, 1 << 12);
+            // adrp imm_hi bits
+            int curValue = (relativePageDifference >> 2) & 0x7FFFF;
+            int[] adrHiBits = {3, 8, 8};
+            int[] adrHiOffsets = {5, 0, 0};
+            PatcherUtil.writeBitSequence(code, pos, curValue, adrHiBits, adrHiOffsets);
+            // adrp imm_lo bits
+            curValue = relativePageDifference & 0x3;
+            int[] adrLoBits = {2};
+            int[] adrLoOffsets = {5};
+            PatcherUtil.writeBitSequence(code, pos + 3, curValue, adrLoBits, adrLoOffsets);
+            // add bits
+            curValue = targetAddress & 0xFFF;
+            int[] addBits = {6, 6};
+            int[] addOffsets = {2, 0};
+            PatcherUtil.writeBitSequence(code, pos + 5, curValue, addBits, addOffsets);
+        }
+    }
+
+    private void annotateImmediateMovSequence(int pos, MovSequenceAnnotation.MovAction[] includeSet) {
+        if (codePatchingAnnotationConsumer != null) {
+            codePatchingAnnotationConsumer.accept(new MovSequenceAnnotation(pos, includeSet));
+        }
+    }
+
+    public static class MovSequenceAnnotation extends PatchableCodeAnnotation {
+
+        /**
+         * An enum to indicate how each 16-bit immediate chunk is represented within a sequence of
+         * mov instructions.
+         */
+        public enum MovAction {
+            USED, // mov instruction is in place for this chunk.
+            SKIPPED, // no mov instruction is in place for this chunk.
+            NEGATED; // movn instruction is in place for this chunk.
+        }
+
+        /**
+         * The size of the operand, in bytes.
+         */
+        public final MovAction[] includeSet;
+
+        MovSequenceAnnotation(int instructionPosition, MovAction[] includeSet) {
+            super(instructionPosition);
+            this.includeSet = includeSet;
+        }
+
+        @Override
+        public String toString() {
+            return "MOV_SEQ";
+        }
+
+        @Override
+        public void patch(int codePos, int relative, byte[] code) {
+            /*
+             * Each move has a 16 bit immediate operand. We use a series of shifted moves to
+             * represent immediate values larger than 16 bits.
+             */
+            int curValue = relative;
+            int[] bitsUsed = {3, 8, 5};
+            int[] offsets = {5, 0, 0};
+            int siteOffset = 0;
+            boolean containsNegatedMov = false;
+            for (MovAction include : includeSet) {
+                if (include == MovAction.NEGATED) {
+                    containsNegatedMov = true;
+                    break;
+                }
+            }
+            for (int i = 0; i < includeSet.length; i++) {
+                int value = curValue & 0xFFFF;
+                curValue = curValue >> 16;
+                switch (includeSet[i]) {
+                    case USED:
+                        break;
+                    case SKIPPED:
+                        assert value == (containsNegatedMov ? 0xFFFF : 0) : "Unable to patch this value.";
+                        continue;
+                    case NEGATED:
+                        value = value ^ 0xFFFF;
+                        break;
+                }
+                int bytePosition = instructionPosition + siteOffset;
+                PatcherUtil.writeBitSequence(code, bytePosition, value, bitsUsed, offsets);
+                siteOffset += 4;
+            }
         }
     }
 }

--- a/compiler/src/org.graalvm.compiler.lir.aarch64/src/org/graalvm/compiler/lir/aarch64/AArch64Move.java
+++ b/compiler/src/org.graalvm.compiler.lir.aarch64/src/org/graalvm/compiler/lir/aarch64/AArch64Move.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -555,7 +555,9 @@ public class AArch64Move {
                     crb.recordInlineDataInCode(input);
                     masm.mov(dst, 0xDEADDEADDEADDEADL, true);
                 } else {
-                    masm.ldr(64, dst, (AArch64Address) crb.recordDataReferenceInCode(input, 8));
+                    crb.recordDataReferenceInCode(input, 8);
+                    AArch64Address address = AArch64Address.createScaledImmediateAddress(dst, 0x0);
+                    masm.adrpLdr(64, dst, address);
                 }
                 break;
             default:

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/ELFMachine.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/ELFMachine.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -426,7 +426,7 @@ enum ELFX86_64Relocation implements ELFRelocationMethod {
 }
 
 /**
- * Reference: http://infocenter.arm.com/help/topic/com.arm.doc.ihi0056b/IHI0056B_aaelf64.pdf.
+ * Reference: https://developer.arm.com/docs/ihi0056/latest.
  */
 enum ELFAArch64Relocation implements ELFRelocationMethod {
     R_AARCH64_NONE(0),

--- a/substratevm/src/com.oracle.svm.core.graal.aarch64/src/com/oracle/svm/core/graal/aarch64/AArch64CGlobalDataLoadAddressOp.java
+++ b/substratevm/src/com.oracle.svm.core.graal.aarch64/src/com/oracle/svm/core/graal/aarch64/AArch64CGlobalDataLoadAddressOp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -60,18 +60,17 @@ public final class AArch64CGlobalDataLoadAddressOp extends AArch64LIRInstruction
         if (SubstrateUtil.HOSTED) {
             // AOT compilation: record patch that is fixed up later
             int before = masm.position();
+            Register resultRegister = asRegister(result);
             if (dataInfo.isSymbolReference()) {
                 // Pure symbol reference: the data contains the symbol's address, load it
-                Register resultRegister = asRegister(result);
                 AArch64Address address = AArch64Address.createScaledImmediateAddress(resultRegister, 0x0);
                 masm.adrpLdr(64, resultRegister, address);
-                crb.compilationResult.recordDataPatch(before, new CGlobalDataReference(dataInfo));
             } else {
                 // Data: load its address
                 AArch64Address address = masm.getPlaceholder(before);
-                masm.loadAddress(asRegister(result), address, 1);
-                crb.compilationResult.recordDataPatch(before, new CGlobalDataReference(dataInfo));
+                masm.loadAddress(resultRegister, address, 1);
             }
+            crb.compilationResult.recordDataPatch(before, new CGlobalDataReference(dataInfo));
         } else {
             // Runtime compilation: compute the actual address
             Pointer globalsBase = CGlobalDataInfo.CGLOBALDATA_RUNTIME_BASE_ADDRESS.get();

--- a/substratevm/src/com.oracle.svm.core.graal.aarch64/src/com/oracle/svm/core/graal/aarch64/AArch64NativeImagePatcher.java
+++ b/substratevm/src/com.oracle.svm.core.graal.aarch64/src/com/oracle/svm/core/graal/aarch64/AArch64NativeImagePatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,7 +27,8 @@ package com.oracle.svm.core.graal.aarch64;
 import java.util.function.Consumer;
 
 import org.graalvm.compiler.asm.Assembler;
-import org.graalvm.compiler.asm.amd64.AMD64BaseAssembler.OperandDataAnnotation;
+import org.graalvm.compiler.asm.aarch64.AArch64Assembler.SingleInstructionAnnotation;
+import org.graalvm.compiler.asm.aarch64.AArch64MacroAssembler;
 import org.graalvm.compiler.code.CompilationResult;
 import org.graalvm.nativeimage.ImageSingletons;
 import org.graalvm.nativeimage.Platform;
@@ -37,10 +38,11 @@ import org.graalvm.nativeimage.hosted.Feature;
 import com.oracle.svm.core.annotate.AutomaticFeature;
 import com.oracle.svm.core.graal.code.NativeImagePatcher;
 import com.oracle.svm.core.graal.code.PatchConsumerFactory;
+import com.oracle.svm.core.util.VMError;
 
 @AutomaticFeature
 @Platforms({Platform.AARCH64.class})
-class AArch64NativeImagePatcherFeature implements Feature {
+public class AArch64NativeImagePatcher implements Feature {
     @Override
     public void afterRegistration(AfterRegistrationAccess access) {
         ImageSingletons.add(PatchConsumerFactory.NativePatchConsumerFactory.class, new PatchConsumerFactory.NativePatchConsumerFactory() {
@@ -49,8 +51,14 @@ class AArch64NativeImagePatcherFeature implements Feature {
                 return new Consumer<Assembler.CodeAnnotation>() {
                     @Override
                     public void accept(Assembler.CodeAnnotation annotation) {
-                        if (annotation instanceof OperandDataAnnotation) {
-                            compilationResult.addAnnotation(new AArch64NativeImagePatcher(annotation.instructionPosition, (OperandDataAnnotation) annotation));
+                        if (annotation instanceof SingleInstructionAnnotation) {
+                            compilationResult.addAnnotation(new SingleInstructionNativeImagePatcher(annotation.instructionPosition, (SingleInstructionAnnotation) annotation));
+                        } else if (annotation instanceof AArch64MacroAssembler.MovSequenceAnnotation) {
+                            compilationResult.addAnnotation(new MovSequenceNativeImagePatcher(annotation.instructionPosition, (AArch64MacroAssembler.MovSequenceAnnotation) annotation));
+                        } else if (annotation instanceof AArch64MacroAssembler.AdrpLdrMacroInstruction) {
+                            compilationResult.addAnnotation(new AdrpLdrMacroInstructionNativeImagePatcher((AArch64MacroAssembler.AdrpLdrMacroInstruction) annotation));
+                        } else if (annotation instanceof AArch64MacroAssembler.AdrpAddMacroInstruction) {
+                            compilationResult.addAnnotation(new AdrpAddMacroInstructionNativeImagePatcher((AArch64MacroAssembler.AdrpAddMacroInstruction) annotation));
                         }
                     }
                 };
@@ -59,39 +67,147 @@ class AArch64NativeImagePatcherFeature implements Feature {
     }
 }
 
-public class AArch64NativeImagePatcher extends CompilationResult.CodeAnnotation implements NativeImagePatcher {
-    private final OperandDataAnnotation annotation;
+class SingleInstructionNativeImagePatcher extends CompilationResult.CodeAnnotation implements NativeImagePatcher {
+    private final SingleInstructionAnnotation annotation;
 
-    public AArch64NativeImagePatcher(int instructionStartPosition, OperandDataAnnotation annotation) {
+    SingleInstructionNativeImagePatcher(int instructionStartPosition, SingleInstructionAnnotation annotation) {
+        super(instructionStartPosition);
+        this.annotation = annotation;
+    }
+
+    /**
+     * The position from the beginning of the method where the patch is applied. This offset is used
+     * in the reference map.
+     */
+    @Override
+    public int getOffset() {
+        return annotation.instructionPosition + annotation.offsetBits;
+    }
+
+    /**
+     * The length of the value to patch in bytes, e.g., the size of an operand.
+     */
+    @Override
+    public int getLength() {
+        assert annotation.operandSizeBits % 8 == 0 : "operandSize is not a byte size";
+        return annotation.operandSizeBits / 8;
+    }
+
+    @Override
+    public void patchCode(int relative, byte[] code) {
+        annotation.patch(annotation.instructionPosition, relative, code);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        return obj == this;
+    }
+}
+
+class AdrpLdrMacroInstructionNativeImagePatcher extends CompilationResult.CodeAnnotation implements NativeImagePatcher {
+    private final AArch64MacroAssembler.AdrpLdrMacroInstruction macroInstruction;
+
+    AdrpLdrMacroInstructionNativeImagePatcher(AArch64MacroAssembler.AdrpLdrMacroInstruction macroInstruction) {
+        super(macroInstruction.instructionPosition);
+        this.macroInstruction = macroInstruction;
+    }
+
+    @Override
+    public void patchCode(int relative, byte[] code) {
+        macroInstruction.patch(macroInstruction.instructionPosition, relative, code);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        return obj == this;
+    }
+
+    /**
+     * The position from the beginning of the method where the patch is applied. This offset is used
+     * in the reference map.
+     */
+    @Override
+    public int getOffset() {
+        throw VMError.unsupportedFeature("trying to get offset of adrp ldr macro instruction");
+    }
+
+    /**
+     * The length of the value to patch in bytes, e.g., the size of an operand.
+     */
+    @Override
+    public int getLength() {
+        throw VMError.unsupportedFeature("trying to get length of adrp ldr macro instruction");
+    }
+}
+
+class AdrpAddMacroInstructionNativeImagePatcher extends CompilationResult.CodeAnnotation implements NativeImagePatcher {
+    private final AArch64MacroAssembler.AdrpAddMacroInstruction macroInstruction;
+
+    AdrpAddMacroInstructionNativeImagePatcher(AArch64MacroAssembler.AdrpAddMacroInstruction macroInstruction) {
+        super(macroInstruction.instructionPosition);
+        this.macroInstruction = macroInstruction;
+    }
+
+    @Override
+    public void patchCode(int relative, byte[] code) {
+        macroInstruction.patch(macroInstruction.instructionPosition, relative, code);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        return obj == this;
+    }
+
+    /**
+     * The position from the beginning of the method where the patch is applied. This offset is used
+     * in the reference map.
+     */
+    @Override
+    public int getOffset() {
+        throw VMError.unsupportedFeature("trying to get offset of adrp add instruction");
+    }
+
+    /**
+     * The length of the value to patch in bytes, e.g., the size of an operand.
+     */
+    @Override
+    public int getLength() {
+        throw VMError.unsupportedFeature("trying to get length of adrp add instruction");
+    }
+}
+
+class MovSequenceNativeImagePatcher extends CompilationResult.CodeAnnotation implements NativeImagePatcher {
+    private final AArch64MacroAssembler.MovSequenceAnnotation annotation;
+
+    MovSequenceNativeImagePatcher(int instructionStartPosition, AArch64MacroAssembler.MovSequenceAnnotation annotation) {
         super(instructionStartPosition);
         this.annotation = annotation;
     }
 
     @Override
     public void patchCode(int relative, byte[] code) {
-        // int curValue = relative - (annotation.nextInstructionPosition -
-        // annotation.instructionPosition);
-        //
-        // for (int i = 0; i < annotation.operandSize; i++) {
-        // assert code[annotation.operandPosition + i] == 0;
-        // code[annotation.operandPosition + i] = (byte) (curValue & 0xFF);
-        // curValue = curValue >>> 8;
-        // }
-        // assert curValue == 0;
-    }
-
-    @Override
-    public int getOffset() {
-        return annotation.operandPosition;
-    }
-
-    @Override
-    public int getLength() {
-        return annotation.operandSize;
+        annotation.patch(annotation.instructionPosition, relative, code);
     }
 
     @Override
     public boolean equals(Object obj) {
         return obj == this;
+    }
+
+    /**
+     * The position from the beginning of the method where the patch is applied. This offset is used
+     * in the reference map.
+     */
+    @Override
+    public int getOffset() {
+        throw VMError.unsupportedFeature("trying to get offset of move sequence");
+    }
+
+    /**
+     * The length of the value to patch in bytes, e.g., the size of an operand.
+     */
+    @Override
+    public int getLength() {
+        throw VMError.unsupportedFeature("trying to get length of move sequence");
     }
 }

--- a/substratevm/src/com.oracle.svm.core.graal.aarch64/src/com/oracle/svm/core/graal/aarch64/SubstrateAArch64Backend.java
+++ b/substratevm/src/com.oracle.svm.core.graal.aarch64/src/com/oracle/svm/core/graal/aarch64/SubstrateAArch64Backend.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -737,7 +737,8 @@ public class SubstrateAArch64Backend extends SubstrateBackend implements LIRGene
                 masm.mov(resultReg, 0xDEADDEADDEADDEADL, true);
             } else {
                 AArch64Address address = (AArch64Address) crb.recordDataReferenceInCode(inputConstant, referenceSize);
-                masm.loadAddress(resultReg, address, 1);
+                address = AArch64Address.createScaledImmediateAddress(resultReg, 0x0);
+                masm.adrpLdr(referenceSize * 8, resultReg, address);
             }
             if (!constant.isCompressed()) { // the result is expected to be uncompressed
                 Register baseReg = getBaseRegister(crb);

--- a/substratevm/src/com.oracle.svm.core.graal.aarch64/src/com/oracle/svm/core/graal/aarch64/SubstrateAArch64Backend.java
+++ b/substratevm/src/com.oracle.svm.core.graal.aarch64/src/com/oracle/svm/core/graal/aarch64/SubstrateAArch64Backend.java
@@ -736,8 +736,8 @@ public class SubstrateAArch64Backend extends SubstrateBackend implements LIRGene
                 crb.recordInlineDataInCode(inputConstant);
                 masm.mov(resultReg, 0xDEADDEADDEADDEADL, true);
             } else {
-                AArch64Address address = (AArch64Address) crb.recordDataReferenceInCode(inputConstant, referenceSize);
-                address = AArch64Address.createScaledImmediateAddress(resultReg, 0x0);
+                crb.recordDataReferenceInCode(inputConstant, referenceSize);
+                AArch64Address address = AArch64Address.createScaledImmediateAddress(resultReg, 0x0);
                 masm.adrpLdr(referenceSize * 8, resultReg, address);
             }
             if (!constant.isCompressed()) { // the result is expected to be uncompressed


### PR DESCRIPTION
Currently, in SVM relocation is only enabled for adrp/ldr,adrp/add, and
sequences of moves. However, this limitation was previously not always
observed in SVM code.

Also fixed an error in the backend where it was loading an address into
a register, instead of loading the value at the address

Change-Id: I5b4999e73cbd926c4e877f5f43803a08ed7be5b3