### PR TITLE
sulong: Blacklist failing interop tests on AArch64

### DIFF
--- a/sulong/tests/com.oracle.truffle.llvm.tests/src/com/oracle/truffle/llvm/tests/interop/DerefHandleTest.java
+++ b/sulong/tests/com.oracle.truffle.llvm.tests/src/com/oracle/truffle/llvm/tests/interop/DerefHandleTest.java
@@ -33,6 +33,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.junit.Assert;
+import org.junit.Assume;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -44,6 +45,7 @@ import com.oracle.truffle.api.interop.UnsupportedMessageException;
 import com.oracle.truffle.llvm.tests.interop.values.NativeValue;
 import com.oracle.truffle.llvm.tests.interop.values.StructObject;
 import com.oracle.truffle.llvm.tests.interop.values.TestCallback;
+import com.oracle.truffle.llvm.tests.Platform;
 import com.oracle.truffle.tck.TruffleRunner;
 import com.oracle.truffle.tck.TruffleRunner.Inject;
 
@@ -165,6 +167,7 @@ public class DerefHandleTest extends InteropTestBase {
 
     @Test
     public void testCallDerefHandleMember(@Inject(TestCallDerefHandlemMemberNode.class) CallTarget callDerefHandleMember) {
+        Assume.assumeFalse("Skipping AArch64 failing test", Platform.isAArch64());
         Object actual = callDerefHandleMember.call(new StructObject(makePointObject()), 3L, 7L);
         Assert.assertEquals(10L, actual);
     }

--- a/sulong/tests/com.oracle.truffle.llvm.tests/src/com/oracle/truffle/llvm/tests/interop/TypedExportTest.java
+++ b/sulong/tests/com.oracle.truffle.llvm.tests/src/com/oracle/truffle/llvm/tests/interop/TypedExportTest.java
@@ -30,10 +30,12 @@
 package com.oracle.truffle.llvm.tests.interop;
 
 import com.oracle.truffle.llvm.tests.interop.values.NullValue;
+import com.oracle.truffle.llvm.tests.Platform;
 import java.util.Set;
 import org.graalvm.polyglot.Value;
 import org.junit.BeforeClass;
 import org.junit.Assert;
+import org.junit.Assume;
 import org.junit.Test;
 
 public class TypedExportTest extends InteropTestBase {
@@ -242,6 +244,7 @@ public class TypedExportTest extends InteropTestBase {
 
     @Test
     public void testAliasedPointer() {
+        Assume.assumeFalse("Skipping AArch64 failing test", Platform.isAArch64());
         Value nested = allocNested.execute();
         try {
             Value pointArray = nested.getMember("pointArray");

--- a/sulong/tests/com.oracle.truffle.llvm.tests/src/com/oracle/truffle/llvm/tests/interop/TypedInteropTest.java
+++ b/sulong/tests/com.oracle.truffle.llvm.tests/src/com/oracle/truffle/llvm/tests/interop/TypedInteropTest.java
@@ -35,6 +35,7 @@ import com.oracle.truffle.llvm.tests.interop.values.ArrayObject;
 import com.oracle.truffle.llvm.tests.interop.values.NullValue;
 import com.oracle.truffle.llvm.tests.interop.values.StructObject;
 import com.oracle.truffle.llvm.tests.interop.values.TestCallback;
+import com.oracle.truffle.llvm.tests.Platform;
 import com.oracle.truffle.tck.TruffleRunner;
 import com.oracle.truffle.tck.TruffleRunner.Inject;
 import java.util.HashMap;
@@ -44,6 +45,7 @@ import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import org.junit.BeforeClass;
 import org.junit.Assert;
+import org.junit.Assume;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -292,6 +294,7 @@ public class TypedInteropTest extends InteropTestBase {
 
     @Test
     public void testSumPoints(@Inject(SumPointsNode.class) CallTarget sumPoints) {
+        Assume.assumeFalse("Skipping AArch64 failing test", Platform.isAArch64());
         ArrayObject array = new ArrayObject(makePoint(13, 7), makePoint(3, 6), makePoint(8, 5));
         Object ret = sumPoints.call(array);
         Assert.assertEquals(42, ret);
@@ -306,6 +309,7 @@ public class TypedInteropTest extends InteropTestBase {
 
     @Test
     public void testFillPoints(@Inject(FillPointsNode.class) CallTarget fillPoints) {
+        Assume.assumeFalse("Skipping AArch64 failing test", Platform.isAArch64());
         StructObject[] arr = new StructObject[42];
         for (int i = 0; i < arr.length; i++) {
             arr[i] = makePoint(0, 0);
@@ -344,6 +348,7 @@ public class TypedInteropTest extends InteropTestBase {
 
     @Test
     public void testAddAndSwapPoint(@Inject(AddAndSwapPoint.class) CallTarget addAndSwapPoint) {
+        Assume.assumeFalse("Skipping AArch64 failing test", Platform.isAArch64());
         StructObject point = makePoint(39, 17);
         Object ret = addAndSwapPoint.call(point, 3, 7);
 
@@ -392,6 +397,7 @@ public class TypedInteropTest extends InteropTestBase {
 
     @Test
     public void testFillNested(@Inject(FillNestedNode.class) CallTarget fillNested) {
+        Assume.assumeFalse("Skipping AArch64 failing test", Platform.isAArch64());
         Object nested = createNested();
         fillNested.call(nested);
         checkNested(nested);
@@ -452,6 +458,7 @@ public class TypedInteropTest extends InteropTestBase {
 
     @Test
     public void testFillFusedArray(@Inject(FillFusedArrayNode.class) CallTarget fillFusedArray) {
+        Assume.assumeFalse("Skipping AArch64 failing test", Platform.isAArch64());
         Object fusedArray = createFusedArray();
         fillFusedArray.call(fusedArray);
         checkFusedArray(fusedArray);


### PR DESCRIPTION
More failing tests.

I've also written up the current status of AArch64 here: https://github.com/oracle/graal/issues/2276