### PR TITLE
Make it clear that the mx "ce" environment doesn't include the native-image tool

### DIFF
--- a/vm/README.md
+++ b/vm/README.md
@@ -27,7 +27,7 @@ It is recommended to verify this output before running `build`.
 
 ### Example: build the base GraalVM CE image
 The base GraalVM CE image includes:
-- SubstrateVM (with the `native-image` tool)
+- SubstrateVM (without the `native-image` tool)
 - GraalVM compiler & the Truffle partial evaluator (imported as a dependency of `substratevm`)
 - The inspector, profiler, and VisualVM tools
 - Sulong


### PR DESCRIPTION
I've been discussing, on the Slack channel, the typical build steps for building the GraalVM from source, specifically the `native-image` tool. During those discussions, it was noticed that the readme file of the `vm` component incorrectly states that the `ce` `env` that's used by `mx` includes the `native-image` tool. In reality, the `native-image` isn't part of the `ce` environment and in fact it explicitly excludes it https://github.com/oracle/graal/blob/master/vm/mx.vm/ce#L2

The commit in this PR fixes the readme to state that the `native-image` isn't included in the `ce` build.