### PR TITLE
AArch64: Merge bitwise not into logical operations.

### DIFF
--- a/compiler/src/org.graalvm.compiler.asm.aarch64/src/org/graalvm/compiler/asm/aarch64/AArch64MacroAssembler.java
+++ b/compiler/src/org.graalvm.compiler.asm.aarch64/src/org/graalvm/compiler/asm/aarch64/AArch64MacroAssembler.java
@@ -1134,6 +1134,42 @@ public class AArch64MacroAssembler extends AArch64Assembler {
     }
 
     /**
+     * dst = src1 & (~src2).
+     *
+     * @param size register size. Has to be 32 or 64.
+     * @param dst general purpose register. May not be null or stackpointer.
+     * @param src1 general purpose register. May not be null or stackpointer.
+     * @param src2 general purpose register. May not be null or stackpointer.
+     */
+    public void bic(int size, Register dst, Register src1, Register src2) {
+        super.bic(size, dst, src1, src2, ShiftType.LSL, 0);
+    }
+
+    /**
+     * dst = src1 ^ (~src2).
+     *
+     * @param size register size. Has to be 32 or 64.
+     * @param dst general purpose register. May not be null or stackpointer.
+     * @param src1 general purpose register. May not be null or stackpointer.
+     * @param src2 general purpose register. May not be null or stackpointer.
+     */
+    public void eon(int size, Register dst, Register src1, Register src2) {
+        super.eon(size, dst, src1, src2, ShiftType.LSL, 0);
+    }
+
+    /**
+     * dst = src1 | (~src2).
+     *
+     * @param size register size. Has to be 32 or 64.
+     * @param dst general purpose register. May not be null or stackpointer.
+     * @param src1 general purpose register. May not be null or stackpointer.
+     * @param src2 general purpose register. May not be null or stackpointer.
+     */
+    public void orn(int size, Register dst, Register src1, Register src2) {
+        super.orn(size, dst, src1, src2, ShiftType.LSL, 0);
+    }
+
+    /**
      * dst = ~src.
      *
      * @param size register size. Has to be 32 or 64.

--- a/compiler/src/org.graalvm.compiler.core.aarch64.test/src/org/graalvm/compiler/core/aarch64/test/AArch64BitwiseLogicalNotTest.java
+++ b/compiler/src/org.graalvm.compiler.core.aarch64.test/src/org/graalvm/compiler/core/aarch64/test/AArch64BitwiseLogicalNotTest.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Arm Limited. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package org.graalvm.compiler.core.aarch64.test;
+
+import org.graalvm.compiler.lir.LIRInstruction;
+import org.graalvm.compiler.lir.aarch64.AArch64ArithmeticOp;
+import org.graalvm.compiler.lir.aarch64.AArch64ArithmeticOp.BinaryOp;
+import org.junit.Test;
+
+import java.util.function.Predicate;
+
+public class AArch64BitwiseLogicalNotTest extends AArch64MatchRuleTest {
+    private static final String BIC = AArch64ArithmeticOp.BIC.name();
+    private static final String ORN = AArch64ArithmeticOp.ORN.name();
+    private static final String EON = AArch64ArithmeticOp.EON.name();
+
+    private void test(String methodName, String opName, Object... args) {
+        test(methodName, args);
+        Predicate<LIRInstruction> predicate = op -> {
+            if (op instanceof BinaryOp && op.name().equalsIgnoreCase(opName)) {
+                return true;
+            }
+            return false;
+        };
+        checkLIR(methodName, predicate, 1);
+    }
+
+    // Tests for and not.
+    public int andNotInt1(int m, int n) {
+        return n & (~m);
+    }
+
+    @Test
+    public void testAndNotInt1() {
+        test("andNotInt1", BIC, 5, 6);
+    }
+
+    public int andNotInt2(int m, int n) {
+        return n & (m ^ 0XFFFFFFFF);
+    }
+
+    @Test
+    public void testAndNotInt2() {
+        test("andNotInt2", BIC, 325, -1);
+    }
+
+    public long andNotLong(long m, long n) {
+        return m & (n ^ -1L);
+    }
+
+    @Test
+    public void testAndNotLong() {
+        test("andNotLong", BIC, 3L, 425L);
+    }
+
+    // Tests for or not.
+    public int orNotInt(int m, int n) {
+        return (n ^ 0XFFFFFFFF) | m;
+    }
+
+    @Test
+    public void testOrNotInt() {
+        test("orNotInt", ORN, -1, Integer.MAX_VALUE);
+    }
+
+    public long orNotLong(long m, long n) {
+        return m | (~n);
+    }
+
+    @Test
+    public void testOrNotLong() {
+        test("orNotLong", ORN, 23L, -1L);
+    }
+
+    // Tests for xor not.
+    public int xorNotInt(int m, int n) {
+        return (~n) ^ m;
+    }
+
+    @Test
+    public void testXorNotInt() {
+        test("xorNotInt", EON, 4132, 24);
+    }
+
+    public long xorNotLong(long m, long n) {
+        return m ^ (~n);
+    }
+
+    @Test
+    public void testXorNotLong() {
+        test("xorNotLong", EON, Long.MIN_VALUE, Long.MAX_VALUE);
+    }
+
+    // Tests for not xor.
+    public int notXorInt1(int m, int n) {
+        return ~(m ^ n);
+    }
+
+    @Test
+    public void testNotXorInt1() {
+        test("notXorInt1", EON, 235, 98);
+    }
+
+    public int notXorInt2(int m, int n) {
+        return (m ^ n) ^ 0XFFFFFFFF;
+    }
+
+    @Test
+    public void testNotXorInt2() {
+        test("notXorInt2", EON, 245, 34654);
+    }
+
+    public long notXorLong(long m, long n) {
+        return ~(m ^ n);
+    }
+
+    @Test
+    public void testNotXorLong() {
+        test("notXorLong", EON, 324L, 235L);
+    }
+}

--- a/compiler/src/org.graalvm.compiler.core.aarch64/src/org/graalvm/compiler/core/aarch64/AArch64NodeMatchRules.java
+++ b/compiler/src/org.graalvm.compiler.core.aarch64/src/org/graalvm/compiler/core/aarch64/AArch64NodeMatchRules.java
@@ -72,6 +72,7 @@ public class AArch64NodeMatchRules extends NodeMatchRules {
     private static final EconomicMap<Class<? extends BinaryNode>, AArch64ArithmeticOp> binaryOpMap;
     private static final EconomicMap<Class<? extends BinaryNode>, AArch64BitFieldOp.BitFieldOpCode> bitFieldOpMap;
     private static final EconomicMap<Class<? extends BinaryNode>, AArch64MacroAssembler.ShiftType> shiftTypeMap;
+    private static final EconomicMap<Class<? extends BinaryNode>, AArch64ArithmeticOp> logicalNotOpMap;
 
     static {
         binaryOpMap = EconomicMap.create(Equivalence.IDENTITY, 9);
@@ -88,6 +89,11 @@ public class AArch64NodeMatchRules extends NodeMatchRules {
         bitFieldOpMap = EconomicMap.create(Equivalence.IDENTITY, 2);
         bitFieldOpMap.put(UnsignedRightShiftNode.class, AArch64BitFieldOp.BitFieldOpCode.UBFX);
         bitFieldOpMap.put(LeftShiftNode.class, AArch64BitFieldOp.BitFieldOpCode.UBFIZ);
+
+        logicalNotOpMap = EconomicMap.create(Equivalence.IDENTITY, 3);
+        logicalNotOpMap.put(AndNode.class, AArch64ArithmeticOp.BIC);
+        logicalNotOpMap.put(OrNode.class, AArch64ArithmeticOp.ORN);
+        logicalNotOpMap.put(XorNode.class, AArch64ArithmeticOp.EON);
 
         shiftTypeMap = EconomicMap.create(Equivalence.IDENTITY, 3);
         shiftTypeMap.put(LeftShiftNode.class, AArch64MacroAssembler.ShiftType.LSL);
@@ -127,8 +133,7 @@ public class AArch64NodeMatchRules extends NodeMatchRules {
         };
     }
 
-    private ComplexMatchResult emitBinaryShift(AArch64ArithmeticOp op, ValueNode value, BinaryNode shift,
-                    boolean isShiftNot) {
+    private ComplexMatchResult emitBinaryShift(AArch64ArithmeticOp op, ValueNode value, BinaryNode shift) {
         AArch64MacroAssembler.ShiftType shiftType = shiftTypeMap.get(shift.getClass());
         assert shiftType != null;
         assert value.getStackKind().isNumericInteger();
@@ -142,7 +147,7 @@ public class AArch64NodeMatchRules extends NodeMatchRules {
             AllocatableValue x = moveSp(gen.asAllocatable(a));
             AllocatableValue y = moveSp(gen.asAllocatable(b));
             int shiftAmount = shift.getY().asJavaConstant().asInt();
-            gen.append(new AArch64ArithmeticOp.BinaryShiftOp(op, result, x, y, shiftType, shiftAmount, isShiftNot));
+            gen.append(new AArch64ArithmeticOp.BinaryShiftOp(op, result, x, y, shiftType, shiftAmount));
             return result;
         };
     }
@@ -206,7 +211,7 @@ public class AArch64NodeMatchRules extends NodeMatchRules {
     public ComplexMatchResult addSubShift(BinaryNode binary, ValueNode a, BinaryNode shift) {
         AArch64ArithmeticOp op = binaryOpMap.get(binary.getClass());
         assert op != null;
-        return emitBinaryShift(op, a, shift, false);
+        return emitBinaryShift(op, a, shift);
     }
 
     @MatchRule("(And=binary a (LeftShift=shift b Constant))")
@@ -228,11 +233,44 @@ public class AArch64NodeMatchRules extends NodeMatchRules {
     @MatchRule("(Xor=binary a (Not (RightShift=shift b Constant)))")
     @MatchRule("(Xor=binary a (Not (UnsignedRightShift=shift b Constant)))")
     public ComplexMatchResult logicShift(BinaryNode binary, ValueNode a, BinaryNode shift) {
-        AArch64ArithmeticOp op = binaryOpMap.get(binary.getClass());
-        assert op != null;
+        AArch64ArithmeticOp op;
         ValueNode operand = binary.getX() == a ? binary.getY() : binary.getX();
-        boolean isShiftNot = operand instanceof NotNode;
-        return emitBinaryShift(op, a, shift, isShiftNot);
+        if (operand instanceof NotNode) {
+            op = logicalNotOpMap.get(binary.getClass());
+        } else {
+            op = binaryOpMap.get(binary.getClass());
+        }
+        assert op != null;
+        return emitBinaryShift(op, a, shift);
+    }
+
+    @MatchRule("(And=logic value1 (Not=not value2))")
+    @MatchRule("(Or=logic value1 (Not=not value2))")
+    @MatchRule("(Xor=logic value1 (Not=not value2))")
+    public ComplexMatchResult bitwiseLogicNot(BinaryNode logic, NotNode not) {
+        assert logic.getStackKind().isNumericInteger();
+        AArch64ArithmeticOp op = logicalNotOpMap.get(logic.getClass());
+        assert op != null;
+        ValueNode src1 = logic.getX() == not ? logic.getY() : logic.getX();
+        ValueNode src2 = not.getValue();
+        return builder -> {
+            Value a = operand(src1);
+            Value b = operand(src2);
+            LIRKind resultKind = LIRKind.combine(a, b);
+            return getArithmeticLIRGenerator().emitBinary(resultKind, op, false, a, b);
+        };
+    }
+
+    @MatchRule("(Not=not (Xor value1 value2))")
+    public ComplexMatchResult bitwiseNotXor(NotNode not) {
+        assert not.getStackKind().isNumericInteger();
+        return builder -> {
+            XorNode xor = (XorNode) not.getValue();
+            Value a = operand(xor.getX());
+            Value b = operand(xor.getY());
+            LIRKind resultKind = LIRKind.combine(a, b);
+            return getArithmeticLIRGenerator().emitBinary(resultKind, AArch64ArithmeticOp.EON, false, a, b);
+        };
     }
 
     @MatchRule("(Add=binary (Mul (SignExtend a) (SignExtend b)) c)")

--- a/compiler/src/org.graalvm.compiler.lir.aarch64/src/org/graalvm/compiler/lir/aarch64/AArch64ArithmeticOp.java
+++ b/compiler/src/org.graalvm.compiler.lir.aarch64/src/org/graalvm/compiler/lir/aarch64/AArch64ArithmeticOp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -72,11 +72,13 @@ public enum AArch64ArithmeticOp {
     ANDS(LOGICAL),
     OR(LOGICAL),
     XOR(LOGICAL),
+    BIC,
+    ORN,
+    EON,
     SHL(SHIFT),
     LSHR(SHIFT),
     ASHR(SHIFT),
     ABS,
-
     FADD,
     FSUB,
     FMUL,
@@ -310,6 +312,15 @@ public enum AArch64ArithmeticOp {
                 case XOR:
                     masm.eor(size, dst, src1, src2);
                     break;
+                case BIC:
+                    masm.bic(size, dst, src1, src2);
+                    break;
+                case ORN:
+                    masm.orn(size, dst, src1, src2);
+                    break;
+                case EON:
+                    masm.eon(size, dst, src1, src2);
+                    break;
                 case SHL:
                     masm.shl(size, dst, src1, src2);
                     break;
@@ -393,24 +404,19 @@ public enum AArch64ArithmeticOp {
         @Use(REG) protected AllocatableValue src2;
         private final AArch64MacroAssembler.ShiftType shiftType;
         private final int shiftAmt;
-        private final boolean isShiftNot;
 
         /**
-         * If shiftNot: Computes <code>result = src1 <op> ~(src2 <shiftType> <shiftAmt>)</code>
-         * (Only for logic ops). else: Computes
          * <code>result = src1 <op> src2 <shiftType> <shiftAmt></code>.
          */
         public BinaryShiftOp(AArch64ArithmeticOp op, AllocatableValue result, AllocatableValue src1, AllocatableValue src2,
-                        AArch64MacroAssembler.ShiftType shiftType, int shiftAmt, boolean isShiftNot) {
+                        AArch64MacroAssembler.ShiftType shiftType, int shiftAmt) {
             super(TYPE);
-            assert op == ADD || op == SUB || op == AND || op == OR || op == XOR;
             this.op = op;
             this.result = result;
             this.src1 = src1;
             this.src2 = src2;
             this.shiftType = shiftType;
             this.shiftAmt = shiftAmt;
-            this.isShiftNot = isShiftNot;
         }
 
         @Override
@@ -424,28 +430,25 @@ public enum AArch64ArithmeticOp {
                     masm.sub(size, asRegister(result), asRegister(src1), asRegister(src2), shiftType, shiftAmt);
                     break;
                 case AND:
-                    if (!isShiftNot) {
-                        masm.and(size, asRegister(result), asRegister(src1), asRegister(src2), shiftType, shiftAmt);
-                    } else {
-                        masm.bic(size, asRegister(result), asRegister(src1), asRegister(src2), shiftType, shiftAmt);
-                    }
+                    masm.and(size, asRegister(result), asRegister(src1), asRegister(src2), shiftType, shiftAmt);
                     break;
                 case OR:
-                    if (!isShiftNot) {
-                        masm.or(size, asRegister(result), asRegister(src1), asRegister(src2), shiftType, shiftAmt);
-                    } else {
-                        masm.orn(size, asRegister(result), asRegister(src1), asRegister(src2), shiftType, shiftAmt);
-                    }
+                    masm.or(size, asRegister(result), asRegister(src1), asRegister(src2), shiftType, shiftAmt);
                     break;
                 case XOR:
-                    if (!isShiftNot) {
-                        masm.eor(size, asRegister(result), asRegister(src1), asRegister(src2), shiftType, shiftAmt);
-                    } else {
-                        masm.eon(size, asRegister(result), asRegister(src1), asRegister(src2), shiftType, shiftAmt);
-                    }
+                    masm.eor(size, asRegister(result), asRegister(src1), asRegister(src2), shiftType, shiftAmt);
+                    break;
+                case BIC:
+                    masm.bic(size, asRegister(result), asRegister(src1), asRegister(src2), shiftType, shiftAmt);
+                    break;
+                case ORN:
+                    masm.orn(size, asRegister(result), asRegister(src1), asRegister(src2), shiftType, shiftAmt);
+                    break;
+                case EON:
+                    masm.eon(size, asRegister(result), asRegister(src1), asRegister(src2), shiftType, shiftAmt);
                     break;
                 default:
-                    throw GraalError.shouldNotReachHere();
+                    throw GraalError.shouldNotReachHere("op=" + op.name());
             }
         }
     }


### PR DESCRIPTION
This patch combines bitwise not with logical operations by
adding match rules for AArch64.

It tries to optimize operations like:
    mvn w0, w2
    and w0, w3, w0
to: bic w0, w3, w2

And it also optimizes:
    eor x0, x2, x3
    mvn x0, x0
to: eon x0, x2, x3

Change-Id: I535ec70472bfca0fe087cbdeab7daeb2c17ef947