### PR TITLE
Don't use the build compiler check in case LLVM backend is used.

### DIFF
--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/NativeImageGenerator.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/NativeImageGenerator.java
@@ -848,7 +848,9 @@ public class NativeImageGenerator {
                 prepareLibC();
 
                 CCompilerInvoker compilerInvoker = CCompilerInvoker.create(tempDirectory());
-                compilerInvoker.verifyCompiler();
+                if (!"llvm".equals(SubstrateOptions.CompilerBackend.getValue())) {
+                    compilerInvoker.verifyCompiler();
+                }
                 ImageSingletons.add(CCompilerInvoker.class, compilerInvoker);
 
                 nativeLibraries = setupNativeLibraries(imageName, aConstantReflection, aMetaAccess, aSnippetReflection, cEnumProcessor, classInitializationSupport, debug);

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/NativeImageGenerator.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/NativeImageGenerator.java
@@ -848,7 +848,7 @@ public class NativeImageGenerator {
                 prepareLibC();
 
                 CCompilerInvoker compilerInvoker = CCompilerInvoker.create(tempDirectory());
-                if (!"llvm".equals(SubstrateOptions.CompilerBackend.getValue())) {
+                if (!("llvm".equals(SubstrateOptions.CompilerBackend.getValue()) && NativeImageOptions.ExitAfterRelocatableImageWrite.getValue())) {
                     compilerInvoker.verifyCompiler();
                 }
                 ImageSingletons.add(CCompilerInvoker.class, compilerInvoker);


### PR DESCRIPTION
This fixes #2166