### PR TITLE
Enable AArch64 travis-ci tests.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,6 +46,12 @@ matrix:
   - env: JDK="jdk11" GATE="style,fullbuild" PRIMARY="compiler"
   - env: JDK="jdk11" GATE="build,test" PRIMARY="compiler"
   - env: JDK="jdk11" GATE="build,bootstraplite" PRIMARY="compiler"
+  - os: linux
+    arch: arm64
+    env: JDK="jdk11" GATE="fullbuild,test" PRIMARY="compiler"
+  - os: linux
+    arch: arm64
+    env: JDK="jdk11" GATE="build,bootstraplite" PRIMARY="compiler"
 # GR-16977
 #  - env: JDK="jdk11" GATE="build,test,helloworld" PRIMARY="substratevm"
 
@@ -88,10 +94,19 @@ install:
         tar -C ${TRAVIS_BUILD_DIR}/.. -xzf ${JDK_TAR}
         export JAVA_HOME=${TRAVIS_BUILD_DIR}/../openjdk1.8.0_${JDK8_UPDATE_VERSION}-${JVMCI_VERSION}
       fi
+  - |
+      if [ "${JDK}" == "jdk11" ]
+      then
+        # Set the JAVA_HOME to openjdk11 if it is not set
+        if [ "${JAVA_HOME}" == "" ]
+        then
+          export JAVA_HOME=$(realpath $(dirname $(which java | xargs realpath))/../)
+        fi
+      fi
 
 script:
   - echo ${JAVA_HOME}
   - ${JAVA_HOME}/bin/java -version
-  - mx --primary-suite-path ${TRAVIS_BUILD_DIR}/${PRIMARY} --java-home=${JAVA_HOME} gate --strict-mode --tags ${GATE}
+  - mx --primary-suite-path ${TRAVIS_BUILD_DIR}/${PRIMARY} --J @"-Xmx2g" --java-home=${JAVA_HOME} gate --strict-mode --tags ${GATE}
 after_failure:
   - cat hs_err*

--- a/compiler/mx.compiler/mx_compiler.py
+++ b/compiler/mx.compiler/mx_compiler.py
@@ -1323,7 +1323,7 @@ def _update_graaljdk(src_jdk, dst_jdk_dir=None, root_module_names=None, export_t
         out = mx.LinesOutputCapture()
         mx.run([jdk.java, '-version'], err=out)
         line = None
-        pattern = re.compile(r'(.* )(?:Server|Graal) VM (?:\d+\.\d+ )?\((?:[a-zA-Z]+ )?build.*')
+        pattern = re.compile(r'(.* )(?:Server|Graal) VM (?:\d+\.\d+ |[a-zA-Z]+ )?\((?:[a-zA-Z]+ )?build.*')
         for line in out.lines:
             m = pattern.match(line)
             if m:


### PR DESCRIPTION
Currently the travis-ci of the graal community does not support
tests on AArch64. This could not block patches that might break
AArch64. Fortunately the travis-ci has supported the multi-cpu
architecture tests recently. So it's time to enable the AArch64
tests for graal.

To enable the AArch64 tests and make them run smoothly, this patch
gives the following modifications:
  - Add compiler tests for AArch64.
  - Set the JAVA_HOME if it is not set.
  - Adjust the java version checking rule to make it also work for
    AdoptOpenJDK, which is the openjdk11 installed on travis Arm64.

Change-Id: Ia5cf7f4ea885c62a630917afd1d2cab74c3bbc19