### PR TITLE
Support dynamic class loading and serialization

### DIFF
--- a/substratevm/src/com.oracle.svm.agent/src/com/oracle/svm/agent/DynamicClassGenerationSupport.java
+++ b/substratevm/src/com.oracle.svm.agent/src/com/oracle/svm/agent/DynamicClassGenerationSupport.java
@@ -1,0 +1,176 @@
+/*
+ * Copyright (c) 2019, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020 Alibaba Group Holding Limited. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package com.oracle.svm.agent;
+
+import static com.oracle.svm.jvmtiagentbase.Support.jniFunctions;
+import static com.oracle.svm.jvmtiagentbase.Support.jvmtiFunctions;
+import static com.oracle.svm.jvmtiagentbase.Support.jvmtiEnv;
+import static com.oracle.svm.jvmtiagentbase.Support.getClassNameOrNull;
+import static com.oracle.svm.jvmtiagentbase.Support.getMethodDeclaringClass;
+import static com.oracle.svm.jvmtiagentbase.Support.getMethodName;
+import static com.oracle.svm.jni.JNIObjectHandles.nullHandle;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import com.oracle.svm.jvmtiagentbase.jvmti.JvmtiError;
+import com.oracle.svm.jvmtiagentbase.jvmti.JvmtiFrameInfo;
+import com.oracle.svm.jni.nativeapi.JNIMethodId;
+import org.graalvm.nativeimage.StackValue;
+import org.graalvm.nativeimage.c.type.CCharPointer;
+import org.graalvm.nativeimage.c.type.CIntPointer;
+import org.graalvm.nativeimage.c.type.CTypeConversion;
+import org.graalvm.word.WordFactory;
+
+import com.oracle.svm.jni.nativeapi.JNIEnvironment;
+import com.oracle.svm.jni.nativeapi.JNIObjectHandle;
+
+public abstract class DynamicClassGenerationSupport {
+
+    protected JNIEnvironment jni;
+    protected JNIObjectHandle callerClass;
+    protected final String generatedClassName;
+    protected TraceWriter traceWriter;
+    protected NativeImageAgent agent;
+
+    private static String dynclassDumpDir = null;
+    private static final String DEFAULT_DUMP = "dynClass";
+
+    static {
+        // Delete the dumping directory if already exists
+        if (dynclassDumpDir == null) {
+            System.out.println("Warning: dynmaic-class-dump-dir= was not set in -agentlib:native-image-agent=, using default location dynClass");
+            dynclassDumpDir = DEFAULT_DUMP;
+        }
+        Path dumpDir = new File(dynclassDumpDir).toPath();
+        try {
+            if (!Files.exists(dumpDir)) {
+                Files.createDirectory(dumpDir);
+            }
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    protected byte[] values = null;
+
+    public static void setDynClassDumpDir(String dir) {
+        dynclassDumpDir = dir;
+    }
+
+    public static DynamicClassGenerationSupport getSerializeSupport(JNIEnvironment jni, JNIObjectHandle callerClass,
+                    JNIObjectHandle serializationTargetClass, String generatedClassName, JNIObjectHandle targetParentClass,
+                    TraceWriter traceWriter, NativeImageAgent agent) {
+        return new SerializationSupport(jni, callerClass, serializationTargetClass, generatedClassName, targetParentClass, traceWriter, agent);
+    }
+
+    public static DynamicClassGenerationSupport getDynamicClassGenerationSupport(JNIEnvironment jni, JNIObjectHandle callerClass,
+                    String generatedClassName, TraceWriter traceWriter, NativeImageAgent agent) {
+        return new DynamicDefineClassSupport(jni, callerClass, generatedClassName, traceWriter, agent);
+    }
+
+    protected DynamicClassGenerationSupport(JNIEnvironment jni, JNIObjectHandle callerClass,
+                    String generatedClassName, TraceWriter traceWriter, NativeImageAgent agent) {
+        this.jni = jni;
+        this.callerClass = callerClass;
+        // Make sure use qualified name for generatedClassName
+        if (generatedClassName.indexOf('/') != -1) {
+            this.generatedClassName = generatedClassName.replace('/', '.');
+        } else {
+            this.generatedClassName = generatedClassName;
+        }
+        this.traceWriter = traceWriter;
+        this.agent = agent;
+    }
+
+    public abstract boolean traceReflects();
+
+    protected abstract JNIObjectHandle getClassDefinitionAsBytes();
+
+    protected abstract int getClassDefinitionBytesLength();
+
+    /**
+     * Save dynamically defined class to file system.
+     *
+     * @return true if successfully dumped
+     */
+    public boolean dumpDefinedClass() {
+        // bytes parameter of defineClass method
+        JNIObjectHandle bytes = getClassDefinitionAsBytes();
+        // len parameter of defineClass method
+        int length = getClassDefinitionBytesLength();
+        // Get generated class' byte array
+        CCharPointer byteArray = jniFunctions().getGetByteArrayElements().invoke(jni, bytes, WordFactory.nullPointer());
+        values = new byte[length];
+        try {
+            CTypeConversion.asByteBuffer(byteArray, length).get(values);
+        } finally {
+            jniFunctions().getReleaseByteArrayElements().invoke(jni, bytes, byteArray, 0);
+        }
+        // Get name for generated class
+        String internalName = generatedClassName;
+        if (internalName.indexOf('.') != -1) {
+            internalName = internalName.replace('.', '/');
+        }
+        String dumpFileName = dynclassDumpDir + "/" + internalName + ".class";
+        String dumpTraceFile = dynclassDumpDir + "/" + internalName + ".txt";
+        // Get directory from package
+        String dumpDirs = dumpFileName.substring(0, dumpFileName.lastIndexOf('/'));
+        try {
+            File dirs = new File(dumpDirs);
+            if (!dirs.exists()) {
+                dirs.mkdirs();
+            }
+            FileOutputStream stream = new FileOutputStream(dumpFileName);
+            stream.write(values);
+            stream.close();
+
+            JvmtiFrameInfo frameInfo = StackValue.get(JvmtiFrameInfo.class);
+            CIntPointer countPtr = StackValue.get(CIntPointer.class);
+            StringBuilder trace = new StringBuilder();
+            int i = 0;
+            while (true) {
+                JvmtiError result = jvmtiFunctions().GetStackTrace().invoke(jvmtiEnv(), nullHandle(), i++, 1, frameInfo, countPtr);
+                if (result == JvmtiError.JVMTI_ERROR_NONE && countPtr.read() == 1) {
+                    JNIMethodId m = frameInfo.getMethod();
+                    trace.append(getClassNameOrNull(jni, getMethodDeclaringClass(m))).append(".").append(getMethodName(m)).append("\n");
+                } else {
+                    break;
+                }
+            }
+            FileOutputStream traceStream = new FileOutputStream(dumpTraceFile);
+            traceStream.write(trace.toString().getBytes());
+            traceStream.close();
+        } catch (IOException e) {
+            e.printStackTrace();
+            return false;
+        }
+        return true;
+    }
+}

--- a/substratevm/src/com.oracle.svm.agent/src/com/oracle/svm/agent/DynamicDefineClassSupport.java
+++ b/substratevm/src/com.oracle.svm.agent/src/com/oracle/svm/agent/DynamicDefineClassSupport.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2019, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020 Alibaba Group Holding Limited. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package com.oracle.svm.agent;
+
+import com.oracle.svm.jni.nativeapi.JNIEnvironment;
+import static com.oracle.svm.jvmtiagentbase.Support.getIntArgument;
+import static com.oracle.svm.jvmtiagentbase.Support.getObjectArgument;
+
+import com.oracle.svm.jni.nativeapi.JNIObjectHandle;
+
+public class DynamicDefineClassSupport extends DynamicClassGenerationSupport {
+
+    protected DynamicDefineClassSupport(JNIEnvironment jni, JNIObjectHandle callerClass, String generatedClassName, TraceWriter traceWriter, NativeImageAgent agent) {
+        super(jni, callerClass, generatedClassName, traceWriter, agent);
+    }
+
+    /**
+     * When java.lang.ClassLoader.defineClass's name argument is null, the name is extract after
+     * class is defined. We use class' byte array hashcode to trace class name.
+     */
+    @Override
+    public boolean traceReflects() {
+        if (values != null) {
+            traceWriter.traceCall("reflect", "getDeclaredMethods", generatedClassName);
+            return true;
+        } else {
+            System.err.println("Class contents are null, cannot be traced. Method dumpDefinedClass() should be called beforehand to get class contents as byte array");
+            return false;
+        }
+    }
+
+    /**
+     * Get value of argument "b" from java.lang.ClassLoader. defineClass(String name, byte[] b, int
+     * off, int len, ProtectionDomain protectionDomain) "b" is the 3rd argument. because the 1st
+     * argument of instance method is always "this"
+     */
+    @Override
+    protected JNIObjectHandle getClassDefinitionAsBytes() {
+        return getObjectArgument(1, 2);
+    }
+
+    /**
+     * Get value of argument "len" from java.lang.ClassLoader. defineClass(String name, byte[] b,
+     * int off, int len, ProtectionDomain protectionDomain) "len" is the 5th argument. because the
+     * 1st argument of instance method is always "this"
+     */
+    @Override
+    protected int getClassDefinitionBytesLength() {
+        return getIntArgument(1, 4);
+    }
+}

--- a/substratevm/src/com.oracle.svm.agent/src/com/oracle/svm/agent/NativeImageAgent.java
+++ b/substratevm/src/com.oracle.svm.agent/src/com/oracle/svm/agent/NativeImageAgent.java
@@ -123,6 +123,7 @@ public final class NativeImageAgent extends JvmtiAgentBase<NativeImageAgentJNIHa
     protected int onLoadCallback(JNIJavaVM vm, JvmtiEnv jvmti, JvmtiEventCallbacks callbacks, String options) {
         String traceOutputFile = null;
         String configOutputDir = null;
+        String dynclassDumpDir = null;
         ConfigurationSet restrictConfigs = new ConfigurationSet();
         ConfigurationSet mergeConfigs = new ConfigurationSet();
         boolean restrict = false;
@@ -154,6 +155,13 @@ public final class NativeImageAgent extends JvmtiAgentBase<NativeImageAgentJNIHa
                 if (token.startsWith("config-merge-dir=")) {
                     mergeConfigs.addDirectory(Paths.get(configOutputDir));
                 }
+            } else if (token.startsWith("dynmaic-class-dump-dir=")) {
+                if (dynclassDumpDir != null) {
+                    System.err.println(MESSAGE_PREFIX + "cannot specify dynmaic-class-dump-dir= more than once.");
+                    return 1;
+                }
+                dynclassDumpDir = getTokenValue(token);
+                DynamicClassGenerationSupport.setDynClassDumpDir(dynclassDumpDir);
             } else if (token.startsWith("restrict-all-dir")) {
                 /* Used for testing */
                 restrictConfigs.addDirectory(Paths.get(getTokenValue(token)));

--- a/substratevm/src/com.oracle.svm.agent/src/com/oracle/svm/agent/NativeImageAgentJNIHandleSet.java
+++ b/substratevm/src/com.oracle.svm.agent/src/com/oracle/svm/agent/NativeImageAgentJNIHandleSet.java
@@ -24,12 +24,14 @@
  */
 package com.oracle.svm.agent;
 
+import static com.oracle.svm.core.util.VMError.guarantee;
 import static com.oracle.svm.jni.JNIObjectHandles.nullHandle;
 
 import com.oracle.svm.jvmtiagentbase.JNIHandleSet;
 import com.oracle.svm.jni.nativeapi.JNIEnvironment;
 import com.oracle.svm.jni.nativeapi.JNIMethodId;
 import com.oracle.svm.jni.nativeapi.JNIObjectHandle;
+import org.graalvm.nativeimage.c.type.CTypeConversion;
 
 public class NativeImageAgentJNIHandleSet extends JNIHandleSet {
 
@@ -38,6 +40,7 @@ public class NativeImageAgentJNIHandleSet extends JNIHandleSet {
     final JNIMethodId javaLangReflectMemberGetDeclaringClass;
     final JNIMethodId javaUtilEnumerationHasMoreElements;
     final JNIMethodId javaUtilMissingResourceExceptionCtor3;
+    public final JNIMethodId javaLangClassLoaderGetResource;
     final JNIObjectHandle javaLangClassLoader;
     public final JNIObjectHandle javaLangSecurityException;
     public final JNIObjectHandle javaLangNoClassDefFoundError;
@@ -65,6 +68,8 @@ public class NativeImageAgentJNIHandleSet extends JNIHandleSet {
         JNIObjectHandle javaLangClass = findClass(env, "java/lang/Class");
         javaLangClassForName3 = getMethodId(env, javaLangClass, "forName", "(Ljava/lang/String;ZLjava/lang/ClassLoader;)Ljava/lang/Class;", true);
 
+        javaLangClassLoaderGetResource = getMethodId(env, findClass(env, "java/lang/ClassLoader"), "getResource", "(Ljava/lang/String;)Ljava/net/URL;", false);
+
         JNIObjectHandle javaLangReflectMember = findClass(env, "java/lang/reflect/Member");
         javaLangReflectMemberGetName = getMethodId(env, javaLangReflectMember, "getName", "()Ljava/lang/String;", false);
         javaLangReflectMemberGetDeclaringClass = getMethodId(env, javaLangReflectMember, "getDeclaringClass", "()Ljava/lang/Class;", false);
@@ -72,8 +77,8 @@ public class NativeImageAgentJNIHandleSet extends JNIHandleSet {
         JNIObjectHandle javaUtilEnumeration = findClass(env, "java/util/Enumeration");
         javaUtilEnumerationHasMoreElements = getMethodId(env, javaUtilEnumeration, "hasMoreElements", "()Z", false);
 
-        javaLangClassLoader = newClassGlobalRef(env, "java/lang/ClassLoader");
         javaLangSecurityException = newClassGlobalRef(env, "java/lang/SecurityException");
+        javaLangClassLoader = newClassGlobalRef(env, "java/lang/ClassLoader");
         javaLangNoClassDefFoundError = newClassGlobalRef(env, "java/lang/NoClassDefFoundError");
         javaLangNoSuchMethodError = newClassGlobalRef(env, "java/lang/NoSuchMethodError");
         javaLangNoSuchMethodException = newClassGlobalRef(env, "java/lang/NoSuchMethodException");

--- a/substratevm/src/com.oracle.svm.agent/src/com/oracle/svm/agent/SerializationSupport.java
+++ b/substratevm/src/com.oracle.svm.agent/src/com/oracle/svm/agent/SerializationSupport.java
@@ -1,0 +1,173 @@
+/*
+ * Copyright (c) 2019, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020 Alibaba Group Holding Limited. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package com.oracle.svm.agent;
+
+import static com.oracle.svm.jvmtiagentbase.Support.fromJniString;
+import static com.oracle.svm.jvmtiagentbase.Support.getClassNameOrNull;
+import static com.oracle.svm.jvmtiagentbase.Support.getIntArgument;
+import static com.oracle.svm.jvmtiagentbase.Support.getObjectArgument;
+import static com.oracle.svm.jvmtiagentbase.Support.jniFunctions;
+
+import java.lang.reflect.Modifier;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static com.oracle.svm.jni.JNIObjectHandles.nullHandle;
+
+import com.oracle.svm.jni.nativeapi.JNIEnvironment;
+import com.oracle.svm.jni.nativeapi.JNIFunctionPointerTypes.CallIntMethodFunctionPointer;
+import com.oracle.svm.jni.nativeapi.JNIFunctionPointerTypes.CallObjectMethod0FunctionPointer;
+import com.oracle.svm.jni.nativeapi.JNIMethodId;
+import com.oracle.svm.jni.nativeapi.JNIObjectHandle;
+
+public class SerializationSupport extends DynamicClassGenerationSupport {
+    private JNIObjectHandle serializationTargetClass;
+    private JNIObjectHandle targetParentClass;
+
+    public SerializationSupport(JNIEnvironment jni, JNIObjectHandle callerClass, JNIObjectHandle serializationTargetClass, String generatedClassName, JNIObjectHandle targetParentClass,
+                    TraceWriter traceWriter, NativeImageAgent agent) {
+        super(jni, callerClass, generatedClassName, traceWriter, agent);
+        this.serializationTargetClass = serializationTargetClass;
+        this.targetParentClass = targetParentClass;
+    }
+
+    @Override
+    protected JNIObjectHandle getClassDefinitionAsBytes() {
+        return getObjectArgument(1);
+    }
+
+    @Override
+    protected int getClassDefinitionBytesLength() {
+        return getIntArgument(3);
+    }
+
+    /**
+     * Serialization/deserialization visits the target class' certain constructors, fields and
+     * methods by reflection. This method add configurations for those reflection accesses.
+     */
+    @Override
+    public boolean traceReflects() {
+        // trace the newInstance call for the generated class
+        traceWriter.traceCall("reflect", "newInstance", generatedClassName);
+        // trace all declaredConstructors
+        BreakpointInterceptor.traceBreakpoint(jni, serializationTargetClass, nullHandle(), callerClass, "getDeclaredConstructors", null);
+        int privateStaticFinalMask = Modifier.PRIVATE | Modifier.STATIC | Modifier.FINAL;
+        int staticFinalMask = Modifier.STATIC | Modifier.FINAL;
+        CallObjectMethod0FunctionPointer noArgRetObjectCall = jniFunctions().getCallObjectMethod();
+        CallIntMethodFunctionPointer noArgRetIntCall = jniFunctions().getCallIntMethod();
+        // call serializationTargetClass.getDeclaredFields();
+        JNIObjectHandle javaLangClass = agent.handles().findClass(jni, "java/lang/Class");
+        JNIMethodId getDeclaredFieldsMI = agent.handles().getMethodId(jni, javaLangClass, "getDeclaredFields",
+                        "()[Ljava/lang/reflect/Field;", false);
+        JNIObjectHandle fieldsJArray = noArgRetObjectCall.invoke(jni, serializationTargetClass, getDeclaredFieldsMI);
+
+        // Prepare JNIMethodIds for later calls
+        JNIObjectHandle javaLangReflectField = agent.handles().findClass(jni, "java/lang/reflect/Field");
+        JNIMethodId getFieldNameId = agent.handles().getMethodId(jni, javaLangReflectField, "getName", "()Ljava/lang/String;", false);
+        JNIMethodId getFieldModifiersId = agent.handles().getMethodId(jni, javaLangReflectField, "getModifiers", "()I", false);
+        JNIMethodId getFieldTypeId = agent.handles().getMethodId(jni, javaLangReflectField, "getType", "()Ljava/lang/Class;", false);
+        // Add serialize and deserialize fields into reflection configs
+        // Check each field
+        int fieldArrayLength = jniFunctions().getGetArrayLength().invoke(jni, fieldsJArray);
+        for (int i = 0; i < fieldArrayLength; i++) {
+            // Get field object from array
+            JNIObjectHandle field = jniFunctions().getGetObjectArrayElement().invoke(jni, fieldsJArray, i);
+            // call field.getName()
+            JNIObjectHandle fieldNameJString = noArgRetObjectCall.invoke(jni, field, getFieldNameId);
+            String fieldName = fromJniString(jni, fieldNameJString);
+
+            // call field.getModifiers
+            int modifiers = noArgRetIntCall.invoke(jni, field, getFieldModifiersId);
+            if (fieldName.equals("serialPersistentFields") &&
+                            (modifiers & privateStaticFinalMask) == privateStaticFinalMask) {
+                BreakpointInterceptor.traceBreakpoint(jni, serializationTargetClass, nullHandle(), callerClass, "getDeclaredField", true,
+                                "serialPersistentFields");
+            } else if (fieldName.equals("serialVersionUID") &&
+                            (modifiers & staticFinalMask) == staticFinalMask) {
+                BreakpointInterceptor.traceBreakpoint(jni, serializationTargetClass, nullHandle(), callerClass, "getDeclaredField", true,
+                                "serialVersionUID");
+            } else if ((modifiers & staticFinalMask) != staticFinalMask) {
+                // Set the field's allowWrite and unsafeAccess properties
+                BreakpointInterceptor.traceBreakpoint(jni, serializationTargetClass, nullHandle(), callerClass, "getDeclaredField",
+                                ((modifiers & Modifier.FINAL) == Modifier.FINAL), ((modifiers & Modifier.STATIC) == 0), true, fieldName);
+            }
+            // Add field's class in config
+            // call field.getType()
+            JNIObjectHandle fieldClass = noArgRetObjectCall.invoke(jni, field, getFieldTypeId);
+            BreakpointInterceptor.traceBreakpoint(jni, javaLangClass, nullHandle(), callerClass, "forName", true, getClassNameOrNull(jni, fieldClass));
+        }
+
+        // Add serialize and deserialize methods into reflection configs
+        // Get all methods in the class.
+        JNIMethodId getDeclaredMethodssMI = agent.handles().getMethodId(jni, javaLangClass, "getDeclaredMethods",
+                        "()[Ljava/lang/reflect/Method;", false);
+        JNIObjectHandle methodsJArray = noArgRetObjectCall.invoke(jni, serializationTargetClass, getDeclaredMethodssMI);
+
+        JNIObjectHandle javaLangReflectMethod = agent.handles().findClass(jni, "java/lang/reflect/Method");
+        JNIMethodId getMethodNameId = agent.handles().getMethodId(jni, javaLangReflectMethod, "getName", "()Ljava/lang/String;", false);
+        // Check each method
+        int methodArrayLength = jniFunctions().getGetArrayLength().invoke(jni, methodsJArray);
+        for (int i = 0; i < methodArrayLength; i++) {
+            // Get method object from array
+            JNIObjectHandle method = jniFunctions().getGetObjectArrayElement().invoke(jni, methodsJArray, i);
+            // call field.getName()
+            JNIObjectHandle methodNameJString = noArgRetObjectCall.invoke(jni, method, getMethodNameId);
+            String methodName = fromJniString(jni, methodNameJString);
+
+            List<String> parameterTypes;
+            switch (methodName) {
+                case "readObject":
+                    parameterTypes = Arrays.asList("java.io.ObjectInputStream");
+                    break;
+                case "writeObject":
+                    parameterTypes = Arrays.asList("java.io.ObjectOutputStream");
+                    break;
+                case "readObjectNoData":
+                case "writeReplace":
+                case "readResolve":
+                    parameterTypes = new ArrayList<>();
+                    break;
+                default:
+                    // Don't need to config other methods
+                    continue;
+            }
+
+            Object[] args = new Object[2];
+            args[0] = methodName;
+            args[1] = parameterTypes;
+            BreakpointInterceptor.traceBreakpoint(jni, serializationTargetClass, nullHandle(), callerClass, "getMethod", true, args);
+        }
+
+        // Add constructor of first non-serializable parent class
+        String superClassName = getClassNameOrNull(jni, targetParentClass);
+        if (superClassName != null) {
+            traceWriter.traceCall("reflect", "getConstructor", superClassName, new ArrayList<>());
+        }
+        return true;
+    }
+
+}

--- a/substratevm/src/com.oracle.svm.agent/src/com/oracle/svm/agent/TraceWriter.java
+++ b/substratevm/src/com.oracle.svm.agent/src/com/oracle/svm/agent/TraceWriter.java
@@ -89,6 +89,23 @@ public abstract class TraceWriter implements Closeable {
      * @param args Arguments to the call, which may contain arrays (which can contain more arrays)
      */
     public void traceCall(String tracer, String function, Object clazz, Object declaringClass, Object callerClass, Object result, Object... args) {
+        Map<String, Object> entry = createTraceEntry(tracer, function, clazz, declaringClass, callerClass, result,
+                        args);
+        traceEntry(entry);
+    }
+
+    public void traceCall(String tracer, String function, Object clazz, Object declaringClass, Object callerClass,
+                    Object result, boolean allowWrite, boolean unsafeAccess, String fieldName) {
+        Map<String, Object> entry = createTraceEntry(tracer, function, clazz, declaringClass, callerClass, result,
+                        fieldName);
+        entry.put("allowWrite", allowWrite);
+        entry.put("unsafeAccess", unsafeAccess);
+        traceEntry(entry);
+    }
+
+    @SuppressWarnings("static-method")
+    private Map<String, Object> createTraceEntry(String tracer, String function, Object clazz, Object declaringClass,
+                    Object callerClass, Object result, Object... args) {
         Map<String, Object> entry = new HashMap<>();
         entry.put("tracer", tracer);
         entry.put("function", function);
@@ -103,6 +120,19 @@ public abstract class TraceWriter implements Closeable {
         }
         if (result != null) {
             entry.put("result", handleSpecialValue(result));
+        }
+        if (args != null) {
+            entry.put("args", handleSpecialValue(args));
+        }
+        return entry;
+    }
+
+    public void traceCall(String tracer, String function, String clazz, Object... args) {
+        Map<String, Object> entry = new HashMap<>();
+        entry.put("tracer", tracer);
+        entry.put("function", function);
+        if (clazz != null) {
+            entry.put("class", clazz);
         }
         if (args != null) {
             entry.put("args", handleSpecialValue(args));

--- a/substratevm/src/com.oracle.svm.configure/src/com/oracle/svm/configure/config/TypeConfiguration.java
+++ b/substratevm/src/com.oracle.svm.configure/src/com/oracle/svm/configure/config/TypeConfiguration.java
@@ -63,7 +63,12 @@ public class TypeConfiguration implements JsonPrintable {
         }
         if (n > 0) { // transform to Java source syntax
             StringBuilder sb = new StringBuilder(s.length() + n);
-            sb.append(s, n + 1, s.length() - 1); // cut off leading '[' and 'L' and trailing ';'
+            if (s.charAt(n) == 'L' && s.charAt(s.length() - 1) == ';') {
+                sb.append(s, n + 1, s.length() - 1); // cut off leading '[' and 'L' and trailing ';'
+            } else {
+                return types.computeIfAbsent(s, ConfigurationType::new);
+            }
+
             for (int i = 0; i < n; i++) {
                 sb.append("[]");
             }

--- a/substratevm/src/com.oracle.svm.configure/src/com/oracle/svm/configure/trace/AccessAdvisor.java
+++ b/substratevm/src/com.oracle.svm.configure/src/com/oracle/svm/configure/trace/AccessAdvisor.java
@@ -51,6 +51,13 @@ public final class AccessAdvisor {
         internalCallerFilter.addOrGetChildren("jdk.**", RuleNode.Inclusion.Exclude);
         internalCallerFilter.addOrGetChildren("org.graalvm.compiler.**", RuleNode.Inclusion.Exclude);
         internalCallerFilter.addOrGetChildren("org.graalvm.libgraal.**", RuleNode.Inclusion.Exclude);
+        // For dynamically generated classes and serializations
+        internalCallerFilter.addOrGetChildren("sun.reflect.MethodAccessorGenerator$1", RuleNode.Inclusion.Include);
+        internalCallerFilter.addOrGetChildren("java.io.ObjectInputStream", RuleNode.Inclusion.Include);
+        internalCallerFilter.addOrGetChildren("java.io.ObjectOutputStream", RuleNode.Inclusion.Include);
+        internalCallerFilter.addOrGetChildren("java.io.ObjectStreamClass", RuleNode.Inclusion.Include);
+        internalCallerFilter.addOrGetChildren("com.sun.org.apache.**", RuleNode.Inclusion.Include);
+        internalCallerFilter.addOrGetChildren("javax.xml.**", RuleNode.Inclusion.Include);
         internalCallerFilter.removeRedundantNodes();
 
         accessWithoutCallerFilter = RuleNode.createRoot();

--- a/substratevm/src/com.oracle.svm.configure/src/com/oracle/svm/configure/trace/ReflectionProcessor.java
+++ b/substratevm/src/com.oracle.svm.configure/src/com/oracle/svm/configure/trace/ReflectionProcessor.java
@@ -143,7 +143,11 @@ class ReflectionProcessor extends AbstractProcessor {
                 memberKind = ConfigurationMemberKind.DECLARED;
                 // fall through
             case "getField": {
-                configuration.getOrCreateType(clazzOrDeclaringClass).addField(singleElement(args), memberKind, false, unsafeAccess);
+                configuration.getOrCreateType(clazzOrDeclaringClass).addField(singleElement(args), memberKind, entry.containsKey("allowWrite") ? (Boolean) entry.get("allowWrite") : false,
+                                entry.containsKey("unsafeAccess") ? (Boolean) entry.get("unsafeAccess") : unsafeAccess);
+                if (!clazzOrDeclaringClass.equals(clazz)) {
+                    configuration.getOrCreateType(clazz).setAllPublicFields();
+                }
                 break;
             }
 

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/hub/DynamicHub.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/hub/DynamicHub.java
@@ -258,6 +258,20 @@ public final class DynamicHub implements JavaKind.FormatWithToString, AnnotatedE
      */
     private ClassInitializationInfo classInitializationInfo;
 
+    public boolean isHasCLinit() {
+        return hasCLinit;
+    }
+
+    public void setHasCLinit(boolean hasCLinit) {
+        this.hasCLinit = hasCLinit;
+    }
+
+    /**
+     * Indicates if this class originally has a <clinit> method. It is used for serialization
+     * support.
+     */
+    private boolean hasCLinit;
+
     /**
      * Classloader used for loading this class during image-build time.
      */

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/JDK9OrLater.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/JDK9OrLater.java
@@ -1,16 +1,17 @@
 /*
- * Copyright (c) 2020, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020 Alibaba Group Holding Limited. All Rights Reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 only, as
- * published by the Free Software Foundation.  Oracle designates this
+ * published by the Free Software Foundation. Alibaba designates this
  * particular file as subject to the "Classpath" exception as provided
  * by Oracle in the LICENSE file that accompanied this code.
  *
  * This code is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
  * version 2 for more details (a copy is included in the LICENSE file that
  * accompanied this code).
  *
@@ -18,16 +19,16 @@
  * 2 along with this work; if not, write to the Free Software Foundation,
  * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
  *
- * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
- * or visit www.oracle.com if you need additional information or have any
- * questions.
  */
 package com.oracle.svm.core.jdk;
 
-import com.oracle.svm.core.annotate.Delete;
-import com.oracle.svm.core.annotate.TargetClass;
+import org.graalvm.compiler.serviceprovider.JavaVersionUtil;
 
-@Delete
-@TargetClass(className = "jdk.internal.reflect.MethodAccessorGenerator", onlyWith = JDK9OrLater.class)
-final class Target_jdk_internal_reflect_MethodAccessorGenerator {
+import java.util.function.BooleanSupplier;
+
+public class JDK9OrLater implements BooleanSupplier {
+    @Override
+    public boolean getAsBoolean() {
+        return JavaVersionUtil.JAVA_SPEC >= 9;
+    }
 }

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/JavaIOSubstitutions.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/JavaIOSubstitutions.java
@@ -29,13 +29,13 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.concurrent.locks.ReentrantLock;
 
-import com.oracle.svm.core.annotate.Alias;
-import com.oracle.svm.core.annotate.InjectAccessors;
-import com.oracle.svm.core.annotate.RecomputeFieldValue;
 import com.oracle.svm.core.annotate.RecomputeFieldValue.Kind;
-import com.oracle.svm.core.annotate.Substitute;
 import com.oracle.svm.core.annotate.TargetClass;
-import com.oracle.svm.core.util.VMError;
+import com.oracle.svm.core.annotate.Alias;
+import com.oracle.svm.core.annotate.RecomputeFieldValue;
+import com.oracle.svm.core.annotate.Substitute;
+import com.oracle.svm.core.annotate.InjectAccessors;
+import com.oracle.svm.core.hub.DynamicHub;
 
 @TargetClass(java.io.FileDescriptor.class)
 final class Target_java_io_FileDescriptor {
@@ -49,28 +49,17 @@ final class Target_java_io_FileDescriptor {
 final class Target_java_io_ObjectInputStream {
 
     @Substitute
-    private Object readObject() {
-        throw VMError.unsupportedFeature("ObjectInputStream.readObject()");
-    }
-
-    @Substitute
-    private Object readUnshared() {
-        throw VMError.unsupportedFeature("ObjectInputStream.readUnshared()");
+    private static ClassLoader latestUserDefinedLoader() {
+        return Target_java_io_ObjectInputStream.class.getClassLoader();
     }
 }
 
-@TargetClass(java.io.ObjectOutputStream.class)
-@SuppressWarnings({"static-method", "unused"})
-final class Target_java_io_ObjectOutputStream {
+@TargetClass(java.io.ObjectStreamClass.class)
+final class Target_java_io_ObjectStreamClass {
 
     @Substitute
-    private void writeObject(Object obj) {
-        throw VMError.unsupportedFeature("ObjectOutputStream.writeObject()");
-    }
-
-    @Substitute
-    private void writeUnshared(Object obj) {
-        throw VMError.unsupportedFeature("ObjectOutputStream.writeUnshared()");
+    private static boolean hasStaticInitializer(Class<?> cl) {
+        return DynamicHub.fromClass(cl).isHasCLinit();
     }
 }
 

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/serialize/MethodAccessorNameGenerator.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/serialize/MethodAccessorNameGenerator.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2019, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020 Alibaba Group Holding Limited. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package com.oracle.svm.core.jdk.serialize;
+
+public class MethodAccessorNameGenerator {
+    /**
+     * This method generates fixed class name across different runs to replace the original
+     * sun.reflect.MethodAccessorGenerator.generateName which generates class name based on sequence
+     * id that can be changed from runs.
+     *
+     * @param isConstructor
+     * @param forSerialization
+     * @param declaringClassName
+     * @return A fixed dynamically generated class name
+     */
+    public static String generateClassName(boolean isConstructor, boolean forSerialization, String declaringClassName) {
+        String className = declaringClassName.replace('.', '_');
+        className = className.replace('$', '_');
+        if (isConstructor) {
+            if (forSerialization) {
+                return "sun/reflect/GeneratedSerializationConstructorAccessor" + className;
+            } else {
+                return "sun/reflect/GeneratedConstructorAccessor" + className;
+            }
+        } else {
+            return "sun/reflect/GeneratedMethodAccessor" + className;
+        }
+    }
+}

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/serialize/Target_sun_reflect_MethodAccessorGenerator.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/serialize/Target_sun_reflect_MethodAccessorGenerator.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2019, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020 Alibaba Group Holding Limited. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package com.oracle.svm.core.jdk.serialize;
+
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+
+import com.oracle.svm.core.annotate.Alias;
+import com.oracle.svm.core.annotate.Substitute;
+import com.oracle.svm.core.annotate.TargetClass;
+import com.oracle.svm.core.hub.ClassForNameSupport;
+import com.oracle.svm.core.jdk.JDK8OrEarlier;
+
+@TargetClass(className = "sun.reflect.MethodAccessorGenerator", onlyWith = JDK8OrEarlier.class)
+public final class Target_sun_reflect_MethodAccessorGenerator {
+    @Alias private static volatile int constructorSymnum = 0;
+
+    @Alias private static volatile int methodSymnum = 0;
+
+    /**
+     * Using a fixed name for the class that is supposed to be generated at runtime. The runtime
+     * generated class must be dumped by Agent in an advanced run, and the classes must have been
+     * added to the build time classpath.
+     *
+     * @param declaringClass
+     * @param name
+     * @param parameterTypes
+     * @param returnType
+     * @param checkedExceptions
+     * @param modifiers
+     * @param isConstructor
+     * @param forSerialization
+     * @param serializationTargetClass
+     * @return A class cached in native-image heap
+     */
+    @Substitute
+    @SuppressWarnings({"static-method", "unused"})
+    private Target_sun_reflect_MagicAccessorImpl generate(final Class<?> declaringClass, String name, Class<?>[] parameterTypes,
+                    Class<?> returnType, Class<?>[] checkedExceptions, int modifiers, boolean isConstructor,
+                    boolean forSerialization, Class<?> serializationTargetClass) {
+        final String generatedName = MethodAccessorNameGenerator.generateClassName(isConstructor, forSerialization, declaringClass.getName());
+        return AccessController.doPrivileged(new PrivilegedAction<Target_sun_reflect_MagicAccessorImpl>() {
+            @Override
+            public Target_sun_reflect_MagicAccessorImpl run() {
+                try {
+                    return (Target_sun_reflect_MagicAccessorImpl) ClassForNameSupport.forName(generatedName.replace('/', '.'), true).newInstance();
+                } catch (InstantiationException | IllegalAccessException | ClassNotFoundException e) {
+                    throw new InternalError(e);
+                }
+            }
+        });
+    }
+}
+
+@TargetClass(className = "sun.reflect.MagicAccessorImpl")
+final class Target_sun_reflect_MagicAccessorImpl {
+}

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/classinitialization/ClassInitializationFeature.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/classinitialization/ClassInitializationFeature.java
@@ -187,8 +187,11 @@ public class ClassInitializationFeature implements Feature {
         classInitializationSupport.checkDelayedInitialization();
 
         for (AnalysisType type : access.getUniverse().getTypes()) {
+            DynamicHub hub = access.getHostVM().dynamicHub(type);
+            boolean hasCLinit = (type.isArray() || type.getClassInitializer() == null) ? false : true;
+            hub.setHasCLinit(hasCLinit);
+
             if (type.isInTypeCheck() || type.isInstantiated()) {
-                DynamicHub hub = access.getHostVM().dynamicHub(type);
                 if (hub.getClassInitializationInfo() == null) {
                     buildClassInitializationInfo(access, type, hub);
                     access.requireAnalysisIteration();

--- a/substratevm/src/com.oracle.svm.jni/src/com/oracle/svm/jni/nativeapi/JNIFunctionPointerTypes.java
+++ b/substratevm/src/com.oracle.svm.jni/src/com/oracle/svm/jni/nativeapi/JNIFunctionPointerTypes.java
@@ -60,6 +60,11 @@ public final class JNIFunctionPointerTypes {
         JNIObjectHandle invoke(JNIEnvironment env, JNIObjectHandle obj);
     }
 
+    public interface CallObjectMethod0FunctionPointer extends CFunctionPointer {
+        @InvokeCFunctionPointer
+        JNIObjectHandle invoke(JNIEnvironment env, JNIObjectHandle objOrClass, JNIMethodId methodID);
+    }
+
     public interface CallObjectMethodAFunctionPointer extends CFunctionPointer {
         @InvokeCFunctionPointer
         JNIObjectHandle invoke(JNIEnvironment env, JNIObjectHandle objOrClass, JNIMethodId methodID, JNIValue args);
@@ -78,6 +83,11 @@ public final class JNIFunctionPointerTypes {
     public interface CallIntMethodAFunctionPointer extends CFunctionPointer {
         @InvokeCFunctionPointer
         int invoke(JNIEnvironment env, JNIObjectHandle objOrClass, JNIMethodId methodId, JNIValue args);
+    }
+
+    public interface CallIntMethodFunctionPointer extends CFunctionPointer {
+        @InvokeCFunctionPointer
+        int invoke(JNIEnvironment env, JNIObjectHandle objOrClass, JNIMethodId methodID);
     }
 
     public interface NewObjectAFunctionPointer extends CFunctionPointer {
@@ -128,6 +138,16 @@ public final class JNIFunctionPointerTypes {
     public interface GetObjectArrayElementFunctionPointer extends CFunctionPointer {
         @InvokeCFunctionPointer
         JNIObjectHandle invoke(JNIEnvironment env, JNIObjectHandle array, int index);
+    }
+
+    public interface GetByteArrayElementsFunctionPointer extends CFunctionPointer {
+        @InvokeCFunctionPointer
+        CCharPointer invoke(JNIEnvironment env, JNIObjectHandle array, JNIObjectHandle isCopy);
+    }
+
+    public interface ReleaseByteArrayElementsFunctionPointer extends CFunctionPointer {
+        @InvokeCFunctionPointer
+        CCharPointer invoke(JNIEnvironment env, JNIObjectHandle array, CCharPointer elems, int mode);
     }
 
     public interface SetObjectArrayElementFunctionPointer extends CFunctionPointer {
@@ -193,18 +213,6 @@ public final class JNIFunctionPointerTypes {
     public interface NewByteArrayFunctionPointer extends CFunctionPointer {
         @InvokeCFunctionPointer
         JNIObjectHandle invoke(JNIEnvironment env, int length);
-    }
-
-    public interface GetByteArrayElementsFunctionPointer extends CFunctionPointer {
-        // isCopy is actually a boolean
-        @InvokeCFunctionPointer
-        CCharPointer invoke(JNIEnvironment env, JNIObjectHandle byteArray, CCharPointer isCopy);
-    }
-
-    public interface ReleaseByteArrayElementsFunctionPointer extends CFunctionPointer {
-        // isCopy is actually a boolean
-        @InvokeCFunctionPointer
-        CCharPointer invoke(JNIEnvironment env, JNIObjectHandle byteArray, int mode);
     }
 
     private JNIFunctionPointerTypes() {

--- a/substratevm/src/com.oracle.svm.jni/src/com/oracle/svm/jni/nativeapi/JNINativeInterface.java
+++ b/substratevm/src/com.oracle.svm.jni/src/com/oracle/svm/jni/nativeapi/JNINativeInterface.java
@@ -38,6 +38,7 @@ import org.graalvm.word.PointerBase;
 import com.oracle.svm.jni.nativeapi.JNIFunctionPointerTypes.CallBooleanMethodAFunctionPointer;
 import com.oracle.svm.jni.nativeapi.JNIFunctionPointerTypes.CallLongMethodAFunctionPointer;
 import com.oracle.svm.jni.nativeapi.JNIFunctionPointerTypes.CallObjectMethodAFunctionPointer;
+import com.oracle.svm.jni.nativeapi.JNIFunctionPointerTypes.CallIntMethodFunctionPointer;
 import com.oracle.svm.jni.nativeapi.JNIFunctionPointerTypes.DefineClassFunctionPointer;
 import com.oracle.svm.jni.nativeapi.JNIFunctionPointerTypes.DeleteGlobalRefFunctionPointer;
 import com.oracle.svm.jni.nativeapi.JNIFunctionPointerTypes.ExceptionCheckFunctionPointer;
@@ -47,6 +48,7 @@ import com.oracle.svm.jni.nativeapi.JNIFunctionPointerTypes.FindClassFunctionPoi
 import com.oracle.svm.jni.nativeapi.JNIFunctionPointerTypes.FromReflectedFieldFunctionPointer;
 import com.oracle.svm.jni.nativeapi.JNIFunctionPointerTypes.FromReflectedMethodFunctionPointer;
 import com.oracle.svm.jni.nativeapi.JNIFunctionPointerTypes.GetArrayLengthFunctionPointer;
+import com.oracle.svm.jni.nativeapi.JNIFunctionPointerTypes.GetByteArrayElementsFunctionPointer;
 import com.oracle.svm.jni.nativeapi.JNIFunctionPointerTypes.GetFieldIDFunctionPointer;
 import com.oracle.svm.jni.nativeapi.JNIFunctionPointerTypes.GetMethodIDFunctionPointer;
 import com.oracle.svm.jni.nativeapi.JNIFunctionPointerTypes.GetObjectArrayElementFunctionPointer;
@@ -59,6 +61,7 @@ import com.oracle.svm.jni.nativeapi.JNIFunctionPointerTypes.NewObjectAFunctionPo
 import com.oracle.svm.jni.nativeapi.JNIFunctionPointerTypes.NewObjectArrayFunctionPointer;
 import com.oracle.svm.jni.nativeapi.JNIFunctionPointerTypes.NewStringUTFFunctionPointer;
 import com.oracle.svm.jni.nativeapi.JNIFunctionPointerTypes.RegisterNativesFunctionPointer;
+import com.oracle.svm.jni.nativeapi.JNIFunctionPointerTypes.ReleaseByteArrayElementsFunctionPointer;
 import com.oracle.svm.jni.nativeapi.JNIFunctionPointerTypes.ReleaseStringUTFCharsFunctionPointer;
 import com.oracle.svm.jni.nativeapi.JNIFunctionPointerTypes.SetObjectArrayElementFunctionPointer;
 import com.oracle.svm.jni.nativeapi.JNIFunctionPointerTypes.ThrowFunctionPointer;
@@ -263,7 +266,7 @@ public interface JNINativeInterface extends PointerBase {
     void setGetMethodID(GetMethodIDFunctionPointer p);
 
     @CField
-    CFunctionPointer getCallObjectMethod();
+    <T extends CFunctionPointer> T getCallObjectMethod();
 
     @CField
     void setCallObjectMethod(CFunctionPointer p);
@@ -353,10 +356,10 @@ public interface JNINativeInterface extends PointerBase {
     void setCallShortMethodA(CFunctionPointer p);
 
     @CField
-    CFunctionPointer getCallIntMethod();
+    <T extends CallIntMethodFunctionPointer> T getCallIntMethod();
 
     @CField
-    void setCallIntMethod(CFunctionPointer p);
+    void setCallIntMethod(CallIntMethodFunctionPointer p);
 
     @CField
     CFunctionPointer getCallIntMethodV();

--- a/substratevm/src/com.oracle.svm.jvmtiagentbase/src/com/oracle/svm/jvmtiagentbase/jvmti/JvmtiInterface.java
+++ b/substratevm/src/com.oracle.svm.jvmtiagentbase/src/com/oracle/svm/jvmtiagentbase/jvmti/JvmtiInterface.java
@@ -173,6 +173,22 @@ public interface JvmtiInterface extends PointerBase {
         JvmtiError invoke(JvmtiEnv jvmtiEnv, JNIObjectHandle klass, WordPointer signaturePtr, WordPointer genericPtr);
     }
 
+    @CField("GetClassFields")
+    GetClassFieldsFunctionPointer GetClassFields();
+
+    interface GetClassFieldsFunctionPointer extends CFunctionPointer {
+        @InvokeCFunctionPointer
+        JvmtiError invoke(JvmtiEnv jvmtiEnv, JNIObjectHandle klass, CIntPointer fieldCountPtr, WordPointer fieldsPtr);
+    }
+
+    @CField("GetClassMethods")
+    GetClassMethodsFunctionPointer GetClassMethods();
+
+    interface GetClassMethodsFunctionPointer extends CFunctionPointer {
+        @InvokeCFunctionPointer
+        JvmtiError invoke(JvmtiEnv jvmtiEnv, JNIObjectHandle klass, CIntPointer methodCountPtr, WordPointer methodsPtr);
+    }
+
     @CField("GetMethodModifiers")
     GetMethodModifiersFunctionPointer GetMethodModifiers();
 
@@ -260,4 +276,13 @@ public interface JvmtiInterface extends PointerBase {
         @InvokeCFunctionPointer
         JvmtiError invoke(JvmtiEnv jvmtiEnv, CIntPointer classCountPtr, WordPointer classesPtr);
     }
+
+    @CField("ForceEarlyReturnInt")
+    ForceEarlyReturnIntFunctionPointer ForceEarlyReturnInt();
+
+    interface ForceEarlyReturnIntFunctionPointer extends CFunctionPointer {
+        @InvokeCFunctionPointer
+        JvmtiError invoke(JvmtiEnv jvmtiEnv, JNIObjectHandle thread, int value);
+    }
+
 }


### PR DESCRIPTION
This patch provides supports for dynamic class loading and serialization/deserialization features for substratevm.
**Overview**
The basic idea for supporting dynamic class loading is dumping classes generated at run time in a beforehand run with native-image-agent to a specified directory which is added to the classpath to build native-image. Serialization/deserialization is basically dynamic class loading + reflection.
This is implemented in 3 steps:

1. Intercept java.lang.ClassLoader.postDefineClass and sun.reflect.ClassDefiner.defineClass by native-image-agent to dump the dynamically generated class to file system.
2. Make sure the generated classes' names are fixed through Hotspot version runtime and native-image version runtime.
3. Substitute relevant classes in SubstrateVM to load the previously dumped classes.

**Features**:

- Add new agent option `-agentlib:native-image-agent=dynmaic-class-dump-dir=` to specify where to dump the dynamically generated classs, the default value is _"dynClass"_ if not specified.
- Both dynamically generated class and its stack trace are dumped.
- Dynamically generated class's name could be decided at runtime (e.g. runtime sequence number as postfix) or null when defineClass is invoked. The former is supported by using same rule to generate fixed names for both Agent runtime and native-image runtime. The latter is supported by retrieving class name from dumped class bytecode at native-image runtime.
- Support JDK serialization/deserialization which replies on dynamic class loading and reflection.

**Limitations**:

1. Don't support serializing proxied class. The proxied class is generated and cached in native-image at build time. The generated class name is profixed with a sequence number which could be different from Agent run and native-image build time run.
2. It is possible the jar on classpath has a different signature file from dynamically generated class and fail the check in `java.lang.ClassLoader.checkCerts(String name, CodeSource cs)` at native-image build time. Current solution is to delete jar's signature file before building.
3. Warning messages such as "WARNING: Method java.lang.Object.<clinit>() not found." will be reported at native-image build time. Because such method has been accessed via JNI calls at serialization time to calculate serializeVersionUID and the Agent has intercepted and recorded them.

**Tests**

We have prepared the `serial` test cases in SPECjvm2008 to test this patch. Simply unzip [specjvm2008-for-serial.zip](https://github.com/oracle/graal/files/4443123/specjvm2008-for-serial.zip), change $GRAALVM_HOME to your GraalVM home and run 

> ./SVMBenchmarks/serial.sh -cr


The script builds and runs `spec.benchmarks.serial.Main` in SPECjvm2008.
"TestProxy" was excluded from the `serial ` tests because of the 1st limitation mentioned above.

**Dependency**

This patch depends on PR https://github.com/oracle/graal/pull/2322
 