### PR TITLE
Use GraalUnsafeAccess where available

### DIFF
--- a/compiler/src/org.graalvm.compiler.core.test/src/org/graalvm/compiler/core/test/OffHeapUnsafeAccessTest.java
+++ b/compiler/src/org.graalvm.compiler.core.test/src/org/graalvm/compiler/core/test/OffHeapUnsafeAccessTest.java
@@ -24,38 +24,17 @@
  */
 package org.graalvm.compiler.core.test;
 
-import java.lang.reflect.Field;
-
 import org.graalvm.compiler.nodes.NamedLocationIdentity;
 import org.graalvm.compiler.nodes.memory.ReadNode;
 import org.junit.Assert;
 import org.junit.Test;
 
 import jdk.vm.ci.meta.JavaKind;
-import sun.misc.Unsafe;
 
 /**
  * Tests that off-heap memory writes don't prevent optimization of on-heap accesses.
  */
 public class OffHeapUnsafeAccessTest extends GraalCompilerTest {
-
-    static final Unsafe UNSAFE = initUnsafe();
-
-    private static Unsafe initUnsafe() {
-        try {
-            // Fast path when we are trusted.
-            return Unsafe.getUnsafe();
-        } catch (SecurityException se) {
-            // Slow path when we are not trusted.
-            try {
-                Field theUnsafe = Unsafe.class.getDeclaredField("theUnsafe");
-                theUnsafe.setAccessible(true);
-                return (Unsafe) theUnsafe.get(Unsafe.class);
-            } catch (Exception e) {
-                throw new RuntimeException("exception while trying to get Unsafe", e);
-            }
-        }
-    }
 
     public byte unboxByteAndStore(long memory, byte[] box) {
         byte val = box[0];

--- a/compiler/src/org.graalvm.compiler.core.test/src/org/graalvm/compiler/core/test/ea/PartialEscapeUnsafeStoreTest.java
+++ b/compiler/src/org.graalvm.compiler.core.test/src/org/graalvm/compiler/core/test/ea/PartialEscapeUnsafeStoreTest.java
@@ -24,12 +24,8 @@
  */
 package org.graalvm.compiler.core.test.ea;
 
-import java.lang.reflect.Field;
-
 import org.graalvm.compiler.core.test.GraalCompilerTest;
 import org.junit.Test;
-
-import sun.misc.Unsafe;
 
 /**
  * Exercise a mix of unsafe and normal reads ands writes in situations where EA might attempt to
@@ -37,24 +33,12 @@ import sun.misc.Unsafe;
  */
 public class PartialEscapeUnsafeStoreTest extends GraalCompilerTest {
 
-    private static final Unsafe unsafe = initUnsafe();
-
-    private static Unsafe initUnsafe() {
-        try {
-            Field theUnsafe = Unsafe.class.getDeclaredField("theUnsafe");
-            theUnsafe.setAccessible(true);
-            return (Unsafe) theUnsafe.get(Unsafe.class);
-        } catch (Exception e) {
-            throw new RuntimeException("exception while trying to get Unsafe", e);
-        }
-    }
-
-    private static final long byteArrayBaseOffset = unsafe.arrayBaseOffset(byte[].class);
+    private static final long byteArrayBaseOffset = UNSAFE.arrayBaseOffset(byte[].class);
     private static byte byteValue = 0x61;
 
     public static byte[] testByteArrayWithCharStoreSnippet(char v) {
         byte[] b = new byte[8];
-        unsafe.putChar(b, byteArrayBaseOffset, v);
+        UNSAFE.putChar(b, byteArrayBaseOffset, v);
         return b;
     }
 
@@ -65,7 +49,7 @@ public class PartialEscapeUnsafeStoreTest extends GraalCompilerTest {
 
     public static byte[] testByteArrayWithShortStoreSnippet(short v) {
         byte[] b = new byte[8];
-        unsafe.putShort(b, byteArrayBaseOffset, v);
+        UNSAFE.putShort(b, byteArrayBaseOffset, v);
         return b;
     }
 
@@ -76,7 +60,7 @@ public class PartialEscapeUnsafeStoreTest extends GraalCompilerTest {
 
     public static byte[] testByteArrayWithIntStoreSnippet(int v) {
         byte[] b = new byte[8];
-        unsafe.putInt(b, byteArrayBaseOffset, v);
+        UNSAFE.putInt(b, byteArrayBaseOffset, v);
         return b;
     }
 
@@ -87,7 +71,7 @@ public class PartialEscapeUnsafeStoreTest extends GraalCompilerTest {
 
     public static byte[] testByteArrayWithLongStoreSnippet(long v) {
         byte[] b = new byte[8];
-        unsafe.putLong(b, byteArrayBaseOffset, v);
+        UNSAFE.putLong(b, byteArrayBaseOffset, v);
         return b;
     }
 
@@ -98,7 +82,7 @@ public class PartialEscapeUnsafeStoreTest extends GraalCompilerTest {
 
     public static byte[] testByteArrayWithFloatStoreSnippet(float v) {
         byte[] b = new byte[8];
-        unsafe.putFloat(b, byteArrayBaseOffset, v);
+        UNSAFE.putFloat(b, byteArrayBaseOffset, v);
         return b;
     }
 
@@ -109,7 +93,7 @@ public class PartialEscapeUnsafeStoreTest extends GraalCompilerTest {
 
     public static byte[] testByteArrayWithDoubleStoreSnippet(double v) {
         byte[] b = new byte[8];
-        unsafe.putDouble(b, byteArrayBaseOffset, v);
+        UNSAFE.putDouble(b, byteArrayBaseOffset, v);
         return b;
     }
 
@@ -118,12 +102,12 @@ public class PartialEscapeUnsafeStoreTest extends GraalCompilerTest {
         test("testByteArrayWithDoubleStoreSnippet", doubleValue);
     }
 
-    private static final long charArrayBaseOffset = unsafe.arrayBaseOffset(char[].class);
+    private static final long charArrayBaseOffset = UNSAFE.arrayBaseOffset(char[].class);
     private static char charValue = 0x4142;
 
     public static char[] testCharArrayWithByteStoreSnippet(byte v) {
         char[] b = new char[4];
-        unsafe.putByte(b, charArrayBaseOffset, v);
+        UNSAFE.putByte(b, charArrayBaseOffset, v);
         return b;
     }
 
@@ -134,7 +118,7 @@ public class PartialEscapeUnsafeStoreTest extends GraalCompilerTest {
 
     public static char[] testCharArrayWithShortStoreSnippet(short v) {
         char[] b = new char[4];
-        unsafe.putShort(b, charArrayBaseOffset, v);
+        UNSAFE.putShort(b, charArrayBaseOffset, v);
         return b;
     }
 
@@ -145,7 +129,7 @@ public class PartialEscapeUnsafeStoreTest extends GraalCompilerTest {
 
     public static char[] testCharArrayWithIntStoreSnippet(int v) {
         char[] b = new char[4];
-        unsafe.putInt(b, charArrayBaseOffset, v);
+        UNSAFE.putInt(b, charArrayBaseOffset, v);
         return b;
     }
 
@@ -156,7 +140,7 @@ public class PartialEscapeUnsafeStoreTest extends GraalCompilerTest {
 
     public static char[] testCharArrayWithLongStoreSnippet(long v) {
         char[] b = new char[4];
-        unsafe.putLong(b, charArrayBaseOffset, v);
+        UNSAFE.putLong(b, charArrayBaseOffset, v);
         return b;
     }
 
@@ -167,7 +151,7 @@ public class PartialEscapeUnsafeStoreTest extends GraalCompilerTest {
 
     public static char[] testCharArrayWithFloatStoreSnippet(float v) {
         char[] b = new char[4];
-        unsafe.putFloat(b, charArrayBaseOffset, v);
+        UNSAFE.putFloat(b, charArrayBaseOffset, v);
         return b;
     }
 
@@ -178,7 +162,7 @@ public class PartialEscapeUnsafeStoreTest extends GraalCompilerTest {
 
     public static char[] testCharArrayWithDoubleStoreSnippet(double v) {
         char[] b = new char[4];
-        unsafe.putDouble(b, charArrayBaseOffset, v);
+        UNSAFE.putDouble(b, charArrayBaseOffset, v);
         return b;
     }
 
@@ -187,12 +171,12 @@ public class PartialEscapeUnsafeStoreTest extends GraalCompilerTest {
         test("testCharArrayWithDoubleStoreSnippet", doubleValue);
     }
 
-    private static final long shortArrayBaseOffset = unsafe.arrayBaseOffset(short[].class);
+    private static final long shortArrayBaseOffset = UNSAFE.arrayBaseOffset(short[].class);
     private static short shortValue = 0x1112;
 
     public static short[] testShortArrayWithByteStoreSnippet(byte v) {
         short[] b = new short[4];
-        unsafe.putByte(b, shortArrayBaseOffset, v);
+        UNSAFE.putByte(b, shortArrayBaseOffset, v);
         return b;
     }
 
@@ -203,7 +187,7 @@ public class PartialEscapeUnsafeStoreTest extends GraalCompilerTest {
 
     public static short[] testShortArrayWithCharStoreSnippet(char v) {
         short[] b = new short[4];
-        unsafe.putChar(b, shortArrayBaseOffset, v);
+        UNSAFE.putChar(b, shortArrayBaseOffset, v);
         return b;
     }
 
@@ -214,7 +198,7 @@ public class PartialEscapeUnsafeStoreTest extends GraalCompilerTest {
 
     public static short[] testShortArrayWithIntStoreSnippet(int v) {
         short[] b = new short[4];
-        unsafe.putInt(b, shortArrayBaseOffset, v);
+        UNSAFE.putInt(b, shortArrayBaseOffset, v);
         return b;
     }
 
@@ -225,7 +209,7 @@ public class PartialEscapeUnsafeStoreTest extends GraalCompilerTest {
 
     public static short[] testShortArrayWithLongStoreSnippet(long v) {
         short[] b = new short[4];
-        unsafe.putLong(b, shortArrayBaseOffset, v);
+        UNSAFE.putLong(b, shortArrayBaseOffset, v);
         return b;
     }
 
@@ -236,7 +220,7 @@ public class PartialEscapeUnsafeStoreTest extends GraalCompilerTest {
 
     public static short[] testShortArrayWithFloatStoreSnippet(float v) {
         short[] b = new short[4];
-        unsafe.putFloat(b, shortArrayBaseOffset, v);
+        UNSAFE.putFloat(b, shortArrayBaseOffset, v);
         return b;
     }
 
@@ -247,7 +231,7 @@ public class PartialEscapeUnsafeStoreTest extends GraalCompilerTest {
 
     public static short[] testShortArrayWithDoubleStoreSnippet(double v) {
         short[] b = new short[4];
-        unsafe.putDouble(b, shortArrayBaseOffset, v);
+        UNSAFE.putDouble(b, shortArrayBaseOffset, v);
         return b;
     }
 
@@ -256,12 +240,12 @@ public class PartialEscapeUnsafeStoreTest extends GraalCompilerTest {
         test("testShortArrayWithDoubleStoreSnippet", doubleValue);
     }
 
-    private static final long intArrayBaseOffset = unsafe.arrayBaseOffset(int[].class);
+    private static final long intArrayBaseOffset = UNSAFE.arrayBaseOffset(int[].class);
     private static int intValue = 0x01020304;
 
     public static int[] testIntArrayWithByteStoreSnippet(byte v) {
         int[] b = new int[4];
-        unsafe.putByte(b, intArrayBaseOffset, v);
+        UNSAFE.putByte(b, intArrayBaseOffset, v);
         return b;
     }
 
@@ -272,7 +256,7 @@ public class PartialEscapeUnsafeStoreTest extends GraalCompilerTest {
 
     public static int[] testIntArrayWithCharStoreSnippet(char v) {
         int[] b = new int[4];
-        unsafe.putChar(b, intArrayBaseOffset, v);
+        UNSAFE.putChar(b, intArrayBaseOffset, v);
         return b;
     }
 
@@ -283,7 +267,7 @@ public class PartialEscapeUnsafeStoreTest extends GraalCompilerTest {
 
     public static int[] testIntArrayWithShortStoreSnippet(short v) {
         int[] b = new int[4];
-        unsafe.putShort(b, intArrayBaseOffset, v);
+        UNSAFE.putShort(b, intArrayBaseOffset, v);
         return b;
     }
 
@@ -294,7 +278,7 @@ public class PartialEscapeUnsafeStoreTest extends GraalCompilerTest {
 
     public static int[] testIntArrayWithLongStoreSnippet(long v) {
         int[] b = new int[4];
-        unsafe.putLong(b, intArrayBaseOffset, v);
+        UNSAFE.putLong(b, intArrayBaseOffset, v);
         return b;
     }
 
@@ -305,7 +289,7 @@ public class PartialEscapeUnsafeStoreTest extends GraalCompilerTest {
 
     public static int[] testIntArrayWithFloatStoreSnippet(float v) {
         int[] b = new int[4];
-        unsafe.putFloat(b, intArrayBaseOffset, v);
+        UNSAFE.putFloat(b, intArrayBaseOffset, v);
         return b;
     }
 
@@ -316,7 +300,7 @@ public class PartialEscapeUnsafeStoreTest extends GraalCompilerTest {
 
     public static int[] testIntArrayWithDoubleStoreSnippet(double v) {
         int[] b = new int[4];
-        unsafe.putDouble(b, intArrayBaseOffset, v);
+        UNSAFE.putDouble(b, intArrayBaseOffset, v);
         return b;
     }
 
@@ -325,12 +309,12 @@ public class PartialEscapeUnsafeStoreTest extends GraalCompilerTest {
         test("testIntArrayWithDoubleStoreSnippet", doubleValue);
     }
 
-    private static final long longArrayBaseOffset = unsafe.arrayBaseOffset(long[].class);
+    private static final long longArrayBaseOffset = UNSAFE.arrayBaseOffset(long[].class);
     private static long longValue = 0x31323334353637L;
 
     public static long[] testLongArrayWithByteStoreSnippet(byte v) {
         long[] b = new long[4];
-        unsafe.putByte(b, longArrayBaseOffset, v);
+        UNSAFE.putByte(b, longArrayBaseOffset, v);
         return b;
     }
 
@@ -341,7 +325,7 @@ public class PartialEscapeUnsafeStoreTest extends GraalCompilerTest {
 
     public static long[] testLongArrayWithCharStoreSnippet(char v) {
         long[] b = new long[4];
-        unsafe.putChar(b, longArrayBaseOffset, v);
+        UNSAFE.putChar(b, longArrayBaseOffset, v);
         return b;
     }
 
@@ -352,7 +336,7 @@ public class PartialEscapeUnsafeStoreTest extends GraalCompilerTest {
 
     public static long[] testLongArrayWithShortStoreSnippet(short v) {
         long[] b = new long[4];
-        unsafe.putShort(b, longArrayBaseOffset, v);
+        UNSAFE.putShort(b, longArrayBaseOffset, v);
         return b;
     }
 
@@ -363,7 +347,7 @@ public class PartialEscapeUnsafeStoreTest extends GraalCompilerTest {
 
     public static long[] testLongArrayWithIntStoreSnippet(int v) {
         long[] b = new long[4];
-        unsafe.putInt(b, longArrayBaseOffset, v);
+        UNSAFE.putInt(b, longArrayBaseOffset, v);
         return b;
     }
 
@@ -374,7 +358,7 @@ public class PartialEscapeUnsafeStoreTest extends GraalCompilerTest {
 
     public static long[] testLongArrayWithFloatStoreSnippet(float v) {
         long[] b = new long[4];
-        unsafe.putFloat(b, longArrayBaseOffset, v);
+        UNSAFE.putFloat(b, longArrayBaseOffset, v);
         return b;
     }
 
@@ -385,7 +369,7 @@ public class PartialEscapeUnsafeStoreTest extends GraalCompilerTest {
 
     public static long[] testLongArrayWithDoubleStoreSnippet(double v) {
         long[] b = new long[4];
-        unsafe.putDouble(b, longArrayBaseOffset, v);
+        UNSAFE.putDouble(b, longArrayBaseOffset, v);
         return b;
     }
 
@@ -394,12 +378,12 @@ public class PartialEscapeUnsafeStoreTest extends GraalCompilerTest {
         test("testLongArrayWithDoubleStoreSnippet", doubleValue);
     }
 
-    private static final long floatArrayBaseOffset = unsafe.arrayBaseOffset(float[].class);
+    private static final long floatArrayBaseOffset = UNSAFE.arrayBaseOffset(float[].class);
     private static float floatValue = Float.NaN;
 
     public static float[] testFloatArrayWithByteStoreSnippet(byte v) {
         float[] b = new float[4];
-        unsafe.putByte(b, floatArrayBaseOffset, v);
+        UNSAFE.putByte(b, floatArrayBaseOffset, v);
         return b;
     }
 
@@ -410,7 +394,7 @@ public class PartialEscapeUnsafeStoreTest extends GraalCompilerTest {
 
     public static float[] testFloatArrayWithCharStoreSnippet(char v) {
         float[] b = new float[4];
-        unsafe.putChar(b, floatArrayBaseOffset, v);
+        UNSAFE.putChar(b, floatArrayBaseOffset, v);
         return b;
     }
 
@@ -421,7 +405,7 @@ public class PartialEscapeUnsafeStoreTest extends GraalCompilerTest {
 
     public static float[] testFloatArrayWithShortStoreSnippet(short v) {
         float[] b = new float[4];
-        unsafe.putShort(b, floatArrayBaseOffset, v);
+        UNSAFE.putShort(b, floatArrayBaseOffset, v);
         return b;
     }
 
@@ -432,7 +416,7 @@ public class PartialEscapeUnsafeStoreTest extends GraalCompilerTest {
 
     public static float[] testFloatArrayWithIntStoreSnippet(int v) {
         float[] b = new float[4];
-        unsafe.putInt(b, floatArrayBaseOffset, v);
+        UNSAFE.putInt(b, floatArrayBaseOffset, v);
         return b;
     }
 
@@ -443,7 +427,7 @@ public class PartialEscapeUnsafeStoreTest extends GraalCompilerTest {
 
     public static float[] testFloatArrayWithLongStoreSnippet(long v) {
         float[] b = new float[4];
-        unsafe.putLong(b, floatArrayBaseOffset, v);
+        UNSAFE.putLong(b, floatArrayBaseOffset, v);
         return b;
     }
 
@@ -454,7 +438,7 @@ public class PartialEscapeUnsafeStoreTest extends GraalCompilerTest {
 
     public static float[] testFloatArrayWithDoubleStoreSnippet(double v) {
         float[] b = new float[4];
-        unsafe.putDouble(b, floatArrayBaseOffset, v);
+        UNSAFE.putDouble(b, floatArrayBaseOffset, v);
         return b;
     }
 
@@ -463,7 +447,7 @@ public class PartialEscapeUnsafeStoreTest extends GraalCompilerTest {
         test("testFloatArrayWithDoubleStoreSnippet", doubleValue);
     }
 
-    private static final long doubleArrayBaseOffset = unsafe.arrayBaseOffset(double[].class);
+    private static final long doubleArrayBaseOffset = UNSAFE.arrayBaseOffset(double[].class);
     private static double doubleValue = Double.NaN;
     private static final int byteSize = 1;
     private static final int charSize = 2;
@@ -475,7 +459,7 @@ public class PartialEscapeUnsafeStoreTest extends GraalCompilerTest {
 
     public static double[] testDoubleArrayWithByteStoreSnippet(byte v) {
         double[] b = new double[4];
-        unsafe.putByte(b, doubleArrayBaseOffset, v);
+        UNSAFE.putByte(b, doubleArrayBaseOffset, v);
         return b;
     }
 
@@ -486,7 +470,7 @@ public class PartialEscapeUnsafeStoreTest extends GraalCompilerTest {
 
     public static double[] testDoubleArrayWithCharStoreSnippet(char v) {
         double[] b = new double[4];
-        unsafe.putChar(b, doubleArrayBaseOffset, v);
+        UNSAFE.putChar(b, doubleArrayBaseOffset, v);
         return b;
     }
 
@@ -497,7 +481,7 @@ public class PartialEscapeUnsafeStoreTest extends GraalCompilerTest {
 
     public static double[] testDoubleArrayWithShortStoreSnippet(short v) {
         double[] b = new double[4];
-        unsafe.putShort(b, doubleArrayBaseOffset, v);
+        UNSAFE.putShort(b, doubleArrayBaseOffset, v);
         return b;
     }
 
@@ -508,7 +492,7 @@ public class PartialEscapeUnsafeStoreTest extends GraalCompilerTest {
 
     public static double[] testDoubleArrayWithIntStoreSnippet(int v) {
         double[] b = new double[4];
-        unsafe.putInt(b, doubleArrayBaseOffset, v);
+        UNSAFE.putInt(b, doubleArrayBaseOffset, v);
         return b;
     }
 
@@ -519,7 +503,7 @@ public class PartialEscapeUnsafeStoreTest extends GraalCompilerTest {
 
     public static double[] testDoubleArrayWithLongStoreSnippet(long v) {
         double[] b = new double[4];
-        unsafe.putLong(b, doubleArrayBaseOffset, v);
+        UNSAFE.putLong(b, doubleArrayBaseOffset, v);
         return b;
     }
 
@@ -530,7 +514,7 @@ public class PartialEscapeUnsafeStoreTest extends GraalCompilerTest {
 
     public static double[] testDoubleArrayWithFloatStoreSnippet(float v) {
         double[] b = new double[4];
-        unsafe.putFloat(b, doubleArrayBaseOffset, v);
+        UNSAFE.putFloat(b, doubleArrayBaseOffset, v);
         return b;
     }
 
@@ -541,7 +525,7 @@ public class PartialEscapeUnsafeStoreTest extends GraalCompilerTest {
 
     public static byte testByteArrayWithCharStoreAndReadSnippet(char v) {
         byte[] b = new byte[4];
-        unsafe.putChar(b, byteArrayBaseOffset, v);
+        UNSAFE.putChar(b, byteArrayBaseOffset, v);
         return b[(byteSize / charSize) + 1];
     }
 
@@ -552,7 +536,7 @@ public class PartialEscapeUnsafeStoreTest extends GraalCompilerTest {
 
     public static byte testByteArrayWithShortStoreAndReadSnippet(short v) {
         byte[] b = new byte[4];
-        unsafe.putShort(b, byteArrayBaseOffset, v);
+        UNSAFE.putShort(b, byteArrayBaseOffset, v);
         return b[(byteSize / shortSize) + 1];
     }
 
@@ -563,7 +547,7 @@ public class PartialEscapeUnsafeStoreTest extends GraalCompilerTest {
 
     public static byte testByteArrayWithIntStoreAndReadSnippet(int v) {
         byte[] b = new byte[4];
-        unsafe.putInt(b, byteArrayBaseOffset, v);
+        UNSAFE.putInt(b, byteArrayBaseOffset, v);
         return b[(byteSize / intSize) + 1];
     }
 
@@ -574,7 +558,7 @@ public class PartialEscapeUnsafeStoreTest extends GraalCompilerTest {
 
     public static byte testByteArrayWithLongStoreAndReadSnippet(long v) {
         byte[] b = new byte[4];
-        unsafe.putLong(b, byteArrayBaseOffset, v);
+        UNSAFE.putLong(b, byteArrayBaseOffset, v);
         return b[(byteSize / longSize) + 1];
     }
 
@@ -585,7 +569,7 @@ public class PartialEscapeUnsafeStoreTest extends GraalCompilerTest {
 
     public static byte testByteArrayWithFloatStoreAndReadSnippet(float v) {
         byte[] b = new byte[4];
-        unsafe.putFloat(b, byteArrayBaseOffset, v);
+        UNSAFE.putFloat(b, byteArrayBaseOffset, v);
         return b[(byteSize / floatSize) + 1];
     }
 
@@ -596,7 +580,7 @@ public class PartialEscapeUnsafeStoreTest extends GraalCompilerTest {
 
     public static byte testByteArrayWithDoubleStoreAndReadSnippet(double v) {
         byte[] b = new byte[4];
-        unsafe.putDouble(b, byteArrayBaseOffset, v);
+        UNSAFE.putDouble(b, byteArrayBaseOffset, v);
         return b[(byteSize / doubleSize) + 1];
     }
 
@@ -607,7 +591,7 @@ public class PartialEscapeUnsafeStoreTest extends GraalCompilerTest {
 
     public static char testCharArrayWithByteStoreAndReadSnippet(byte v) {
         char[] b = new char[4];
-        unsafe.putByte(b, charArrayBaseOffset, v);
+        UNSAFE.putByte(b, charArrayBaseOffset, v);
         return b[(charSize / byteSize) + 1];
     }
 
@@ -618,7 +602,7 @@ public class PartialEscapeUnsafeStoreTest extends GraalCompilerTest {
 
     public static char testCharArrayWithShortStoreAndReadSnippet(short v) {
         char[] b = new char[4];
-        unsafe.putShort(b, charArrayBaseOffset, v);
+        UNSAFE.putShort(b, charArrayBaseOffset, v);
         return b[(charSize / shortSize) + 1];
     }
 
@@ -629,7 +613,7 @@ public class PartialEscapeUnsafeStoreTest extends GraalCompilerTest {
 
     public static char testCharArrayWithIntStoreAndReadSnippet(int v) {
         char[] b = new char[4];
-        unsafe.putInt(b, charArrayBaseOffset, v);
+        UNSAFE.putInt(b, charArrayBaseOffset, v);
         return b[(charSize / intSize) + 1];
     }
 
@@ -640,7 +624,7 @@ public class PartialEscapeUnsafeStoreTest extends GraalCompilerTest {
 
     public static char testCharArrayWithLongStoreAndReadSnippet(long v) {
         char[] b = new char[4];
-        unsafe.putLong(b, charArrayBaseOffset, v);
+        UNSAFE.putLong(b, charArrayBaseOffset, v);
         return b[(charSize / longSize) + 1];
     }
 
@@ -651,7 +635,7 @@ public class PartialEscapeUnsafeStoreTest extends GraalCompilerTest {
 
     public static char testCharArrayWithFloatStoreAndReadSnippet(float v) {
         char[] b = new char[4];
-        unsafe.putFloat(b, charArrayBaseOffset, v);
+        UNSAFE.putFloat(b, charArrayBaseOffset, v);
         return b[(charSize / floatSize) + 1];
     }
 
@@ -662,7 +646,7 @@ public class PartialEscapeUnsafeStoreTest extends GraalCompilerTest {
 
     public static char testCharArrayWithDoubleStoreAndReadSnippet(double v) {
         char[] b = new char[4];
-        unsafe.putDouble(b, charArrayBaseOffset, v);
+        UNSAFE.putDouble(b, charArrayBaseOffset, v);
         return b[(charSize / doubleSize) + 1];
     }
 
@@ -673,7 +657,7 @@ public class PartialEscapeUnsafeStoreTest extends GraalCompilerTest {
 
     public static short testShortArrayWithByteStoreAndReadSnippet(byte v) {
         short[] b = new short[4];
-        unsafe.putByte(b, shortArrayBaseOffset, v);
+        UNSAFE.putByte(b, shortArrayBaseOffset, v);
         return b[(shortSize / byteSize) + 1];
     }
 
@@ -684,7 +668,7 @@ public class PartialEscapeUnsafeStoreTest extends GraalCompilerTest {
 
     public static short testShortArrayWithCharStoreAndReadSnippet(char v) {
         short[] b = new short[4];
-        unsafe.putChar(b, shortArrayBaseOffset, v);
+        UNSAFE.putChar(b, shortArrayBaseOffset, v);
         return b[(shortSize / charSize) + 1];
     }
 
@@ -695,7 +679,7 @@ public class PartialEscapeUnsafeStoreTest extends GraalCompilerTest {
 
     public static short testShortArrayWithIntStoreAndReadSnippet(int v) {
         short[] b = new short[4];
-        unsafe.putInt(b, shortArrayBaseOffset, v);
+        UNSAFE.putInt(b, shortArrayBaseOffset, v);
         return b[(shortSize / intSize) + 1];
     }
 
@@ -706,7 +690,7 @@ public class PartialEscapeUnsafeStoreTest extends GraalCompilerTest {
 
     public static short testShortArrayWithLongStoreAndReadSnippet(long v) {
         short[] b = new short[4];
-        unsafe.putLong(b, shortArrayBaseOffset, v);
+        UNSAFE.putLong(b, shortArrayBaseOffset, v);
         return b[(shortSize / longSize) + 1];
     }
 
@@ -717,7 +701,7 @@ public class PartialEscapeUnsafeStoreTest extends GraalCompilerTest {
 
     public static short testShortArrayWithFloatStoreAndReadSnippet(float v) {
         short[] b = new short[4];
-        unsafe.putFloat(b, shortArrayBaseOffset, v);
+        UNSAFE.putFloat(b, shortArrayBaseOffset, v);
         return b[(shortSize / floatSize) + 1];
     }
 
@@ -728,7 +712,7 @@ public class PartialEscapeUnsafeStoreTest extends GraalCompilerTest {
 
     public static short testShortArrayWithDoubleStoreAndReadSnippet(double v) {
         short[] b = new short[4];
-        unsafe.putDouble(b, shortArrayBaseOffset, v);
+        UNSAFE.putDouble(b, shortArrayBaseOffset, v);
         return b[(shortSize / doubleSize) + 1];
     }
 
@@ -739,7 +723,7 @@ public class PartialEscapeUnsafeStoreTest extends GraalCompilerTest {
 
     public static int testIntArrayWithByteStoreAndReadSnippet(byte v) {
         int[] b = new int[4];
-        unsafe.putByte(b, intArrayBaseOffset, v);
+        UNSAFE.putByte(b, intArrayBaseOffset, v);
         return b[(intSize / byteSize) + 1];
     }
 
@@ -750,7 +734,7 @@ public class PartialEscapeUnsafeStoreTest extends GraalCompilerTest {
 
     public static int testIntArrayWithCharStoreAndReadSnippet(char v) {
         int[] b = new int[4];
-        unsafe.putChar(b, intArrayBaseOffset, v);
+        UNSAFE.putChar(b, intArrayBaseOffset, v);
         return b[(intSize / charSize) + 1];
     }
 
@@ -761,7 +745,7 @@ public class PartialEscapeUnsafeStoreTest extends GraalCompilerTest {
 
     public static int testIntArrayWithShortStoreAndReadSnippet(short v) {
         int[] b = new int[4];
-        unsafe.putShort(b, intArrayBaseOffset, v);
+        UNSAFE.putShort(b, intArrayBaseOffset, v);
         return b[(intSize / shortSize) + 1];
     }
 
@@ -772,7 +756,7 @@ public class PartialEscapeUnsafeStoreTest extends GraalCompilerTest {
 
     public static int testIntArrayWithLongStoreAndReadSnippet(long v) {
         int[] b = new int[4];
-        unsafe.putLong(b, intArrayBaseOffset, v);
+        UNSAFE.putLong(b, intArrayBaseOffset, v);
         return b[(intSize / longSize) + 1];
     }
 
@@ -783,7 +767,7 @@ public class PartialEscapeUnsafeStoreTest extends GraalCompilerTest {
 
     public static int testIntArrayWithFloatStoreAndReadSnippet(float v) {
         int[] b = new int[4];
-        unsafe.putFloat(b, intArrayBaseOffset, v);
+        UNSAFE.putFloat(b, intArrayBaseOffset, v);
         return b[(intSize / floatSize) + 1];
     }
 
@@ -794,7 +778,7 @@ public class PartialEscapeUnsafeStoreTest extends GraalCompilerTest {
 
     public static int testIntArrayWithDoubleStoreAndReadSnippet(double v) {
         int[] b = new int[4];
-        unsafe.putDouble(b, intArrayBaseOffset, v);
+        UNSAFE.putDouble(b, intArrayBaseOffset, v);
         return b[(intSize / doubleSize) + 1];
     }
 
@@ -805,7 +789,7 @@ public class PartialEscapeUnsafeStoreTest extends GraalCompilerTest {
 
     public static long testLongArrayWithByteStoreAndReadSnippet(byte v) {
         long[] b = new long[4];
-        unsafe.putByte(b, longArrayBaseOffset, v);
+        UNSAFE.putByte(b, longArrayBaseOffset, v);
         return b[(longSize / byteSize) + 1];
     }
 
@@ -816,7 +800,7 @@ public class PartialEscapeUnsafeStoreTest extends GraalCompilerTest {
 
     public static long testLongArrayWithCharStoreAndReadSnippet(char v) {
         long[] b = new long[4];
-        unsafe.putChar(b, longArrayBaseOffset, v);
+        UNSAFE.putChar(b, longArrayBaseOffset, v);
         return b[(longSize / charSize) + 1];
     }
 
@@ -827,7 +811,7 @@ public class PartialEscapeUnsafeStoreTest extends GraalCompilerTest {
 
     public static long testLongArrayWithShortStoreAndReadSnippet(short v) {
         long[] b = new long[4];
-        unsafe.putShort(b, longArrayBaseOffset, v);
+        UNSAFE.putShort(b, longArrayBaseOffset, v);
         return b[(longSize / shortSize) + 1];
     }
 
@@ -838,7 +822,7 @@ public class PartialEscapeUnsafeStoreTest extends GraalCompilerTest {
 
     public static long testLongArrayWithIntStoreAndReadSnippet(int v) {
         long[] b = new long[4];
-        unsafe.putInt(b, longArrayBaseOffset, v);
+        UNSAFE.putInt(b, longArrayBaseOffset, v);
         return b[(longSize / intSize) + 1];
     }
 
@@ -849,7 +833,7 @@ public class PartialEscapeUnsafeStoreTest extends GraalCompilerTest {
 
     public static long testLongArrayWithFloatStoreAndReadSnippet(float v) {
         long[] b = new long[4];
-        unsafe.putFloat(b, longArrayBaseOffset, v);
+        UNSAFE.putFloat(b, longArrayBaseOffset, v);
         return b[(longSize / floatSize) + 1];
     }
 
@@ -860,7 +844,7 @@ public class PartialEscapeUnsafeStoreTest extends GraalCompilerTest {
 
     public static long testLongArrayWithDoubleStoreAndReadSnippet(double v) {
         long[] b = new long[4];
-        unsafe.putDouble(b, longArrayBaseOffset, v);
+        UNSAFE.putDouble(b, longArrayBaseOffset, v);
         return b[(longSize / doubleSize) + 1];
     }
 
@@ -871,7 +855,7 @@ public class PartialEscapeUnsafeStoreTest extends GraalCompilerTest {
 
     public static float testFloatArrayWithByteStoreAndReadSnippet(byte v) {
         float[] b = new float[4];
-        unsafe.putByte(b, floatArrayBaseOffset, v);
+        UNSAFE.putByte(b, floatArrayBaseOffset, v);
         return b[(floatSize / byteSize) + 1];
     }
 
@@ -882,7 +866,7 @@ public class PartialEscapeUnsafeStoreTest extends GraalCompilerTest {
 
     public static float testFloatArrayWithCharStoreAndReadSnippet(char v) {
         float[] b = new float[4];
-        unsafe.putChar(b, floatArrayBaseOffset, v);
+        UNSAFE.putChar(b, floatArrayBaseOffset, v);
         return b[(floatSize / charSize) + 1];
     }
 
@@ -893,7 +877,7 @@ public class PartialEscapeUnsafeStoreTest extends GraalCompilerTest {
 
     public static float testFloatArrayWithShortStoreAndReadSnippet(short v) {
         float[] b = new float[4];
-        unsafe.putShort(b, floatArrayBaseOffset, v);
+        UNSAFE.putShort(b, floatArrayBaseOffset, v);
         return b[(floatSize / shortSize) + 1];
     }
 
@@ -904,7 +888,7 @@ public class PartialEscapeUnsafeStoreTest extends GraalCompilerTest {
 
     public static float testFloatArrayWithIntStoreAndReadSnippet(int v) {
         float[] b = new float[4];
-        unsafe.putInt(b, floatArrayBaseOffset, v);
+        UNSAFE.putInt(b, floatArrayBaseOffset, v);
         return b[(floatSize / intSize) + 1];
     }
 
@@ -915,7 +899,7 @@ public class PartialEscapeUnsafeStoreTest extends GraalCompilerTest {
 
     public static float testFloatArrayWithLongStoreAndReadSnippet(long v) {
         float[] b = new float[4];
-        unsafe.putLong(b, floatArrayBaseOffset, v);
+        UNSAFE.putLong(b, floatArrayBaseOffset, v);
         return b[(floatSize / longSize) + 1];
     }
 
@@ -926,7 +910,7 @@ public class PartialEscapeUnsafeStoreTest extends GraalCompilerTest {
 
     public static float testFloatArrayWithDoubleStoreAndReadSnippet(double v) {
         float[] b = new float[4];
-        unsafe.putDouble(b, floatArrayBaseOffset, v);
+        UNSAFE.putDouble(b, floatArrayBaseOffset, v);
         return b[(floatSize / doubleSize) + 1];
     }
 
@@ -937,7 +921,7 @@ public class PartialEscapeUnsafeStoreTest extends GraalCompilerTest {
 
     public static double testDoubleArrayWithByteStoreAndReadSnippet(byte v) {
         double[] b = new double[4];
-        unsafe.putByte(b, doubleArrayBaseOffset, v);
+        UNSAFE.putByte(b, doubleArrayBaseOffset, v);
         return b[(doubleSize / byteSize) + 1];
     }
 
@@ -948,7 +932,7 @@ public class PartialEscapeUnsafeStoreTest extends GraalCompilerTest {
 
     public static double testDoubleArrayWithCharStoreAndReadSnippet(char v) {
         double[] b = new double[4];
-        unsafe.putChar(b, doubleArrayBaseOffset, v);
+        UNSAFE.putChar(b, doubleArrayBaseOffset, v);
         return b[(doubleSize / charSize) + 1];
     }
 
@@ -959,7 +943,7 @@ public class PartialEscapeUnsafeStoreTest extends GraalCompilerTest {
 
     public static double testDoubleArrayWithShortStoreAndReadSnippet(short v) {
         double[] b = new double[4];
-        unsafe.putShort(b, doubleArrayBaseOffset, v);
+        UNSAFE.putShort(b, doubleArrayBaseOffset, v);
         return b[(doubleSize / shortSize) + 1];
     }
 
@@ -970,7 +954,7 @@ public class PartialEscapeUnsafeStoreTest extends GraalCompilerTest {
 
     public static double testDoubleArrayWithIntStoreAndReadSnippet(int v) {
         double[] b = new double[4];
-        unsafe.putInt(b, doubleArrayBaseOffset, v);
+        UNSAFE.putInt(b, doubleArrayBaseOffset, v);
         return b[(doubleSize / intSize) + 1];
     }
 
@@ -981,7 +965,7 @@ public class PartialEscapeUnsafeStoreTest extends GraalCompilerTest {
 
     public static double testDoubleArrayWithLongStoreAndReadSnippet(long v) {
         double[] b = new double[4];
-        unsafe.putLong(b, doubleArrayBaseOffset, v);
+        UNSAFE.putLong(b, doubleArrayBaseOffset, v);
         return b[(doubleSize / longSize) + 1];
     }
 
@@ -992,7 +976,7 @@ public class PartialEscapeUnsafeStoreTest extends GraalCompilerTest {
 
     public static double testDoubleArrayWithFloatStoreAndReadSnippet(float v) {
         double[] b = new double[4];
-        unsafe.putFloat(b, doubleArrayBaseOffset, v);
+        UNSAFE.putFloat(b, doubleArrayBaseOffset, v);
         return b[(doubleSize / floatSize) + 1];
     }
 

--- a/compiler/src/org.graalvm.compiler.test/src/org/graalvm/compiler/test/GraalTest.java
+++ b/compiler/src/org.graalvm.compiler.test/src/org/graalvm/compiler/test/GraalTest.java
@@ -30,7 +30,6 @@ import static org.graalvm.compiler.debug.DebugContext.NO_DESCRIPTION;
 import java.io.IOException;
 import java.io.PrintStream;
 import java.io.PrintWriter;
-import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
@@ -52,6 +51,7 @@ import org.graalvm.compiler.debug.DebugHandlersFactory;
 import org.graalvm.compiler.debug.GlobalMetrics;
 import org.graalvm.compiler.options.OptionValues;
 import org.graalvm.compiler.serviceprovider.GraalServices;
+import org.graalvm.compiler.serviceprovider.GraalUnsafeAccess;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.AssumptionViolatedException;
@@ -69,16 +69,7 @@ import sun.misc.Unsafe;
  */
 public class GraalTest {
 
-    public static final Unsafe UNSAFE;
-    static {
-        try {
-            Field theUnsafe = Unsafe.class.getDeclaredField("theUnsafe");
-            theUnsafe.setAccessible(true);
-            UNSAFE = (Unsafe) theUnsafe.get(Unsafe.class);
-        } catch (Exception e) {
-            throw new RuntimeException("exception while trying to get Unsafe", e);
-        }
-    }
+    public static final Unsafe UNSAFE = GraalUnsafeAccess.getUnsafe();
 
     protected Method getMethod(String methodName) {
         return getMethod(getClass(), methodName);


### PR DESCRIPTION
Use `GraalUnsafeAccess` where possible. Let's not write out `Field theUnsafe = Unsafe.class.getDeclaredField("theUnsafe");` so many times.

https://github.com/Shopify/truffleruby/issues/1