### PR TITLE
Allow user to override extra_jvm_args with --vm.…

### DIFF
--- a/sdk/mx.sdk/vm/launcher_template.cmd
+++ b/sdk/mx.sdk/vm/launcher_template.cmd
@@ -101,4 +101,4 @@ if not "%~1"=="" (
 
 if "%VERBOSE_GRAALVM_LAUNCHERS%"=="true" echo on
 
-"%location%<jre_bin>\java" %jvm_args% <extra_jvm_args> -cp "%realcp%" <main_class> %launcher_args%
+"%location%<jre_bin>\java" <extra_jvm_args> %jvm_args% -cp "%realcp%" <main_class> %launcher_args%

--- a/sdk/mx.sdk/vm/launcher_template.sh
+++ b/sdk/mx.sdk/vm/launcher_template.sh
@@ -110,4 +110,4 @@ if [[ "${VERBOSE_GRAALVM_LAUNCHERS}" == "true" ]]; then
     set -x
 fi
 
-exec "${location}/<jre_bin>/java" "${jvm_args[@]}" <extra_jvm_args> -cp "${cp}" '<main_class>' "${launcher_args[@]}"
+exec "${location}/<jre_bin>/java" <extra_jvm_args> "${jvm_args[@]}" -cp "${cp}" '<main_class>' "${launcher_args[@]}"


### PR DESCRIPTION
Although the name `extra_jvm_args` implies they should be at the end, I think it'd make sense to move them in front of any dynamic arguments to allow users to override them.
The GraalSqueak launcher, for example, [presets some VM options](https://github.com/hpi-swa/graalsqueak/blob/fb5f87b4045b05c964aae32526f2dded420c1d66/mx.graalsqueak/mx_graalsqueak.py#L492) that can no longer be modified with `--vm.…`. Not sure this breaks other launchers, maybe a prefix/suffix solution is needed?