### PR TITLE
MarkBasePointersPhase:  Base pointers do not die at the definition of…

### DIFF
--- a/compiler/src/org.graalvm.compiler.lir/src/org/graalvm/compiler/lir/util/IndexedValueMap.java
+++ b/compiler/src/org.graalvm.compiler.lir/src/org/graalvm/compiler/lir/util/IndexedValueMap.java
@@ -65,9 +65,6 @@ public final class IndexedValueMap {
 
     public void put(int index, Value value) {
         if (values.length <= index) {
-            if (value == null) {
-                return;
-            }
             Value[] newValues = new Value[index + 1];
             if (values.length > 0) {
                 System.arraycopy(values, 0, newValues, 0, values.length);


### PR DESCRIPTION
@XiaohongGong This change is related to point 1 in your PR #1059. It simplifies the `MarkBasePointersPhase`.

This change also outlined an issue in the `ConstantLoadOptimization` where it did not update the basepointers in `LIRKind`. The simplest solution I could find here is to not optimize those cases, where the constant is used as a base pointer. Otherwise it would require to also update all dependent uses, which is not simply possible.

I want to merge this PR independently from #1059. 