### PR TITLE
Allow Windows-dependent conditional compilation

### DIFF
--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/os/IsDefined.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/os/IsDefined.java
@@ -47,6 +47,11 @@ public class IsDefined {
     }
 
     @Fold
+    public static final boolean isWindows() {
+        return Platform.includedIn(Platform.WINDOWS.class);
+    }
+
+    @Fold
     public static final boolean __solaris__() {
         return false;
     }


### PR DESCRIPTION
This PR makes os-dependent conditional compilation available for Windows.

Now that Windows is no longer an experimental platform in GraalVM, this feature will certainly be needed in the near future in Quarkus.