### PR TITLE
Fix 2287 - ImageClassLoader should only hold on to method/field that have annotations

### DIFF
--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/ImageClassLoader.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/ImageClassLoader.java
@@ -257,10 +257,31 @@ public final class ImageClassLoader {
         }
     }
 
-    private static boolean annotationsAvailable(AnnotatedElement element) {
+    /**
+     * @param element The element to check
+     * @return Returns true if the annotations on the {@code element} can be loaded without any
+     *         errors.
+     */
+    private static boolean canLoadAnnotations(AnnotatedElement element) {
         try {
             element.getAnnotations();
             return true;
+        } catch (Throwable t) {
+            handleClassLoadingError(t);
+            return false;
+        }
+    }
+
+    /**
+     *
+     * @param element The element to check
+     * @return Returns true if and only if the the {@code element} has any annotations present and
+     *         the {@link AnnotatedElement#getAnnotations()} did not throw any error.
+     */
+    private static boolean annotationsAvailable(AnnotatedElement element) {
+        try {
+            final Annotation[] annotations = element.getAnnotations();
+            return annotations.length != 0;
         } catch (Throwable t) {
             handleClassLoadingError(t);
             return false;
@@ -362,7 +383,7 @@ public final class ImageClassLoader {
             cur = clazz;
         }
         do {
-            if (!annotationsAvailable(cur)) {
+            if (!canLoadAnnotations(cur)) {
                 return;
             }
             Platforms platformsAnnotation = cur.getAnnotation(Platforms.class);


### PR DESCRIPTION
The commit in this PR fixes the issue noted in https://github.com/oracle/graal/issues/2287.

This commit changes the implementation of `annotationsAvailable` (private) method to return `true` only if there are any annotations available on the element. 
This commit also introduces a new `canLoadAnnotations` method which returns `true` if there were no errors like loading the annotations on an element (through the use of `AnnotatedElement#getAnnotations()`). This new method is used/necessary to retain the current semantics of how the `ImageClassLoader` decides to hold on to "hosted only classes" and "application classes" (i.e. these classes are held on to, even if they don't have any annotations, since those classes are then checked/used when there's a call on the `ImageClassLoader` to find any sub-classes of a specific type).

Here's the exact difference in the number of methods and fields against a sample application (based on Quarkus) that this `ImageClassLoader` holds on to:

Without this fix:
--------------------
Application classes 25419
Hosted only classes 640
System methods 202701
System fields 61007

With this fix:
----------------
Application classes 25419
Hosted only classes 640
System methods 16698
System fields 5925

Notice the drastic difference in numbers of methods and fields. I've run a bunch of Quarkus native image application tests with this change and haven't noticed any issues/regressions in the actual functionality.