### PR TITLE
Fix ambiguity of newFileSystem() calls

### DIFF
--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/image/sources/ApplicationSourceCache.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/image/sources/ApplicationSourceCache.java
@@ -82,7 +82,7 @@ public class ApplicationSourceCache extends SourceCache {
                 sourcePath = sourcePath.getParent().resolve(fileNameString);
                 if (sourcePath.toFile().exists()) {
                     try {
-                        FileSystem fileSystem = FileSystems.newFileSystem(sourcePath, null);
+                        FileSystem fileSystem = FileSystems.newFileSystem(sourcePath, (ClassLoader) null);
                         for (Path root : fileSystem.getRootDirectories()) {
                             srcRoots.add(root);
                         }

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/image/sources/GraalVMSourceCache.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/image/sources/GraalVMSourceCache.java
@@ -83,7 +83,7 @@ public class GraalVMSourceCache extends SourceCache {
                 Path srcPath = sourcePath.getParent().resolve(fileNameString);
                 if (srcPath.toFile().exists()) {
                     try {
-                        FileSystem fileSystem = FileSystems.newFileSystem(srcPath, null);
+                        FileSystem fileSystem = FileSystems.newFileSystem(srcPath, (ClassLoader) null);
                         for (Path root : fileSystem.getRootDirectories()) {
                             if (filterSrcRoot(root)) {
                                 srcRoots.add(root);

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/image/sources/JDKSourceCache.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/image/sources/JDKSourceCache.java
@@ -68,7 +68,7 @@ public class JDKSourceCache extends SourceCache {
         }
         if (srcZipPath.toFile().exists()) {
             try {
-                FileSystem srcFileSystem = FileSystems.newFileSystem(srcZipPath, null);
+                FileSystem srcFileSystem = FileSystems.newFileSystem(srcZipPath, (ClassLoader) null);
                 for (Path root : srcFileSystem.getRootDirectories()) {
                     srcRoots.add(root);
                 }


### PR DESCRIPTION
After the debuginfo patch from @adinn went in I'm seeing build errors with JDK head like:

```
/home/jenkins/workspace/jdk-15-gaovm-x86-64_linux/src/graal/graal-ce/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/image/sources/ApplicationSourceCache.java:85: error: reference to newFileSystem is ambiguous
                        FileSystem fileSystem = FileSystems.newFileSystem(sourcePath, null);
                                                           ^
  both method newFileSystem(Path,ClassLoader) in FileSystems and method newFileSystem(Path,Map<String,?>) in FileSystems match
/home/jenkins/workspace/jdk-15-gaovm-x86-64_linux/src/graal/graal-ce/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/image/sources/GraalVMSourceCache.java:86: error: reference to newFileSystem is ambiguous
                        FileSystem fileSystem = FileSystems.newFileSystem(srcPath, null);
                                                           ^
  both method newFileSystem(Path,ClassLoader) in FileSystems and method newFileSystem(Path,Map<String,?>) in FileSystems match
/home/jenkins/workspace/jdk-15-gaovm-x86-64_linux/src/graal/graal-ce/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/image/sources/JDKSourceCache.java:71: error: reference to newFileSystem is ambiguous
                FileSystem srcFileSystem = FileSystems.newFileSystem(srcZipPath, null);
                                                      ^
  both method newFileSystem(Path,ClassLoader) in FileSystems and method newFileSystem(Path,Map<String,?>) in FileSystems match
Compiling com.oracle.svm.core.genscavenge with javac-daemon(JDK 15)... [dependency GRAAL_PROCESSOR updated]
Compiling com.oracle.svm.core.posix with javac-daemon(JDK 15)... [dependency GRAAL_PROCESSOR updated]
3 errors
```

This patch should fix it. OK?