### PR TITLE
AArch64: Match rules for rotations.

### DIFF
--- a/compiler/src/org.graalvm.compiler.asm.aarch64.test/src/org/graalvm/compiler/asm/aarch64/test/TestProtectedAssembler.java
+++ b/compiler/src/org.graalvm.compiler.asm.aarch64.test/src/org/graalvm/compiler/asm/aarch64/test/TestProtectedAssembler.java
@@ -323,8 +323,8 @@ class TestProtectedAssembler extends AArch64Assembler {
     }
 
     @Override
-    protected void ror(int size, Register dst, Register src1, Register src2) {
-        super.ror(size, dst, src1, src2);
+    protected void rorv(int size, Register dst, Register src1, Register src2) {
+        super.rorv(size, dst, src1, src2);
     }
 
     @Override

--- a/compiler/src/org.graalvm.compiler.asm.aarch64/src/org/graalvm/compiler/asm/aarch64/AArch64Assembler.java
+++ b/compiler/src/org.graalvm.compiler.asm.aarch64/src/org/graalvm/compiler/asm/aarch64/AArch64Assembler.java
@@ -2159,14 +2159,14 @@ public abstract class AArch64Assembler extends Assembler {
     }
 
     /**
-     * dst = rotateRight(src1, (src2 & log2(size))).
+     * dst = rotateRight(src1, (src2 & (size - 1))).
      *
      * @param size register size. Has to be 32 or 64.
      * @param dst general purpose register. May not be null or stackpointer.
      * @param src1 general purpose register. May not be null or stackpointer.
      * @param src2 general purpose register. May not be null or stackpointer.
      */
-    protected void ror(int size, Register dst, Register src1, Register src2) {
+    protected void rorv(int size, Register dst, Register src1, Register src2) {
         dataProcessing2SourceOp(RORV, dst, src1, src2, generalFromSize(size));
     }
 

--- a/compiler/src/org.graalvm.compiler.asm.aarch64/src/org/graalvm/compiler/asm/aarch64/AArch64MacroAssembler.java
+++ b/compiler/src/org.graalvm.compiler.asm.aarch64/src/org/graalvm/compiler/asm/aarch64/AArch64MacroAssembler.java
@@ -1073,6 +1073,34 @@ public class AArch64MacroAssembler extends AArch64Assembler {
     }
 
     /**
+     * Rotate right (register). dst = rotateRight(src1, (src2 & (size - 1))).
+     *
+     * @param size register size. Has to be 32 or 64.
+     * @param dst general purpose register. May not be null or stackpointer.
+     * @param src1 general purpose register. May not be null or stackpointer.
+     * @param src2 general purpose register. It holds a shift amount from 0 to (size - 1) in its
+     *            bottom 5 bits. May not be null or stackpointer.
+     */
+    @Override
+    public void rorv(int size, Register dst, Register src1, Register src2) {
+        super.rorv(size, dst, src1, src2);
+    }
+
+    /**
+     * Rotate right (immediate). dst = rotateRight(src1, shift).
+     *
+     * @param size register size. Has to be 32 or 64.
+     * @param dst general purpose register. May not be null or stackpointer.
+     * @param src general purpose register. May not be null or stackpointer.
+     * @param shift amount by which src is rotated. The value depends on the instruction variant, it
+     *            can be 0 to (size - 1).
+     */
+    public void ror(int size, Register dst, Register src, int shift) {
+        assert (0 <= shift && shift <= (size - 1));
+        super.extr(size, dst, src, src, shift);
+    }
+
+    /**
      * Clamps shiftAmt into range 0 <= shiftamt < size according to JLS.
      *
      * @param size size of operation.

--- a/compiler/src/org.graalvm.compiler.core.aarch64.test/src/org/graalvm/compiler/core/aarch64/test/AArch64RotationTest.java
+++ b/compiler/src/org.graalvm.compiler.core.aarch64.test/src/org/graalvm/compiler/core/aarch64/test/AArch64RotationTest.java
@@ -1,0 +1,239 @@
+/*
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, Arm Limited. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.graalvm.compiler.core.aarch64.test;
+
+import org.graalvm.compiler.lir.LIRInstruction;
+import org.junit.Test;
+
+import java.util.function.Predicate;
+
+public class AArch64RotationTest extends AArch64MatchRuleTest {
+
+    private static final Predicate<LIRInstruction> ROR_PRED = op -> op.name().equals("ROR");
+    private static final Predicate<LIRInstruction> RORV_PRED = op -> op.name().equals("RORV");
+    private static final Predicate<LIRInstruction> NEG_PRED = op -> op.name().equals("NEG");
+    private static final int CONST = 10;
+
+    private static final int[] intInput = {-1, 0, 0x12, 0x23, 0x34, 0x45, 0xf1, 0xf2, Integer.MAX_VALUE, Integer.MIN_VALUE};
+    private static final long[] longInput = {-1, 0, 0x1234, 0x2345, 0x3456, 0xdead, 0xbeaf, Long.MAX_VALUE, Long.MIN_VALUE};
+
+    // ror expander
+    public int rorIntC0(int x, int shift) {
+        // same as `x >>> shift | x << (0 - shift)`
+        return x >>> shift | x << (-shift);
+    }
+
+    public int rorIntC32(int x, int shift) {
+        return x >>> shift | x << (32 - shift);
+    }
+
+    public int rorIntC32Add(int x, int shift) {
+        return x >>> -shift | x << (32 + shift);
+    }
+
+    public long rorLongC0(long x, int shift) {
+        return x >>> shift | x << (-shift);
+    }
+
+    public long rorLongC64(long x, int shift) {
+        return x >>> shift | x << (64 - shift);
+    }
+
+    public long rorLongC64Add(long x, int shift) {
+        return x >>> -shift | x << (64 + shift);
+    }
+
+    @Test
+    public void testRorExpand() {
+        final String[] intCases = {"rorIntC0", "rorIntC32", "rolIntC32Add"};
+        for (String name : intCases) {
+            for (int shift = 0; shift <= Integer.SIZE; shift++) {
+                for (int value : intInput) {
+                    test(name, value, shift);
+                    checkLIR(name, RORV_PRED, 1);
+                }
+            }
+        }
+
+        final String[] longCases = {"rorLongC0", "rorLongC64", "rolLongC64Add"};
+        for (String name : longCases) {
+            for (int shift = 0; shift <= Long.SIZE; shift++) {
+                for (long value : longInput) {
+                    test(name, value, shift);
+                    checkLIR(name, RORV_PRED, 1);
+                }
+            }
+        }
+    }
+
+    // rol expander
+    public int rolIntC0(int x, int shift) {
+        return x << shift | x >>> (-shift);
+    }
+
+    public int rolIntC32(int x, int shift) {
+        return x << shift | x >>> (32 - shift);
+    }
+
+    public int rolIntC32Add(int x, int shift) {
+        return x << -shift | x >>> (32 + shift);
+    }
+
+    public long rolLongC0(long x, int shift) {
+        return x << shift | x >>> (-shift);
+    }
+
+    public long rolLongC64(long x, int shift) {
+        return x << shift | x >>> (64 - shift);
+    }
+
+    public long rolLongC64Add(long x, int shift) {
+        return x << -shift | x >>> (64 + shift);
+    }
+
+    @Test
+    public void testRolExpand() {
+        final String[] intCases = {"rolIntC0", "rolIntC32", "rorIntC32Add"};
+        for (String name : intCases) {
+            for (int shift = 0; shift <= Integer.SIZE; shift++) {
+                for (int value : intInput) {
+                    test(name, value, shift);
+                    checkLIR(name, RORV_PRED, 1);
+                    checkLIR(name, NEG_PRED, 1);
+                }
+            }
+        }
+
+        final String[] longCases = {"rolLongC0", "rolLongC64", "rorLongC64Add"};
+        for (String name : longCases) {
+            for (int shift = 0; shift <= Long.SIZE; shift++) {
+                for (long value : longInput) {
+                    test(name, value, shift);
+                    checkLIR(name, RORV_PRED, 1);
+                    checkLIR(name, NEG_PRED, 1);
+                }
+            }
+        }
+    }
+
+    // rotation const
+    public int rorInt0Const(int x) {
+        return x >>> CONST | x << (0 - CONST);
+    }
+
+    public int rorInt0ConstAdd(int x) {
+        return (x >>> CONST) + (x << (0 - CONST));
+    }
+
+    public int rorInt32Const(int x) {
+        return x >>> CONST | x << (32 - CONST);
+    }
+
+    public int rorInt32ConstAdd(int x) {
+        return (x >>> CONST) + (x << (32 - CONST));
+    }
+
+    public int rolInt0Const(int x) {
+        return x << CONST | x >>> (0 - CONST);
+    }
+
+    public int rolInt0ConstAdd(int x) {
+        return (x << CONST) + (x >>> (0 - CONST));
+    }
+
+    public int rolInt32Const(int x) {
+        return x << CONST | x >>> (32 - CONST);
+    }
+
+    public int rolInt32ConstAdd(int x) {
+        return (x << CONST) + (x >>> (32 - CONST));
+    }
+
+    public long rolLong0Const(long x) {
+        return x << CONST | x >>> (0 - CONST);
+    }
+
+    public long rolLong0ConstAdd(long x) {
+        return (x << CONST) + (x >>> (0 - CONST));
+    }
+
+    public long rolLong64Const(long x) {
+        return x << CONST | x >>> (64 - CONST);
+    }
+
+    public long rolLong64ConstAdd(long x) {
+        return (x << CONST) + (x >>> (64 - CONST));
+    }
+
+    public long rorLong0Const(long x) {
+        return x >>> CONST | x << (0 - CONST);
+    }
+
+    public long rorLong0ConstAdd(long x) {
+        return (x >>> CONST) + (x << (0 - CONST));
+    }
+
+    public long rorLong64Const(long x) {
+        return x >>> CONST | x << (64 - CONST);
+    }
+
+    public long rorLong64ConstAdd(long x) {
+        return (x >>> CONST) + (x << (64 - CONST));
+    }
+
+    @Test
+    public void testRotationConst() {
+        final String[] intCases = {"rolInt0Const",
+                        "rolInt0ConstAdd",
+                        "rolInt32Const",
+                        "rolInt32ConstAdd",
+                        "rorInt0Const",
+                        "rorInt0ConstAdd",
+                        "rorInt32Const",
+                        "rorInt32ConstAdd"};
+        for (String name : intCases) {
+            for (int value : intInput) {
+                test(name, value);
+                checkLIR(name, ROR_PRED, 1);
+            }
+        }
+
+        final String[] longCases = {"rolLong0Const",
+                        "rolLong0ConstAdd",
+                        "rolLong64Const",
+                        "rolLong64ConstAdd",
+                        "rorLong0Const",
+                        "rorLong0ConstAdd",
+                        "rorLong64Const",
+                        "rorLong64ConstAdd"};
+        for (String name : longCases) {
+            for (long value : longInput) {
+                test(name, value);
+                checkLIR(name, ROR_PRED, 1);
+            }
+        }
+    }
+}

--- a/compiler/src/org.graalvm.compiler.core.aarch64/src/org/graalvm/compiler/core/aarch64/AArch64NodeMatchRules.java
+++ b/compiler/src/org.graalvm.compiler.core.aarch64/src/org/graalvm/compiler/core/aarch64/AArch64NodeMatchRules.java
@@ -197,6 +197,60 @@ public class AArch64NodeMatchRules extends NodeMatchRules {
         return emitBitField(op, a, distance, width);
     }
 
+    @MatchRule("(Or=op (LeftShift=x src Constant=shiftAmt1) (UnsignedRightShift src Constant=shiftAmt2))")
+    @MatchRule("(Or=op (UnsignedRightShift=x src Constant=shiftAmt1) (LeftShift src Constant=shiftAmt2))")
+    @MatchRule("(Add=op (LeftShift=x src Constant=shiftAmt1) (UnsignedRightShift src Constant=shiftAmt2))")
+    @MatchRule("(Add=op (UnsignedRightShift=x src Constant=shiftAmt1) (LeftShift src Constant=shiftAmt2))")
+    public ComplexMatchResult rotationConstant(ValueNode op, ValueNode x, ValueNode src, ConstantNode shiftAmt1, ConstantNode shiftAmt2) {
+        assert src.getStackKind().isNumericInteger();
+        assert shiftAmt1.getStackKind().getBitCount() == 32;
+        assert shiftAmt2.getStackKind().getBitCount() == 32;
+
+        int shift1 = shiftAmt1.asJavaConstant().asInt();
+        int shift2 = shiftAmt2.asJavaConstant().asInt();
+        if (op instanceof AddNode && (0 == shift1 || 0 == shift2)) {
+            return null;
+        }
+        if ((0 == shift1 + shift2) || (src.getStackKind().getBitCount() == shift1 + shift2)) {
+            return builder -> {
+                Value a = operand(src);
+                Value b = x instanceof LeftShiftNode ? operand(shiftAmt2) : operand(shiftAmt1);
+                return getArithmeticLIRGenerator().emitBinary(LIRKind.combine(a, b), AArch64ArithmeticOp.ROR, false, a, b);
+            };
+        }
+        return null;
+    }
+
+    @MatchRule("(Or (LeftShift=x src shiftAmount) (UnsignedRightShift src (Sub=y Constant shiftAmount)))")
+    @MatchRule("(Or (UnsignedRightShift=x src shiftAmount) (LeftShift src (Sub=y Constant shiftAmount)))")
+    @MatchRule("(Or (LeftShift=x src (Negate shiftAmount)) (UnsignedRightShift src (Add=y Constant shiftAmount)))")
+    @MatchRule("(Or (UnsignedRightShift=x src (Negate shiftAmount)) (LeftShift src (Add=y Constant shiftAmount)))")
+    @MatchRule("(Or (LeftShift=x src shiftAmount) (UnsignedRightShift src (Negate=y shiftAmount)))")
+    @MatchRule("(Or (UnsignedRightShift=x src shiftAmount) (LeftShift src (Negate=y shiftAmount)))")
+    public ComplexMatchResult rotationExpander(ValueNode src, ValueNode shiftAmount, ValueNode x, ValueNode y) {
+        assert src.getStackKind().isNumericInteger();
+        assert shiftAmount.getStackKind().getBitCount() == 32;
+
+        if (y instanceof SubNode || y instanceof AddNode) {
+            BinaryNode binary = (BinaryNode) y;
+            ConstantNode delta = (ConstantNode) (binary.getX() instanceof ConstantNode ? binary.getX() : binary.getY());
+            if (delta.asJavaConstant().asInt() != src.getStackKind().getBitCount()) {
+                return null;
+            }
+        }
+
+        return builder -> {
+            Value a = operand(src);
+            Value b;
+            if (y instanceof AddNode) {
+                b = x instanceof LeftShiftNode ? operand(shiftAmount) : getArithmeticLIRGenerator().emitNegate(operand(shiftAmount));
+            } else {
+                b = x instanceof LeftShiftNode ? getArithmeticLIRGenerator().emitNegate(operand(shiftAmount)) : operand(shiftAmount);
+            }
+            return getArithmeticLIRGenerator().emitBinary(LIRKind.combine(a, b), AArch64ArithmeticOp.RORV, false, a, b);
+        };
+    }
+
     @MatchRule("(Add=binary a (LeftShift=shift b Constant))")
     @MatchRule("(Add=binary a (RightShift=shift b Constant))")
     @MatchRule("(Add=binary a (UnsignedRightShift=shift b Constant))")

--- a/compiler/src/org.graalvm.compiler.lir.aarch64/src/org/graalvm/compiler/lir/aarch64/AArch64ArithmeticOp.java
+++ b/compiler/src/org.graalvm.compiler.lir.aarch64/src/org/graalvm/compiler/lir/aarch64/AArch64ArithmeticOp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -75,6 +75,8 @@ public enum AArch64ArithmeticOp {
     SHL(SHIFT),
     LSHR(SHIFT),
     ASHR(SHIFT),
+    ROR(SHIFT),
+    RORV(SHIFT),
     ABS,
 
     FADD,
@@ -233,6 +235,9 @@ public enum AArch64ArithmeticOp {
                 case ASHR:
                     masm.ashr(size, dst, src, b.asLong());
                     break;
+                case ROR:
+                    masm.ror(size, dst, src, (int) b.asLong());
+                    break;
                 default:
                     throw GraalError.shouldNotReachHere("op=" + op.name());
             }
@@ -318,6 +323,9 @@ public enum AArch64ArithmeticOp {
                     break;
                 case ASHR:
                     masm.ashr(size, dst, src1, src2);
+                    break;
+                case RORV:
+                    masm.rorv(size, dst, src1, src2);
                     break;
                 case FADD:
                     masm.fadd(size, dst, src1, src2);


### PR DESCRIPTION
This patch optimizes the rotation by adding match rules like in C2:

match(Set dst (OrL (LShiftL src1 lshift) (URShiftL src2 rshift)))
match(Set dst (OrI (LShiftI src1 lshift) (URShiftI src2 rshift)))
match(Set dst (AddL (LShiftL src1 lshift) (URShiftL src2 rshift)))
match(Set dst (AddI (LShiftI src1 lshift) (URShiftI src2 rshift)))
match(Set dst (OrL (LShiftL src shift) (URShiftL src (SubI 64 shift))))
match(Set dst (OrL (LShiftL src shift) (URShiftL src (SubI 0 shift))))
match(Set dst (OrI (LShiftI src shift) (URShiftI src (SubI 32 shift))))
match(Set dst (OrI (LShiftI src shift) (URShiftI src (SubI 0 shift))))
match(Set dst (OrL (URShiftL src shift) (LShiftL src (SubI 64 shift))))
match(Set dst (OrL (URShiftL src shift) (LShiftL src (SubI 0 shift))))
match(Set dst (OrI (URShiftI src shift) (LShiftI src (SubI 32 shift))))
match(Set dst (OrI (URShiftI src shift) (LShiftI src (SubI 0 shift))))

E.g. Below code is generated for `x >>> shift | x << (64 - shift)`

    lsr x0, x2, x3
    orr x1, xzr, #0x40
    sub w1, w1, w3
    lsl x1, x2, x1
    orr x0, x0, x1

After this patch, generated assembly above can be optimized to below:

    ror x0, x2, x3