### PR TITLE
Explain why implicitExceptionBytes may be null

### DIFF
--- a/compiler/src/jdk.tools.jaotc/src/jdk/tools/jaotc/MetadataBuilder.java
+++ b/compiler/src/jdk.tools.jaotc/src/jdk/tools/jaotc/MetadataBuilder.java
@@ -98,7 +98,9 @@ final class MetadataBuilder {
             byte[] scopeDesc = metaData.scopesDescBytes();
             byte[] relocationInfo = metaData.relocBytes();
             byte[] oopMapInfo = metaData.oopMaps();
+            // this may be null as the field does not exist before JDK 13
             byte[] implicitExceptionBytes = HotSpotGraalServices.getImplicitExceptionBytes(metaData);
+            byte[] exceptionBytes = metaData.exceptionBytes();
 
             // create a global symbol at this position for this method
             NativeOrderOutputStream metadataStream = new NativeOrderOutputStream();
@@ -160,7 +162,7 @@ final class MetadataBuilder {
                 metadataStream.put(relocationInfo).align(8);
 
                 exceptionOffset.set(metadataStream.position());
-                metadataStream.put(metaData.exceptionBytes()).align(8);
+                metadataStream.put(exceptionBytes).align(8);
 
                 if (implicitExceptionBytes != null) {
                     implictTableOffset.set(metadataStream.position());


### PR DESCRIPTION
Because not all versions of the JDK have the field aot_metadata._nul_chk_table_begin, you do not always
want to generate this field depending on the target JDK's version. This difference is taken care of by
HotSpotGraalServices which has different implementations based on the target JDK's version. The
HotSpotGraalServices.getImplicitExceptionBytes returns null in case the field does not exist.

Additionally, harmonize how exceptionBytes is generated with the other variables.

This change was previously discussed in the graal-dev mailing list (https://mail.openjdk.java.net/pipermail/graal-dev/2020-January/005935.html)