### PR TITLE
Fix distribution redefinition warning

### DIFF
--- a/substratevm/mx.substratevm/mx_substratevm.py
+++ b/substratevm/mx.substratevm/mx_substratevm.py
@@ -1242,7 +1242,7 @@ if is_musl_building_supported:
         license_files=[],
         third_party_license_files=[],
         dependencies=['svm'],
-        support_distributions=['substratevm:JDK11_NATIVE_IMAGE_MUSL_SUPPORT'],
+        support_distributions=['substratevm:JDK11_NATIVE_IMAGE_MUSL_SUPPORT_CE'],
         priority=5
     ))
 

--- a/substratevm/mx.substratevm/suite.py
+++ b/substratevm/mx.substratevm/suite.py
@@ -1052,7 +1052,7 @@ suite = {
             },
         },
 
-        "JDK11_NATIVE_IMAGE_MUSL_SUPPORT" : {
+        "JDK11_NATIVE_IMAGE_MUSL_SUPPORT_CE" : {
             "native" : True,
             "platformDependent" : True,
             "description" : "Static JDK11 libraries required for building images with musl",


### PR DESCRIPTION
Fix the `distribution JDK11_NATIVE_IMAGE_MUSL_SUPPORT redefined` warning that occurs when building the EE version.