### PR TITLE
Use a darwin AMD64 based UContextRegisterDumper in case of darwin AArch64

### DIFF
--- a/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/aarch64/AArch64UContextRegisterDumper.java
+++ b/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/aarch64/AArch64UContextRegisterDumper.java
@@ -24,7 +24,6 @@
  */
 package com.oracle.svm.core.posix.aarch64;
 
-import com.oracle.svm.core.SubstrateOptions;
 import org.graalvm.compiler.api.replacements.Fold;
 import org.graalvm.nativeimage.ImageSingletons;
 import org.graalvm.nativeimage.Platform;
@@ -46,31 +45,12 @@ import com.oracle.svm.core.util.VMError;
 
 import jdk.vm.ci.aarch64.AArch64;
 
-@Platforms(Platform.AARCH64.class)
+@Platforms(Platform.LINUX_AARCH64.class)
 @AutomaticFeature
 class AArch64UContextRegisterDumperFeature implements Feature {
     @Override
     public void afterRegistration(AfterRegistrationAccess access) {
-        UContextRegisterDumper regdumper;
-        if (SubstrateOptions.CompilerBackend.getValue().equals("llvm")) {
-            regdumper = new UContextRegisterDumper() {
-                public void dumpRegisters(Log log, ucontext_t uContext) {
-                    log.newline().string("No support for UContextRegisterDumper with CompilerBackend llvm").newline();
-                }
-
-                public PointerBase getHeapBase(ucontext_t uContext) {
-                    return null;
-                }
-
-                public PointerBase getThreadPointer(ucontext_t uContext) {
-                    return null;
-                }
-            };
-
-        } else {
-            regdumper = new AArch64UContextRegisterDumper();
-        }
-        ImageSingletons.add(UContextRegisterDumper.class, regdumper);
+        ImageSingletons.add(UContextRegisterDumper.class, new AArch64UContextRegisterDumper());
     }
 }
 

--- a/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/aarch64/AArch64UContextRegisterDumper.java
+++ b/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/aarch64/AArch64UContextRegisterDumper.java
@@ -24,6 +24,7 @@
  */
 package com.oracle.svm.core.posix.aarch64;
 
+import com.oracle.svm.core.SubstrateOptions;
 import org.graalvm.compiler.api.replacements.Fold;
 import org.graalvm.nativeimage.ImageSingletons;
 import org.graalvm.nativeimage.Platform;
@@ -50,7 +51,26 @@ import jdk.vm.ci.aarch64.AArch64;
 class AArch64UContextRegisterDumperFeature implements Feature {
     @Override
     public void afterRegistration(AfterRegistrationAccess access) {
-        ImageSingletons.add(UContextRegisterDumper.class, new AArch64UContextRegisterDumper());
+        UContextRegisterDumper regdumper;
+        if (SubstrateOptions.CompilerBackend.getValue().equals("llvm")) {
+            regdumper = new UContextRegisterDumper() {
+                public void dumpRegisters(Log log, ucontext_t uContext) {
+                    log.newline().string("No support for UContextRegisterDumper with CompilerBackend llvm").newline();
+                }
+
+                public PointerBase getHeapBase(ucontext_t uContext) {
+                    return null;
+                }
+
+                public PointerBase getThreadPointer(ucontext_t uContext) {
+                    return null;
+                }
+            };
+
+        } else {
+            regdumper = new AArch64UContextRegisterDumper();
+        }
+        ImageSingletons.add(UContextRegisterDumper.class, regdumper);
     }
 }
 

--- a/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/darwin/DarwinUContextRegisterDumper.java
+++ b/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/darwin/DarwinUContextRegisterDumper.java
@@ -46,7 +46,7 @@ import com.oracle.svm.core.util.VMError;
 
 import jdk.vm.ci.amd64.AMD64;
 
-@Platforms({DeprecatedPlatform.DARWIN_SUBSTITUTION_AMD64.class, Platform.DARWIN_AMD64.class})
+@Platforms({DeprecatedPlatform.DARWIN_SUBSTITUTION_AMD64.class, Platform.DARWIN_AMD64.class, Platform.DARWIN_AARCH64.class})
 @AutomaticFeature
 class DarwinUContextRegisterDumperFeature implements Feature {
     @Override

--- a/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/headers/Signal.java
+++ b/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/headers/Signal.java
@@ -143,11 +143,11 @@ public class Signal {
         mcontext_t uc_mcontext();
 
         @CField("uc_mcontext")
-        @Platforms({DeprecatedPlatform.DARWIN_SUBSTITUTION_AMD64.class, Platform.DARWIN_AMD64.class})
+        @Platforms({DeprecatedPlatform.DARWIN_SUBSTITUTION_AMD64.class, Platform.DARWIN_AMD64.class, Platform.DARWIN_AARCH64.class})
         MContext64 uc_mcontext64();
     }
 
-    @Platforms({DeprecatedPlatform.DARWIN_SUBSTITUTION_AMD64.class, Platform.DARWIN_AMD64.class})
+    @Platforms({DeprecatedPlatform.DARWIN_SUBSTITUTION_AMD64.class, Platform.DARWIN_AMD64.class, Platform.DARWIN_AARCH64.class})
     @CStruct(value = "__darwin_mcontext64", addStructKeyword = true)
     public interface MContext64 extends PointerBase {
 


### PR DESCRIPTION
This patch was mentioned a couple of months ago by someone from the GraalVM team.
It is sub-optimal since it is not providing a real solution for a register dump on iOS, and it uses the compilerBackend as the condition between using a real registerDumper or a fake one.
On the other hand, this functionality makes little sense on iOS, so from a functional point, this patch seems ok.
Without this patch, native-image fails to compile applications, as there is no Signal$ucontext_t method for Platform.DARWIN_AARCH64.class and neither using the LINUX_AARCH64 or the DARWIN_AMD64 platform will do (since either the architecture or the OS is wrong).