### PR TITLE
native-image: Include the original cause that led to the failure of CollectionPolicy instantiation

### DIFF
--- a/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/HeapPolicy.java
+++ b/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/HeapPolicy.java
@@ -85,7 +85,7 @@ public class HeapPolicy {
         try {
             result = policy.getDeclaredConstructor().newInstance();
         } catch (Exception ex) {
-            throw UserError.abort("policy " + className + " cannot be instantiated.");
+            throw UserError.abort(ex, "policy " + className + " cannot be instantiated.");
         }
 
         if (!policyClass.isInstance(result)) {


### PR DESCRIPTION
In Quarkus, we have seen more than one user reporting an exception, during the native-image generation, of the form:

```
Error: policy com.oracle.svm.core.genscavenge.CollectionPolicy cannot be instantiated.
com.oracle.svm.core.util.UserError$UserException: policy com.oracle.svm.core.genscavenge.CollectionPolicy cannot be instantiated.
        at com.oracle.svm.core.util.UserError.abort(UserError.java:65)
        at com.oracle.svm.core.genscavenge.HeapPolicy.instantiatePolicy(HeapPolicy.java:87)
        at com.oracle.svm.core.genscavenge.CollectionPolicy.getInitialPolicy(CollectionPolicy.java:59)
        at com.oracle.svm.core.genscavenge.GCImpl.<init>(GCImpl.java:148)
        at com.oracle.svm.core.genscavenge.HeapImpl.<init>(HeapImpl.java:106)
        at com.oracle.svm.core.genscavenge.graal.HeapFeature.afterRegistration(HeapFeature.java:65)
        at com.oracle.svm.hosted.NativeImageGenerator.lambda$setupNativeImage$11(NativeImageGenerator.java:812)
        at com.oracle.svm.hosted.FeatureHandler.forEachFeature(FeatureHandler.java:63)
        at com.oracle.svm.hosted.NativeImageGenerator.setupNativeImage(NativeImageGenerator.java:812)
        at com.oracle.svm.hosted.NativeImageGenerator.doRun(NativeImageGenerator.java:528)
        at com.oracle.svm.hosted.NativeImageGenerator.lambda$run$0(NativeImageGenerator.java:445)
        at java.base/java.util.concurrent.ForkJoinTask$AdaptedRunnableAction.exec(ForkJoinTask.java:1407)
        at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:290)
        at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1020)
        at java.base/java.util.concurrent.ForkJoinPool.scan(ForkJoinPool.java:1656)
        at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1594)
        at java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:177)
Error: Image build request failed with exit status 1
```
like here https://github.com/quarkusio/quarkus/issues/7684 and here https://github.com/quarkusio/quarkus/issues/2414

The error reported doesn't include the root cause which caused the failure. 

The commit here now includes the original cause of the exception to help in situations like these.

