### PR TITLE
relax check on version info for MacOS toolchain

### DIFF
--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/c/codegen/CCompilerInvoker.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/c/codegen/CCompilerInvoker.java
@@ -211,7 +211,7 @@ public abstract class CCompilerInvoker {
         @Override
         protected CompilerInfo createCompilerInfo(Scanner scanner) {
             try {
-                while (scanner.findInLine("Apple LLVM version ") == null) {
+                while (scanner.findInLine("Apple.*version ") == null) {
                     scanner.nextLine();
                 }
                 scanner.useDelimiter("[. ]");

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/c/codegen/CCompilerInvoker.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/c/codegen/CCompilerInvoker.java
@@ -211,7 +211,7 @@ public abstract class CCompilerInvoker {
         @Override
         protected CompilerInfo createCompilerInfo(Scanner scanner) {
             try {
-                while (scanner.findInLine("Apple.*version ") == null) {
+                while (scanner.findInLine("Apple (LLVM|clang) version ") == null) {
                     scanner.nextLine();
                 }
                 scanner.useDelimiter("[. ]");


### PR DESCRIPTION
Old compilers use "Apple LLVM version" where new compilers use "Apple clang version"