### PR TITLE
Add --expert-options-detail and PrintFlagsWithExtraHelp options.

### DIFF
--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/SubstrateOptions.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/SubstrateOptions.java
@@ -94,6 +94,9 @@ public class SubstrateOptions {
     @Option(help = "Show available options based on comma-separated option-types (allowed categories: User, Expert, Debug).")//
     public static final OptionKey<String> PrintFlags = new OptionKey<>(null);
 
+    @Option(help = "Print extra help, if available, based on comma-separated option names. Pass * to show all options that contain extra help.")//
+    public static final OptionKey<String> PrintFlagsWithExtraHelp = new OptionKey<>(null);
+
     @Option(help = "Control native-image code optimizations: 0 - no optimizations, 1 - basic optimizations, 2 - aggressive optimizations.", type = OptionType.User)//
     public static final HostedOptionKey<Integer> Optimize = new HostedOptionKey<Integer>(2) {
         @Override

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/option/RuntimeOptionParser.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/option/RuntimeOptionParser.java
@@ -194,8 +194,8 @@ public final class RuntimeOptionParser {
      */
     private void parseOptionAtRuntime(String arg, String optionPrefix, BooleanOptionFormat booleanOptionFormat, EconomicMap<OptionKey<?>, Object> values, boolean systemExitOnError) {
         OptionParseResult parseResult = SubstrateOptionsParser.parseOption(sortedOptions, arg.substring(optionPrefix.length()), values, optionPrefix, booleanOptionFormat);
-        if (parseResult.printFlags()) {
-            SubstrateOptionsParser.printFlags(parseResult::matchesFlagsRuntime, sortedOptions, optionPrefix, Log.logStream());
+        if (parseResult.printFlags() || parseResult.printFlagsWithExtraHelp()) {
+            SubstrateOptionsParser.printFlags(parseResult::matchesFlagsRuntime, sortedOptions, optionPrefix, Log.logStream(), parseResult.printFlagsWithExtraHelp());
             System.exit(0);
         }
         if (!parseResult.isValid()) {

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/option/SubstrateOptionsParser.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/option/SubstrateOptionsParser.java
@@ -32,6 +32,7 @@ import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.EnumSet;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map.Entry;
 import java.util.Set;
@@ -68,31 +69,47 @@ public class SubstrateOptionsParser {
      */
     static final class OptionParseResult {
         private final EnumSet<OptionType> printFlags;
+        private final Set<String> optionNameFilter;
         private final String error;
+        private static final String EXTRA_HELP_OPTIONS_WILDCARD = "*";
 
-        private OptionParseResult(EnumSet<OptionType> printFlags, String error) {
+        private OptionParseResult(EnumSet<OptionType> printFlags, String error, Set<String> optionNameFilter) {
             this.printFlags = printFlags;
             this.error = error;
+            this.optionNameFilter = optionNameFilter;
         }
 
         static OptionParseResult error(String message) {
-            return new OptionParseResult(EnumSet.noneOf(OptionType.class), message);
+            return new OptionParseResult(EnumSet.noneOf(OptionType.class), message, new HashSet<>());
         }
 
         static OptionParseResult correct() {
-            return new OptionParseResult(EnumSet.noneOf(OptionType.class), null);
+            return new OptionParseResult(EnumSet.noneOf(OptionType.class), null, new HashSet<>());
         }
 
         static OptionParseResult printFlags(EnumSet<OptionType> selectedOptionTypes) {
-            return new OptionParseResult(selectedOptionTypes, null);
+            return new OptionParseResult(selectedOptionTypes, null, new HashSet<>());
+        }
+
+        static OptionParseResult printFlagsWithExtraHelp(Set<String> optionNameFilter) {
+            Set<String> optionNames = optionNameFilter;
+            if (optionNames.contains(EXTRA_HELP_OPTIONS_WILDCARD)) {
+                optionNames = new HashSet<>();
+                optionNames.add(EXTRA_HELP_OPTIONS_WILDCARD);
+            }
+            return new OptionParseResult(EnumSet.noneOf(OptionType.class), null, optionNames);
         }
 
         boolean printFlags() {
             return !printFlags.isEmpty();
         }
 
+        boolean printFlagsWithExtraHelp() {
+            return !optionNameFilter.isEmpty();
+        }
+
         public boolean isValid() {
-            return printFlags.isEmpty() && error == null;
+            return printFlags.isEmpty() && optionNameFilter.isEmpty() && error == null;
         }
 
         public String getError() {
@@ -100,8 +117,17 @@ public class SubstrateOptionsParser {
         }
 
         private boolean matchesFlags(OptionDescriptor d, boolean svmOption) {
-            boolean showAll = printFlags.equals(EnumSet.allOf(OptionType.class));
-            return showAll || svmOption && printFlags.contains(d.getOptionType());
+            if (!printFlags.isEmpty()) {
+                boolean showAll = printFlags.equals(EnumSet.allOf(OptionType.class));
+                return showAll || svmOption && printFlags.contains(d.getOptionType());
+            }
+            if (!optionNameFilter.isEmpty()) {
+                if (optionNameFilter.contains(EXTRA_HELP_OPTIONS_WILDCARD) && !d.getExtraHelp().isEmpty()) {
+                    return true;
+                }
+                return optionNameFilter.contains(d.getName());
+            }
+            return false;
         }
 
         boolean matchesFlagsRuntime(OptionDescriptor d) {
@@ -254,6 +280,12 @@ public class SubstrateOptionsParser {
             }
             return OptionParseResult.printFlags(selectedOptionTypes);
         }
+        if (SubstrateOptions.PrintFlagsWithExtraHelp.getName().equals(optionName)) {
+            String optionValue = (String) value;
+            String[] optionNames = SubstrateUtil.split(optionValue, ",");
+            HashSet<String> selectedOptionNames = new HashSet<>(Arrays.asList(optionNames));
+            return OptionParseResult.printFlagsWithExtraHelp(selectedOptionNames);
+        }
 
         return OptionParseResult.correct();
     }
@@ -309,8 +341,8 @@ public class SubstrateOptionsParser {
         }
 
         OptionParseResult optionParseResult = SubstrateOptionsParser.parseOption(options, arg.substring(optionPrefix.length()), valuesMap, optionPrefix, booleanOptionFormat);
-        if (optionParseResult.printFlags()) {
-            SubstrateOptionsParser.printFlags(optionParseResult::matchesFlagsHosted, options, optionPrefix, out);
+        if (optionParseResult.printFlags() || optionParseResult.printFlagsWithExtraHelp()) {
+            SubstrateOptionsParser.printFlags(optionParseResult::matchesFlagsHosted, options, optionPrefix, out, optionParseResult.printFlagsWithExtraHelp());
             throw new InterruptImageBuilding();
         }
         if (!optionParseResult.isValid()) {
@@ -341,13 +373,14 @@ public class SubstrateOptionsParser {
         return sb.toString();
     }
 
-    private static void printOption(PrintStream out, String option, String description) {
-        printOption(out::println, option, description, 2, 45, 120);
+    private static void printOption(PrintStream out, String option, String description, boolean wrap) {
+        printOption(out::println, option, description, 2, 45, 120, wrap);
     }
 
-    public static void printOption(Consumer<String> println, String option, String description, int indentation, int optionWidth, int wrapWidth) {
+    public static void printOption(Consumer<String> println, String option, String description, int indentation, int optionWidth, int wrapWidth, boolean wrap) {
         String indent = spaces(indentation);
-        String desc = wrap(description != null ? description : "", wrapWidth);
+        String desc = description != null ? description : "";
+        desc = wrap ? wrap(desc, wrapWidth) : desc;
         String nl = System.lineSeparator();
         String[] descLines = SubstrateUtil.split(desc, nl);
         if (option.length() >= optionWidth && description != null) {
@@ -360,13 +393,13 @@ public class SubstrateOptionsParser {
         }
     }
 
-    static void printFlags(Predicate<OptionDescriptor> filter, SortedMap<String, OptionDescriptor> sortedOptions, String prefix, PrintStream out) {
+    static void printFlags(Predicate<OptionDescriptor> filter, SortedMap<String, OptionDescriptor> sortedOptions, String prefix, PrintStream out, boolean verbose) {
         for (Entry<String, OptionDescriptor> entry : sortedOptions.entrySet()) {
             OptionDescriptor descriptor = entry.getValue();
             if (!filter.test(descriptor)) {
                 continue;
             }
-            String helpMsg = descriptor.getHelp();
+            String helpMsg = verbose && !descriptor.getExtraHelp().isEmpty() ? "" : descriptor.getHelp();
             int helpLen = helpMsg.length();
             if (helpLen > 0 && helpMsg.charAt(helpLen - 1) != '.') {
                 helpMsg += '.';
@@ -401,6 +434,12 @@ public class SubstrateOptionsParser {
                     stringifiedArrayValue = true;
                 }
             }
+            String verboseHelp = "";
+            if (verbose) {
+                verboseHelp = System.lineSeparator() + descriptor.getHelp() + System.lineSeparator() + String.join(System.lineSeparator(), descriptor.getExtraHelp());
+            } else if (!descriptor.getExtraHelp().isEmpty()) {
+                verboseHelp = " [Extra help available]";
+            }
             if (descriptor.getOptionValueType() == Boolean.class) {
                 Boolean val = (Boolean) defaultValue;
                 if (helpLen != 0) {
@@ -413,7 +452,7 @@ public class SubstrateOptionsParser {
                         helpMsg += "Default: - (disabled).";
                     }
                 }
-                printOption(out, prefix + "\u00b1" + entry.getKey(), helpMsg);
+                printOption(out, prefix + "\u00b1" + entry.getKey(), helpMsg + verboseHelp, !verbose);
             } else {
                 if (defaultValue == null) {
                     if (helpLen != 0) {
@@ -421,13 +460,14 @@ public class SubstrateOptionsParser {
                     }
                     helpMsg += "Default: None";
                 }
+                helpMsg += verboseHelp;
                 if (stringifiedArrayValue || defaultValue == null) {
-                    printOption(out, prefix + entry.getKey() + "=...", helpMsg);
+                    printOption(out, prefix + entry.getKey() + "=...", helpMsg, !verbose);
                 } else {
                     if (defaultValue instanceof String) {
                         defaultValue = '"' + String.valueOf(defaultValue) + '"';
                     }
-                    printOption(out, prefix + entry.getKey() + "=" + defaultValue, helpMsg);
+                    printOption(out, prefix + entry.getKey() + "=" + defaultValue, helpMsg, !verbose);
                 }
             }
         }

--- a/substratevm/src/com.oracle.svm.driver/resources/HelpExtra.txt
+++ b/substratevm/src/com.oracle.svm.driver/resources/HelpExtra.txt
@@ -1,7 +1,12 @@
 Non-standard options help:
 
     --expert-options      lists image build options for experts
-    --expert-options-all  lists all image build options for experts (use at your own risk)
+    --expert-options-all  lists all image build options for experts (use at your own risk).
+                          Options marked with [Extra help available] contain help that can be
+                          shown with --expert-options-detail
+    --expert-options-detail
+                          displays all available help for a comma-separated list of option names.
+                          Pass * to show extra help for all options that contain it.
 
     --configurations-path <search path of option-configuration directories>
                           A %pathsep% separated list of directories to be treated as

--- a/substratevm/src/com.oracle.svm.driver/src/com/oracle/svm/driver/APIOptionHandler.java
+++ b/substratevm/src/com.oracle.svm.driver/src/com/oracle/svm/driver/APIOptionHandler.java
@@ -235,7 +235,7 @@ class APIOptionHandler extends NativeImage.OptionHandler<NativeImage> {
     void printOptions(Consumer<String> println) {
         apiOptions.entrySet().stream()
                         .filter(e -> !e.getValue().isDeprecated())
-                        .forEach(e -> SubstrateOptionsParser.printOption(println, e.getKey(), e.getValue().helpText, 4, 22, 66));
+                        .forEach(e -> SubstrateOptionsParser.printOption(println, e.getKey(), e.getValue().helpText, 4, 22, 66, true));
     }
 }
 

--- a/substratevm/src/com.oracle.svm.driver/src/com/oracle/svm/driver/DefaultOptionHandler.java
+++ b/substratevm/src/com.oracle.svm.driver/src/com/oracle/svm/driver/DefaultOptionHandler.java
@@ -132,11 +132,16 @@ class DefaultOptionHandler extends NativeImage.OptionHandler<NativeImage> {
                 return true;
             case "--expert-options":
                 args.poll();
-                nativeImage.setQueryOption(OptionType.User.name());
+                nativeImage.setPrintFlagsOptionQuery(OptionType.User.name());
                 return true;
             case "--expert-options-all":
                 args.poll();
-                nativeImage.setQueryOption("");
+                nativeImage.setPrintFlagsOptionQuery("");
+                return true;
+            case "--expert-options-detail":
+                args.poll();
+                String optionNames = args.poll();
+                nativeImage.setPrintFlagsWithExtraHelpOptionQuery(optionNames);
                 return true;
             case noServerOption:
             case verboseServerOption:

--- a/substratevm/src/com.oracle.svm.driver/src/com/oracle/svm/driver/NativeImage.java
+++ b/substratevm/src/com.oracle.svm.driver/src/com/oracle/svm/driver/NativeImage.java
@@ -156,6 +156,7 @@ public class NativeImage {
     static final String oR = "-R:";
 
     final String enablePrintFlags = SubstrateOptions.PrintFlags.getName() + "=";
+    final String enablePrintFlagsWithExtraHelp = SubstrateOptions.PrintFlagsWithExtraHelp.getName() + "=";
 
     private static <T> String oH(OptionKey<T> option) {
         return oH + option.getName() + "=";
@@ -209,7 +210,8 @@ public class NativeImage {
     private boolean verbose = Boolean.valueOf(System.getenv("VERBOSE_GRAALVM_LAUNCHERS"));
     private boolean jarOptionMode = false;
     private boolean dryRun = false;
-    private String queryOption = null;
+    private String printFlagsOptionQuery = null;
+    private String printFlagsWithExtraHelpOptionQuery = null;
 
     final Registry optionRegistry;
     private LinkedHashSet<EnabledOption> enabledLanguages;
@@ -1027,13 +1029,16 @@ public class NativeImage {
 
         completeOptionArgs();
 
-        if (queryOption != null) {
-            addPlainImageBuilderArg(NativeImage.oH + enablePrintFlags + queryOption);
-            addPlainImageBuilderArg(NativeImage.oR + enablePrintFlags + queryOption);
+        if (printFlagsOptionQuery != null) {
+            addPlainImageBuilderArg(NativeImage.oH + enablePrintFlags + printFlagsOptionQuery);
+            addPlainImageBuilderArg(NativeImage.oR + enablePrintFlags + printFlagsOptionQuery);
+        } else if (printFlagsWithExtraHelpOptionQuery != null) {
+            addPlainImageBuilderArg(NativeImage.oH + enablePrintFlagsWithExtraHelp + printFlagsWithExtraHelpOptionQuery);
+            addPlainImageBuilderArg(NativeImage.oR + enablePrintFlagsWithExtraHelp + printFlagsWithExtraHelpOptionQuery);
         }
 
         /* If no customImageClasspath was specified put "." on classpath */
-        if (!config.buildFallbackImage() && customImageClasspath.isEmpty() && queryOption == null) {
+        if (!config.buildFallbackImage() && customImageClasspath.isEmpty() && printFlagsOptionQuery == null && printFlagsWithExtraHelpOptionQuery == null) {
             addImageClasspath(Paths.get("."));
         } else {
             imageClasspath.addAll(customImageClasspath);
@@ -1075,7 +1080,7 @@ public class NativeImage {
         consolidateArgs(imageBuilderArgs, oHName, Function.identity(), Function.identity(), () -> null, takeLast);
         mainClass = consolidateSingleValueArg(imageBuilderArgs, oHClass);
         boolean buildExecutable = imageBuilderArgs.stream().noneMatch(arg -> arg.contains(enableSharedLibraryFlag));
-        boolean printFlags = imageBuilderArgs.stream().anyMatch(arg -> arg.contains(enablePrintFlags));
+        boolean printFlags = imageBuilderArgs.stream().anyMatch(arg -> arg.contains(enablePrintFlags) || arg.contains(enablePrintFlagsWithExtraHelp));
 
         if (!printFlags) {
             List<String> extraImageArgs = new ArrayList<>();
@@ -1481,8 +1486,12 @@ public class NativeImage {
         return dryRun;
     }
 
-    public void setQueryOption(String val) {
-        this.queryOption = val;
+    public void setPrintFlagsOptionQuery(String val) {
+        this.printFlagsOptionQuery = val;
+    }
+
+    public void setPrintFlagsWithExtraHelpOptionQuery(String val) {
+        this.printFlagsWithExtraHelpOptionQuery = val;
     }
 
     void showVerboseMessage(boolean show, String message) {

--- a/substratevm/src/com.oracle.svm.driver/src/com/oracle/svm/driver/NativeImageServer.java
+++ b/substratevm/src/com.oracle.svm.driver/src/com/oracle/svm/driver/NativeImageServer.java
@@ -739,7 +739,7 @@ final class NativeImageServer extends NativeImage {
 
     @Override
     protected int buildImage(List<String> javaArgs, LinkedHashSet<Path> bcp, LinkedHashSet<Path> cp, LinkedHashSet<String> imageArgs, LinkedHashSet<Path> imagecp) {
-        boolean printFlags = imageArgs.stream().anyMatch(arg -> arg.contains(enablePrintFlags));
+        boolean printFlags = imageArgs.stream().anyMatch(arg -> arg.contains(enablePrintFlags) || arg.contains(enablePrintFlagsWithExtraHelp));
         if (useServer && !printFlags && !useDebugAttach()) {
             AbortBuildSignalHandler signalHandler = new AbortBuildSignalHandler();
             sun.misc.Signal.handle(new sun.misc.Signal("TERM"), signalHandler);


### PR DESCRIPTION
This PR solves #2238 by adding the `PrintFlagsWithExtraHelp`. This flag can also be set using `--expert-options-detail`. The output of the `PrintFlags` command now marks options that contain extra help, and that extra help can be displayed as follows:
```
$ native-image --expert-options-all
...
-H:MethodFilter=...                          Pattern for matching methods. The syntax for a pattern is:. Default: None [Extra help available]
...
$ native-image --expert-options-detail MethodFilter
  -H:MethodFilter=...                          Default: None
                                               Pattern for matching methods. The syntax for a pattern is:
                                               
                                                 SourcePatterns = SourcePattern ["," SourcePatterns] .
                                                 SourcePattern = [ "~" ] [ Class "." ] method [ "(" [ Parameter { ";" Parameter } ] ")" ] .
                                                 Parameter = Class | "int" | "long" | "float" | "double" | "short" | "char" | "boolean" .
                                                 Class = { package "." } class .
                                               
                                               Glob pattern matching (*, ?) is allowed in all parts of the source pattern.
                                               The "~" prefix negates the pattern.
                                               
                                               Positive patterns are joined by an "or" operator: "A,B" matches anything
                                               matched by "A" or "B". Negative patterns are joined by "and not": "~A,~B"
                                               matches anything not matched by "A" and not matched by "B". "A,~B,~C,D"
                                               matches anything matched by "A" or "D" and not matched by "B" and not
                                               matched by "C".
                                               
                                               A set of patterns containing negative patterns but no positive ones contains
                                               an implicit positive "*" pattern: "~A,~B" is equivalent to "*,~A,~B".
                                               
                                               Examples of method filters:
                                               ---------
                                                 *
                                               
                                                 Matches all methods in all classes.
                                               ---------
                                                 canonical(CanonicalizerTool;LogicNode;LogicNode)
                                               
                                                 Matches all methods named "canonical", with the first parameter of type
                                                 "CanonicalizerTool", and the second and third parameters of type
                                                 "LogicNode".
                                                 The packages of the parameter types are irrelevant.
                                               ---------
                                                 arraycopy(Object;;;;)
                                               
                                                 Matches all methods named "arraycopy", with the first parameter
                                                 of type "Object", and four more parameters of any type. The
                                                 packages of the parameter types are irrelevant.
                                               ---------
                                                 org.graalvm.compiler.nodes.PhiNode.*
                                               
                                                 Matches all methods in the class "org.graalvm.compiler.nodes.PhiNode".
                                               ---------
                                                 org.graalvm.compiler.nodes.*.canonical
                                               
                                                 Matches all methods named "canonical" in classes in the package
                                                 "org.graalvm.compiler.nodes".
                                               ---------
                                                 arraycopy,toString
                                               
                                                 Matches all methods named "arraycopy" or "toString", meaning that ',' acts
                                                 as an "or" operator.
                                               ---------
                                                 java.util.*.*.,~java.util.*Array*.*
                                                 java.util.*.*.,~*Array*.*
                                               
                                                 These patterns are equivalent and match all methods in the package
                                                 "java.util" except for classes that have "Array" in their name.
                                               ---------
                                                 ~java.util.*.*
                                               
                                                 Matches all methods in all classes in all packages except for anything in
                                                 the "java.util" package.

```
The extra help output is not line-wrapped.