### PR TITLE
Update Arm copyright regex.

### DIFF
--- a/compiler/mx.compiler/copyrights/oracle.copyright.regex.star
+++ b/compiler/mx.compiler/copyrights/oracle.copyright.regex.star
@@ -3,7 +3,7 @@
 (?: \* Copyright \(c\) \d\d\d\d, Red Hat Inc\. All rights reserved\.
 | \* Copyright \(c\) \d\d\d\d, Intel Corporation\. All rights reserved\.
  \* Intel Math Library \(LIBM\) Source Code
-| \* Copyright \(c\) \d\d\d\d, Arm Limited(?: and affiliates)?\. All rights reserved\.
+| \* Copyright \(c\) \d\d\d\d(?:, \d\d\d\d)?, Arm Limited(?: and affiliates)?\. All rights reserved\.
 )? \* DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER\.
  \*
  \* This code is free software; you can redistribute it and\/or modify it


### PR DESCRIPTION
Currently the copyright regex for Arm part assumes that it has only one year recorded. Considering that we might update the AArch64 files and together with appending the latest modification year after the created year, we should make the copyright regex be matched for other valid pattern. Or it will report warning like "copyright that does not match the regex". This issue has happened when we execute "mx updategraalinopenjdk" and the copyright of one AArch64 file contains "Copyright (c) 2019, 2020, Arm Limited.".

Change-Id: I0a8dc283886150c07286dc4f5efe1e2f2c0f5656