### PR TITLE
Re-enable unittest StringIndexOfTest for AArch64

### DIFF
--- a/compiler/src/org.graalvm.compiler.replacements.test/src/org/graalvm/compiler/replacements/test/StringIndexOfTestBase.java
+++ b/compiler/src/org.graalvm.compiler.replacements.test/src/org/graalvm/compiler/replacements/test/StringIndexOfTestBase.java
@@ -24,8 +24,6 @@
  */
 package org.graalvm.compiler.replacements.test;
 
-import static org.junit.Assume.assumeFalse;
-
 import java.util.ArrayList;
 import java.util.Collection;
 
@@ -33,8 +31,6 @@ import org.graalvm.compiler.core.test.GraalCompilerTest;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
-
-import jdk.vm.ci.aarch64.AArch64;
 
 @RunWith(value = Parameterized.class)
 public abstract class StringIndexOfTestBase extends GraalCompilerTest {
@@ -128,7 +124,6 @@ public abstract class StringIndexOfTestBase extends GraalCompilerTest {
 
     @Test
     public void testStringBuilderIndexOfConstant() {
-        assumeFalse("Disabled on AArch64 due to issues on AArch64; see GR-13100 or JDK-8215792", getTarget().arch instanceof AArch64);
         /*
          * Put a copy of the target string in the space after the current string to detect cases
          * where we search too far.
@@ -141,7 +136,6 @@ public abstract class StringIndexOfTestBase extends GraalCompilerTest {
 
     @Test
     public void testStringBuilderIndexOfConstantOffset() {
-        assumeFalse("Disabled on AArch64 due to issues on AArch64; see GR-13100 or JDK-8215792", getTarget().arch instanceof AArch64);
         /*
          * Put a copy of the target string in the space after the current string to detect cases
          * where we search too far.


### PR DESCRIPTION
The Graal compiler unittest for String.indexOf was disabled for AArch64 before because of the bug JDK-8215792. Now the issue has been fixed and the fix has been backported. We should re-enable the test now.
