### PR TITLE
Print Java version in the output of "native-image --version" command

### DIFF
--- a/substratevm/src/com.oracle.svm.driver/src/com/oracle/svm/driver/DefaultOptionHandler.java
+++ b/substratevm/src/com.oracle.svm.driver/src/com/oracle/svm/driver/DefaultOptionHandler.java
@@ -81,6 +81,7 @@ class DefaultOptionHandler extends NativeImage.OptionHandler<NativeImage> {
                 if (!NativeImage.graalvmConfig.isEmpty()) {
                     message += " " + NativeImage.graalvmConfig;
                 }
+                message += " (Java Version " + System.getProperty("java.version") + ")";
                 nativeImage.showMessage(message);
                 System.exit(0);
                 return true;


### PR DESCRIPTION
The `native-image --version` command currently prints:
```
GraalVM Version 19.3.1 CE
```
Given that the Graal VM ships in more than one variant of Java version (i.e. Java 8 and Java 11) and given that we have noticed there can be considerable difference in behaviour of native image generation depending on which variant is used, it is going to be useful to print out, in that `native-image --version` output, the Java version on which that Graal VM is based on.

This has been asked in a couple of places:
https://github.com/oracle/graal/issues/1911#issuecomment-565874506
https://github.com/quarkusio/quarkus/issues/6162

The commit here enhances the `native-image --version` output to even include the Java version. With this change, the output should look something like:
```
GraalVM Version 19.3.1 CE (Java Version 11.0.6)
```
(where Java 11.0.6 was the version this Graal VM was built upon).