### PR TITLE
AArch64: Eliminate redundant constant load instructions.

### DIFF
--- a/compiler/src/org.graalvm.compiler.core.aarch64/src/org/graalvm/compiler/core/aarch64/AArch64ArithmeticLIRGenerator.java
+++ b/compiler/src/org.graalvm.compiler.core.aarch64/src/org/graalvm/compiler/core/aarch64/AArch64ArithmeticLIRGenerator.java
@@ -371,7 +371,7 @@ public class AArch64ArithmeticLIRGenerator extends ArithmeticLIRGenerator implem
         }
     }
 
-    private void emitBinaryConst(Variable result, AArch64ArithmeticOp op, AllocatableValue a, JavaConstant b) {
+    public void emitBinaryConst(Variable result, AArch64ArithmeticOp op, AllocatableValue a, JavaConstant b) {
         AllocatableValue x = moveSp(a);
         getLIRGen().append(new AArch64ArithmeticOp.BinaryConstOp(op, result, x, b));
     }

--- a/compiler/src/org.graalvm.compiler.core.aarch64/src/org/graalvm/compiler/core/aarch64/AArch64NodeMatchRules.java
+++ b/compiler/src/org.graalvm.compiler.core.aarch64/src/org/graalvm/compiler/core/aarch64/AArch64NodeMatchRules.java
@@ -74,6 +74,7 @@ import org.graalvm.compiler.nodes.memory.MemoryAccess;
 import jdk.vm.ci.aarch64.AArch64Kind;
 import jdk.vm.ci.code.CodeUtil;
 import jdk.vm.ci.meta.AllocatableValue;
+import jdk.vm.ci.meta.JavaConstant;
 import jdk.vm.ci.meta.JavaKind;
 import jdk.vm.ci.meta.Value;
 
@@ -438,9 +439,11 @@ public class AArch64NodeMatchRules extends NodeMatchRules {
         }
         if ((0 == shift1 + shift2) || (src.getStackKind().getBitCount() == shift1 + shift2)) {
             return builder -> {
-                Value a = operand(src);
-                Value b = x instanceof LeftShiftNode ? operand(shiftAmt2) : operand(shiftAmt1);
-                return getArithmeticLIRGenerator().emitBinary(LIRKind.combine(a, b), AArch64ArithmeticOp.ROR, false, a, b);
+                AllocatableValue a = gen.asAllocatable(operand(src));
+                JavaConstant b = x instanceof LeftShiftNode ? shiftAmt2.asJavaConstant() : shiftAmt1.asJavaConstant();
+                Variable result = gen.newVariable(LIRKind.combine(a));
+                getArithmeticLIRGenerator().emitBinaryConst(result, AArch64ArithmeticOp.ROR, a, b);
+                return result;
             };
         }
         return null;

--- a/compiler/src/org.graalvm.compiler.core/src/org/graalvm/compiler/core/match/MatchContext.java
+++ b/compiler/src/org.graalvm.compiler.core/src/org/graalvm/compiler/core/match/MatchContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -68,10 +68,12 @@ public class MatchContext {
     static final class ConsumedNode {
         final Node node;
         final boolean ignoresSideEffects;
+        final boolean singleUser;
 
-        ConsumedNode(Node node, boolean ignoresSideEffects) {
+        ConsumedNode(Node node, boolean ignoresSideEffects, boolean singleUser) {
             this.node = node;
             this.ignoresSideEffects = ignoresSideEffects;
+            this.singleUser = singleUser;
         }
     }
 
@@ -85,11 +87,11 @@ public class MatchContext {
             this.nodes = null;
         }
 
-        public void add(Node node, boolean ignoresSideEffects) {
+        public void add(Node node, boolean ignoresSideEffects, boolean singlerUser) {
             if (nodes == null) {
                 nodes = new ArrayList<>(2);
             }
-            nodes.add(new ConsumedNode(node, ignoresSideEffects));
+            nodes.add(new ConsumedNode(node, ignoresSideEffects, singlerUser));
         }
 
         public boolean contains(Node node) {
@@ -373,10 +375,7 @@ public class MatchContext {
             if (cn.node == root || cn.node == emitNode) {
                 continue;
             }
-            // All the interior nodes should be skipped during the normal doRoot calls in
-            // NodeLIRBuilder so mark them as interior matches. The root of the match will get a
-            // closure which will be evaluated to produce the final LIR.
-            builder.setMatchResult(cn.node, ComplexMatchValue.INTERIOR_MATCH);
+            setResult(cn);
         }
         builder.setMatchResult(emitNode, value);
         if (root != emitNode) {
@@ -387,23 +386,34 @@ public class MatchContext {
         }
     }
 
+    private void setResult(ConsumedNode consumedNode) {
+        Node node = consumedNode.node;
+        if (consumedNode.singleUser) {
+            // All the interior nodes should be skipped during the normal doRoot calls in
+            // NodeLIRBuilder so mark them as interior matches. The root of the match will get a
+            // closure which will be evaluated to produce the final LIR.
+            builder.setMatchResult(node, ComplexMatchValue.INTERIOR_MATCH);
+            return;
+        }
+        builder.setSharedMatchResult(node);
+    }
+
     /**
      * Mark a node as consumed by the match. Consumed nodes will never be evaluated.
      *
      * @return Result.OK if the node can be safely consumed.
      */
-    public Result consume(Node node, boolean ignoresSideEffects, boolean atRoot) {
+    public Result consume(Node node, boolean ignoresSideEffects, boolean atRoot, boolean singleUser) {
         if (atRoot) {
-            consumed.add(node, ignoresSideEffects);
+            consumed.add(node, ignoresSideEffects, singleUser);
             return Result.OK;
         }
-        assert MatchPattern.isSingleValueUser(node) : "should have already been checked";
 
         if (builder.hasOperand(node)) {
             return Result.alreadyUsed(node, rule.getPattern());
         }
 
-        consumed.add(node, ignoresSideEffects);
+        consumed.add(node, ignoresSideEffects, singleUser);
         return Result.OK;
     }
 

--- a/compiler/src/org.graalvm.compiler.core/src/org/graalvm/compiler/core/match/MatchPattern.java
+++ b/compiler/src/org.graalvm.compiler.core/src/org/graalvm/compiler/core/match/MatchPattern.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -158,6 +158,8 @@ public class MatchPattern {
      */
     private final boolean singleUser;
 
+    private final boolean consumable;
+
     /**
      * Can this node be subsumed into a match even if there are side effecting nodes between this
      * node and the match.
@@ -166,41 +168,47 @@ public class MatchPattern {
 
     private static final MatchPattern[] EMPTY_PATTERNS = new MatchPattern[0];
 
-    public MatchPattern(String name, boolean singleUser, boolean ignoresSideEffects) {
-        this(null, name, singleUser, ignoresSideEffects);
+    public MatchPattern(String name, boolean singleUser, boolean consumable, boolean ignoresSideEffects) {
+        this(null, name, singleUser, consumable, ignoresSideEffects);
     }
 
-    public MatchPattern(Class<? extends Node> nodeClass, String name, boolean singleUser, boolean ignoresSideEffects) {
+    public MatchPattern(Class<? extends Node> nodeClass, String name, boolean singleUser, boolean consumable, boolean ignoresSideEffects) {
         this.nodeClass = nodeClass;
         this.name = name;
         this.singleUser = singleUser;
+        this.consumable = consumable;
         this.ignoresSideEffects = ignoresSideEffects;
         this.patterns = EMPTY_PATTERNS;
         this.inputs = null;
         assert !ignoresSideEffects || FloatingNode.class.isAssignableFrom(nodeClass);
     }
 
-    private MatchPattern(Class<? extends Node> nodeClass, String name, boolean singleUser, boolean ignoresSideEffects, MatchPattern[] patterns, Position[] inputs) {
+    private MatchPattern(Class<? extends Node> nodeClass, String name, boolean singleUser, boolean consumable,
+                    boolean ignoresSideEffects, MatchPattern[] patterns, Position[] inputs) {
         assert inputs == null || inputs.length == patterns.length;
         this.nodeClass = nodeClass;
         this.name = name;
         this.singleUser = singleUser;
+        this.consumable = consumable;
         this.ignoresSideEffects = ignoresSideEffects;
         this.patterns = patterns;
         this.inputs = inputs;
         assert !ignoresSideEffects || FloatingNode.class.isAssignableFrom(nodeClass);
     }
 
-    public MatchPattern(Class<? extends Node> nodeClass, String name, MatchPattern first, Position[] inputs, boolean singleUser, boolean ignoresSideEffects) {
-        this(nodeClass, name, singleUser, ignoresSideEffects, new MatchPattern[]{first}, inputs);
+    public MatchPattern(Class<? extends Node> nodeClass, String name, MatchPattern first, Position[] inputs,
+                    boolean singleUser, boolean consumable, boolean ignoresSideEffects) {
+        this(nodeClass, name, singleUser, consumable, ignoresSideEffects, new MatchPattern[]{first}, inputs);
     }
 
-    public MatchPattern(Class<? extends Node> nodeClass, String name, MatchPattern first, MatchPattern second, Position[] inputs, boolean singleUser, boolean ignoresSideEffects) {
-        this(nodeClass, name, singleUser, ignoresSideEffects, new MatchPattern[]{first, second}, inputs);
+    public MatchPattern(Class<? extends Node> nodeClass, String name, MatchPattern first, MatchPattern second,
+                    Position[] inputs, boolean singleUser, boolean consumable, boolean ignoresSideEffects) {
+        this(nodeClass, name, singleUser, consumable, ignoresSideEffects, new MatchPattern[]{first, second}, inputs);
     }
 
-    public MatchPattern(Class<? extends Node> nodeClass, String name, MatchPattern first, MatchPattern second, MatchPattern third, Position[] inputs, boolean singleUser, boolean ignoresSideEffects) {
-        this(nodeClass, name, singleUser, ignoresSideEffects, new MatchPattern[]{first, second, third}, inputs);
+    public MatchPattern(Class<? extends Node> nodeClass, String name, MatchPattern first, MatchPattern second, MatchPattern third,
+                    Position[] inputs, boolean singleUser, boolean consumable, boolean ignoresSideEffects) {
+        this(nodeClass, name, singleUser, consumable, ignoresSideEffects, new MatchPattern[]{first, second, third}, inputs);
     }
 
     Class<? extends Node> nodeClass() {
@@ -234,8 +242,9 @@ public class MatchPattern {
         if (result != Result.OK) {
             return result;
         }
-        if (singleUser) {
-            result = context.consume(node, ignoresSideEffects, atRoot);
+
+        if (consumable) {
+            result = context.consume(node, ignoresSideEffects, atRoot, singleUser);
             if (result != Result.OK) {
                 return result;
             }

--- a/compiler/src/org.graalvm.compiler.core/src/org/graalvm/compiler/core/match/MatchableNode.java
+++ b/compiler/src/org.graalvm.compiler.core/src/org/graalvm/compiler/core/match/MatchableNode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -66,4 +66,9 @@ public @interface MatchableNode {
     boolean shareable() default false;
 
     boolean ignoresSideEffects() default false;
+
+    /**
+     * Can a node be consumed by a matched rule regardless of whether it is shareable.
+     */
+    boolean consumable() default true;
 }

--- a/compiler/src/org.graalvm.compiler.core/src/org/graalvm/compiler/core/match/SharedMatchValue.java
+++ b/compiler/src/org.graalvm.compiler.core/src/org/graalvm/compiler/core/match/SharedMatchValue.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, Arm Limited and affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.graalvm.compiler.core.match;
+
+import org.graalvm.compiler.core.common.LIRKind;
+
+import jdk.vm.ci.meta.Value;
+
+public class SharedMatchValue extends Value {
+    private int usageCount;
+
+    public SharedMatchValue() {
+        super(LIRKind.Illegal);
+    }
+
+    public void incrementUsageCount() {
+        usageCount++;
+    }
+
+    public int getUsageCount() {
+        return usageCount;
+    }
+}


### PR DESCRIPTION
This patch fixes issue: https://github.com/oracle/graal/issues/2216

Unused constant load won't be deleted after match rules. As a result, it might generate redundant "mov/orr" instructions if the constants cannot be inlined to codes.

For example, the original codes:

      lsr    w0, w0, #6
      orr    w1, wzr, #0xfffff
      and    w0, w0, w1

will be optimized to the following pattern by adding match rules:

      orr    w1, wzr, #0xfffff
      ubfx   w0, w0, #6, #20

However, the constant `"0xfffff"` is not deleted even though it will never be used. To fix it, this patch inserts a phase applied to LIRInstructions. It's used to eliminate the unused constant load ops before code generation. Although it is limited to constant load ops currently, it can also be extended to remove other kinds of unused instructions if needed in future.

Change-Id: Ibed66714c12e02f400ab494683dee8826ede01a1