### PR TITLE
Make image symbols accessible after image write phase

### DIFF
--- a/substratevm/src/com.oracle.svm.core.graal.llvm/src/com/oracle/svm/core/graal/llvm/LLVMNativeImageCodeCache.java
+++ b/substratevm/src/com.oracle.svm.core.graal.llvm/src/com/oracle/svm/core/graal/llvm/LLVMNativeImageCodeCache.java
@@ -431,7 +431,7 @@ public class LLVMNativeImageCodeCache extends NativeImageCodeCache {
     }
 
     @Override
-    public List<ObjectFile.Symbol> getGlobalSymbols(ObjectFile objectFile) {
+    public List<ObjectFile.Symbol> getSymbols(ObjectFile objectFile, boolean onlyGlobal) {
         return globalSymbols;
     }
 

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/LinkerInvocation.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/LinkerInvocation.java
@@ -60,4 +60,6 @@ public interface LinkerInvocation {
     List<String> getCommand();
 
     void addAdditionalPreOption(String option);
+
+    List<String> getImageSymbols(boolean onlyGlobal);
 }

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/FeatureImpl.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/FeatureImpl.java
@@ -45,7 +45,6 @@ import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
-import com.oracle.svm.hosted.code.CEntryPointData;
 import org.graalvm.collections.Pair;
 import org.graalvm.compiler.debug.DebugContext;
 import org.graalvm.nativeimage.hosted.Feature;
@@ -69,6 +68,7 @@ import com.oracle.svm.core.meta.SharedType;
 import com.oracle.svm.core.meta.SubstrateObjectConstant;
 import com.oracle.svm.hosted.analysis.Inflation;
 import com.oracle.svm.hosted.c.NativeLibraries;
+import com.oracle.svm.hosted.code.CEntryPointData;
 import com.oracle.svm.hosted.code.CompilationInfoSupport;
 import com.oracle.svm.hosted.code.SharedRuntimeConfigurationBuilder;
 import com.oracle.svm.hosted.image.AbstractBootImage;
@@ -627,15 +627,16 @@ public class FeatureImpl {
 
     public static class AfterImageWriteAccessImpl extends FeatureAccessImpl implements Feature.AfterImageWriteAccess {
         private final HostedUniverse hUniverse;
-        protected final Path imagePath;
+        protected final LinkerInvocation linkerInvocation;
         protected final Path tempDirectory;
         protected final NativeImageKind imageKind;
 
-        AfterImageWriteAccessImpl(FeatureHandler featureHandler, ImageClassLoader imageClassLoader, HostedUniverse hUniverse, Path imagePath, Path tempDirectory, NativeImageKind imageKind,
+        AfterImageWriteAccessImpl(FeatureHandler featureHandler, ImageClassLoader imageClassLoader, HostedUniverse hUniverse, LinkerInvocation linkerInvocation, Path tempDirectory,
+                        NativeImageKind imageKind,
                         DebugContext debugContext) {
             super(featureHandler, imageClassLoader, debugContext);
             this.hUniverse = hUniverse;
-            this.imagePath = imagePath;
+            this.linkerInvocation = linkerInvocation;
             this.tempDirectory = tempDirectory;
             this.imageKind = imageKind;
         }
@@ -646,7 +647,7 @@ public class FeatureImpl {
 
         @Override
         public Path getImagePath() {
-            return imagePath;
+            return linkerInvocation.getOutputFile();
         }
 
         public Path getTempDirectory() {
@@ -655,6 +656,10 @@ public class FeatureImpl {
 
         public NativeImageKind getImageKind() {
             return imageKind;
+        }
+
+        public List<String> getImageSymbols(boolean onlyGlobal) {
+            return linkerInvocation.getImageSymbols(onlyGlobal);
         }
     }
 }

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/NativeImageGenerator.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/NativeImageGenerator.java
@@ -664,9 +664,8 @@ public class NativeImageGenerator {
                 if (NativeImageOptions.ExitAfterRelocatableImageWrite.getValue()) {
                     return;
                 }
-                Path imagePath = inv.getOutputFile();
 
-                AfterImageWriteAccessImpl afterConfig = new AfterImageWriteAccessImpl(featureHandler, loader, hUniverse, imagePath, tmpDir, image.getBootImageKind(), debug);
+                AfterImageWriteAccessImpl afterConfig = new AfterImageWriteAccessImpl(featureHandler, loader, hUniverse, inv, tmpDir, image.getBootImageKind(), debug);
                 featureHandler.forEachFeature(feature -> feature.afterImageWrite(afterConfig));
             }
         }

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/image/LIRNativeImageCodeCache.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/image/LIRNativeImageCodeCache.java
@@ -30,6 +30,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.concurrent.ForkJoinPool;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
 import org.graalvm.compiler.code.CompilationResult;
@@ -214,10 +215,11 @@ public class LIRNativeImageCodeCache extends NativeImageCodeCache {
     }
 
     @Override
-    public List<ObjectFile.Symbol> getGlobalSymbols(ObjectFile objectFile) {
-        return StreamSupport.stream(objectFile.getSymbolTable().spliterator(), false)
-                        .filter(ObjectFile.Symbol::isGlobal)
-                        .filter(ObjectFile.Symbol::isDefined)
-                        .collect(Collectors.toList());
+    public List<ObjectFile.Symbol> getSymbols(ObjectFile objectFile, boolean onlyGlobal) {
+        Stream<ObjectFile.Symbol> stream = StreamSupport.stream(objectFile.getSymbolTable().spliterator(), false);
+        if (onlyGlobal) {
+            stream = stream.filter(ObjectFile.Symbol::isGlobal);
+        }
+        return stream.filter(ObjectFile.Symbol::isDefined).collect(Collectors.toList());
     }
 }

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/image/NativeBootImageViaCC.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/image/NativeBootImageViaCC.java
@@ -102,14 +102,14 @@ public abstract class NativeBootImageViaCC extends NativeBootImage {
              */
             if (!SubstrateOptions.StaticExecutable.getValue()) {
                 try {
-                    List<String> exportedSymbols = new ArrayList<>();
-                    exportedSymbols.add("{");
-                    codeCache.getGlobalSymbols(getOrCreateDebugObjectFile()).stream()
-                                    .map(symbol -> "\"" + symbol.getName() + "\";")
-                                    .forEachOrdered(exportedSymbols::add);
-                    exportedSymbols.add("};");
+                    StringBuilder exportedSymbols = new StringBuilder();
+                    exportedSymbols.append("{\n");
+                    for (String symbol : getImageSymbols(true)) {
+                        exportedSymbols.append('\"').append(symbol).append("\";\n");
+                    }
+                    exportedSymbols.append("};");
                     Path exportedSymbolsPath = nativeLibs.tempDirectory.resolve("exported_symbols.list");
-                    Files.write(exportedSymbolsPath, exportedSymbols);
+                    Files.write(exportedSymbolsPath, Collections.singleton(exportedSymbols.toString()));
                     additionalPreOptions.add("-Wl,--dynamic-list");
                     additionalPreOptions.add("-Wl," + exportedSymbolsPath.toAbsolutePath());
 
@@ -126,6 +126,13 @@ public abstract class NativeBootImageViaCC extends NativeBootImage {
 
             LibCBase currentLibc = ImageSingletons.lookup(LibCBase.class);
             additionalPreOptions.addAll(currentLibc.getLinkerPreOptions());
+        }
+
+        @Override
+        public List<String> getImageSymbols(boolean onlyGlobal) {
+            return codeCache.getSymbols(getOrCreateDebugObjectFile(), onlyGlobal).stream()
+                            .map(ObjectFile.Symbol::getName)
+                            .collect(Collectors.toList());
         }
 
         @Override
@@ -163,11 +170,8 @@ public abstract class NativeBootImageViaCC extends NativeBootImage {
              * as global symbols in the dynamic symbol table of the image.
              */
             try {
-                List<ObjectFile.Symbol> exportedSymbols = codeCache.getGlobalSymbols(getOrCreateDebugObjectFile());
                 Path exportedSymbolsPath = nativeLibs.tempDirectory.resolve("exported_symbols.list");
-                Files.write(exportedSymbolsPath, exportedSymbols.stream()
-                                .map(symbol -> ((MachOSymtab.Entry) symbol).getNameInObject())
-                                .collect(Collectors.toList()));
+                Files.write(exportedSymbolsPath, getImageSymbols(true));
                 additionalPreOptions.add("-Wl,-exported_symbols_list");
                 additionalPreOptions.add("-Wl," + exportedSymbolsPath.toAbsolutePath());
             } catch (IOException e) {
@@ -184,6 +188,13 @@ public abstract class NativeBootImageViaCC extends NativeBootImage {
             } else if (Platform.includedIn(Platform.AARCH64.class)) {
                 additionalPreOptions.add("arm64");
             }
+        }
+
+        @Override
+        public List<String> getImageSymbols(boolean onlyGlobal) {
+            return codeCache.getSymbols(getOrCreateDebugObjectFile(), onlyGlobal).stream()
+                            .map(symbol -> ((MachOSymtab.Entry) symbol).getNameInObject())
+                            .collect(Collectors.toList());
         }
 
         @Override
@@ -220,6 +231,13 @@ public abstract class NativeBootImageViaCC extends NativeBootImage {
                 default:
                     VMError.shouldNotReachHere();
             }
+        }
+
+        @Override
+        public List<String> getImageSymbols(boolean onlyGlobal) {
+            return codeCache.getSymbols(getOrCreateDebugObjectFile(), onlyGlobal).stream()
+                            .map(ObjectFile.Symbol::getName)
+                            .collect(Collectors.toList());
         }
 
         @Override

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/image/NativeImageCodeCache.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/image/NativeImageCodeCache.java
@@ -304,7 +304,7 @@ public abstract class NativeImageCodeCache {
         return new Path[]{tempDirectory.resolve(imageName + ObjectFile.getFilenameSuffix())};
     }
 
-    public abstract List<ObjectFile.Symbol> getGlobalSymbols(ObjectFile objectFile);
+    public abstract List<ObjectFile.Symbol> getSymbols(ObjectFile objectFile, boolean onlyGlobal);
 
     public Map<HostedMethod, CompilationResult> getCompilations() {
         return compilations;


### PR DESCRIPTION
To allow post-processing of image binaries after linking it is sometimes necessary to know the symbols that correspond to the AOT-compiled methods. To make that accessible
`List<String> AfterImageWriteAccessImpl.getImageSymbols(boolean onlyGlobal)` is added.