### PR TITLE
AArch64: Elide NarrowNode for Extend.

### DIFF
--- a/compiler/src/org.graalvm.compiler.core.aarch64.test/src/org/graalvm/compiler/core/aarch64/test/AArch64ElideL2ITest.java
+++ b/compiler/src/org.graalvm.compiler.core.aarch64.test/src/org/graalvm/compiler/core/aarch64/test/AArch64ElideL2ITest.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2019, Arm Limited. All rights reserved.
+ * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2020, Arm Limited. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -67,7 +67,7 @@ public class AArch64ElideL2ITest extends AArch64MatchRuleTest {
     @Test
     public void testAddWithTwoNarrow() {
         test("addWithTwoNarrow", 0x80000000L, 6L);
-        checkLIR("addWithTwoNarrow", predicate, 1);
+        checkLIR("addWithTwoNarrow", predicate, 0);
     }
 
     public int subSingleL2I(int m, long n) {

--- a/compiler/src/org.graalvm.compiler.core.aarch64.test/src/org/graalvm/compiler/core/aarch64/test/AArch64MergeNarrowWithExtendTest.java
+++ b/compiler/src/org.graalvm.compiler.core.aarch64.test/src/org/graalvm/compiler/core/aarch64/test/AArch64MergeNarrowWithExtendTest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, Arm Limited. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package org.graalvm.compiler.core.aarch64.test;
+
+import org.graalvm.compiler.lir.LIRInstruction;
+import org.graalvm.compiler.lir.aarch64.AArch64ArithmeticOp.BinaryConstOp;
+import org.junit.Test;
+
+import java.util.function.Predicate;
+
+public class AArch64MergeNarrowWithExtendTest extends AArch64MatchRuleTest {
+    private static final Predicate<LIRInstruction> PRED_AND = op -> (op instanceof BinaryConstOp && op.name().toUpperCase().equals("AND"));
+
+    private static final long[] VALUES = {-1L, 0L, 0x1234567812345678L, 0xFFFFFFFFL, 0x12L, 0x1234L, Long.MIN_VALUE, Long.MAX_VALUE};
+
+    public long l2i2l(long x) {
+        return (int) x;
+    }
+
+    public long l2s2l(long x) {
+        return (short) x;
+    }
+
+    public int l2s2i(long x) {
+        return (short) x;
+    }
+
+    public long l2b2l(long x) {
+        return (byte) x;
+    }
+
+    public int l2b2i(long x) {
+        return (byte) x;
+    }
+
+    @Test
+    public void testSignedExtendedNarrow() {
+        String[] testCases = {"l2i2l", "l2i2l", "l2s2l", "l2s2i", "l2b2l", "l2b2i"};
+        for (String fname : testCases) {
+            for (long value : VALUES) {
+                test(fname, value);
+                checkLIR(fname, PRED_AND, 0);
+            }
+        }
+    }
+
+    public long l2c2l(long x) {
+        return (char) x;
+    }
+
+    public int l2c2i(long x) {
+        return (char) x;
+    }
+
+    @Test
+    public void testZeroExtendedNarrow() {
+        String[] testCases = {"l2c2l", "l2c2i"};
+        for (String fname : testCases) {
+            for (long value : VALUES) {
+                test(fname, value);
+                checkLIR(fname, PRED_AND, 1);
+            }
+        }
+    }
+}

--- a/compiler/src/org.graalvm.compiler.core.aarch64/src/org/graalvm/compiler/core/aarch64/AArch64NodeMatchRules.java
+++ b/compiler/src/org.graalvm.compiler.core.aarch64/src/org/graalvm/compiler/core/aarch64/AArch64NodeMatchRules.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -64,10 +64,12 @@ import org.graalvm.compiler.nodes.calc.NegateNode;
 import org.graalvm.compiler.nodes.calc.NotNode;
 import org.graalvm.compiler.nodes.calc.OrNode;
 import org.graalvm.compiler.nodes.calc.RightShiftNode;
+import org.graalvm.compiler.nodes.calc.SignExtendNode;
 import org.graalvm.compiler.nodes.calc.SubNode;
 import org.graalvm.compiler.nodes.calc.UnaryNode;
 import org.graalvm.compiler.nodes.calc.UnsignedRightShiftNode;
 import org.graalvm.compiler.nodes.calc.XorNode;
+import org.graalvm.compiler.nodes.calc.ZeroExtendNode;
 import org.graalvm.compiler.nodes.memory.Access;
 
 public class AArch64NodeMatchRules extends NodeMatchRules {
@@ -395,6 +397,18 @@ public class AArch64NodeMatchRules extends NodeMatchRules {
             }
         }
         return null;
+    }
+
+    @MatchRule("(SignExtend=extend (Narrow value))")
+    @MatchRule("(ZeroExtend=extend (Narrow value))")
+    public ComplexMatchResult mergeNarrowExtend(UnaryNode extend, ValueNode value) {
+        if (extend instanceof SignExtendNode) {
+            SignExtendNode sxt = (SignExtendNode) extend;
+            return builder -> getArithmeticLIRGenerator().emitSignExtend(operand(value), sxt.getInputBits(), sxt.getResultBits());
+        }
+        assert extend instanceof ZeroExtendNode;
+        ZeroExtendNode zxt = (ZeroExtendNode) extend;
+        return builder -> getArithmeticLIRGenerator().emitZeroExtend(operand(value), zxt.getInputBits(), zxt.getResultBits());
     }
 
     @Override


### PR DESCRIPTION
Extending value from narrow type to a wider one will generate a "sxt" or
"and" instruction, and if its input is a NarrowNode, the narrow could be
eliminated.

        and     w0, w2, #0xffff
        sxth    x0, w0

With this patch, the generated assembly above can be optimized to below:

        sxth    x0, w2

Change-Id: Ic1db0f2b11a9d80ca0fab9b042bedff3de66e95a