### PR TITLE
Fixing debug usage performance defect in GraalDebugHandlersFactory

### DIFF
--- a/compiler/src/org.graalvm.compiler.printer/src/org/graalvm/compiler/printer/GraalDebugHandlersFactory.java
+++ b/compiler/src/org.graalvm.compiler.printer/src/org/graalvm/compiler/printer/GraalDebugHandlersFactory.java
@@ -74,14 +74,16 @@ public class GraalDebugHandlersFactory implements DebugHandlersFactory {
     private static class NodeDumper implements DebugDumpHandler {
         @Override
         public void dump(DebugContext debug, Object object, String format, Object... arguments) {
-            if (object instanceof Node) {
-                Node node = (Node) object;
-                String location = GraphUtil.approxSourceLocation(node);
-                String nodeName = node.toString(Verbosity.Debugger);
-                if (location != null) {
-                    debug.log("Context obj %s (approx. location: %s)", nodeName, location);
-                } else {
-                    debug.log("Context obj %s", nodeName);
+            if (debug.isLogEnabled()) {
+                if (object instanceof Node) {
+                    Node node = (Node) object;
+                    String location = GraphUtil.approxSourceLocation(node);
+                    String nodeName = node.toString(Verbosity.Debugger);
+                    if (location != null) {
+                        debug.log("Context obj %s (approx. location: %s)", nodeName, location);
+                    } else {
+                        debug.log("Context obj %s", nodeName);
+                    }
                 }
             }
         }


### PR DESCRIPTION
According to my inspections: The modified code invokes node.toString, though this is wasted effort when debug logs are not enabled.

This is a direct violation of the policy laid out in https://github.com/oracle/graal/blob/a9db7dd44c3a6a37f6805bc93e7c366a201d2e9a/compiler/src/org.graalvm.compiler.core.test/src/org/graalvm/compiler/core/test/VerifyDebugUsage.java . However, the checker misses this code because of the indirection. It is, however, caught by our Yogo tool, which can search for patterns in a way that does not care about indirection. 

I unfortunately did not see an easy fix other than the explicit if-check.

Thanks to @thomaswue for directing us to VerifyDebugUsage.