### PR TITLE
Explain missing stack traces in polyglot exceptions

### DIFF
--- a/truffle/src/com.oracle.truffle.polyglot/src/com/oracle/truffle/polyglot/PolyglotExceptionImpl.java
+++ b/truffle/src/com.oracle.truffle.polyglot/src/com/oracle/truffle/polyglot/PolyglotExceptionImpl.java
@@ -51,6 +51,7 @@ import java.util.ListIterator;
 import java.util.NoSuchElementException;
 import java.util.Objects;
 
+import com.oracle.truffle.api.nodes.ControlFlowException;
 import org.graalvm.polyglot.Engine;
 import org.graalvm.polyglot.PolyglotException;
 import org.graalvm.polyglot.PolyglotException.StackFrame;
@@ -254,6 +255,9 @@ final class PolyglotExceptionImpl extends AbstractExceptionImpl implements com.o
             if (isInternalError()) {
                 s.println("Original Internal Error: ");
                 s.printStackTrace(exception);
+                if (exception instanceof ControlFlowException) {
+                    s.println("(there is no stack trace because the error is a control flow exception)");
+                }
             }
         }
     }


### PR DESCRIPTION
People in practice seem to get very confused why some polyglot exceptions can't print a stack trace.

From:

```
org.graalvm.polyglot.PolyglotException: org.truffleruby.language.control.ReturnException
Original Internal Error: 
org.truffleruby.language.control.ReturnException
```

To:

```
org.graalvm.polyglot.PolyglotException: org.truffleruby.language.control.ReturnException
Original Internal Error: 
org.truffleruby.language.control.ReturnException
(there is no stack trace because the error is a control flow exception)
```

@chumer

https://github.com/Shopify/truffleruby/issues/1