### PR TITLE
Sulong: Blacklist failing AArch64 tests

### DIFF
--- a/sulong/mx.sulong/suite.py
+++ b/sulong/mx.sulong/suite.py
@@ -428,6 +428,9 @@ suite = {
     "com.oracle.truffle.llvm.tests.llirtestgen" : {
       "subDir" : "tests",
       "sourceDirs" : ["src"],
+      "dependencies" : [
+        "com.oracle.truffle.llvm.tests",
+      ],
       "checkstyle" : "com.oracle.truffle.llvm.runtime",
       "javaCompliance" : "1.8+",
       "license" : "BSD-new",
@@ -447,6 +450,7 @@ suite = {
       "buildEnv" : {
         "LDFLAGS": "-lm",
         "LLIR_TEST_GEN_JAR" : "<path:LLIR_TEST_GEN>",
+        "SULONG_TEST_JAR" : "<path:SULONG_TEST>",
         "OS" : "<os>",
       },
       "license" : "BSD-new",
@@ -1149,6 +1153,9 @@ suite = {
       "relpath" : True,
       "dependencies" : [
         "com.oracle.truffle.llvm.tests.llirtestgen",
+      ],
+      "distDependencies" : [
+        "SULONG_TEST",
       ],
       "license" : "BSD-new",
       "testDistribution" : True,

--- a/sulong/tests/com.oracle.truffle.llvm.tests.llirtestgen.generated/Makefile
+++ b/sulong/tests/com.oracle.truffle.llvm.tests.llirtestgen.generated/Makefile
@@ -29,7 +29,7 @@
 #
 
 JAVA=$(JAVA_HOME)/bin/java
-LLIRTESTGEN_CMD=$(JAVA) -Dllirtestgen.prelude=prelude.ll -cp $(LLIR_TEST_GEN_JAR) com.oracle.truffle.llvm.tests.llirtestgen.LLIRTestGen
+LLIRTESTGEN_CMD=$(JAVA) -Dllirtestgen.prelude=prelude.ll -cp $(LLIR_TEST_GEN_JAR):$(SULONG_TEST_JAR) com.oracle.truffle.llvm.tests.llirtestgen.LLIRTestGen
 OUTPUT_DIR=gen
 GENERATED=$(TESTS:.dir=)
 TIMESTAMP=timestamp

--- a/sulong/tests/com.oracle.truffle.llvm.tests.llirtestgen/src/com/oracle/truffle/llvm/tests/llirtestgen/LLIRTestGen.java
+++ b/sulong/tests/com.oracle.truffle.llvm.tests.llirtestgen/src/com/oracle/truffle/llvm/tests/llirtestgen/LLIRTestGen.java
@@ -761,7 +761,8 @@ public class LLIRTestGen {
                         "fdiv_x86_fp80"  // Fails with managed sulong
         ));
         if (Platform.isAArch64()) {
-            filenameBlacklist.add("bitcast_x86_fp80");
+            filenameBlacklist.addAll(Arrays.asList(
+                            "ashr_3xi8", "ashr_4xi8", "bitcast_x86_fp80", "lshr_2xi8", "lshr_3xi8", "lshr_4xi8", "shl_2xi8", "shl_3xi8", "shl_4xi8"));
         }
 
         filenameBlacklist = filenameBlacklist.stream().map(s -> makeBlacklistFilename(outputDir, s)).collect(Collectors.toSet());

--- a/sulong/tests/com.oracle.truffle.llvm.tests.llirtestgen/src/com/oracle/truffle/llvm/tests/llirtestgen/LLIRTestGen.java
+++ b/sulong/tests/com.oracle.truffle.llvm.tests.llirtestgen/src/com/oracle/truffle/llvm/tests/llirtestgen/LLIRTestGen.java
@@ -46,6 +46,8 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import com.oracle.truffle.llvm.tests.Platform;
+
 /**
  * This class (with an executable main method) produces an exhaustive test of all unary/binary/cast
  * bitcode operations on all arithmetic types (incl. vectors).
@@ -68,28 +70,6 @@ public class LLIRTestGen {
         boolean isFloat();
 
         String toName();
-    }
-
-    enum Architecture {
-        AMD64,
-        AArch64;
-
-        private static Architecture findCurrent() {
-            final String name = System.getProperty("os.arch");
-            if (name.equals("amd64") || name.equals("x86_64")) {
-                return AMD64;
-            }
-            if (name.equals("aarch64")) {
-                return AArch64;
-            }
-            throw new IllegalArgumentException("unknown architecture: " + name);
-        }
-
-        private static final Architecture current = findCurrent();
-
-        public static Architecture getCurrent() {
-            return current;
-        }
     }
 
     private enum ScalarType implements Type {
@@ -780,8 +760,7 @@ public class LLIRTestGen {
                         "fsub_x86_fp80", // Fails with managed sulong
                         "fdiv_x86_fp80"  // Fails with managed sulong
         ));
-        Architecture arch = Architecture.getCurrent();
-        if (arch == Architecture.AArch64) {
+        if (Platform.isAArch64()) {
             filenameBlacklist.add("bitcast_x86_fp80");
         }
 

--- a/sulong/tests/com.oracle.truffle.llvm.tests/src/com/oracle/truffle/llvm/tests/Platform.java
+++ b/sulong/tests/com.oracle.truffle.llvm.tests/src/com/oracle/truffle/llvm/tests/Platform.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates.
+ * Copyright (c) 2020, Arm Limited.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are
+ * permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of
+ * conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of
+ * conditions and the following disclaimer in the documentation and/or other materials provided
+ * with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be used to
+ * endorse or promote products derived from this software without specific prior written
+ * permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS
+ * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+ * GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.oracle.truffle.llvm.tests;
+
+public class Platform {
+
+    public enum Architecture {
+        AMD64,
+        AArch64;
+
+        private static Architecture findArchitecture() {
+            final String name = System.getProperty("os.arch");
+            if (name.equals("amd64") || name.equals("x86_64")) {
+                return AMD64;
+            }
+            if (name.equals("aarch64")) {
+                return AArch64;
+            }
+            throw new IllegalArgumentException("unknown architecture: " + name);
+        }
+
+        private static final Architecture architecture = findArchitecture();
+
+        public static Architecture getArchitecture() {
+            return architecture;
+        }
+    }
+
+    public enum OS {
+        Linux,
+        Solaris,
+        Darwin;
+
+        private static OS findOS() {
+            final String name = System.getProperty("os.name");
+            if (name.equals("Linux")) {
+                return Linux;
+            }
+            if (name.equals("SunOS")) {
+                return Solaris;
+            }
+            if (name.equals("Mac OS X") || name.equals("Darwin")) {
+                return Darwin;
+            }
+            throw new IllegalArgumentException("unknown OS: " + name);
+        }
+
+        private static final OS os = findOS();
+
+        public static OS getOS() {
+            return os;
+        }
+    }
+
+    public static Architecture getArchitecture() {
+        return Architecture.getArchitecture();
+    }
+
+    public static OS getOS() {
+        return OS.getOS();
+    }
+
+    public static boolean isAMD64() {
+        return Architecture.getArchitecture() == Architecture.AMD64;
+    }
+
+    public static boolean isAArch64() {
+        return Architecture.getArchitecture() == Architecture.AArch64;
+    }
+
+    public static boolean isLinux() {
+        return OS.getOS() == OS.Linux;
+    }
+
+    public static boolean isSolaris() {
+        return OS.getOS() == OS.Solaris;
+    }
+
+    public static boolean isDarwin() {
+        return OS.getOS() == OS.Darwin;
+    }
+}

--- a/sulong/tests/com.oracle.truffle.llvm.tests/src/com/oracle/truffle/llvm/tests/SulongSuite.java
+++ b/sulong/tests/com.oracle.truffle.llvm.tests/src/com/oracle/truffle/llvm/tests/SulongSuite.java
@@ -33,7 +33,10 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Arrays;
 import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -59,9 +62,49 @@ public class SulongSuite extends BaseSuiteHarness {
     }
 
     protected static Collection<Object[]> getData(Path suitesPath) {
+
+        Set<String> filenameBlacklist = new HashSet<>();
+
+        if (Platform.isAArch64()) {
+            // Tests that cause the JVM to crash.
+            filenameBlacklist.addAll(Arrays.asList(
+                            "c/builtin_gcc/__builtin_va_list.c",
+                            "c/truffle-c/structTest/passPerValue9.c", "c/truffle-c/structTest/structTest23.c", "c/truffle-c/structTest/structTest24.c",
+                            "c/truffle-c/structTest/structTest25.c", "c/truffle-c/structTest/structTest26.c", "c/truffle-c/structTest/structTest27.c",
+                            "c/varargs/var80bit.c", "c/varargs/varFloatVec.c", "c/varargs/varFunctionPointer.c", "c/varargs/varSmallStruct.c", "c/varargs/varStructBeforePrimitive.c",
+                            "c/varargs/varStructBeforePrimitiveAMD64Explicite.c", "c/varargs/varStructDouble.c", "c/varargs/varStructDoubleAMD64Explicite.c",
+                            "c/varargs/varStructLong.c", "c/varargs/varStructLongAMD64Explicite.c", "c/varargs/varStructModify.c", "c/varargs/varStructModifyPtr.c",
+                            "c/varargs/varStructPtr.c", "c/varargs/varStructStackOnly.c", "c/varargs/varStructStackOnlyAMD64Explicite.c",
+                            "cpp/test005.cpp", "cpp/test015.cpp", "cpp/test017.cpp", "cpp/test018.cpp", "cpp/test019.cpp", "cpp/test020.cpp", "cpp/test022.cpp", "cpp/test023.cpp", "cpp/test024.cpp",
+                            "cpp/test028.cpp",
+                            "cpp/test031.cpp", "cpp/test033.cpp", "cpp/test034.cpp", "cpp/test036.cpp", "cpp/test039.cpp",
+                            "cpp/test041.cpp", "cpp/test042.cpp", "cpp/test043.cpp", "cpp/test044.cpp", "cpp/test045.cpp", "cpp/test046.cpp", "cpp/test047.cpp", "cpp/test049.cpp", "cpp/test050.cpp",
+                            "cpp/test051.cpp", "cpp/test052.cpp", "cpp/test053.cpp", "cpp/testRuntimeError.cpp",
+                            "libc/memcpy/memcpy-struct-mixed.c", "libc/vfprintf/vfprintf.c", "libc/vprintf/vprintf.c"));
+            // Tests that fail.
+            filenameBlacklist.addAll(Arrays.asList(
+                            "c/arrays/intArray.c",
+                            "c/builtin_gcc/__builtin_copysign.c", "c/builtin_gcc/__builtin_fabsl.c", "c/builtin_gcc/__builtin_fpclassify.c", "c/builtin_gcc/__builtin_isfinite.c",
+                            "c/builtin_gcc/__builtin_isinf.c", "c/builtin_gcc/__builtin_isnan.c", "c/builtin_gcc/__builtin_signbit.c", "c/builtin_gcc/__builtin_signbitl.c",
+                            "c/lfplayout.c",
+                            "c/longdouble/add.c", "c/longdouble/longdouble-add.c", "c/longdouble/longdouble-div.c", "c/longdouble/longdouble-mul.c", "c/longdouble/longdouble-sub.c",
+                            "c/max-unsigned-int-to-double-cast.c",
+                            "c/stdlib/math/fmodl.c", "c/stdlib/math/sqrt.c", "c/stdlib/signal_errno.c", "c/stdlib/stat.c",
+                            "c/truffle-c/arrayTest/arrayTest18.c", "c/truffle-c/arrayTest/arrayTest22.c", "c/truffle-c/arrayTest/arrayTest5.c", "c/truffle-c/charTest/charArray.c",
+                            "c/truffle-c/programTest/programTest0.c", "c/truffle-c/structTest/structTest22.c", "c/truffle-c/unionTest/memberInitialization2.c", "c/truffle-c/unionTest/unionTest12.c",
+                            "cpp/test004.cpp", "cpp/test011.cpp", "cpp/test013.cpp", "cpp/test014.cpp", "cpp/test016.cpp",
+                            "cpp/test021.cpp", "cpp/test025.cpp", "cpp/test026.cpp", "cpp/test027.cpp", "cpp/test029.cpp",
+                            "cpp/test030.cpp", "cpp/test032.cpp", "cpp/test035.cpp", "cpp/test037.cpp", "cpp/test038.cpp", "cpp/test040.cpp", "cpp/test048.cpp",
+                            "libc/errno/errno.c"));
+        }
+
+        Set<String> directoryBlacklist = filenameBlacklist.stream().map((s) -> s.concat(".dir")).collect(Collectors.toSet());
+
         try (Stream<Path> files = Files.walk(suitesPath)) {
             Stream<Path> destDirs = files.filter(SulongSuite::isReference).map(Path::getParent);
-            return destDirs.map(testPath -> new Object[]{testPath, suitesPath.relativize(testPath).toString()}).collect(Collectors.toList());
+            Collection<Object[]> collection = destDirs.map(testPath -> new Object[]{testPath, suitesPath.relativize(testPath).toString()}).collect(Collectors.toList());
+            collection.removeIf(d -> directoryBlacklist.contains(d[1]));
+            return collection;
         } catch (IOException e) {
             throw new AssertionError("Test cases not found", e);
         }

--- a/sulong/tests/com.oracle.truffle.llvm.tests/src/com/oracle/truffle/llvm/tests/SulongSuite.java
+++ b/sulong/tests/com.oracle.truffle.llvm.tests/src/com/oracle/truffle/llvm/tests/SulongSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2019, Oracle and/or its affiliates.
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.
  *
  * All rights reserved.
  *
@@ -49,7 +49,6 @@ import com.oracle.truffle.llvm.tests.options.TestOptions;
 @RunWith(Parameterized.class)
 public class SulongSuite extends BaseSuiteHarness {
 
-    public static final boolean IS_MAC = System.getProperty("os.name").toLowerCase().indexOf("mac") >= 0;
     @Parameter(value = 0) public Path path;
     @Parameter(value = 1) public String testName;
 
@@ -69,7 +68,7 @@ public class SulongSuite extends BaseSuiteHarness {
     }
 
     private static boolean isReference(Path path) {
-        return path.endsWith("ref.out") && (!IS_MAC || pathStream(path).noneMatch(p -> p.endsWith("ref.out.dSYM")));
+        return path.endsWith("ref.out") && (!Platform.isDarwin() || pathStream(path).noneMatch(p -> p.endsWith("ref.out.dSYM")));
     }
 
     private static Stream<Path> pathStream(Path path) {
@@ -81,7 +80,7 @@ public class SulongSuite extends BaseSuiteHarness {
         return f -> {
             boolean isBC = f.getFileName().toString().endsWith(".bc");
             boolean isOut = f.getFileName().toString().endsWith(".out");
-            return isBC || (isOut && !IS_MAC);
+            return isBC || (isOut && !Platform.isDarwin());
         };
     }
 

--- a/sulong/tests/com.oracle.truffle.llvm.tests/src/com/oracle/truffle/llvm/tests/bitcodeformat/BitcodeFormatTest.java
+++ b/sulong/tests/com.oracle.truffle.llvm.tests/src/com/oracle/truffle/llvm/tests/bitcodeformat/BitcodeFormatTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates.
+ * Copyright (c) 2019, 2020, Oracle and/or its affiliates.
  *
  * All rights reserved.
  *
@@ -39,6 +39,7 @@ import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
+import com.oracle.truffle.llvm.tests.Platform;
 import com.oracle.truffle.llvm.tests.pipe.CaptureNativeOutput;
 import com.oracle.truffle.llvm.tests.pipe.CaptureOutput;
 import com.oracle.truffle.llvm.tests.util.ProcessUtil;
@@ -65,32 +66,6 @@ public class BitcodeFormatTest {
     @ClassRule public static TruffleRunner.RunWithPolyglotRule runWithPolyglot = new TruffleRunner.RunWithPolyglotRule();
 
     private static final Path testBase = Paths.get(TestOptions.TEST_SUITE_PATH, "bitcodeformat");
-
-    enum OS {
-        Darwin,
-        Linux,
-        Solaris;
-
-        private static OS findCurrent() {
-            final String name = System.getProperty("os.name");
-            if (name.equals("Linux")) {
-                return Linux;
-            }
-            if (name.equals("SunOS")) {
-                return Solaris;
-            }
-            if (name.equals("Mac OS X") || name.equals("Darwin")) {
-                return Darwin;
-            }
-            throw new IllegalArgumentException("unknown OS: " + name);
-        }
-
-        private static final OS current = findCurrent();
-
-        public static OS getCurrent() {
-            return current;
-        }
-    }
 
     protected Map<String, String> getContextOptions() {
         return Collections.emptyMap();
@@ -122,9 +97,8 @@ public class BitcodeFormatTest {
 
     @Before
     public void checkOS() {
-        OS os = OS.getCurrent();
-        Assume.assumeTrue("Linux only test", os != OS.Darwin || !value.toString().contains("linux-link"));
-        Assume.assumeTrue("Darwin only test", os == OS.Darwin || !value.toString().contains("darwin-link"));
+        Assume.assumeTrue("Linux only test", !Platform.isDarwin() || !value.toString().contains("linux-link"));
+        Assume.assumeTrue("Darwin only test", Platform.isDarwin() || !value.toString().contains("darwin-link"));
     }
 
     @Test

--- a/sulong/tests/com.oracle.truffle.llvm.tests/src/com/oracle/truffle/llvm/tests/interop/LLVMInteropTest.java
+++ b/sulong/tests/com.oracle.truffle.llvm.tests/src/com/oracle/truffle/llvm/tests/interop/LLVMInteropTest.java
@@ -63,11 +63,11 @@ import com.oracle.truffle.llvm.runtime.LLVMContext;
 import com.oracle.truffle.llvm.runtime.LLVMLanguage;
 import com.oracle.truffle.llvm.runtime.NFIContextExtension;
 import com.oracle.truffle.llvm.runtime.except.LLVMNativePointerException;
-import com.oracle.truffle.llvm.tests.SulongSuite;
 import com.oracle.truffle.llvm.tests.interop.values.ArrayObject;
 import com.oracle.truffle.llvm.tests.interop.values.BoxedIntValue;
 import com.oracle.truffle.llvm.tests.interop.values.NullValue;
 import com.oracle.truffle.llvm.tests.options.TestOptions;
+import com.oracle.truffle.llvm.tests.Platform;
 
 public class LLVMInteropTest {
     @Test
@@ -1413,7 +1413,7 @@ public class LLVMInteropTest {
             runner.load();
             Assert.assertEquals("construct\n", buf.toString());
         }
-        if (SulongSuite.IS_MAC) {
+        if (Platform.isDarwin()) {
             /*
              * On MacOS, newer clang version implement destructors by registering it via `atexit` in
              * a generated constructor. Our test also registers an `atexit` function in a


### PR DESCRIPTION
Improve OS/Arch detection in tests. Then blacklist all failing AArch64 tests.

I wanted to use the new platform class in lirtestgen, but mx gate checks complained that you can't share the classes across different packages.

Once this and https://github.com/oracle/graal/pull/2173 is merged, then SulongSuite will fully pass on AArch64 Linux.

(I'm also assuming this comment doesn't end up in the final commit message)