### PR TITLE
Package is wrong for shouldIgnoreJniMethodLookup

### DIFF
--- a/substratevm/src/com.oracle.svm.configure/src/com/oracle/svm/configure/trace/AccessAdvisor.java
+++ b/substratevm/src/com.oracle.svm.configure/src/com/oracle/svm/configure/trace/AccessAdvisor.java
@@ -104,12 +104,12 @@ public final class AccessAdvisor {
         }
         // Ignore libjvmcicompiler internal JNI calls:
         // * jdk.vm.ci.services.Services.getJVMCIClassLoader
-        // * org.graalvm.compiler.hotspot.management.libgraal.runtime.SVMToHotSpotEntryPoints
+        // * org.graalvm.compiler.hotspot.management.SVMToHotSpotEntryPoints
         if (callerClass.get() == null && "jdk.vm.ci.services.Services".equals(queriedClass.get()) && "getJVMCIClassLoader".equals(name.get()) &&
                         "()Ljava/lang/ClassLoader;".equals(signature.get())) {
             return true;
         }
-        if (callerClass.get() == null && "org.graalvm.compiler.hotspot.management.libgraal.runtime.SVMToHotSpotEntryPoints".equals(queriedClass.get())) {
+        if (callerClass.get() == null && "org.graalvm.compiler.hotspot.management.SVMToHotSpotEntryPoints".equals(queriedClass.get())) {
             return true;
         }
         /*


### PR DESCRIPTION
Package name was wrong for the class to be ignored. This patch can fix the following build time error:

```
Error: type is not available in this platform: org.graalvm.compiler.hotspot.management.SVMToHotSpotEntryPoints
com.oracle.svm.core.util.UserError$UserException: type is not available in this platform: org.graalvm.compiler.hotspot.management.SVMToHotSpotEntryPoints
        at com.oracle.svm.core.util.UserError.abort(UserError.java:79)
        at com.oracle.svm.hosted.FallbackFeature.reportAsFallback(FallbackFeature.java:221)
        at com.oracle.svm.hosted.NativeImageGenerator.runPointsToAnalysis(NativeImageGenerator.java:756)
        at com.oracle.svm.hosted.NativeImageGenerator.doRun(NativeImageGenerator.java:540)
        at com.oracle.svm.hosted.NativeImageGenerator.lambda$run$0(NativeImageGenerator.java:453)
        at java.util.concurrent.ForkJoinTask$AdaptedRunnableAction.exec(ForkJoinTask.java:1386)
        at java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:289)
        at java.util.concurrent.ForkJoinPool$WorkQueue.runTask(ForkJoinPool.java:1056)
        at java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1692)
        at java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:157)
Caused by: com.oracle.graal.pointsto.constraints.UnsupportedFeatureException: type is not available in this platform: org.graalvm.compiler.hotspot.management.SVMToHotSpotEntryPoints
        at com.oracle.graal.pointsto.meta.AnalysisUniverse.createType(AnalysisUniverse.java:214)
        at com.oracle.graal.pointsto.meta.AnalysisUniverse.lookupAllowUnresolved(AnalysisUniverse.java:205)
        at com.oracle.graal.pointsto.meta.AnalysisUniverse.lookup(AnalysisUniverse.java:182)
        at com.oracle.graal.pointsto.meta.AnalysisUniverse.lookup(AnalysisUniverse.java:75)
        at com.oracle.graal.pointsto.infrastructure.UniverseMetaAccess$1.apply(UniverseMetaAccess.java:52)
        at com.oracle.graal.pointsto.infrastructure.UniverseMetaAccess$1.apply(UniverseMetaAccess.java:49)
        at java.util.concurrent.ConcurrentHashMap.computeIfAbsent(ConcurrentHashMap.java:1660)
        at com.oracle.graal.pointsto.infrastructure.UniverseMetaAccess.lookupJavaType(UniverseMetaAccess.java:84)
        at com.oracle.graal.pointsto.meta.AnalysisMetaAccess.lookupJavaType(AnalysisMetaAccess.java:47)
        at com.oracle.svm.hosted.substitute.SubstitutionReflectivityFilter.shouldExclude(SubstitutionReflectivityFilter.java:46)
        at com.oracle.svm.jni.access.JNIAccessFeature.addClass(JNIAccessFeature.java:243)
        at com.oracle.svm.jni.access.JNIAccessFeature.duringAnalysis(JNIAccessFeature.java:222)
        at com.oracle.svm.hosted.NativeImageGenerator.lambda$runPointsToAnalysis$8(NativeImageGenerator.java:723)
        at com.oracle.svm.hosted.FeatureHandler.forEachFeature(FeatureHandler.java:63)
        at com.oracle.svm.hosted.NativeImageGenerator.runPointsToAnalysis(NativeImageGenerator.java:723)
        ... 7 more
```
