### PR TITLE
Bug Fix: Output of mx igv incorrectly points to GraalVM EE Distribution

### DIFF
--- a/compiler/mx.compiler/mx_graal_tools.py
+++ b/compiler/mx.compiler/mx_graal_tools.py
@@ -81,9 +81,8 @@ def igv(args):
     mx.warn(
         """IGV (idealgraphvisualizer) is available from
     https://www.oracle.com/technetwork/graalvm/downloads/index.html
-Please download the distribution and run
+Please download the Ideal Graph Visualizer (IGV) install and run
     bin/idealgraphvisualizer
-from the GraalVM EE installation.
 """)
 
 def c1visualizer(args):


### PR DESCRIPTION
The location of IGV has moved outside of the GraalVM EE Distribution. 

This is a proposed change to the warning to avoid downloading the GraalVM EE Distribution and then finding IGV is not there 😄. 