### PR TITLE
sulong: test libc/getchar/getchar should use int

### DIFF
--- a/sulong/tests/com.oracle.truffle.llvm.tests.libc.native/libc/getchar/getchar.c
+++ b/sulong/tests/com.oracle.truffle.llvm.tests.libc.native/libc/getchar/getchar.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2019, Oracle and/or its affiliates.
+ * Copyright (c) 2017, 2020, Oracle and/or its affiliates.
  *
  * All rights reserved.
  *
@@ -31,7 +31,7 @@
 #include <stdlib.h>
 
 int main() {
-  char c;
+  int c;
   int oldStdin = dup(0);
   FILE *file = freopen(__FILE__, "r", stdin);
   while ((c = getchar()) != EOF) {


### PR DESCRIPTION
On AArch64, chars are unsigned by default.
The test libc/getchar/getchar requires "c" to be signed, otherwise
an infinite loop will occur. Switch to int (signed).