### PR TITLE
[SVM GC] Add Survivor Space to SVM GC

### DIFF
--- a/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/AlignedHeapChunk.java
+++ b/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/AlignedHeapChunk.java
@@ -258,7 +258,7 @@ public class AlignedHeapChunk extends HeapChunk {
         final Pointer cardTableStart = getCardTableStart(chunk);
         final UnsignedWord index = getObjectIndex(chunk, objectPointer);
         if (verifyOnly) {
-            AssertionNode.assertion(false, CardTable.isDirtyEntryAtIndexUnchecked(cardTableStart, index), "card must be dirty");
+            AssertionNode.assertion(false, CardTable.isDirtyEntryAtIndexUnchecked(cardTableStart, index), "card must be dirty", "", "");
         } else {
             CardTable.dirtyEntryAtIndex(cardTableStart, index);
         }
@@ -454,6 +454,9 @@ public class AlignedHeapChunk extends HeapChunk {
             trace.newline().string("  ").string("  index: ").unsigned(index);
             /* If the card is dirty, visit the objects it covers. */
             if (CardTable.isDirtyEntryAtIndex(cardTableStart, index)) {
+                if (clean) {
+                    CardTable.cleanEntryAtIndex(cardTableStart, index);
+                }
                 final Pointer cardLimit = CardTable.indexToMemoryPointer(objectsStart, index.add(1));
                 final Pointer crossingOntoPointer = FirstObjectTable.getPreciseFirstObjectPointer(fotStart, objectsStart, objectsLimit, index);
                 final Object crossingOntoObject = crossingOntoPointer.toObject();
@@ -496,9 +499,6 @@ public class AlignedHeapChunk extends HeapChunk {
                         return false;
                     }
                     ptr = objEnd;
-                }
-                if (clean) {
-                    CardTable.cleanEntryAtIndex(cardTableStart, index);
                 }
             }
         }

--- a/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/DiscoverableReferenceProcessing.java
+++ b/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/DiscoverableReferenceProcessing.java
@@ -118,6 +118,7 @@ public class DiscoverableReferenceProcessing {
                 /* The referent will not survive the collection: put it on the new list. */
                 trace.string("  unpromoted current: ").object(current).newline();
                 newList = current.prependToDiscoveredReference(newList);
+                HeapImpl.getHeapImpl().dirtyCardIfNecessary(current, current.getNextRefPointer(), newList);
             } else {
                 /* Referent will survive the collection: don't add it to the new list. */
                 trace.string("  promoted current: ").object(current).newline();
@@ -149,6 +150,7 @@ public class DiscoverableReferenceProcessing {
             final Pointer forwardedPointer = ObjectHeaderImpl.getObjectHeaderImpl().getForwardingPointer(refPointer);
             dr.setReferentPointer(forwardedPointer);
             trace.string("  forwarded header: updated referent: ").hex(forwardedPointer).string("]").newline();
+            HeapImpl.getHeapImpl().dirtyCardIfNecessary(dr, refPointer, forwardedPointer.toObject());
             return true;
         }
         /*
@@ -158,6 +160,7 @@ public class DiscoverableReferenceProcessing {
         if (HeapImpl.getHeapImpl().hasSurvivedThisCollection(refObject)) {
             /* The referent has survived, it does not need to be updated. */
             trace.string("  referent will survive: not updated").string("]").newline();
+            HeapImpl.getHeapImpl().dirtyCardIfNecessary(dr, refPointer, refObject);
             return true;
         }
         /*

--- a/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/GreyObjectsWalker.java
+++ b/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/GreyObjectsWalker.java
@@ -78,7 +78,7 @@ public final class GreyObjectsWalker {
      *
      * @return True if the snapshot updated, false otherwise.
      */
-    private boolean haveGreyObjects() {
+    protected boolean haveGreyObjects() {
         final Log trace = Log.noopLog().string("[Space.GreyObjectsWalker.haveGreyObjects:");
         /* Any difference is a difference. */
         boolean result = false;

--- a/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/HeapChunk.java
+++ b/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/HeapChunk.java
@@ -167,6 +167,17 @@ public class HeapChunk {
         @RawField
         @UniqueLocationIdentity
         void setNext(T newNext);
+
+        /**
+         * The age information maintained by Chunk.
+         */
+        @RawField
+        @UniqueLocationIdentity
+        int getAge();
+
+        @RawField
+        @UniqueLocationIdentity
+        void setAge(int age);
     }
 
     /** Apply an ObjectVisitor to all the Objects in the given HeapChunk. */

--- a/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/HeapChunkProvider.java
+++ b/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/HeapChunkProvider.java
@@ -130,7 +130,7 @@ class HeapChunkProvider {
             zap(result, HeapPolicy.getProducedHeapChunkZapWord());
         }
 
-        HeapPolicy.bytesAllocatedSinceLastCollection.addAndGet(chunkSize);
+        HeapPolicy.youngUsedBytes.addAndGet(chunkSize);
 
         log().string("  result chunk: ").hex(result).string("  ]").newline();
         return result;
@@ -272,7 +272,7 @@ class HeapChunkProvider {
             zap(result, HeapPolicy.getProducedHeapChunkZapWord());
         }
 
-        HeapPolicy.bytesAllocatedSinceLastCollection.addAndGet(chunkSize);
+        HeapPolicy.youngUsedBytes.addAndGet(chunkSize);
 
         log().string("  returns ").hex(result).string("  ]").newline();
         return result;

--- a/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/HeapImpl.java
+++ b/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/HeapImpl.java
@@ -112,7 +112,7 @@ public class HeapImpl extends Heap {
         this.heapPolicy = new HeapPolicy(access);
         this.pinHead = new AtomicReference<>();
         /* Pre-allocate verifiers for use during collection. */
-        if (getVerifyHeapBeforeGC() || getVerifyHeapAfterGC() || getVerifyStackBeforeGC() || getVerifyStackAfterGC()) {
+        if (getVerifyHeapBeforeGC() || getVerifyHeapAfterGC() || getVerifyStackBeforeGC() || getVerifyStackAfterGC() || getVerifyDirtyCardBeforeGC() || getVerifyDirtyCardAfterGC()) {
             this.heapVerifier = HeapVerifierImpl.factory();
             this.stackVerifier = new StackVerifier();
         } else {
@@ -258,7 +258,7 @@ public class HeapImpl extends Heap {
      * This method has to be final so it can be called (transitively) from the allocation snippets.
      */
     final Space getAllocationSpace() {
-        return getYoungGeneration().getSpace();
+        return getYoungGeneration().getEden();
     }
 
     public HeapChunk.Header<?> getEnclosingHeapChunk(Object obj) {
@@ -283,11 +283,43 @@ public class HeapImpl extends Heap {
     public Object promoteObject(Object original) {
         final Log trace = Log.noopLog().string("[HeapImpl.promoteObject:").string("  original: ").object(original);
 
-        final OldGeneration oldGen = getOldGeneration();
-        final Object result = oldGen.promoteObject(original);
+        Object result;
+        if (!getGCImpl().isCompleteCollection()) {
+            result = getYoungGeneration().promoteObject(original);
+        } else {
+            result = getOldGeneration().promoteObject(original);
+        }
 
         trace.string("  result: ").object(result).string("]").newline();
         return result;
+    }
+
+    void dirtyCardIfNecessary(Object holderObject, Pointer objRef, Object object) {
+        final Log trace = Log.noopLog().string("[HeapImpl.dirtyCardIfNecessary:");
+        trace.string(" holderObject: ").hex(Word.objectToUntrackedPointer(holderObject));
+        trace.string(", objRef: ").hex(objRef);
+        trace.string(", object: ").hex(Word.objectToUntrackedPointer(object)).newline();
+
+        if (holderObject == null || GCImpl.getGCImpl().isCompleteCollection()) {
+            return;
+        }
+
+        if (!youngGeneration.contains(object)) {
+            return;
+        }
+
+        final ObjectHeaderImpl ohi = ObjectHeaderImpl.getObjectHeaderImpl();
+        final UnsignedWord objectHeader = ObjectHeaderImpl.readHeaderFromObject(holderObject);
+        if (ObjectHeaderImpl.hasRememberedSet(objectHeader)) {
+            if (ohi.isAlignedObject(holderObject)) {
+                AlignedHeapChunk.dirtyCardForObjectOfAlignedHeapChunk(holderObject, false);
+                trace.string("[Dirty card] aligned holderObject: ").hex(Word.objectToUntrackedPointer(holderObject));
+            } else {
+                assert ohi.isUnalignedObject(holderObject) : "sanity";
+                UnalignedHeapChunk.dirtyCardForObjectOfUnalignedHeapChunk(holderObject, false);
+                trace.string("[Dirty card] unaligned holderObject: ").hex(Word.objectToUntrackedPointer(holderObject));
+            }
+        }
     }
 
     boolean hasSurvivedThisCollection(Object obj) {
@@ -303,8 +335,7 @@ public class HeapImpl extends Heap {
              */
             final HeapChunk.Header<?> chunk = getEnclosingHeapChunk(obj);
             final Space space = chunk.getSpace();
-            final OldGeneration oldGen = getOldGeneration();
-            return space == oldGen.getToSpace();
+            return !space.isFrom();
         }
         return false;
     }
@@ -336,6 +367,10 @@ public class HeapImpl extends Heap {
 
     public OldGeneration getOldGeneration() {
         return oldGeneration;
+    }
+
+    public boolean isOldGeneration(Space space) {
+        return space.isOldSpace();
     }
 
     /** The head of the linked list of object pins. */
@@ -371,8 +406,7 @@ public class HeapImpl extends Heap {
     }
 
     UnsignedWord getYoungUsedChunkBytes() {
-        final Space.Accounting young = getYoungGeneration().getSpace().getAccounting();
-        return young.getAlignedChunkBytes().add(young.getUnalignedChunkBytes());
+        return getYoungGeneration().getChunkUsedBytes();
     }
 
     UnsignedWord getOldUsedChunkBytes() {
@@ -397,11 +431,15 @@ public class HeapImpl extends Heap {
 
     /** Return the size, in bytes, of the actual used memory, not the committed memory. */
     public UnsignedWord getUsedObjectBytes() {
-        final Space youngSpace = getYoungGeneration().getSpace();
-        final UnsignedWord youngBytes = youngSpace.getObjectBytes();
+        final Space edenSpace = getYoungGeneration().getEden();
+        final UnsignedWord edenBytes = edenSpace.getObjectBytes();
+        final UnsignedWord survivorFromBytes = WordFactory.zero();
+        for (int i = 0; i < HeapPolicy.getMaxSurvivorSpaces(); i++) {
+            survivorFromBytes.add(getYoungGeneration().getSurvivorFromSpaceAt(i).getObjectBytes());
+        }
         final Space fromSpace = getOldGeneration().getFromSpace();
-        final UnsignedWord fromBytes = fromSpace.getObjectBytes();
-        return youngBytes.add(fromBytes);
+        final UnsignedWord oldFromBytes = fromSpace.getObjectBytes();
+        return edenBytes.add(survivorFromBytes).add(oldFromBytes);
     }
 
     protected void report(Log log) {
@@ -537,6 +575,16 @@ public class HeapImpl extends Heap {
         return (SubstrateOptions.VerifyHeap.getValue() || HeapOptions.VerifyStackAfterCollection.getValue());
     }
 
+    @Fold
+    static boolean getVerifyDirtyCardBeforeGC() {
+        return (SubstrateOptions.VerifyHeap.getValue() || HeapOptions.VerifyDirtyCardsBeforeCollection.getValue());
+    }
+
+    @Fold
+    static boolean getVerifyDirtyCardAfterGC() {
+        return (SubstrateOptions.VerifyHeap.getValue() || HeapOptions.VerifyDirtyCardsAfterCollection.getValue());
+    }
+
     @NeverInline("Starting a stack walk in the caller frame")
     void verifyBeforeGC(String cause, UnsignedWord epoch) {
         final Log trace = Log.noopLog().string("[HeapImpl.verifyBeforeGC:");
@@ -556,6 +604,11 @@ public class HeapImpl extends Heap {
                 assert false;
             }
         }
+        if (getVerifyDirtyCardBeforeGC()) {
+            assert heapVerifier != null : "No heap verifier!";
+            Log.log().string("[Verify dirtyCard before GC: ");
+            heapVerifier.verifyDirtyCard(false);
+        }
         trace.string("]").newline();
     }
 
@@ -574,6 +627,11 @@ public class HeapImpl extends Heap {
                 Log.log().string("[HeapImpl.verifyAfterGC:").string("  cause: ").string(cause).string("  stack fails to verify after epoch: ").unsigned(epoch).string("]").newline();
                 assert false;
             }
+        }
+        if (getVerifyDirtyCardAfterGC()) {
+            assert heapVerifier != null : "No heap verifier!";
+            Log.log().string("[Verify dirtyCard after GC: ");
+            heapVerifier.verifyDirtyCard(true);
         }
     }
 
@@ -609,7 +667,7 @@ public class HeapImpl extends Heap {
         /*
          * Report "chunk bytes" rather than the slower but more accurate "object bytes".
          */
-        return maxMemory().subtract(HeapPolicy.getBytesAllocatedSinceLastCollection()).subtract(getOldUsedChunkBytes());
+        return maxMemory().subtract(HeapPolicy.getYoungUsedBytes()).subtract(getOldUsedChunkBytes());
     }
 
     /**

--- a/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/HeapOptions.java
+++ b/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/HeapOptions.java
@@ -66,4 +66,10 @@ public class HeapOptions {
 
     @Option(help = "Trace stack verification.")//
     public static final HostedOptionKey<Boolean> TraceStackVerification = new HostedOptionKey<>(false);
+
+    @Option(help = "Verify dirty cards before each collection.") //
+    public static final HostedOptionKey<Boolean> VerifyDirtyCardsBeforeCollection = new HostedOptionKey<>(false);
+
+    @Option(help = "Verify dirty cards after each collection.") //
+    public static final HostedOptionKey<Boolean> VerifyDirtyCardsAfterCollection = new HostedOptionKey<>(false);
 }

--- a/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/HeapPolicyOptions.java
+++ b/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/HeapPolicyOptions.java
@@ -74,4 +74,7 @@ public class HeapPolicyOptions {
 
     @Option(help = "Defines the upper bound for the number of remaining bytes in the young generation that cause a collection when `System.gc` is called.") //
     public static final RuntimeOptionKey<Long> UserRequestedGCThreshold = new RuntimeOptionKey<>(16L * 1024L * 1024L);
+
+    @Option(help = "Maximum value for survivor space") //
+    public static final HostedOptionKey<Integer> MaxSurvivorSpaces = new HostedOptionKey<>(4);
 }

--- a/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/HeapVerifierImpl.java
+++ b/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/HeapVerifierImpl.java
@@ -241,6 +241,11 @@ public class HeapVerifierImpl implements HeapVerifier {
         return result;
     }
 
+    void verifyDirtyCard(boolean isTo) {
+        OldGeneration oldGen = HeapImpl.getHeapImpl().getOldGeneration();
+        oldGen.verifyDirtyCards(isTo);
+    }
+
     @Override
     public Log getTraceLog() {
         return (HeapOptions.TraceHeapVerification.getValue() ? Log.log() : Log.noopLog());

--- a/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/OldGeneration.java
+++ b/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/OldGeneration.java
@@ -56,8 +56,9 @@ public class OldGeneration extends Generation {
     @Platforms(Platform.HOSTED_ONLY.class)
     OldGeneration(String name) {
         super(name);
-        this.fromSpace = new Space("fromSpace", false);
-        this.toSpace = new Space("toSpace", false);
+        int age = HeapPolicy.getMaxSurvivorSpaces() + 1;
+        this.fromSpace = new Space("fromSpace", false, true, age);
+        this.toSpace = new Space("toSpace", false, false, age);
         this.toGreyObjectsWalker = GreyObjectsWalker.factory();
     }
 
@@ -107,31 +108,23 @@ public class OldGeneration extends Generation {
     void releaseSpaces() {
         /* Release any spaces associated with this generation after a collection. */
         getFromSpace().release();
-        /* Clean the spaces that have been scanned for grey objects. */
-        getToSpace().cleanRememberedSet();
+        /* Just clean remember set in complete collection */
+        if (HeapImpl.getHeapImpl().getGCImpl().isCompleteCollection()) {
+            /* Clean the spaces that have been scanned for grey objects. */
+            getToSpace().cleanRememberedSet();
+        }
     }
 
-    private boolean shouldPromoteFrom(Space originalSpace) {
+    private static boolean shouldPromoteFrom(Space originalSpace) {
         final Log trace = Log.noopLog();
         trace.string("[OldGeneration.shouldPromoteFrom:").string("  originalSpace: ").string(originalSpace.getName());
-        final boolean result;
-        final HeapImpl heap = HeapImpl.getHeapImpl();
-        if (heap.isYoungGeneration(originalSpace)) {
-            /* The most likely case: the original Space is young space. */
-            result = true;
-        } else if (originalSpace == getFromSpace()) {
-            /* The next most likely case: the original Space is from space. */
-            result = true;
-        } else {
-            /* Otherwise, do not promote to old toSpace. */
-            result = false;
-        }
+        final boolean result = originalSpace.isFrom();
         trace.string("  returns: ").bool(result);
         trace.string("]").newline();
         return result;
     }
 
-    private Object promoteAlignedObject(Object original) {
+    Object promoteAlignedObject(Object original) {
         final Log trace = Log.noopLog().string("[OldGeneration.promoteAlignedObject:").string("  original: ").object(original);
         assert ObjectHeaderImpl.getObjectHeaderImpl().isAlignedObject(original);
         final AlignedHeapChunk.AlignedHeader originalChunk = AlignedHeapChunk.getEnclosingAlignedHeapChunk(original);
@@ -159,7 +152,7 @@ public class OldGeneration extends Generation {
         return result;
     }
 
-    private Object promoteUnalignedObjectChunk(Object original) {
+    Object promoteUnalignedObjectChunk(Object original) {
         final Log trace = Log.noopLog().string("[OldGeneration.promoteUnalignedObjectChunk:").string("  original: ").object(original);
         assert ObjectHeaderImpl.getObjectHeaderImpl().isUnalignedObject(original);
         final UnalignedHeapChunk.UnalignedHeader uChunk = UnalignedHeapChunk.getEnclosingUnalignedHeapChunk(original);
@@ -199,11 +192,17 @@ public class OldGeneration extends Generation {
         getToGreyObjectsWalker().setScanStart(getToSpace());
     }
 
-    protected void scanGreyObjects() {
+    protected boolean scanGreyObjects() {
         final Log trace = Log.noopLog().string("[OldGeneration.scanGreyObjects:");
         final GCImpl gc = HeapImpl.getHeapImpl().getGCImpl();
+
+        if (!getToGreyObjectsWalker().haveGreyObjects()) {
+            return false;
+        }
+
         getToGreyObjectsWalker().walkGreyObjects(gc.getGreyToBlackObjectVisitor());
         trace.string("]").newline();
+        return true;
     }
 
     @Override
@@ -256,6 +255,14 @@ public class OldGeneration extends Generation {
             }
         }
         return result;
+    }
+
+    protected void verifyDirtyCards(boolean isTo) {
+        if (isTo) {
+            getToSpace().verifyDirtyCards();
+        } else {
+            getFromSpace().verifyDirtyCards();
+        }
     }
 
     boolean slowlyFindPointer(Pointer p) {

--- a/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/ThreadLocalAllocation.java
+++ b/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/ThreadLocalAllocation.java
@@ -314,7 +314,7 @@ public final class ThreadLocalAllocation {
 
     static boolean isThreadLocalAllocationSpace(Space space) {
         // Compare "space" to a compile-time constant, rather than accessing a field of the space.
-        return (space == HeapImpl.getHeapImpl().getYoungGeneration().getSpace());
+        return (space == HeapImpl.getHeapImpl().getYoungGeneration().getEden());
     }
 
     /** Stop using the current chunk for thread-local allocation. */

--- a/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/ThreadLocalMTWalker.java
+++ b/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/ThreadLocalMTWalker.java
@@ -44,7 +44,7 @@ public class ThreadLocalMTWalker {
         VMThreadLocalMTSupport threadLocals = ImageSingletons.lookup(VMThreadLocalMTSupport.class);
         for (IsolateThread vmThread = VMThreads.firstThread(); vmThread.isNonNull(); vmThread = VMThreads.nextThread(vmThread)) {
             if (!InstanceReferenceMapDecoder.walkOffsetsFromPointer((Pointer) vmThread, NonmovableArrays.fromImageHeap(threadLocals.vmThreadReferenceMapEncoding),
-                            threadLocals.vmThreadReferenceMapIndex, referenceVisitor)) {
+                            threadLocals.vmThreadReferenceMapIndex, referenceVisitor, null)) {
                 return false;
             }
         }

--- a/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/UnalignedHeapChunk.java
+++ b/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/UnalignedHeapChunk.java
@@ -197,7 +197,7 @@ public class UnalignedHeapChunk extends HeapChunk {
         final Pointer cardTableStart = getCardTableStart(chunk);
         final UnsignedWord objectIndex = getObjectIndex();
         if (verifyOnly) {
-            AssertionNode.assertion(false, CardTable.isDirtyEntryAtIndexUnchecked(cardTableStart, objectIndex), "card must be dirty");
+            AssertionNode.assertion(false, CardTable.isDirtyEntryAtIndexUnchecked(cardTableStart, objectIndex), "card must be dirty", "", "");
         } else {
             CardTable.dirtyEntryAtIndex(cardTableStart, objectIndex);
         }
@@ -230,15 +230,15 @@ public class UnalignedHeapChunk extends HeapChunk {
         trace.string("  rememberedSetStart: ").hex(rememberedSetStart).string("  objectIndex: ").unsigned(objectIndex);
         // If the card for this chunk is dirty, visit the object.
         if (CardTable.isDirtyEntryAtIndex(rememberedSetStart, objectIndex)) {
+            if (clean) {
+                CardTable.cleanEntryAtIndex(rememberedSetStart, objectIndex);
+            }
             final Pointer objectsStart = getUnalignedStart(that);
             final Object obj = objectsStart.toObject();
             trace.string("  obj: ").object(obj);
             // Visit the object.
             if (!visitor.visitObjectInline(obj)) {
                 result = false;
-            }
-            if (clean) {
-                CardTable.cleanEntryAtIndex(rememberedSetStart, objectIndex);
             }
         }
         trace.string("  returns: ").bool(result).string("]").newline();

--- a/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/YoungGeneration.java
+++ b/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/YoungGeneration.java
@@ -24,6 +24,7 @@
  */
 package com.oracle.svm.core.genscavenge;
 
+import com.oracle.svm.core.hub.LayoutEncoding;
 import org.graalvm.nativeimage.Platform;
 import org.graalvm.nativeimage.Platforms;
 import org.graalvm.word.Pointer;
@@ -32,7 +33,8 @@ import com.oracle.svm.core.MemoryWalker;
 import com.oracle.svm.core.annotate.Uninterruptible;
 import com.oracle.svm.core.heap.ObjectVisitor;
 import com.oracle.svm.core.log.Log;
-import com.oracle.svm.core.util.VMError;
+import org.graalvm.word.UnsignedWord;
+import org.graalvm.word.WordFactory;
 
 /**
  * A Young Generation has one space, for ordinary objects.
@@ -40,40 +42,79 @@ import com.oracle.svm.core.util.VMError;
 public class YoungGeneration extends Generation {
 
     // Final State.
-    private final Space space;
+    private final Space eden;
+    private final Space[] survivorFromSpaces;
+    private final Space[] survivorToSpaces;
+    private final GreyObjectsWalker[] survivorGreyObjectsWalkers;
+    private final int maxSurvivorSpaces;
 
     /* Constructors. */
 
     @Platforms(Platform.HOSTED_ONLY.class)
     YoungGeneration(String name) {
-        this(name, new Space("youngSpace", true));
+        this(name, new Space("edenSpace", true, true, 0));
     }
 
     @Platforms(Platform.HOSTED_ONLY.class)
     private YoungGeneration(String name, Space space) {
         super(name);
-        this.space = space;
+        this.eden = space;
+        this.maxSurvivorSpaces = HeapPolicy.getMaxSurvivorSpaces();
+        this.survivorFromSpaces = new Space[maxSurvivorSpaces];
+        this.survivorToSpaces = new Space[maxSurvivorSpaces];
+        this.survivorGreyObjectsWalkers = new GreyObjectsWalker[maxSurvivorSpaces];
+        for (int i = 0; i < maxSurvivorSpaces; i++) {
+            this.survivorFromSpaces[i] = new Space("Survivor-" + (i + 1) + " From", true, true, (i + 1));
+            this.survivorToSpaces[i] = new Space("Survivor-" + (i + 1) + " To", true, false, (i + 1));
+            this.survivorGreyObjectsWalkers[i] = GreyObjectsWalker.factory();
+        }
     }
 
     /** Return all allocated virtual memory chunks to HeapChunkProvider. */
     @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
     public final void tearDown() {
         ThreadLocalAllocation.tearDown();
-        space.tearDown();
+        eden.tearDown();
+        for (int i = 0; i < maxSurvivorSpaces; i++) {
+            survivorFromSpaces[i].tearDown();
+            survivorToSpaces[i].tearDown();
+        }
     }
 
     @Override
     public boolean walkObjects(ObjectVisitor visitor) {
         /* Flush the thread-local allocation data. */
         ThreadLocalAllocation.disableThreadLocalAllocation();
-        return getSpace().walkObjects(visitor);
+        if (!getEden().walkObjects(visitor)) {
+            return false;
+        }
+        for (int i = 0; i < maxSurvivorSpaces; i++) {
+            if (!survivorFromSpaces[i].walkObjects(visitor)) {
+                return false;
+            }
+            if (!survivorToSpaces[i].walkObjects(visitor)) {
+                return false;
+            }
+        }
+        return true;
     }
 
     @Override
     public Log report(Log log, boolean traceHeapChunks) {
         log.string("[Young generation: ").indent(true);
-        getSpace().report(log, traceHeapChunks);
-        log.redent(false).string("]");
+
+        log.string("[Eden: ").indent(true);
+        getEden().report(log, traceHeapChunks);
+        log.redent(false).string("]").newline();
+        log.string("[Survivors: ").indent(true);
+        for (int i = 0; i < maxSurvivorSpaces; i++) {
+            this.survivorFromSpaces[i].report(log, traceHeapChunks).newline();
+            this.survivorToSpaces[i].report(log, traceHeapChunks);
+            if (i < maxSurvivorSpaces - 1) {
+                log.newline();
+            }
+        }
+        log.redent(false).string("]").redent(false).string("]");
         return log;
     }
 
@@ -82,22 +123,82 @@ public class YoungGeneration extends Generation {
      *
      * This method is final because it is called (transitively) from the allocation snippets.
      */
-    public final Space getSpace() {
-        return space;
+    public final Space getEden() {
+        return eden;
+    }
+
+    Space getSurvivorToSpaceAt(int index) {
+        assert index >= 0 && index < maxSurvivorSpaces : "Survivor index should be between 0 and NumberOfSurvivorSpaces";
+        return survivorToSpaces[index];
+    }
+
+    Space getSurvivorFromSpaceAt(int index) {
+        assert index >= 0 && index < maxSurvivorSpaces : "Survivor index should be between 0 and NumberOfSurvivorSpaces";
+        return survivorFromSpaces[index];
+    }
+
+    private GreyObjectsWalker getSurvivorGreyObjectsWalker(int index) {
+        return survivorGreyObjectsWalkers[index];
     }
 
     /** Check if that space is the young space. */
     boolean isYoungSpace(Space thatSpace) {
-        return (getSpace() == thatSpace);
+        return thatSpace.isYoungSpace();
     }
 
     @Override
     protected Object promoteObject(Object original) {
-        throw VMError.shouldNotReachHere("Can not promote to a YoungGeneration.");
+        final Log trace = Log.noopLog().string("[YoungGeneration.promoteObject:").string("  original: ").object(original).newline();
+        /* Choose between object copying and chunk motion. */
+        Object result = null;
+        if (ObjectHeaderImpl.getObjectHeaderImpl().isAlignedObject(original)) {
+            trace.string("  aligned header: ").hex(ObjectHeaderImpl.readHeaderFromObject(original)).newline();
+            /* Promote by Object copying to the next age space. */
+            AlignedHeapChunk.AlignedHeader originalChunk = AlignedHeapChunk.getEnclosingAlignedHeapChunk(original);
+            final Space originalSpace = originalChunk.getSpace();
+            if (originalChunk.getAge() < maxSurvivorSpaces) {
+                result = promoteAlignedObject(original, originalSpace);
+            } else {
+                result = HeapImpl.getHeapImpl().getOldGeneration().promoteAlignedObject(original);
+            }
+        } else {
+            trace.string("  unaligned header: ").hex(ObjectHeaderImpl.readHeaderFromObject(original)).newline();
+            UnalignedHeapChunk.UnalignedHeader originalUnalignedChunk = UnalignedHeapChunk.getEnclosingUnalignedHeapChunk(original);
+            final Space originalSpace = originalUnalignedChunk.getSpace();
+            if (originalUnalignedChunk.getAge() < maxSurvivorSpaces) {
+                result = promoteUnalignedObject(original, originalSpace);
+            } else {
+                result = HeapImpl.getHeapImpl().getOldGeneration().promoteUnalignedObjectChunk(original);
+            }
+        }
+        trace.string("  OldGeneration.promoteObject returns: ").object(result).string("]").newline();
+        return result;
+    }
+
+    private void releaseSurvivorSpaces(boolean isFromSpace) {
+        for (int i = 0; i < maxSurvivorSpaces; i++) {
+            if (isFromSpace) {
+                getSurvivorFromSpaceAt(i).release();
+            } else {
+                getSurvivorToSpaceAt(i).release();
+            }
+        }
     }
 
     void releaseSpaces() {
-        getSpace().release();
+        getEden().release();
+
+        releaseSurvivorSpaces(true);
+        if (HeapImpl.getHeapImpl().getGCImpl().isCompleteCollection()) {
+            releaseSurvivorSpaces(false);
+        }
+    }
+
+    void swapSpaces() {
+        for (int i = 0; i < maxSurvivorSpaces; i++) {
+            assert getSurvivorFromSpaceAt(i).isEmpty() : "Survivor fromSpace should be empty.";
+            getSurvivorFromSpaceAt(i).absorb(getSurvivorToSpaceAt(i));
+        }
     }
 
     @Override
@@ -107,37 +208,193 @@ public class YoungGeneration extends Generation {
 
     @Override
     protected boolean verify(final HeapVerifierImpl.Occasion occasion) {
-        // The young "generation" consists of just one space.
         boolean result = true;
         final HeapImpl heap = HeapImpl.getHeapImpl();
         final HeapVerifierImpl heapVerifier = heap.getHeapVerifierImpl();
         final SpaceVerifierImpl spaceVerifier = heapVerifier.getSpaceVerifierImpl();
-        spaceVerifier.initialize(getSpace());
+        // Verify eden space
+        spaceVerifier.initialize(getEden());
         if (occasion.equals(HeapVerifier.Occasion.AFTER_COLLECTION)) {
-            // After a collection the young space should be empty.
+            // After a collection the eden space should be empty.
             if (spaceVerifier.containsChunks()) {
                 result = false;
-                heapVerifier.getWitnessLog().string("[YoungGeneration.verify:").string("  young space contains chunks after collection").string("]").newline();
+                heapVerifier.getWitnessLog().string("[YoungGeneration.verify:").string("  eden space contains chunks after collection").string("]").newline();
             }
         } else {
             // Otherwise, verify the space.
             if (!spaceVerifier.verify()) {
                 result = false;
-                heapVerifier.getWitnessLog().string("[YoungGeneration.verify:").string("  young space fails to verify").string("]").newline();
+                heapVerifier.getWitnessLog().string("[YoungGeneration.verify:").string("  eden space fails to verify").string("]").newline();
             }
         }
+        // Verify survivor spaces
+        for (int i = 0; i < maxSurvivorSpaces; i++) {
+            // Verify survivor from space,
+            spaceVerifier.initialize(survivorFromSpaces[i]);
+            if (!spaceVerifier.verify()) {
+                result = false;
+                heapVerifier.getWitnessLog().string("[YoungGeneration.verify:").string("  survivor to space fails to verify").string("]").newline();
+            }
+            /*
+             * The survivor to space, which should be empty except during a collection
+             */
+            spaceVerifier.initialize(survivorToSpaces[i]);
+            if (!spaceVerifier.verify()) {
+                result = false;
+                heapVerifier.getWitnessLog().string("[YoungGeneration.verify:").string("  survivor to space fails to verify").string("]").newline();
+            }
+            if (!occasion.equals(HeapVerifier.Occasion.DURING_COLLECTION)) {
+                if (spaceVerifier.containsChunks()) {
+                    result = false;
+                    heapVerifier.getWitnessLog().string("[YoungGeneration.verify:").string("  survivor to space contains chunks").string("]").newline();
+                }
+            }
+        }
+
         return result;
     }
 
     boolean slowlyFindPointer(Pointer p) {
-        if (HeapVerifierImpl.slowlyFindPointerInSpace(getSpace(), p, HeapVerifierImpl.ChunkLimit.top)) {
+        if (HeapVerifierImpl.slowlyFindPointerInSpace(getEden(), p, HeapVerifierImpl.ChunkLimit.top)) {
             return true;
+        }
+
+        for (int i = 0; i < maxSurvivorSpaces; i++) {
+            if (HeapVerifierImpl.slowlyFindPointerInSpace(getSurvivorFromSpaceAt(i), p, HeapVerifierImpl.ChunkLimit.top)) {
+                return true;
+            }
+            if (HeapVerifierImpl.slowlyFindPointerInSpace(getSurvivorToSpaceAt(i), p, HeapVerifierImpl.ChunkLimit.top)) {
+                return true;
+            }
         }
 
         return false;
     }
 
     boolean walkHeapChunks(MemoryWalker.Visitor visitor) {
-        return getSpace().walkHeapChunks(visitor);
+        if (getEden().walkHeapChunks(visitor)) {
+            for (int i = 0; i < maxSurvivorSpaces; i++) {
+                if (!(getSurvivorFromSpaceAt(i).walkHeapChunks(visitor) && getSurvivorToSpaceAt(i).walkHeapChunks(visitor))) {
+                    return false;
+                }
+            }
+            return true;
+        }
+        return false;
     }
+
+    void prepareForPromotion() {
+        /* Prepare the Space walkers. */
+        for (int i = 0; i < maxSurvivorSpaces; i++) {
+            assert getSurvivorToSpaceAt(i).isEmpty() : "SurvivorToSpace should be empty.";
+            getSurvivorGreyObjectsWalker(i).setScanStart(getSurvivorToSpaceAt(i));
+        }
+    }
+
+    boolean scanGreyObjects() {
+        final Log trace = Log.noopLog().string("[YoungGeneration.scanGreyObjects:");
+        final GCImpl gc = HeapImpl.getHeapImpl().getGCImpl();
+        boolean needScan = false;
+
+        for (int i = 0; i < maxSurvivorSpaces; i++) {
+            if (getSurvivorGreyObjectsWalker(i).haveGreyObjects()) {
+                needScan = true;
+                break;
+            }
+        }
+
+        if (!needScan) {
+            return false;
+        }
+
+        for (int i = 0; i < maxSurvivorSpaces; i++) {
+            trace.string("[Scanning survivor-").signed(i).string("]").newline();
+            getSurvivorGreyObjectsWalker(i).walkGreyObjects(gc.getGreyToBlackObjectVisitor());
+        }
+        trace.string("]").newline();
+
+        return true;
+    }
+
+    UnsignedWord getSurvivorChunkUsedBytes() {
+        UnsignedWord usedBytes = WordFactory.zero();
+        for (int i = 0; i < maxSurvivorSpaces; i++) {
+            usedBytes.add(this.survivorFromSpaces[i].getChunkBytes());
+            usedBytes.add(this.survivorToSpaces[i].getChunkBytes());
+        }
+        return usedBytes;
+    }
+
+    UnsignedWord getEdenChunkUsedBytes() {
+        return getEden().getChunkBytes();
+    }
+
+    UnsignedWord getChunkUsedBytes() {
+        return getEdenChunkUsedBytes().add(getSurvivorChunkUsedBytes());
+    }
+
+    UnsignedWord getSurvivorObjectBytes() {
+        UnsignedWord usedObjectBytes = WordFactory.zero();
+        for (int i = 0; i < maxSurvivorSpaces; i++) {
+            usedObjectBytes.add(this.survivorFromSpaces[i].getObjectBytes());
+            usedObjectBytes.add(this.survivorToSpaces[i].getObjectBytes());
+        }
+        return usedObjectBytes;
+    }
+
+    UnsignedWord getEdenObjectBytes() {
+        return getEden().getObjectBytes();
+    }
+
+    UnsignedWord getObjectBytes() {
+        return getEdenObjectBytes().add(getSurvivorObjectBytes());
+    }
+
+    boolean contains(Object object) {
+        final ObjectHeaderImpl ohi = ObjectHeaderImpl.getObjectHeaderImpl();
+        if (ohi.isAlignedObject(object)) {
+            return isYoungSpace(AlignedHeapChunk.getEnclosingAlignedHeapChunk(object).getSpace());
+        } else if (ohi.isUnalignedObject(object)) {
+            return isYoungSpace(UnalignedHeapChunk.getEnclosingUnalignedHeapChunk(object).getSpace());
+        }
+        return false;
+    }
+
+    private static boolean shouldPromoteFrom(Space originalSpace) {
+        return originalSpace.isFrom();
+    }
+
+    private Object promoteAlignedObject(Object original, Space originalSpace) {
+        assert originalSpace.isEdenSpace() || originalSpace.isSurvivorSpace() : "Should be Eden or survivor.";
+        if (!shouldPromoteFrom(originalSpace)) {
+            return original;
+        }
+        int age = originalSpace.getNextAgeForPromotion();
+        Space toSpace = getSurvivorToSpaceAt(age - 1);
+        return toSpace.promoteAlignedObject(original);
+    }
+
+    private Object promoteUnalignedObject(Object original, Space originalSpace) {
+        final Log trace = Log.noopLog().string("[YoungGeneration.promoteUnalignedObjectChunk:").string("  original: ").object(original);
+        assert ObjectHeaderImpl.getObjectHeaderImpl().isUnalignedObject(original);
+        trace.string("  originalSpace: ").string(originalSpace.getName());
+        if (shouldPromoteFrom(originalSpace)) {
+            trace.string("  promoting");
+            final UnalignedHeapChunk.UnalignedHeader uChunk = UnalignedHeapChunk.getEnclosingUnalignedHeapChunk(original);
+            int age = originalSpace.getNextAgeForPromotion();
+            Space toSpace = getSurvivorToSpaceAt(age - 1);
+            if (HeapOptions.TraceObjectPromotion.getValue()) {
+                final Log promotionTrace = Log.log().string("[YoungGeneration.promoteUnalignedObjectChunk:").string("  original: ").object(original);
+                final UnsignedWord size = LayoutEncoding.getSizeFromObject(original);
+                promotionTrace.string("  size: ").unsigned(size).string("]").newline();
+            }
+            toSpace.promoteUnalignedHeapChunk(uChunk);
+        } else {
+            trace.string("  not promoting");
+        }
+        trace.string("  returns: ").object(original);
+        trace.string("]").newline();
+        return original;
+    }
+
 }

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/heap/DiscoverableReference.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/heap/DiscoverableReference.java
@@ -228,4 +228,12 @@ public class DiscoverableReference {
             return that.getNextDiscoverableReference();
         }
     }
+
+    /**
+     * Read access to the next field, as a Pointer. This is the low-level access for the garbage
+     * collector, so no barriers are used.
+     */
+    public Pointer getNextRefPointer() {
+        return Word.objectToUntrackedPointer(this).add(WordFactory.signed(NEXT_FIELD_OFFSET));
+    }
 }

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/heap/InstanceReferenceMapDecoder.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/heap/InstanceReferenceMapDecoder.java
@@ -36,7 +36,7 @@ import com.oracle.svm.core.util.NonmovableByteArrayReader;
 @DuplicatedInNativeCode
 public class InstanceReferenceMapDecoder {
     @AlwaysInline("de-virtualize calls to ObjectReferenceVisitor")
-    public static boolean walkOffsetsFromPointer(Pointer baseAddress, NonmovableArray<Byte> referenceMapEncoding, long referenceMapIndex, ObjectReferenceVisitor visitor) {
+    public static boolean walkOffsetsFromPointer(Pointer baseAddress, NonmovableArray<Byte> referenceMapEncoding, long referenceMapIndex, ObjectReferenceVisitor visitor, Object holderObject) {
         assert referenceMapIndex >= CodeInfoQueryResult.EMPTY_REFERENCE_MAP;
         assert referenceMapEncoding.isNonNull();
 
@@ -53,7 +53,7 @@ public class InstanceReferenceMapDecoder {
 
             Pointer objRef = baseAddress.add(offset);
             for (int c = 0; c < count; c++) {
-                final boolean visitResult = visitor.visitObjectReferenceInline(objRef, 0, compressed);
+                final boolean visitResult = visitor.visitObjectReferenceInline(objRef, 0, compressed, holderObject);
                 if (!visitResult) {
                     return false;
                 }

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/heap/ObjectReferenceVisitor.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/heap/ObjectReferenceVisitor.java
@@ -45,6 +45,11 @@ public interface ObjectReferenceVisitor {
     @RestrictHeapAccess(access = RestrictHeapAccess.Access.UNRESTRICTED, overridesCallers = true, reason = "Some implementations allocate.")
     boolean visitObjectReference(Pointer objRef, boolean compressed);
 
+    @RestrictHeapAccess(access = RestrictHeapAccess.Access.UNRESTRICTED, overridesCallers = true, reason = "Some implementations allocate.")
+    default boolean visitObjectReference(Pointer objRef, boolean compressed, @SuppressWarnings("unused") Object holderObject) {
+        return visitObjectReference(objRef, compressed);
+    }
+
     /** Like visitObjectReference(Pointer), but always inlined for performance. */
     @RestrictHeapAccess(access = RestrictHeapAccess.Access.UNRESTRICTED, overridesCallers = true, reason = "Some implementations allocate.")
     default boolean visitObjectReferenceInline(Pointer objRef, boolean compressed) {
@@ -54,5 +59,16 @@ public interface ObjectReferenceVisitor {
     @RestrictHeapAccess(access = RestrictHeapAccess.Access.UNRESTRICTED, overridesCallers = true, reason = "Some implementations allocate.")
     default boolean visitObjectReferenceInline(Pointer objRef, @SuppressWarnings("unused") int innerOffset, boolean compressed) {
         return visitObjectReference(objRef, compressed);
+    }
+
+    /** Like visitObjectReference(Pointer), but always inlined for performance. */
+    @RestrictHeapAccess(access = RestrictHeapAccess.Access.UNRESTRICTED, overridesCallers = true, reason = "Some implementations allocate.")
+    default boolean visitObjectReferenceInline(Pointer objRef, boolean compressed, @SuppressWarnings("unused") Object holderObject) {
+        return visitObjectReferenceInline(objRef, compressed);
+    }
+
+    @RestrictHeapAccess(access = RestrictHeapAccess.Access.UNRESTRICTED, overridesCallers = true, reason = "Some implementations allocate.")
+    default boolean visitObjectReferenceInline(Pointer objRef, @SuppressWarnings("unused") int innerOffset, boolean compressed, @SuppressWarnings("unused") Object holderObject) {
+        return visitObjectReferenceInline(objRef, innerOffset, compressed);
     }
 }

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/hub/InteriorObjRefWalker.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/hub/InteriorObjRefWalker.java
@@ -70,7 +70,7 @@ public class InteriorObjRefWalker {
                 final UnsignedWord elementOffset = LayoutEncoding.getArrayElementOffset(layoutEncoding, index);
                 final Pointer elementPointer = objPointer.add(elementOffset);
                 boolean isCompressed = ReferenceAccess.singleton().haveCompressedReferences();
-                final boolean visitResult = visitor.visitObjectReferenceInline(elementPointer, isCompressed);
+                final boolean visitResult = visitor.visitObjectReferenceInline(elementPointer, isCompressed, obj);
                 if (!visitResult) {
                     return false;
                 }
@@ -81,6 +81,6 @@ public class InteriorObjRefWalker {
         long referenceMapIndex = objHub.getReferenceMapIndex();
 
         // Visit Object reference in the fields of the Object.
-        return InstanceReferenceMapDecoder.walkOffsetsFromPointer(objPointer, referenceMapEncoding, referenceMapIndex, visitor);
+        return InstanceReferenceMapDecoder.walkOffsetsFromPointer(objPointer, referenceMapEncoding, referenceMapIndex, visitor, obj);
     }
 }


### PR DESCRIPTION
This patch will use the multi-survivors for SVM GC to reduce the frequency of full GC.
In the micro benchmark it could reduce the frequently of full GC(the full GC times could change from ~17/260 to ~9/250)
And in the real workload in Alibaba, it could also reduce the frequency of full GC(the full GC times could change from ~30/100 to ~1/200)
