### PR TITLE
[native-image]  AArch64: SVM inlined object code installation

### DIFF
--- a/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/GCRefAccessor.java
+++ b/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/GCRefAccessor.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2020, 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package com.oracle.svm.core.genscavenge;
+
+import org.graalvm.compiler.api.replacements.Fold;
+import org.graalvm.nativeimage.ImageSingletons;
+import org.graalvm.nativeimage.Platform;
+import org.graalvm.nativeimage.Platforms;
+import org.graalvm.nativeimage.hosted.Feature;
+import org.graalvm.word.Pointer;
+
+import com.oracle.svm.core.annotate.AutomaticFeature;
+import com.oracle.svm.core.heap.ReferenceAccess;
+
+public class GCRefAccessor {
+    static void initialize() {
+        ImageSingletons.add(GCRefAccessor.class, new GCRefAccessor());
+    }
+
+    @Fold
+    public static GCRefAccessor singleton() {
+        return ImageSingletons.lookup(GCRefAccessor.class);
+    }
+
+    public Pointer readRef(Pointer objRef, boolean compressed, @SuppressWarnings("unused") int numPieces) {
+        assert numPieces == 1;
+        return ReferenceAccess.singleton().readObjectAsUntrackedPointer(objRef, compressed);
+    }
+
+    public void writeRefUpdate(Pointer objRef, Object value, boolean compressed, @SuppressWarnings("unused") int numPieces) {
+        assert numPieces == 1;
+        ReferenceAccess.singleton().writeObjectAt(objRef, value, compressed);
+    }
+
+}
+
+@AutomaticFeature
+@Platforms(Platform.AMD64.class)
+class GCRefAccessorFeature implements Feature {
+    @Override
+    public void afterRegistration(AfterRegistrationAccess access) {
+        GCRefAccessor.initialize();
+    }
+}

--- a/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/aarch64/AArch64GCRefAccessor.java
+++ b/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/aarch64/AArch64GCRefAccessor.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2020, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2020, Arm Limited. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package com.oracle.svm.core.genscavenge.aarch64;
+
+import org.graalvm.nativeimage.ImageSingletons;
+import org.graalvm.nativeimage.Platform.AARCH64;
+import org.graalvm.nativeimage.Platforms;
+import org.graalvm.nativeimage.hosted.Feature;
+import org.graalvm.word.Pointer;
+
+import com.oracle.svm.core.CodeSynchronizationOperations;
+import com.oracle.svm.core.annotate.AutomaticFeature;
+import com.oracle.svm.core.genscavenge.GCRefAccessor;
+import com.oracle.svm.core.heap.ReferenceAccess;
+import com.oracle.svm.core.heap.aarch64.AArch64ReferenceAccess;
+import com.oracle.svm.core.thread.VMThreads;
+
+public class AArch64GCRefAccessor extends GCRefAccessor {
+    static void initialize() {
+        ImageSingletons.add(GCRefAccessor.class, new AArch64GCRefAccessor());
+    }
+
+    @Override
+    public Pointer readRef(Pointer objRef, boolean compressed, int numPieces) {
+        if (numPieces == 1) {
+            return ReferenceAccess.singleton().readObjectAsUntrackedPointer(objRef, compressed);
+        } else {
+            return ((AArch64ReferenceAccess) ReferenceAccess.singleton()).readSplitObjectAsUntrackedPointer(objRef, compressed, numPieces);
+        }
+    }
+
+    @Override
+    public void writeRefUpdate(Pointer objRef, Object value, boolean compressed, int numPieces) {
+        if (numPieces == 1) {
+            ReferenceAccess.singleton().writeObjectAt(objRef, value, compressed);
+        } else {
+            ((AArch64ReferenceAccess) ReferenceAccess.singleton()).writeSplitObjectAt(objRef, value, compressed, numPieces);
+            CodeSynchronizationOperations.clearCache(objRef.rawValue(), numPieces * 4);
+            VMThreads.ActionOnTransitionToJavaSupport.requestAllThreadsSynchronizeCode();
+        }
+    }
+
+}
+
+@AutomaticFeature
+@Platforms(AARCH64.class)
+class AArch64GCRefAccessorFeature implements Feature {
+    @Override
+    public void afterRegistration(AfterRegistrationAccess access) {
+        AArch64GCRefAccessor.initialize();
+    }
+}

--- a/substratevm/src/com.oracle.svm.core.graal.aarch64/src/com/oracle/svm/core/graal/aarch64/AArch64NativeImagePatcher.java
+++ b/substratevm/src/com.oracle.svm.core.graal.aarch64/src/com/oracle/svm/core/graal/aarch64/AArch64NativeImagePatcher.java
@@ -29,6 +29,7 @@ import java.util.function.Consumer;
 import org.graalvm.compiler.asm.Assembler;
 import org.graalvm.compiler.asm.aarch64.AArch64Assembler.SingleInstructionAnnotation;
 import org.graalvm.compiler.asm.aarch64.AArch64MacroAssembler;
+import org.graalvm.compiler.asm.aarch64.AArch64MacroAssembler.MovSequenceAnnotation.MovAction;
 import org.graalvm.compiler.code.CompilationResult;
 import org.graalvm.nativeimage.ImageSingletons;
 import org.graalvm.nativeimage.Platform;
@@ -200,7 +201,7 @@ class MovSequenceNativeImagePatcher extends CompilationResult.CodeAnnotation imp
      */
     @Override
     public int getOffset() {
-        throw VMError.unsupportedFeature("trying to get offset of move sequence");
+        return annotation.instructionPosition;
     }
 
     /**
@@ -208,6 +209,12 @@ class MovSequenceNativeImagePatcher extends CompilationResult.CodeAnnotation imp
      */
     @Override
     public int getLength() {
-        throw VMError.unsupportedFeature("trying to get length of move sequence");
+        MovAction[] includeSet = annotation.includeSet;
+        for (MovAction action : includeSet) {
+            if (action != MovAction.USED) {
+                throw VMError.unsupportedFeature("querying length of mov sequence with skips or negations");
+            }
+        }
+        return includeSet.length;
     }
 }

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/code/ReferenceAdjuster.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/code/ReferenceAdjuster.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -50,7 +50,7 @@ public interface ReferenceAdjuster {
     <T> void setObjectInArray(NonmovableObjectArray<T> array, int index, T object);
 
     @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
-    void setConstantTargetAt(PointerBase address, int length, SubstrateObjectConstant constant);
+    void setConstantTargetAt(PointerBase address, int length, SubstrateObjectConstant constant, boolean codeInlined);
 
     @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
     default <T extends Constant> NonmovableObjectArray<Object> copyOfObjectConstantArray(T[] constants) {

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/code/aarch64/AArch64InstantReferenceAdjuster.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/code/aarch64/AArch64InstantReferenceAdjuster.java
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2020, Arm Limited. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,49 +23,30 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
-package com.oracle.svm.core.code;
+package com.oracle.svm.core.code.aarch64;
 
 import org.graalvm.word.Pointer;
 import org.graalvm.word.PointerBase;
 
 import com.oracle.svm.core.annotate.Uninterruptible;
-import com.oracle.svm.core.c.NonmovableArrays;
-import com.oracle.svm.core.c.NonmovableObjectArray;
+import com.oracle.svm.core.code.InstantReferenceAdjuster;
+import com.oracle.svm.core.heap.ReferenceAccess;
+import com.oracle.svm.core.heap.aarch64.AArch64ReferenceAccess;
 import com.oracle.svm.core.meta.DirectSubstrateObjectConstant;
 import com.oracle.svm.core.meta.SubstrateObjectConstant;
 
-/**
- * Immediately writes object references and fails if it cannot do so.
- */
-public class InstantReferenceAdjuster implements ReferenceAdjuster {
-    @Override
-    @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
-    public <T> void setObjectInArray(NonmovableObjectArray<T> array, int index, T object) {
-        NonmovableArrays.setObject(array, index, object);
-    }
-
-    @Override
-    @SuppressWarnings("unchecked")
-    @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
-    public <T> void setConstantTargetInArray(NonmovableObjectArray<T> array, int index, SubstrateObjectConstant constant) {
-        NonmovableArrays.setObject(array, index, (T) ((DirectSubstrateObjectConstant) constant).getObject());
-    }
+public class AArch64InstantReferenceAdjuster extends InstantReferenceAdjuster {
 
     @Override
     @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
     public void setConstantTargetAt(PointerBase address, int length, SubstrateObjectConstant constant, boolean codeInlined) {
-        ReferenceAdjuster.writeReference((Pointer) address, length, ((DirectSubstrateObjectConstant) constant).getObject());
-    }
-
-    @Override
-    @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
-    public <T> NonmovableObjectArray<T> copyOfObjectArray(T[] source) {
-        return NonmovableArrays.copyOfObjectArray(source);
-    }
-
-    @Override
-    @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
-    public boolean isFinished() {
-        return true;
+        if (!codeInlined) {
+            super.setConstantTargetAt(address, length, constant, codeInlined);
+        } else {
+            Pointer ptr = (Pointer) address;
+            Object constObj = ((DirectSubstrateObjectConstant) constant).getObject();
+            boolean compressed = ReferenceAccess.singleton().haveCompressedReferences();
+            ((AArch64ReferenceAccess) ReferenceAccess.singleton()).writeSplitObjectAt(ptr, constObj, compressed, length);
+        }
     }
 }

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/heap/ObjectReferenceVisitor.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/heap/ObjectReferenceVisitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -69,6 +69,13 @@ public interface ObjectReferenceVisitor {
 
     @RestrictHeapAccess(access = RestrictHeapAccess.Access.UNRESTRICTED, overridesCallers = true, reason = "Some implementations allocate.")
     default boolean visitObjectReferenceInline(Pointer objRef, @SuppressWarnings("unused") int innerOffset, boolean compressed, @SuppressWarnings("unused") Object holderObject) {
+        return visitObjectReferenceInline(objRef, innerOffset, compressed);
+    }
+
+    /** Like above, but keeps track of the number of pieces the reference is split into. */
+    @RestrictHeapAccess(access = RestrictHeapAccess.Access.UNRESTRICTED, overridesCallers = true, reason = "Some implementations allocate.")
+    default boolean visitObjectReferenceInline(Pointer objRef, @SuppressWarnings("unused") int innerOffset, boolean compressed, @SuppressWarnings("unused") Object holderObject,
+                    @SuppressWarnings("unused") int numPieces) {
         return visitObjectReferenceInline(objRef, innerOffset, compressed);
     }
 }

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/heap/ReferenceAccessImpl.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/heap/ReferenceAccessImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,6 +30,8 @@ import org.graalvm.compiler.word.BarrieredAccess;
 import org.graalvm.compiler.word.ObjectAccess;
 import org.graalvm.compiler.word.Word;
 import org.graalvm.nativeimage.ImageSingletons;
+import org.graalvm.nativeimage.Platform;
+import org.graalvm.nativeimage.Platforms;
 import org.graalvm.nativeimage.hosted.Feature;
 import org.graalvm.word.Pointer;
 import org.graalvm.word.UnsignedWord;
@@ -40,12 +42,12 @@ import com.oracle.svm.core.annotate.AlwaysInline;
 import com.oracle.svm.core.annotate.AutomaticFeature;
 import com.oracle.svm.core.annotate.Uninterruptible;
 
-public final class ReferenceAccessImpl implements ReferenceAccess {
+public class ReferenceAccessImpl implements ReferenceAccess {
     static void initialize() {
         ImageSingletons.add(ReferenceAccess.class, new ReferenceAccessImpl());
     }
 
-    private ReferenceAccessImpl() {
+    protected ReferenceAccessImpl() {
     }
 
     @Override
@@ -110,6 +112,7 @@ public final class ReferenceAccessImpl implements ReferenceAccess {
 }
 
 @AutomaticFeature
+@Platforms(Platform.AMD64.class)
 class ReferenceAccessFeature implements Feature {
     @Override
     public void afterRegistration(AfterRegistrationAccess access) {

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/heap/ReferenceMapEncoder.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/heap/ReferenceMapEncoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -60,6 +60,10 @@ public abstract class ReferenceMapEncoder {
         boolean isNextDerived();
 
         Set<Integer> getDerivedOffsets(int baseOffset);
+
+        default int getNumPieces() {
+            return 1;
+        }
     }
 
     public interface Input {

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/heap/SubstrateReferenceMap.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/heap/SubstrateReferenceMap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -55,11 +55,11 @@ public class SubstrateReferenceMap extends ReferenceMap implements ReferenceMapE
      * frame. Because {@link BitSet} only supports positive indices, the whole bit set is shifted by
      * {@link #shift} bits when negative offsets are required.
      */
-    private BitSet shiftedOffsets;
-    private int shift;
+    protected BitSet shiftedOffsets;
+    protected int shift;
 
     /* Maps base references with references pointing to the interior of that object */
-    private EconomicMap<Integer, Set<Integer>> derived;
+    protected EconomicMap<Integer, Set<Integer>> derived;
 
     private Map<Integer, Object> debugAllUsedRegisters;
     private Map<Integer, Object> debugAllUsedStackSlots;
@@ -72,7 +72,7 @@ public class SubstrateReferenceMap extends ReferenceMap implements ReferenceMapE
         return shiftedOffsets != null && offset + shift >= 0 && shiftedOffsets.get(offset + shift);
     }
 
-    public void markReferenceAtOffset(int offset, boolean compressed) {
+    protected void updateShiftedOffsets(int offset) {
         if (shiftedOffsets == null) {
             shiftedOffsets = new BitSet();
         }
@@ -87,6 +87,10 @@ public class SubstrateReferenceMap extends ReferenceMap implements ReferenceMapE
             shiftedOffsets = BitSet.valueOf(newData);
             shift = newShift;
         }
+    }
+
+    public void markReferenceAtOffset(int offset, boolean compressed) {
+        updateShiftedOffsets(offset);
 
         assert isValidToMark(offset, compressed) : "already marked or would overlap with predecessor or successor";
         shiftedOffsets.set(offset + shift);
@@ -121,7 +125,7 @@ public class SubstrateReferenceMap extends ReferenceMap implements ReferenceMapE
         derivedOffsets.add(offset);
     }
 
-    private boolean isValidToMark(int offset, boolean isCompressed) {
+    protected boolean isValidToMark(int offset, boolean isCompressed) {
         int uncompressedSize = FrameAccess.uncompressedReferenceSize();
         int compressedSize = ConfigurationValues.getObjectLayout().getReferenceSize();
 

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/heap/aarch64/AArch64CodeReferenceMapDecoder.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/heap/aarch64/AArch64CodeReferenceMapDecoder.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2020, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2020, Arm Limited. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package com.oracle.svm.core.heap.aarch64;
+
+import org.graalvm.nativeimage.ImageSingletons;
+import org.graalvm.nativeimage.Platform;
+import org.graalvm.nativeimage.Platforms;
+import org.graalvm.nativeimage.hosted.Feature;
+import org.graalvm.word.UnsignedWord;
+import org.graalvm.word.WordFactory;
+
+import com.oracle.svm.core.annotate.AutomaticFeature;
+import com.oracle.svm.core.heap.CodeReferenceMapDecoder;
+
+public class AArch64CodeReferenceMapDecoder extends CodeReferenceMapDecoder {
+
+    @Override
+    public int getNumPieces(long gap, boolean derived) {
+        int rem = (int) gap % 4;
+        if (derived || rem == 0) {
+            return 1;
+        }
+        int numPieces = rem << 1;
+        assert numPieces == 2 || numPieces == 4;
+        return numPieces;
+    }
+
+    @Override
+    public long correctGap(long gap, boolean derived, int numPieces) {
+        if (numPieces == 1) {
+            return gap;
+        }
+        assert numPieces == 2 || numPieces == 4;
+        return gap - (numPieces >> 1);
+    }
+
+    @Override
+    public UnsignedWord getRefSize(boolean compressed, UnsignedWord compressedSize, UnsignedWord uncompressedSize, int numPieces) {
+        if (numPieces == 1) {
+            return compressed ? compressedSize : uncompressedSize;
+        }
+        return WordFactory.unsigned(numPieces * 4);
+    }
+
+}
+
+@AutomaticFeature
+@Platforms(Platform.AARCH64.class)
+class AArch64RuntimeCodeReferenceMapDecoderFeature implements Feature {
+    @Override
+    public void afterRegistration(AfterRegistrationAccess access) {
+        ImageSingletons.add(CodeReferenceMapDecoder.class, new AArch64CodeReferenceMapDecoder());
+    }
+}

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/heap/aarch64/AArch64ReferenceAccess.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/heap/aarch64/AArch64ReferenceAccess.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2020, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2020, Arm Limited. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package com.oracle.svm.core.heap.aarch64;
+
+import org.graalvm.compiler.word.Word;
+import org.graalvm.word.Pointer;
+
+import com.oracle.svm.core.heap.ReferenceAccess;
+
+public interface AArch64ReferenceAccess extends ReferenceAccess {
+
+    /**
+     * Read the absolute address of the object referenced by the split object reference starting at
+     * address {@code p} and return it as a word which is not tracked by garbage collection.
+     */
+    Word readSplitObjectAsUntrackedPointer(Pointer p, boolean compressed, int numPieces);
+
+    /**
+     * Write the location of object {@code value} to the split object reference starting at address
+     * {@code p}.
+     */
+    void writeSplitObjectAt(Pointer p, Object value, boolean compressed, int numPieces);
+
+}

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/heap/aarch64/AArch64ReferenceAccessImpl.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/heap/aarch64/AArch64ReferenceAccessImpl.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2020, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2020, Arm Limited. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package com.oracle.svm.core.heap.aarch64;
+
+import org.graalvm.compiler.word.Word;
+import org.graalvm.nativeimage.ImageSingletons;
+import org.graalvm.nativeimage.Platform;
+import org.graalvm.nativeimage.Platforms;
+import org.graalvm.nativeimage.hosted.Feature;
+import org.graalvm.word.Pointer;
+import org.graalvm.word.UnsignedWord;
+import org.graalvm.word.WordFactory;
+
+import com.oracle.svm.core.annotate.AutomaticFeature;
+import com.oracle.svm.core.annotate.Uninterruptible;
+import com.oracle.svm.core.heap.ReferenceAccess;
+import com.oracle.svm.core.heap.ReferenceAccessImpl;
+
+public class AArch64ReferenceAccessImpl extends ReferenceAccessImpl implements AArch64ReferenceAccess {
+
+    static void initialize() {
+        ImageSingletons.add(ReferenceAccess.class, new AArch64ReferenceAccessImpl());
+    }
+
+    @Override
+    @Uninterruptible(reason = "for uninterruptible callers", mayBeInlined = true)
+    public Word readSplitObjectAsUntrackedPointer(Pointer p, boolean compressed, int numPieces) {
+        final int mask = 0xFFFF; // 16 bit unit size
+        final int bitOffset = 5;
+        long inlinedAddress = 0;
+        for (int i = 0; i < numPieces; i++) {
+            long value = p.readInt(i * 4);
+            value = (value >> bitOffset) & mask;
+            inlinedAddress = inlinedAddress | (value << (16 * i));
+        }
+        if (compressed) {
+            UnsignedWord w = WordFactory.unsigned(inlinedAddress);
+            Object obj = ReferenceAccess.singleton().uncompressReference(w);
+            return Word.objectToUntrackedPointer(obj);
+        }
+
+        return WordFactory.unsigned(inlinedAddress);
+    }
+
+    @Override
+    @Uninterruptible(reason = "for uninterruptible callers", mayBeInlined = true)
+    public void writeSplitObjectAt(Pointer p, Object value, boolean compressed, int numPieces) {
+        final int mask = 0xFFFF; // 16 bit unit size
+        final int bitOffset = 5;
+        long objAddress = compressed ? ReferenceAccess.singleton().getCompressedRepresentation(value).rawValue() : Word.objectToUntrackedPointer(value).rawValue();
+        for (int i = 0; i < numPieces; i++) {
+            int current = 0;
+            current = p.readInt(i * 4);
+            current = (current & ~(mask << bitOffset)) | (((int) objAddress & mask) << bitOffset);
+            p.writeInt(i * 4, current);
+            objAddress = objAddress >>> 16;
+        }
+        assert objAddress != 0 : "could not write full address at position";
+    }
+}
+
+@AutomaticFeature
+@Platforms(Platform.AARCH64.class)
+class ReferenceAccessFeature implements Feature {
+    @Override
+    public void afterRegistration(AfterRegistrationAccess access) {
+        AArch64ReferenceAccessImpl.initialize();
+    }
+}

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/heap/aarch64/AArch64RuntimeCodeReferenceMapEncoder.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/heap/aarch64/AArch64RuntimeCodeReferenceMapEncoder.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2020, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2020, Arm Limited. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package com.oracle.svm.core.heap.aarch64;
+
+import com.oracle.svm.core.heap.CodeReferenceMapEncoder;
+
+public class AArch64RuntimeCodeReferenceMapEncoder extends CodeReferenceMapEncoder {
+
+    @Override
+    protected int getSize(boolean compressed, int compressedSize, int uncompressedSize, int numPieces) {
+        if (numPieces == 1) {
+            return (compressed ? compressedSize : uncompressedSize);
+        }
+        return numPieces * 4;
+    }
+
+    @Override
+    protected int encodeGap(int gap, boolean derived, int numPieces) {
+        if (numPieces == 1) {
+            return derived ? -gap - 1 : gap;
+        }
+        assert !derived;
+        assert numPieces == 2 || numPieces == 4;
+        int numPiecesEncoding = numPieces >> 1;
+        return gap + numPiecesEncoding;
+    }
+}

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/heap/aarch64/AArch64RuntimeReferenceMap.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/heap/aarch64/AArch64RuntimeReferenceMap.java
@@ -1,0 +1,175 @@
+/*
+ * Copyright (c) 2020, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2020, Arm Limited. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package com.oracle.svm.core.heap.aarch64;
+
+import java.util.HashSet;
+import java.util.NoSuchElementException;
+import java.util.Set;
+
+import org.graalvm.collections.EconomicMap;
+import org.graalvm.collections.Equivalence;
+
+import com.oracle.svm.core.config.ConfigurationValues;
+import com.oracle.svm.core.heap.ReferenceMapEncoder;
+import com.oracle.svm.core.heap.SubstrateReferenceMap;
+
+/**
+ * Encoding for runtime code references in AArch64. A different encoding is required to denote when
+ * a reference inlined into code and split across multiple mov instructions. To accomplish this, a
+ * notion of the number of pieces (i.e. number of places the reference is split across) is
+ * introduced. This encoding differs from SubstrateReferenceMap in that if offset + 3 is set, then
+ * it means the the following 4 bytes also contains a "piece" of the reference.
+ */
+public class AArch64RuntimeReferenceMap extends SubstrateReferenceMap {
+
+    public AArch64RuntimeReferenceMap() {
+        assert ConfigurationValues.getObjectLayout().getReferenceSize() > 3 : "needs to be four bits or more for encoding and validation";
+    }
+
+    public void markReferenceAtOffset(int offset, boolean compressed, int numPieces) {
+        updateShiftedOffsets(offset);
+
+        shiftedOffsets.set(offset + shift);
+        if (compressed) {
+            shiftedOffsets.set(offset + 1 + shift);
+        }
+        for (int i = 0; i < numPieces - 1; i++) {
+            shiftedOffsets.set(offset + (i * 4) + 2 + shift);
+        }
+    }
+
+    @Override
+    public void markReferenceAtOffset(int offset, boolean compressed) {
+        markReferenceAtOffset(offset, compressed, 1);
+    }
+
+    public void markReferenceAtOffset(int offset, int baseOffset, boolean compressed, int numPieces) {
+        if (offset == baseOffset) {
+            /* We might have already seen the offset as a base to a derived offset */
+            if (derived == null || !derived.containsKey(baseOffset)) {
+                markReferenceAtOffset(baseOffset, compressed, numPieces);
+            }
+            return;
+        }
+
+        assert numPieces == 1;
+
+        if (!isOffsetMarked(baseOffset)) {
+            markReferenceAtOffset(baseOffset, compressed, numPieces);
+        }
+
+        if (derived == null) {
+            derived = EconomicMap.create(Equivalence.DEFAULT);
+        }
+        Set<Integer> derivedOffsets = derived.get(baseOffset);
+        if (derivedOffsets == null) {
+            derivedOffsets = new HashSet<>();
+            derived.put(baseOffset, derivedOffsets);
+        }
+
+        assert !derivedOffsets.contains(offset);
+        derivedOffsets.add(offset);
+    }
+
+    @Override
+    public ReferenceMapEncoder.OffsetIterator getOffsets() {
+        return new ReferenceMapEncoder.OffsetIterator() {
+            private int nextShiftedOffset = shiftedOffsets == null ? -1 : shiftedOffsets.nextSetBit(0);
+
+            private int getNumPieces(int offset) {
+                assert isOffsetMarked(offset);
+                int count = 1;
+                int index = offset + 2;
+                while (shiftedOffsets.get(index)) {
+                    count++;
+                    index += 4;
+                }
+                return count;
+            }
+
+            @Override
+            public boolean hasNext() {
+                return (nextShiftedOffset != -1);
+            }
+
+            @Override
+            public int nextInt() {
+                if (!hasNext()) {
+                    throw new NoSuchElementException();
+                }
+                int result = nextShiftedOffset - shift;
+                int numPieces = getNumPieces(nextShiftedOffset);
+                // skip bits corresponding to this marking
+                nextShiftedOffset = shiftedOffsets.nextSetBit(nextShiftedOffset + (numPieces - 1) * 4 + 2);
+                return result;
+            }
+
+            @Override
+            public boolean isNextCompressed() {
+                if (!hasNext()) {
+                    throw new NoSuchElementException();
+                }
+                return shiftedOffsets.get(nextShiftedOffset + 1);
+            }
+
+            @Override
+            public boolean isNextDerived() {
+                if (!hasNext()) {
+                    throw new NoSuchElementException();
+                }
+                return derived != null && derived.containsKey(nextShiftedOffset - shift);
+            }
+
+            @Override
+            public Set<Integer> getDerivedOffsets(int baseOffset) {
+                if (derived == null || !derived.containsKey(baseOffset)) {
+                    throw new NoSuchElementException();
+                }
+                return derived.get(baseOffset);
+            }
+
+            @Override
+            public int getNumPieces() {
+                if (!hasNext()) {
+                    throw new NoSuchElementException();
+                }
+                return getNumPieces(nextShiftedOffset);
+            }
+        };
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == this) {
+            return true;
+        } else if (obj instanceof AArch64RuntimeReferenceMap) {
+            return super.equals(obj);
+        } else {
+            return false;
+        }
+    }
+
+}

--- a/substratevm/src/com.oracle.svm.graal/src/com/oracle/svm/graal/meta/amd64/AMD64RuntimeCodeInstallerPlatformHelper.java
+++ b/substratevm/src/com.oracle.svm.graal/src/com/oracle/svm/graal/meta/amd64/AMD64RuntimeCodeInstallerPlatformHelper.java
@@ -37,7 +37,11 @@ import org.graalvm.nativeimage.hosted.Feature;
 
 import com.oracle.svm.core.annotate.AutomaticFeature;
 import com.oracle.svm.core.code.CodeInfo;
+import com.oracle.svm.core.code.InstantReferenceAdjuster;
+import com.oracle.svm.core.code.ReferenceAdjuster;
 import com.oracle.svm.core.config.ConfigurationValues;
+import com.oracle.svm.core.heap.CodeReferenceMapEncoder;
+import com.oracle.svm.core.heap.SubstrateReferenceMap;
 import com.oracle.svm.graal.meta.RuntimeCodeInstaller.RuntimeCodeInstallerPlatformHelper;
 
 @AutomaticFeature
@@ -102,5 +106,25 @@ public class AMD64RuntimeCodeInstallerPlatformHelper implements RuntimeCodeInsta
     @Override
     public void performCodeSynchronization(CodeInfo codeInfo) {
 
+    }
+
+    @Override
+    public ReferenceAdjuster createReferenceAdjuster() {
+        return new InstantReferenceAdjuster();
+    }
+
+    @Override
+    public SubstrateReferenceMap createReferenceMap() {
+        return new SubstrateReferenceMap();
+    }
+
+    @Override
+    public CodeReferenceMapEncoder createCodeReferenceMapEncoder() {
+        return new CodeReferenceMapEncoder();
+    }
+
+    @Override
+    public void markConstantRef(SubstrateReferenceMap refMap, int offset, int length, boolean compressed, boolean inlined) {
+        refMap.markReferenceAtOffset(offset, compressed);
     }
 }


### PR DESCRIPTION
Added support for inlined objects within runtime installed code.

In AArch64 these objects are represented through a sequence of mov instructions and hence the reference is not contiguous within the code. To handle this, had to add multiple components, including:
    
1. Means of adjusting split references
2. Ability to encode split references within reference maps
3. Ability to walk split references in visitors