### PR TITLE
Native-image fails on JDK 15 due to ClassLoader changes

### DIFF
--- a/substratevm/mx.substratevm/suite.py
+++ b/substratevm/mx.substratevm/suite.py
@@ -214,6 +214,22 @@ suite = {
             "workingSets": "SVM",
         },
 
+        "com.oracle.svm.core.jdk15": {
+            "subDir": "src",
+            "sourceDirs": ["src"],
+            "dependencies": ["com.oracle.svm.core"],
+            "requiresConcealed" : {
+                "java.base" : [
+                    "jdk.internal.loader",
+                ],
+            },
+            "javaCompliance": "15+",
+            "overlayTarget" : "com.oracle.svm.core",
+            "multiReleaseJarVersion": "15",
+            "checkstyle": "com.oracle.svm.core",
+            "workingSets": "SVM",
+        },
+
         "com.oracle.svm.core.genscavenge": {
             "subDir": "src",
             "sourceDirs": [

--- a/substratevm/src/com.oracle.svm.core.jdk15/src/com/oracle/svm/core/jdk15/Target_java_lang_ClassLoader_JDK15OrLater.java
+++ b/substratevm/src/com.oracle.svm.core.jdk15/src/com/oracle/svm/core/jdk15/Target_java_lang_ClassLoader_JDK15OrLater.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2020, 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package com.oracle.svm.core.jdk15;
+
+import com.oracle.svm.core.annotate.Substitute;
+import com.oracle.svm.core.annotate.TargetClass;
+import com.oracle.svm.core.jdk.JDK15OrLater;
+import com.oracle.svm.core.jdk.NativeLibrarySupport;
+
+import jdk.internal.loader.NativeLibrary;
+
+@TargetClass(value = ClassLoader.class, onlyWith = JDK15OrLater.class)
+@SuppressWarnings("static-method")
+final class Target_java_lang_ClassLoader_JDK15OrLater {
+
+    @Substitute
+    @SuppressWarnings("unused")
+    static NativeLibrary loadLibrary(Class<?> fromClass, String name) {
+        NativeLibrarySupport.singleton().loadLibrary(name);
+        // We don't use the JDK's NativeLibraries or NativeLibrary implementations
+        return (NativeLibrary) null;
+    }
+}

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/JavaLangSubstitutions.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/JavaLangSubstitutions.java
@@ -129,26 +129,10 @@ final class Target_java_lang_Object {
     }
 }
 
-@TargetClass(className = "jdk.internal.loader.ClassLoaderHelper", onlyWith = JDK15OrLater.class)
+@TargetClass(classNameProvider = Package_jdk_internal_loader_helper.class, className = "ClassLoaderHelper")
 final class Target_jdk_internal_loader_ClassLoaderHelper {
     @Alias
     static native File mapAlternativeName(File lib);
-}
-
-@TargetClass(className = "java.lang.ClassLoaderHelper", onlyWith = JDK14OrEarlier.class)
-final class Target_java_lang_ClassLoaderHelper {
-    @Alias
-    static native File mapAlternativeName(File lib);
-}
-
-final class Util_java_lang_ClassLoaderHelper {
-    static File mapAlternativeName(File lib) {
-        if (JavaVersionUtil.JAVA_SPEC >= 15) {
-            return Target_jdk_internal_loader_ClassLoaderHelper.mapAlternativeName(lib);
-        } else {
-            return Target_java_lang_ClassLoaderHelper.mapAlternativeName(lib);
-        }
-    }
 }
 
 @TargetClass(java.lang.Enum.class)

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/JavaLangSubstitutions.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/JavaLangSubstitutions.java
@@ -48,7 +48,6 @@ import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Predicate;
 
 import org.graalvm.compiler.core.common.SuppressFBWarnings;
-import org.graalvm.compiler.serviceprovider.JavaVersionUtil;
 import org.graalvm.compiler.word.ObjectAccess;
 import org.graalvm.compiler.word.Word;
 import org.graalvm.nativeimage.ImageSingletons;

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/JavaLangSubstitutions.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/JavaLangSubstitutions.java
@@ -48,6 +48,7 @@ import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Predicate;
 
 import org.graalvm.compiler.core.common.SuppressFBWarnings;
+import org.graalvm.compiler.serviceprovider.JavaVersionUtil;
 import org.graalvm.compiler.word.ObjectAccess;
 import org.graalvm.compiler.word.Word;
 import org.graalvm.nativeimage.ImageSingletons;
@@ -128,10 +129,26 @@ final class Target_java_lang_Object {
     }
 }
 
-@TargetClass(className = "java.lang.ClassLoaderHelper")
+@TargetClass(className = "jdk.internal.loader.ClassLoaderHelper", onlyWith = JDK15OrLater.class)
+final class Target_jdk_internal_loader_ClassLoaderHelper {
+    @Alias
+    static native File mapAlternativeName(File lib);
+}
+
+@TargetClass(className = "java.lang.ClassLoaderHelper", onlyWith = JDK14OrEarlier.class)
 final class Target_java_lang_ClassLoaderHelper {
     @Alias
     static native File mapAlternativeName(File lib);
+}
+
+final class Util_java_lang_ClassLoaderHelper {
+    static File mapAlternativeName(File lib) {
+        if (JavaVersionUtil.JAVA_SPEC >= 15) {
+            return Target_jdk_internal_loader_ClassLoaderHelper.mapAlternativeName(lib);
+        } else {
+            return Target_java_lang_ClassLoaderHelper.mapAlternativeName(lib);
+        }
+    }
 }
 
 @TargetClass(java.lang.Enum.class)

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/NativeLibrarySupport.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/NativeLibrarySupport.java
@@ -97,34 +97,6 @@ public final class NativeLibrarySupport {
         return knownLibraries.stream().anyMatch(l -> l.isBuiltin() && l.getCanonicalIdentifier().equals(name));
     }
 
-    public void loadLibrary(String name) {
-        // Test if this is a built-in library
-        if (loadLibrary0(new File(name), true)) {
-            return;
-        }
-        String libname = System.mapLibraryName(name);
-        if (paths == null) {
-            String[] tokens = SubstrateUtil.split(System.getProperty("java.library.path", ""), File.pathSeparator);
-            for (int i = 0; i < tokens.length; i++) {
-                if (tokens[i].isEmpty()) {
-                    tokens[i] = ".";
-                }
-            }
-            paths = tokens;
-        }
-        for (String path : paths) {
-            File libpath = new File(path, libname);
-            if (loadLibrary0(libpath, false)) {
-                return;
-            }
-            File altpath = Util_java_lang_ClassLoaderHelper.mapAlternativeName(libpath);
-            if (altpath != null && loadLibrary0(libpath, false)) {
-                return;
-            }
-        }
-        throw new UnsatisfiedLinkError("no " + name + " in java.library.path");
-    }
-
     public void loadLibrary(String name, boolean isAbsolute) {
         if (isAbsolute) {
             if (loadLibrary0(new File(name), false)) {
@@ -151,7 +123,7 @@ public final class NativeLibrarySupport {
             if (loadLibrary0(libpath, false)) {
                 return;
             }
-            File altpath = Util_java_lang_ClassLoaderHelper.mapAlternativeName(libpath);
+            File altpath = Target_jdk_internal_loader_ClassLoaderHelper.mapAlternativeName(libpath);
             if (altpath != null && loadLibrary0(libpath, false)) {
                 return;
             }

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/NativeLibrarySupport.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/NativeLibrarySupport.java
@@ -97,6 +97,34 @@ public final class NativeLibrarySupport {
         return knownLibraries.stream().anyMatch(l -> l.isBuiltin() && l.getCanonicalIdentifier().equals(name));
     }
 
+    public void loadLibrary(String name) {
+        // Test if this is a built-in library
+        if (loadLibrary0(new File(name), true)) {
+            return;
+        }
+        String libname = System.mapLibraryName(name);
+        if (paths == null) {
+            String[] tokens = SubstrateUtil.split(System.getProperty("java.library.path", ""), File.pathSeparator);
+            for (int i = 0; i < tokens.length; i++) {
+                if (tokens[i].isEmpty()) {
+                    tokens[i] = ".";
+                }
+            }
+            paths = tokens;
+        }
+        for (String path : paths) {
+            File libpath = new File(path, libname);
+            if (loadLibrary0(libpath, false)) {
+                return;
+            }
+            File altpath = Util_java_lang_ClassLoaderHelper.mapAlternativeName(libpath);
+            if (altpath != null && loadLibrary0(libpath, false)) {
+                return;
+            }
+        }
+        throw new UnsatisfiedLinkError("no " + name + " in java.library.path");
+    }
+
     public void loadLibrary(String name, boolean isAbsolute) {
         if (isAbsolute) {
             if (loadLibrary0(new File(name), false)) {
@@ -123,7 +151,7 @@ public final class NativeLibrarySupport {
             if (loadLibrary0(libpath, false)) {
                 return;
             }
-            File altpath = Target_java_lang_ClassLoaderHelper.mapAlternativeName(libpath);
+            File altpath = Util_java_lang_ClassLoaderHelper.mapAlternativeName(libpath);
             if (altpath != null && loadLibrary0(libpath, false)) {
                 return;
             }

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/Package_jdk_internal_loader_helper.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/Package_jdk_internal_loader_helper.java
@@ -22,24 +22,26 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
-package com.oracle.svm.core.jdk15;
+package com.oracle.svm.core.jdk;
 
-import com.oracle.svm.core.annotate.Substitute;
+import java.util.function.Function;
+
+import org.graalvm.compiler.serviceprovider.JavaVersionUtil;
+import org.graalvm.nativeimage.Platform;
+import org.graalvm.nativeimage.Platforms;
+
 import com.oracle.svm.core.annotate.TargetClass;
-import com.oracle.svm.core.jdk.JDK15OrLater;
-import com.oracle.svm.core.jdk.NativeLibrarySupport;
 
-import jdk.internal.loader.NativeLibrary;
+@Platforms(Platform.HOSTED_ONLY.class)
+public class Package_jdk_internal_loader_helper implements Function<TargetClass, String> {
 
-@TargetClass(value = ClassLoader.class, onlyWith = JDK15OrLater.class)
-@SuppressWarnings("static-method")
-final class Target_java_lang_ClassLoader_JDK15OrLater {
-
-    @Substitute
-    @SuppressWarnings("unused")
-    static NativeLibrary loadLibrary(Class<?> fromClass, String name) {
-        NativeLibrarySupport.singleton().loadLibrary(name, false);
-        // We don't use the JDK's NativeLibraries or NativeLibrary implementations
-        return (NativeLibrary) null;
+    @Override
+    public String apply(TargetClass annotation) {
+        if (JavaVersionUtil.JAVA_SPEC <= 14) {
+            return "java.lang." + annotation.className();
+        } else {
+            return "jdk.internal.loader." + annotation.className();
+        }
     }
 }
+

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/Target_java_lang_ClassLoader.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/Target_java_lang_ClassLoader.java
@@ -220,6 +220,7 @@ final class Target_java_lang_ClassLoader {
 
     @Substitute
     @SuppressWarnings("unused")
+    @TargetElement(onlyWith = JDK14OrEarlier.class) //
     static void loadLibrary(Class<?> fromClass, String name, boolean isAbsolute) {
         NativeLibrarySupport.singleton().loadLibrary(name, isAbsolute);
     }
@@ -371,13 +372,14 @@ final class Target_java_lang_ClassLoader {
     private native Class<?> findBootstrapClass(String name);
 
     @Delete
+    @TargetElement(onlyWith = JDK14OrEarlier.class)
     private static native String findBuiltinLib(String name);
 
     @Delete
     private static native Target_java_lang_AssertionStatusDirectives retrieveDirectives();
 }
 
-@TargetClass(value = ClassLoader.class, innerClass = "NativeLibrary")
+@TargetClass(value = ClassLoader.class, innerClass = "NativeLibrary", onlyWith = JDK14OrEarlier.class)
 final class Target_java_lang_ClassLoader_NativeLibrary {
 
     /*

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/image/sources/ApplicationSourceCache.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/image/sources/ApplicationSourceCache.java
@@ -82,7 +82,7 @@ public class ApplicationSourceCache extends SourceCache {
                 sourcePath = sourcePath.getParent().resolve(fileNameString);
                 if (sourcePath.toFile().exists()) {
                     try {
-                        FileSystem fileSystem = FileSystems.newFileSystem(sourcePath, null);
+                        FileSystem fileSystem = FileSystems.newFileSystem(sourcePath, (ClassLoader) null);
                         for (Path root : fileSystem.getRootDirectories()) {
                             srcRoots.add(root);
                         }

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/image/sources/GraalVMSourceCache.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/image/sources/GraalVMSourceCache.java
@@ -83,7 +83,7 @@ public class GraalVMSourceCache extends SourceCache {
                 Path srcPath = sourcePath.getParent().resolve(fileNameString);
                 if (srcPath.toFile().exists()) {
                     try {
-                        FileSystem fileSystem = FileSystems.newFileSystem(srcPath, null);
+                        FileSystem fileSystem = FileSystems.newFileSystem(srcPath, (ClassLoader) null);
                         for (Path root : fileSystem.getRootDirectories()) {
                             if (filterSrcRoot(root)) {
                                 srcRoots.add(root);

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/image/sources/JDKSourceCache.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/image/sources/JDKSourceCache.java
@@ -68,7 +68,7 @@ public class JDKSourceCache extends SourceCache {
         }
         if (srcZipPath.toFile().exists()) {
             try {
-                FileSystem srcFileSystem = FileSystems.newFileSystem(srcZipPath, null);
+                FileSystem srcFileSystem = FileSystems.newFileSystem(srcZipPath, (ClassLoader) null);
                 for (Path root : srcFileSystem.getRootDirectories()) {
                     srcRoots.add(root);
                 }


### PR DESCRIPTION
PR for fixing https://github.com/oracle/graal/issues/2310

ClassLoader methods and internal classes have been altered to move internal methods to jdk.internal.loader.  This PR allows existing substratevm classLoader substituted functionality to continue to work with JDK 15.

-------------------------

Describe the issue
Building and running native-image from the latest Graal and OpenJDK sources no longer works
due to native library loading changes that have been made to the ClassLoader in JDK 15.

Steps to reproduce the issue

Build the latest GraalVM using JDK binaries built from the latest OpenJDK 15 sources.
Run mx native-image Hello
native-image will fail due to missing substituted methods.

Describe GraalVM and your environment:

This fails on all platforms
More details

Here is the change in OpenJDK responsible for this problem:

http://hg.openjdk.java.net/jdk/jdk/rev/1ca940d73efc
This change was integrated under this RFE:

8228336: Refactor native library loading implementation
https://bugs.openjdk.java.net/browse/JDK-8228336
