### PR TITLE
Substitute parseParameterAnnotations method

### DIFF
--- a/substratevm/src/com.oracle.svm.reflect/src/com/oracle/svm/reflect/target/Target_java_lang_reflect_Executable.java
+++ b/substratevm/src/com.oracle.svm.reflect/src/com/oracle/svm/reflect/target/Target_java_lang_reflect_Executable.java
@@ -104,6 +104,13 @@ public final class Target_java_lang_reflect_Executable {
     }
 
     @Substitute
+    @SuppressWarnings({"unused", "hiding"})
+    Annotation[][] parseParameterAnnotations(byte[] parameterAnnotations) {
+        Target_java_lang_reflect_Executable holder = ReflectionHelper.getHolder(this);
+        return ReflectionHelper.requireNonNull(holder.parseParameterAnnotations(parameterAnnotations), "Parameter annotations must be computed during native image generation");
+    }
+
+    @Substitute
     public AnnotatedType getAnnotatedReceiverType() {
         Target_java_lang_reflect_Executable holder = ReflectionHelper.getHolder(this);
         /* The annotatedReceiverType can be null. */


### PR DESCRIPTION
Original Executable.parseParameterAnnotations can access not supported
method java.lang.Class.getConstantPool. And Executable.parseParameterAnnotations could be reached by reflection calls. 

This patch can fix issue https://github.com/oracle/graal/issues/2062 
