### PR TITLE
Add legacy_stdio_definitions.lib for a successful native-image with VS2017

### DIFF
--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/image/NativeBootImageViaCC.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/image/NativeBootImageViaCC.java
@@ -265,6 +265,7 @@ public abstract class NativeBootImageViaCC extends NativeBootImage {
             cmd.add("ws2_32.lib");
             cmd.add("secur32.lib");
             cmd.add("iphlpapi.lib");
+	    cmd.add("legacy_stdio_definitions.lib");
             cmd.add("userenv.lib");
 
             Collections.addAll(cmd, Options.NativeLinkerOption.getValue());

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/image/NativeBootImageViaCC.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/image/NativeBootImageViaCC.java
@@ -265,7 +265,7 @@ public abstract class NativeBootImageViaCC extends NativeBootImage {
             cmd.add("ws2_32.lib");
             cmd.add("secur32.lib");
             cmd.add("iphlpapi.lib");
-	    cmd.add("legacy_stdio_definitions.lib");
+            cmd.add("legacy_stdio_definitions.lib");
             cmd.add("userenv.lib");
 
             Collections.addAll(cmd, Options.NativeLinkerOption.getValue());


### PR DESCRIPTION
When running `native-image` on Windows 10 with the VS2017 build tools, the linker complains that symbols related to printing functions are missing (e.g. unresolved external symbol __imp_sprintf , etc.). As mentioned in the PR #1546  adding `legacy_stdio_definitions.lib` solves this issue. However, this PR has not been merged because apparently its author had some issue signing the OCA.