### PR TITLE
Update supported max java version to 15.

### DIFF
--- a/compiler/src/org.graalvm.compiler.replacements/src/org/graalvm/compiler/replacements/classfile/Classfile.java
+++ b/compiler/src/org.graalvm.compiler.replacements/src/org/graalvm/compiler/replacements/classfile/Classfile.java
@@ -49,7 +49,7 @@ public class Classfile {
     private final List<ClassfileBytecode> codeAttributes;
 
     private static final int MAJOR_VERSION_JAVA_MIN = 51; // JDK7
-    private static final int MAJOR_VERSION_JAVA_MAX = 58; // JDK14
+    private static final int MAJOR_VERSION_JAVA_MAX = 59; // JDK15
     private static final int MAGIC = 0xCAFEBABE;
 
     /**


### PR DESCRIPTION
The aot and graalunit jtreg tests fail when run with graal after
the java version of the jdk/jdk master being updated to 15. This
is caused by the class file version checking in Graal. It should
be inside the defined java version range. Currently the max java
version is defined to 14, which should be updated to 15.

Change-Id: I4431ceda3ea2f62efdc5ebee3c8ba13c319b4a4d