### PR TITLE
[wasm] Use numArgs to decrement stackPointer

### DIFF
--- a/wasm/src/org.graalvm.wasm/src/org/graalvm/wasm/nodes/WasmBlockNode.java
+++ b/wasm/src/org.graalvm.wasm/src/org/graalvm/wasm/nodes/WasmBlockNode.java
@@ -530,7 +530,7 @@ public final class WasmBlockNode extends WasmNode implements RepeatingNode {
                     callNodeOffset++;
 
                     Object[] args = createArgumentsForCall(frame, function, numArgs, stackPointer);
-                    stackPointer -= args.length;
+                    stackPointer -= numArgs;
 
                     trace("direct call to function %s (%d args)", function, args.length);
                     Object result = callNode.call(args);
@@ -612,7 +612,7 @@ public final class WasmBlockNode extends WasmNode implements RepeatingNode {
 
                     int numArgs = module().symbolTable().functionTypeArgumentCount(expectedFunctionTypeIndex);
                     Object[] args = createArgumentsForCall(frame, function, numArgs, stackPointer);
-                    stackPointer -= args.length;
+                    stackPointer -= numArgs;
 
                     trace("indirect call to function %s (%d args)", function, args.length);
                     Object result = callNode.execute(function, args);


### PR DESCRIPTION
`numArgs` is a PE constant, so this should not affect compiled code. However, this avoids two redundant length checks in the interpreter.