### PR TITLE
Account for JDK-8236925 changes

### DIFF
--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/jdk/JNIRegistrationJavaNet.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/jdk/JNIRegistrationJavaNet.java
@@ -115,8 +115,13 @@ class JNIRegistrationJavaNet extends JNIRegistrationUtil implements Feature {
         a.registerReachabilityHandler(JNIRegistrationJavaNet::registerDatagramPacketInit,
                         method(a, "java.net.DatagramPacket", "init"));
 
-        a.registerReachabilityHandler(JNIRegistrationJavaNet::registerDatagramSocketCheckOldImpl,
-                        method(a, "java.net.DatagramSocket", "checkOldImpl"));
+        if (JavaVersionUtil.JAVA_SPEC >= 15) {
+            a.registerReachabilityHandler(JNIRegistrationJavaNet::registerDatagramSocketCheckOldImpl,
+                            method(a, "java.net.DatagramSocket", "checkOldImpl", java.net.DatagramSocketImpl.class));
+        } else {
+            a.registerReachabilityHandler(JNIRegistrationJavaNet::registerDatagramSocketCheckOldImpl,
+                            method(a, "java.net.DatagramSocket", "checkOldImpl"));
+        }
 
         String plainDatagramSocketImpl = isWindows() ? "TwoStacksPlainDatagramSocketImpl" : "PlainDatagramSocketImpl";
         a.registerReachabilityHandler(JNIRegistrationJavaNet::registerPlainDatagramSocketImplInit,


### PR DESCRIPTION
8236925: (dc) Upgrade DatagramChannel socket adaptor to extend MulticastSocket

Prior to JDK-8236925 the constructor was no-arg. After, it takes an
argument of type java.net.DatagramSocketImpl.