### PR TITLE
Field java.net.URL.handlers is deleted but still reachable

### DIFF
--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/JavaNetSubstitutions.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/JavaNetSubstitutions.java
@@ -33,6 +33,7 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLConnection;
 import java.net.URLStreamHandler;
+import java.net.URLStreamHandlerFactory;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Hashtable;
@@ -68,6 +69,12 @@ final class Target_java_net_URL {
          * available, and how to add a protocol at image build time.
          */
         return JavaNetSubstitutions.getURLStreamHandler(protocol);
+    }
+
+    @Substitute
+    @SuppressWarnings("unused")
+    public static void setURLStreamHandlerFactory(URLStreamHandlerFactory fac) {
+        VMError.unsupportedFeature("Setting a custom URLStreamHandlerFactory.");
     }
 }
 


### PR DESCRIPTION
Fixes https://github.com/oracle/graal/issues/2058
Field java.net.URL.handlers has been annotated as @delete, but is still
reachable from method
java.net.URL.setURLStreamHandlerFactory(URLStreamHandlerFactory fac).
For example, it can be reached in Tomcat:
```
Error: com.oracle.svm.hosted.substitute.DeletedElementException: Unsupported field java.net.URL.handlers is reachable
To diagnose the issue, you can add the option --report-unsupported-elements-at-runtime. The unsupported element is then reported at run time when it is accessed the first time.
Trace:
        at parsing java.net.URL.setURLStreamHandlerFactory(URL.java:1140)
Call path from entry point to java.net.URL.setURLStreamHandlerFactory(URLStreamHandlerFactory):
        at java.net.URL.setURLStreamHandlerFactory(URL.java:1132)
        at org.apache.catalina.webresources.TomcatURLStreamHandlerFactory.<init>(TomcatURLStreamHandlerFactory.java:130)
        at org.apache.catalina.webresources.TomcatURLStreamHandlerFactory.getInstanceInternal(TomcatURLStreamHandlerFactory.java:53)
        at org.apache.catalina.webresources.TomcatURLStreamHandlerFactory.register(TomcatURLStreamHandlerFactory.java:77)
        at org.apache.catalina.webresources.StandardRoot.registerURLStreamHandlerFactory(StandardRoot.java:701)
        at org.apache.catalina.webresources.StandardRoot.initInternal(StandardRoot.java:683)
        at com.oracle.svm.reflect.LifecycleBase_initInternal_2c3834aa3310147b20fd8ef80a4760d3192d9e91_27816.invoke(Unknown Source)
        at java.lang.reflect.Method.invoke(Method.java:498)
        at javax.xml.transform.TransformerException.printStackTrace(TransformerException.java:348)
        at javax.xml.transform.TransformerException.printStackTrace(TransformerException.java:282)
        at com.oracle.svm.jni.functions.JNIFunctions.ExceptionDescribe(JNIFunctions.java:749)
        at com.oracle.svm.core.code.IsolateEnterStub.JNIFunctions_ExceptionDescribe_b5412f7570bccae90b000bc37855f00408b2ad73(generated:0)
```