### PR TITLE
AArch64: Merge shift pair and integral narrow into add/sub

### DIFF
--- a/compiler/src/org.graalvm.compiler.asm.aarch64.test/src/org/graalvm/compiler/asm/aarch64/test/TestProtectedAssembler.java
+++ b/compiler/src/org.graalvm.compiler.asm.aarch64.test/src/org/graalvm/compiler/asm/aarch64/test/TestProtectedAssembler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -258,7 +258,7 @@ class TestProtectedAssembler extends AArch64Assembler {
     }
 
     @Override
-    protected void sub(int size, Register dst, Register src1, Register src2, ExtendType extendType, int shiftAmt) {
+    public void sub(int size, Register dst, Register src1, Register src2, ExtendType extendType, int shiftAmt) {
         super.sub(size, dst, src1, src2, extendType, shiftAmt);
     }
 

--- a/compiler/src/org.graalvm.compiler.asm.aarch64/src/org/graalvm/compiler/asm/aarch64/AArch64Assembler.java
+++ b/compiler/src/org.graalvm.compiler.asm.aarch64/src/org/graalvm/compiler/asm/aarch64/AArch64Assembler.java
@@ -1992,7 +1992,7 @@ public abstract class AArch64Assembler extends Assembler {
      * @param extendType defines how src2 is extended to the same size as src1.
      * @param shiftAmt must be in range 0 to 4.
      */
-    protected void sub(int size, Register dst, Register src1, Register src2, ExtendType extendType, int shiftAmt) {
+    public void sub(int size, Register dst, Register src1, Register src2, ExtendType extendType, int shiftAmt) {
         assert !dst.equals(zr);
         assert !src1.equals(zr);
         assert !src2.equals(sp);

--- a/compiler/src/org.graalvm.compiler.core.aarch64.test/src/org/graalvm/compiler/core/aarch64/test/AArch64ArrayAddressTest.java
+++ b/compiler/src/org.graalvm.compiler.core.aarch64.test/src/org/graalvm/compiler/core/aarch64/test/AArch64ArrayAddressTest.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2019, Arm Limited. All rights reserved.
+ * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2020, Arm Limited. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,7 +27,7 @@ package org.graalvm.compiler.core.aarch64.test;
 
 import org.graalvm.compiler.api.directives.GraalDirectives;
 import org.graalvm.compiler.lir.LIRInstruction;
-import org.graalvm.compiler.lir.aarch64.AArch64ArithmeticOp.ExtendedAddShiftOp;
+import org.graalvm.compiler.lir.aarch64.AArch64ArithmeticOp.ExtendedAddSubShiftOp;
 import org.junit.Test;
 
 import java.util.ArrayDeque;
@@ -36,7 +36,7 @@ import java.util.Set;
 import java.util.function.Predicate;
 
 public class AArch64ArrayAddressTest extends AArch64MatchRuleTest {
-    private static final Predicate<LIRInstruction> predicate = op -> (op instanceof ExtendedAddShiftOp);
+    private static final Predicate<LIRInstruction> predicate = op -> (op instanceof ExtendedAddSubShiftOp);
 
     public static byte loadByte(byte[] arr, int n) {
         return arr[n];

--- a/compiler/src/org.graalvm.compiler.core.aarch64.test/src/org/graalvm/compiler/core/aarch64/test/AArch64MergeExtendWithAddSubTest.java
+++ b/compiler/src/org.graalvm.compiler.core.aarch64.test/src/org/graalvm/compiler/core/aarch64/test/AArch64MergeExtendWithAddSubTest.java
@@ -1,0 +1,238 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, Arm Limited. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.graalvm.compiler.core.aarch64.test;
+
+import org.graalvm.compiler.lir.LIRInstruction;
+import org.graalvm.compiler.lir.aarch64.AArch64ArithmeticOp;
+import org.junit.Test;
+
+import java.util.function.Predicate;
+
+public class AArch64MergeExtendWithAddSubTest extends AArch64MatchRuleTest {
+
+    private static final Predicate<LIRInstruction> PRED_EXTEND_ADD_SHIFT = op -> (op instanceof AArch64ArithmeticOp.ExtendedAddSubShiftOp && op.name().equals("ADD"));
+    private static final Predicate<LIRInstruction> PRED_EXTEND_SUB_SHIFT = op -> (op instanceof AArch64ArithmeticOp.ExtendedAddSubShiftOp && op.name().equals("SUB"));
+
+    private static final Long[] LONG_VALUES = {-1L, 0L, 0x1234567812345678L, 0xFFFFFFFFL, 0x12L, 0x1234L, Long.MIN_VALUE, Long.MAX_VALUE};
+    private static final Integer[] INT_VALUES = {-1, 0, 0x1234, 0x12345678, Integer.MIN_VALUE, Integer.MAX_VALUE};
+
+    private <T> void predicateExist(String[] testCases, T[] values, Predicate<LIRInstruction> predicate) {
+        for (String t : testCases) {
+            for (T value : values) {
+                test(t, value, value);
+                checkLIR(t, predicate, 1);
+            }
+        }
+    }
+
+    public long addI2LShift(long x, long y) {
+        int z = (int) y;
+        return x + (((long) z) << 3);
+    }
+
+    public long addB2LShift(long x, long y) {
+        byte z = (byte) y;
+        return x + (((long) z) << 2);
+    }
+
+    public long addC2LShift(long x, long y) {
+        char z = (char) y;
+        return x + (((long) z) << 1);
+    }
+
+    public long addS2LShift(long x, long y) {
+        short z = (short) y;
+        return x + (((long) z) << 4);
+    }
+
+    public long subI2LShift(long x, long y) {
+        int z = (int) y;
+        return x - (((long) z) << 1);
+    }
+
+    public long subB2LShift(long x, long y) {
+        byte z = (byte) y;
+        return x - (((long) z) << 2);
+    }
+
+    public long subC2LShift(long x, long y) {
+        char z = (char) y;
+        return x - (((long) z) << 3);
+    }
+
+    public long subS2LShift(long x, long y) {
+        short z = (short) y;
+        return x - (((long) z) << 4);
+    }
+
+    public long addI2L(long x, long y) {
+        int z = (int) y;
+        return x + z;
+    }
+
+    public long addB2L(long x, long y) {
+        byte z = (byte) y;
+        return x + z;
+    }
+
+    public long addC2L(long x, long y) {
+        char z = (char) y;
+        return x + z;
+    }
+
+    public long addS2L(long x, long y) {
+        short z = (short) y;
+        return x + z;
+    }
+
+    public int addB2S(int x, int y) {
+        short a = (short) x;
+        byte b = (byte) y;
+        return a + b;
+    }
+
+    public int addB2SShift(int x, int y) {
+        short a = (short) x;
+        byte b = (byte) y;
+        return a + (b << 2);
+    }
+
+    public int addB2I(int x, int y) {
+        byte z = (byte) y;
+        return x + z;
+    }
+
+    public int addB2IShift(int x, int y) {
+        byte z = (byte) y;
+        return x + (z << 3);
+    }
+
+    public int addS2I(int x, int y) {
+        short z = (short) y;
+        return x + z;
+    }
+
+    public int addS2IShift(int x, int y) {
+        short z = (short) y;
+        return x + (z << 2);
+    }
+
+    public int addC2I(int x, int y) {
+        char z = (char) y;
+        return x + z;
+    }
+
+    public int addC2IShift(int x, int y) {
+        char z = (char) y;
+        return x + (z << 1);
+    }
+
+    @Test
+    public void mergeSignExtendIntoAdd() {
+        predicateExist(new String[]{"addB2S", "addB2I", "addS2I", "addC2I"}, INT_VALUES, PRED_EXTEND_ADD_SHIFT);
+        predicateExist(new String[]{"addB2L", "addC2L", "addI2L", "addS2L"}, LONG_VALUES, PRED_EXTEND_ADD_SHIFT);
+    }
+
+    @Test
+    public void mergeSignExtendShiftIntoAdd() {
+        predicateExist(new String[]{"addB2SShift", "addB2IShift", "addS2IShift", "addC2IShift"}, INT_VALUES, PRED_EXTEND_ADD_SHIFT);
+        predicateExist(new String[]{"addB2LShift", "addC2LShift", "addI2LShift", "addS2LShift"}, LONG_VALUES, PRED_EXTEND_ADD_SHIFT);
+    }
+
+    public long subI2L(long x, long y) {
+        int z = (int) y;
+        return x - z;
+    }
+
+    public long subB2L(long x, long y) {
+        byte z = (byte) y;
+        return x - z;
+    }
+
+    public long subC2L(long x, long y) {
+        char z = (char) y;
+        return x - z;
+    }
+
+    public long subS2L(long x, long y) {
+        short z = (short) y;
+        return x - z;
+    }
+
+    public int subB2S(int x, int y) {
+        short a = (short) x;
+        byte b = (byte) y;
+        return a - b;
+    }
+
+    public int subB2SShift(int x, int y) {
+        short a = (short) x;
+        byte b = (byte) y;
+        return a - (b << 2);
+    }
+
+    public int subB2I(int x, int y) {
+        byte z = (byte) y;
+        return x - z;
+    }
+
+    public int subB2IShift(int x, int y) {
+        byte z = (byte) y;
+        return x - (z << 3);
+    }
+
+    public int subS2I(int x, int y) {
+        short z = (short) y;
+        return x - z;
+    }
+
+    public int subS2IShift(int x, int y) {
+        short z = (short) y;
+        return x - (z << 2);
+    }
+
+    public int subC2I(int x, int y) {
+        char z = (char) y;
+        return x - z;
+    }
+
+    public int subC2IShift(int x, int y) {
+        char z = (char) y;
+        return x - (z << 1);
+    }
+
+    @Test
+    public void mergeSignExtendShiftIntoSub() {
+        predicateExist(new String[]{"subB2SShift", "subB2IShift", "subS2IShift", "subC2IShift"}, INT_VALUES, PRED_EXTEND_SUB_SHIFT);
+        predicateExist(new String[]{"subB2LShift", "subC2LShift", "subI2LShift", "subS2LShift"}, LONG_VALUES, PRED_EXTEND_SUB_SHIFT);
+    }
+
+    @Test
+    public void mergeSignExtendIntoSub() {
+        predicateExist(new String[]{"subB2S", "subB2I", "subS2I", "subC2I"}, INT_VALUES, PRED_EXTEND_SUB_SHIFT);
+        predicateExist(new String[]{"subB2L", "subC2L", "subI2L", "subS2L"}, LONG_VALUES, PRED_EXTEND_SUB_SHIFT);
+    }
+}

--- a/compiler/src/org.graalvm.compiler.core.aarch64.test/src/org/graalvm/compiler/core/aarch64/test/AArch64MergeNarrowWithAddSubTest.java
+++ b/compiler/src/org.graalvm.compiler.core.aarch64.test/src/org/graalvm/compiler/core/aarch64/test/AArch64MergeNarrowWithAddSubTest.java
@@ -1,0 +1,314 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, Arm Limited. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.graalvm.compiler.core.aarch64.test;
+
+import org.graalvm.compiler.lir.LIRInstruction;
+import org.graalvm.compiler.lir.aarch64.AArch64ArithmeticOp;
+import org.junit.Test;
+
+import java.util.function.Predicate;
+
+public class AArch64MergeNarrowWithAddSubTest extends AArch64MatchRuleTest {
+
+    private static final Predicate<LIRInstruction> PRED_EXTEND_ADD_SHIFT = op -> (op instanceof AArch64ArithmeticOp.ExtendedAddSubShiftOp && op.name().equals("ADD"));
+    private static final Predicate<LIRInstruction> PRED_EXTEND_SUB_SHIFT = op -> (op instanceof AArch64ArithmeticOp.ExtendedAddSubShiftOp && op.name().equals("SUB"));
+
+    private static final Long[] LONG_VALUES = {-1L, 0L, 0x1234567812345678L, 0xFFFFFFFFL, 0x12L, 0x1234L, Long.MIN_VALUE, Long.MAX_VALUE};
+    private static final Integer[] INT_VALUES = {-1, 0, 0x1234, 0x12345678, Integer.MIN_VALUE, Integer.MAX_VALUE};
+
+    private <T> void predicateExist(String[] testCases, T[] values, Predicate<LIRInstruction> predicate) {
+        for (String t : testCases) {
+            for (T value : values) {
+                test(t, value, value);
+                checkLIR(t, predicate, 1);
+            }
+        }
+    }
+
+    public int addIB(int x, int y) {
+        return x + (y & 0xff);
+    }
+
+    public int addIH(int x, int y) {
+        return x + (y & 0xffff);
+    }
+
+    public long addLB(long x, long y) {
+        return x + (y & 0xff);
+    }
+
+    public long addLH(long x, long y) {
+        return x + (y & 0xffff);
+    }
+
+    public long addLW(long x, long y) {
+        return x + (y & 0xffffffffL);
+    }
+
+    @Test
+    public void mergeDowncastIntoAdd() {
+        predicateExist(new String[]{"addIB", "addIH"}, INT_VALUES, PRED_EXTEND_ADD_SHIFT);
+        predicateExist(new String[]{"addLB", "addLH", "addLW"}, LONG_VALUES, PRED_EXTEND_ADD_SHIFT);
+    }
+
+    public int subIB(int x, int y) {
+        return x - (y & 0xff);
+    }
+
+    public int subIH(int x, int y) {
+        return x - (y & 0xffff);
+    }
+
+    public long subLB(long x, long y) {
+        return x - (y & 0xff);
+    }
+
+    public long subLH(long x, long y) {
+        return x - (y & 0xffff);
+    }
+
+    public long subLW(long x, long y) {
+        return x - (y & 0xffffffffL);
+    }
+
+    @Test
+    public void mergeDowncastIntoSub() {
+        predicateExist(new String[]{"subIB", "subIH"}, INT_VALUES, PRED_EXTEND_SUB_SHIFT);
+        predicateExist(new String[]{"subLB", "subLH", "subLW"}, LONG_VALUES, PRED_EXTEND_SUB_SHIFT);
+    }
+
+    public int addIBShift(int x, int y) {
+        return x + ((y & 0xff) << 3);
+    }
+
+    public int addIHShift(int x, int y) {
+        return x + ((y & 0xffff) << 3);
+    }
+
+    public long addLBShift(long x, long y) {
+        return x + ((y & 0xffL) << 3);
+    }
+
+    public long addLHShift(long x, long y) {
+        return x + ((y & 0xffffL) << 3);
+    }
+
+    public long addLWShift(long x, long y) {
+        return x + ((y & 0xffffffffL) << 3);
+    }
+
+    @Test
+    public void mergeShiftDowncastIntoAdd() {
+        predicateExist(new String[]{"addIBShift", "addIHShift"}, INT_VALUES, PRED_EXTEND_ADD_SHIFT);
+        predicateExist(new String[]{"addLBShift", "addLHShift", "addLWShift"}, LONG_VALUES, PRED_EXTEND_ADD_SHIFT);
+    }
+
+    public int subIBShift(int x, int y) {
+        return x - ((y & 0xff) << 3);
+    }
+
+    public int subIHShift(int x, int y) {
+        return x - ((y & 0xffff) << 3);
+    }
+
+    public long subLBShift(long x, long y) {
+        return x - ((y & 0xffL) << 3);
+    }
+
+    public long subLHShift(long x, long y) {
+        return x - ((y & 0xffffL) << 3);
+    }
+
+    public long subLWShift(long x, long y) {
+        return x - ((y & 0xffffffffL) << 3);
+    }
+
+    @Test
+    public void mergeShiftDowncastIntoSub() {
+        predicateExist(new String[]{"subIBShift", "subIHShift"}, INT_VALUES, PRED_EXTEND_SUB_SHIFT);
+        predicateExist(new String[]{"subLBShift", "subLHShift", "subLWShift"}, LONG_VALUES, PRED_EXTEND_SUB_SHIFT);
+    }
+
+    public int addIntExtractShort(int x, int y) {
+        return x + ((y << 16) >> 16);
+    }
+
+    public int addIntExtractByte(int x, int y) {
+        return x + ((y << 24) >> 24);
+    }
+
+    public long addLongExtractInt(long x, long y) {
+        return x + ((y << 32) >> 32);
+    }
+
+    public long addLongExtractShort(long x, long y) {
+        return x + ((y << 48) >> 48);
+    }
+
+    public long addLongExtractByte(long x, long y) {
+        return x + ((y << 56) >> 56);
+    }
+
+    @Test
+    public void addSignExtractTest() {
+        predicateExist(new String[]{"addIntExtractShort", "addIntExtractByte"}, INT_VALUES, PRED_EXTEND_ADD_SHIFT);
+        predicateExist(new String[]{"addLongExtractInt", "addLongExtractShort", "addLongExtractByte"}, LONG_VALUES, PRED_EXTEND_ADD_SHIFT);
+    }
+
+    public int addIntExtractShortByShift(int x, int y) {
+        return x + (((y << 16) >> 16) << 3);
+    }
+
+    public int addIntExtractByteByShift(int x, int y) {
+        return x + (((y << 24) >> 24) << 3);
+    }
+
+    public long addLongExtractIntByShift(long x, long y) {
+        return x + (((y << 32) >> 32) << 3);
+    }
+
+    public long addLongExtractShortByShift(long x, long y) {
+        return x + (((y << 48) >> 48) << 3);
+    }
+
+    public long addLongExtractByteByShift(long x, long y) {
+        return x + (((y << 56) >> 56) << 3);
+    }
+
+    @Test
+    public void addExtractByShiftTest() {
+        predicateExist(new String[]{"addIntExtractShortByShift", "addIntExtractByteByShift"}, INT_VALUES, PRED_EXTEND_ADD_SHIFT);
+        predicateExist(new String[]{"addLongExtractIntByShift", "addLongExtractShortByShift", "addLongExtractByteByShift"}, LONG_VALUES, PRED_EXTEND_ADD_SHIFT);
+    }
+
+    public int addIntUnsignedExtractByte(int x, int y) {
+        return x + ((y << 24) >>> 24);
+    }
+
+    public long addLongUnsignedExtractByte(long x, long y) {
+        return x + ((y << 56) >>> 56);
+    }
+
+    @Test
+    public void addUnsignedExtractTest() {
+        predicateExist(new String[]{"addIntUnsignedExtractByte"}, INT_VALUES, PRED_EXTEND_ADD_SHIFT);
+        predicateExist(new String[]{"addLongUnsignedExtractByte"}, LONG_VALUES, PRED_EXTEND_ADD_SHIFT);
+    }
+
+    public int addIntUnsignedExtractByteByShift(int x, int y) {
+        return x + (((y << 24) >>> 24) << 2);
+    }
+
+    public long addLongUnsignedExtractByteByShift(long x, long y) {
+        return x + (((y << 56) >>> 56) << 1);
+    }
+
+    @Test
+    public void addUnsignedExtractByShiftTest() {
+        predicateExist(new String[]{"addIntUnsignedExtractByteByShift"}, INT_VALUES, PRED_EXTEND_ADD_SHIFT);
+        predicateExist(new String[]{"addLongUnsignedExtractByteByShift"}, LONG_VALUES, PRED_EXTEND_ADD_SHIFT);
+    }
+
+    public int subIntExtractShort(int x, int y) {
+        return x - ((y << 16) >> 16);
+    }
+
+    public int subIntExtractByte(int x, int y) {
+        return x - ((y << 24) >> 24);
+    }
+
+    public long subLongExtractInt(long x, long y) {
+        return x - ((y << 32) >> 32);
+    }
+
+    public long subLongExtractShort(long x, long y) {
+        return x - ((y << 48) >> 48);
+    }
+
+    public long subLongExtractByte(long x, long y) {
+        return x - ((y << 56) >> 56);
+    }
+
+    @Test
+    public void subExtractTest() {
+        predicateExist(new String[]{"subIntExtractShort", "subIntExtractByte"}, INT_VALUES, PRED_EXTEND_SUB_SHIFT);
+        predicateExist(new String[]{"subLongExtractInt", "subLongExtractShort", "subLongExtractByte"}, LONG_VALUES, PRED_EXTEND_SUB_SHIFT);
+    }
+
+    public int subIntExtractShortByShift(int x, int y) {
+        return x - (((y << 16) >> 16) << 3);
+    }
+
+    public int subIntExtractByteByShift(int x, int y) {
+        return x - (((y << 24) >> 24) << 3);
+    }
+
+    public long subLongExtractIntByShift(long x, long y) {
+        return x - (((y << 32) >> 32) << 3);
+    }
+
+    public long subLongExtractShortByShift(long x, long y) {
+        return x - (((y << 48) >> 48) << 3);
+    }
+
+    public long subLongExtractByteByShift(long x, long y) {
+        return x - (((y << 56) >> 56) << 3);
+    }
+
+    @Test
+    public void subExtractByShiftTest() {
+        predicateExist(new String[]{"subIntExtractShortByShift", "subIntExtractByteByShift"}, INT_VALUES, PRED_EXTEND_SUB_SHIFT);
+        predicateExist(new String[]{"subLongExtractIntByShift", "subLongExtractShortByShift", "subLongExtractByteByShift"}, LONG_VALUES, PRED_EXTEND_SUB_SHIFT);
+    }
+
+    public int subIntUnsignedExtractByte(int x, int y) {
+        return x - ((y << 24) >>> 24);
+    }
+
+    public long subLongUnsignedExtractByte(long x, long y) {
+        return x - ((y << 56) >>> 56);
+    }
+
+    @Test
+    public void subUnsignedExtractTest() {
+        predicateExist(new String[]{"subIntUnsignedExtractByte"}, INT_VALUES, PRED_EXTEND_SUB_SHIFT);
+        predicateExist(new String[]{"subLongUnsignedExtractByte"}, LONG_VALUES, PRED_EXTEND_SUB_SHIFT);
+    }
+
+    public int subIntUnsignedExtractByteByShift(int x, int y) {
+        return x - (((y << 24) >>> 24) << 1);
+    }
+
+    public long subLongUnsignedExtractByteByShift(long x, long y) {
+        return x - (((y << 56) >>> 56) << 2);
+    }
+
+    @Test
+    public void subUnsignedExtractByShiftTest() {
+        predicateExist(new String[]{"subIntUnsignedExtractByteByShift"}, INT_VALUES, PRED_EXTEND_SUB_SHIFT);
+        predicateExist(new String[]{"subLongUnsignedExtractByteByShift"}, LONG_VALUES, PRED_EXTEND_SUB_SHIFT);
+    }
+}

--- a/compiler/src/org.graalvm.compiler.lir.aarch64/src/org/graalvm/compiler/lir/aarch64/AArch64ArithmeticOp.java
+++ b/compiler/src/org.graalvm.compiler.lir.aarch64/src/org/graalvm/compiler/lir/aarch64/AArch64ArithmeticOp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -461,8 +461,9 @@ public enum AArch64ArithmeticOp {
         }
     }
 
-    public static class ExtendedAddShiftOp extends AArch64LIRInstruction {
-        private static final LIRInstructionClass<ExtendedAddShiftOp> TYPE = LIRInstructionClass.create(ExtendedAddShiftOp.class);
+    public static class ExtendedAddSubShiftOp extends AArch64LIRInstruction {
+        private static final LIRInstructionClass<ExtendedAddSubShiftOp> TYPE = LIRInstructionClass.create(ExtendedAddSubShiftOp.class);
+        @Opcode private final AArch64ArithmeticOp op;
         @Def(REG) protected AllocatableValue result;
         @Use(REG) protected AllocatableValue src1;
         @Use(REG) protected AllocatableValue src2;
@@ -475,8 +476,9 @@ public enum AArch64ArithmeticOp {
          * @param extendType defines how src2 is extended to the same size as src1.
          * @param shiftAmt must be in range 0 to 4.
          */
-        public ExtendedAddShiftOp(AllocatableValue result, AllocatableValue src1, AllocatableValue src2, AArch64Assembler.ExtendType extendType, int shiftAmt) {
+        public ExtendedAddSubShiftOp(AArch64ArithmeticOp op, AllocatableValue result, AllocatableValue src1, AllocatableValue src2, AArch64Assembler.ExtendType extendType, int shiftAmt) {
             super(TYPE);
+            this.op = op;
             this.result = result;
             this.src1 = src1;
             this.src2 = src2;
@@ -487,7 +489,16 @@ public enum AArch64ArithmeticOp {
         @Override
         public void emitCode(CompilationResultBuilder crb, AArch64MacroAssembler masm) {
             int size = result.getPlatformKind().getSizeInBytes() * Byte.SIZE;
-            masm.add(size, asRegister(result), asRegister(src1), asRegister(src2), extendType, shiftAmt);
+            switch (op) {
+                case ADD:
+                    masm.add(size, asRegister(result), asRegister(src1), asRegister(src2), extendType, shiftAmt);
+                    break;
+                case SUB:
+                    masm.sub(size, asRegister(result), asRegister(src1), asRegister(src2), extendType, shiftAmt);
+                    break;
+                default:
+                    throw GraalError.shouldNotReachHere();
+            }
         }
     }
 


### PR DESCRIPTION
This patch implements two types of match rules like C2.

1. Merge shift pair into add/sub.
2. Merge integral narrow into add/sub.

E.g. Below code is generated for `x + (((y << 56) >> 56) << 3)`

        lsl x0, x3, #56
        asr x0, x0, #56
        add x0, x2, x0, lsl #3

After this patch, generated assembly above can be optimized to below:

        add x0, x2, w3, sxtb #3

The test cases in this patch can show more details about those match
rules.




Change-Id: I71b392eefd990d2ad838afc06fccebb3438e467c