### PR TITLE
Add safe unsafe methods to TruffleRuntime

### DIFF
--- a/sulong/projects/com.oracle.truffle.llvm.runtime/src/com/oracle/truffle/llvm/runtime/memory/LLVMNativeMemory.java
+++ b/sulong/projects/com.oracle.truffle.llvm.runtime/src/com/oracle/truffle/llvm/runtime/memory/LLVMNativeMemory.java
@@ -35,6 +35,7 @@ import java.util.Arrays;
 import java.util.function.IntBinaryOperator;
 import java.util.function.LongBinaryOperator;
 
+import com.oracle.truffle.api.Truffle;
 import org.graalvm.collections.EconomicMap;
 
 import com.oracle.truffle.api.Assumption;
@@ -525,7 +526,7 @@ public final class LLVMNativeMemory extends LLVMMemory {
 
     @Override
     public void fullFence() {
-        unsafe.fullFence();
+        Truffle.getRuntime().fullFence();
     }
 
     /**

--- a/truffle/src/com.oracle.truffle.api/src/com/oracle/truffle/api/TruffleRuntime.java
+++ b/truffle/src/com.oracle.truffle.api/src/com/oracle/truffle/api/TruffleRuntime.java
@@ -217,4 +217,22 @@ public interface TruffleRuntime {
      */
     boolean isProfilingEnabled();
 
+    /**
+     * Ensures lack of reordering of loads before the fence
+     * with loads or stores after the fence.
+     */
+    void loadFence();
+
+    /**
+     * Ensures lack of reordering of stores before the fence
+     * with loads or stores after the fence.
+     */
+    void storeFence();
+
+    /**
+     * Ensures lack of reordering of loads or stores before the fence
+     * with loads or stores after the fence.
+     */
+    void fullFence();
+
 }


### PR DESCRIPTION
Are we interested in reducing the need for `Unsafe` in Truffle guest languages?

Add these *safe* methods from `Unsafe` to `TruffleRuntime`, as a starting point.

This reduces the use of `Unsafe` in TruffleRuby, GraalJS (PRs available if this is merged), and Sulong (included in this PR.)

Let's cut out the need for direct references to `Unsafe` and make more Truffle interpreters pure Java code without the need for explicit reflection to access internal fields!

https://github.com/Shopify/truffleruby/issues/1