### PR TITLE
Add --engine.TraceCompilationCompact option, which fits better in limited terminal space

### DIFF
--- a/compiler/src/org.graalvm.compiler.truffle.options/src/org/graalvm/compiler/truffle/options/PolyglotCompilerOptions.java
+++ b/compiler/src/org.graalvm.compiler.truffle.options/src/org/graalvm/compiler/truffle/options/PolyglotCompilerOptions.java
@@ -265,6 +265,9 @@ public final class PolyglotCompilerOptions {
 
     // Tracing
 
+    @Option(help = "Print compact information for compilation results.", category = OptionCategory.EXPERT, stability = OptionStability.STABLE)
+    public static final OptionKey<Boolean> TraceCompilationCompact = new OptionKey<>(false);
+
     @Option(help = "Print information for compilation results.", category = OptionCategory.EXPERT, stability = OptionStability.STABLE)
     public static final OptionKey<Boolean> TraceCompilation = new OptionKey<>(false);
 

--- a/compiler/src/org.graalvm.compiler.truffle.runtime/src/org/graalvm/compiler/truffle/runtime/EngineData.java
+++ b/compiler/src/org.graalvm.compiler.truffle.runtime/src/org/graalvm/compiler/truffle/runtime/EngineData.java
@@ -53,6 +53,7 @@ import static org.graalvm.compiler.truffle.options.PolyglotCompilerOptions.Split
 import static org.graalvm.compiler.truffle.options.PolyglotCompilerOptions.SplittingMaxNumberOfSplitNodes;
 import static org.graalvm.compiler.truffle.options.PolyglotCompilerOptions.SplittingMaxPropagationDepth;
 import static org.graalvm.compiler.truffle.options.PolyglotCompilerOptions.SplittingTraceEvents;
+import static org.graalvm.compiler.truffle.options.PolyglotCompilerOptions.TraceCompilationCompact;
 import static org.graalvm.compiler.truffle.options.PolyglotCompilerOptions.TraceCompilation;
 import static org.graalvm.compiler.truffle.options.PolyglotCompilerOptions.TraceCompilationDetails;
 import static org.graalvm.compiler.truffle.options.PolyglotCompilerOptions.TraceSplitting;
@@ -118,6 +119,7 @@ public final class EngineData {
     @CompilationFinal public boolean multiTier;
     @CompilationFinal public boolean returnTypeSpeculation;
     @CompilationFinal public boolean argumentTypeSpeculation;
+    @CompilationFinal public boolean traceCompilationCompact;
     @CompilationFinal public boolean traceCompilation;
     @CompilationFinal public boolean traceCompilationDetails;
     @CompilationFinal public boolean backgroundCompilation;
@@ -169,6 +171,7 @@ public final class EngineData {
 
         this.returnTypeSpeculation = getPolyglotOptionValue(options, ReturnTypeSpeculation);
         this.argumentTypeSpeculation = getPolyglotOptionValue(options, ArgumentTypeSpeculation);
+        this.traceCompilationCompact = getPolyglotOptionValue(options, TraceCompilationCompact);
         this.traceCompilation = getPolyglotOptionValue(options, TraceCompilation);
         this.traceCompilationDetails = getPolyglotOptionValue(options, TraceCompilationDetails);
         this.backgroundCompilation = getPolyglotOptionValue(options, BackgroundCompilation);

--- a/truffle/docs/Optimizing.md
+++ b/truffle/docs/Optimizing.md
@@ -44,6 +44,8 @@ for more details about instrumenting branches and boundaries.
 
 `--engine.TraceCompilation` prints a line each time a method is compiled.
 
+`--engine.TraceCompilationCompact` prints a line each time a method is compiled but more compact.
+
 `--engine.TraceCompilationDetail` also prints a line when compilation is queued, starts or completes.
 
 `--engine.TraceCompilationAST` prints the Truffle AST for each compilation.


### PR DESCRIPTION
I don't know how big your screens are, but for me on typical development hardware, software, and default sizes of things, `--engine.TraceCompilation` prints lines that are far too long. Rather than being able to easily observe what is being compiled, I just see a wall of characters that is extremely hard to scan.

<img width="1680" alt="Screenshot 2020-01-06 at 00 11 43" src="https://user-images.githubusercontent.com/341094/71788331-2d447c00-3019-11ea-8681-16ee58547e11.png">

I've added an option `--engine.TraceCompilationCompact`, which prints just enough to see what methods are being compiled, and lets you track your eye down the list of names much more easily.

<img width="1680" alt="Screenshot 2020-01-06 at 00 12 05" src="https://user-images.githubusercontent.com/341094/71788351-42b9a600-3019-11ea-9440-b7396ab8d659.png">

@eregon suggested I modify the original option to support something like `--engine.TraceCompilation=compact`. That doesn't seem to be easy, due to having to pair it up to the legacy `--vm.Dgraal` equivalent, it being documented as a stable option, and having to differentiate between not being set, and set to a default, which I'm not sure the current option system supports?

https://github.com/Shopify/truffleruby/issues/1