### PR TITLE
Canonicalize negate node to unsigned right shift.

### DIFF
--- a/compiler/src/org.graalvm.compiler.core.test/src/org/graalvm/compiler/core/test/NegateCanonicalizationTest.java
+++ b/compiler/src/org.graalvm.compiler.core.test/src/org/graalvm/compiler/core/test/NegateCanonicalizationTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, Arm Limited and affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.graalvm.compiler.core.test;
+
+import org.graalvm.compiler.nodes.StructuredGraph;
+import org.graalvm.compiler.nodes.calc.NegateNode;
+import org.graalvm.compiler.nodes.calc.RightShiftNode;
+import org.graalvm.compiler.nodes.calc.UnsignedRightShiftNode;
+import org.junit.Test;
+
+public class NegateCanonicalizationTest extends GraalCompilerTest {
+
+    public static int negateInt(int x) {
+        return -(x >> 31);
+    }
+
+    public static long negateLong(long x) {
+        return -(x >> 63);
+    }
+
+    public static int signExtractInt(int x) {
+        return (x >> 31) >>> 31;
+    }
+
+    public static long signExtractLong(long x) {
+        return (x >> 63) >>> 63;
+    }
+
+    private void checkNodes(String methodName) {
+        StructuredGraph graph = parseForCompile(getResolvedJavaMethod(methodName));
+        createCanonicalizerPhase().apply(graph, getProviders());
+        assertTrue(graph.getNodes().filter(NegateNode.class).count() == 0);
+        assertTrue(graph.getNodes().filter(RightShiftNode.class).count() == 0);
+        assertTrue(graph.getNodes().filter(UnsignedRightShiftNode.class).count() == 1);
+    }
+
+    @Test
+    public void testNegate() {
+        checkNodes("negateInt");
+        checkNodes("negateLong");
+        checkNodes("signExtractInt");
+        checkNodes("signExtractLong");
+    }
+}


### PR DESCRIPTION
This patch fixes issue: #2220 

Negate a right shift with the max shift amount equals to unsigned right
shift.

As the final code, just take AArch64 for example:

        asr x0, x2, #63
        neg x0, x0

After this patch, generated assembly above can be optimized to below:

        lsr x0, x2, #63

Change-Id: Ifd1c4f7885822b92798341f4728c887fddf7c654