### PR TITLE
Reinitialize random seed at runtime in Windows Native image, JDK 11

### DIFF
--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/SecurityServicesFeature.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/SecurityServicesFeature.java
@@ -109,6 +109,11 @@ public class SecurityServicesFeature extends JNIRegistrationUtil implements Feat
         ImageSingletons.lookup(RuntimeClassInitializationSupport.class).rerunInitialization(clazz(access, "sun.security.provider.SeedGenerator"), "for substitutions");
         ImageSingletons.lookup(RuntimeClassInitializationSupport.class).rerunInitialization(clazz(access, "sun.security.provider.SecureRandom$SeederHolder"), "for substitutions");
 
+        if(JavaVersionUtil.JAVA_SPEC >= 11) {
+            /* sun.security.provider.AbstractDrbg$SeederHolder has a static final EntropySource seeder field. */
+            ImageSingletons.lookup(RuntimeClassInitializationSupport.class).rerunInitialization(clazz(access, "sun.security.provider.AbstractDrbg$SeederHolder"), "for substitutions");
+        }
+
         if (JavaVersionUtil.JAVA_SPEC > 8) {
             ImageSingletons.lookup(RuntimeClassInitializationSupport.class).rerunInitialization(clazz(access, "sun.security.provider.FileInputStreamPool"), "for substitutions");
         }


### PR DESCRIPTION
Fixes issue #2265 

# Code used to test it

```java
import java.security.SecureRandom;
import java.util.UUID;
import java.util.stream.Collectors;
import java.util.stream.IntStream;

public class Main {
    public static void main(String[] args) {
        System.out.println("Hello, UUID: " + UUID.randomUUID().toString());
        IntStream intStream = new SecureRandom().ints(10, 0, 100);
        System.out.println("Hello, secureRandom: " + intStream.boxed().collect(Collectors.toList()));
    }
}
```

# JDK 11
Fixes the issue #2265, tested with GraalVM substratevm,compiler,sdk HEAD 753b137, system: Windows 2019 Server, Visual Studio 2019, Windows 10 SDK.

```
SET JAVA_HOME=C:\Users\Administrator\source\graal\sdk\mxbuild\windows-amd64\GRAALVM_UNKNOWN_JAVA11\graalvm-unknown-java11-20.1.0-dev
SET GRAALVM_HOME=%JAVA_HOME%
set PATH=%GRAALVM_HOME%\bin;%PATH%
```

## Output :heavy_check_mark: 
```
C:\Users\Administrator\source\UUID\src\com\company
λ  javac Main.java && native-image -H:+ReportExceptionStackTraces -H:+TraceClassInitialization -H:+PrintClassInitialization Main

C:\Users\Administrator\source\UUID\src\com\company
λ main
Hello, UUID: e01bdeec-4fe5-48b3-a1f0-8324a5411284
Hello, secureRandom: [2, 78, 90, 68, 98, 17, 22, 12, 1, 94]

C:\Users\Administrator\source\UUID\src\com\company
λ main
Hello, UUID: a0f76a24-cdfd-45e9-9018-f718b49fa1f8
Hello, secureRandom: [55, 26, 11, 91, 44, 8, 40, 69, 98, 66]
```

# JDK 8
I had some troubles building GraalVM substratevm,compiler,sdk HEAD 753b137 on WIndows 2019. I finally managed that with: Visual Studio 2010, Windows 7.1 SDK. I had to swap JVMCI_20_1_b01 for  JVMCI_20_0_b03 in GraalHotSpotVMConfig.java to make the substratevm build work:

```
compiler/src/org.graalvm.compiler.hotspot/src/org/graalvm/compiler/hotspot/GraalHotSpotVMConfig.java

     public final boolean CPU_HAS_INTEL_JCC_ERRATUM = getFieldValue("VM_Version::_has_intel_jcc_erratum", Boolean.class, "bool",
-                    true, "amd64".equals(osArch) && (JVMCI ? jvmciGE(JVMCI_20_1_b01) : JDK >= 15));
+                    true, "amd64".equals(osArch) && (JVMCI ? jvmciGE(JVMCI_20_0_b03) : JDK >= 15));
```
Without this change, I kept getting:
```
Exception during JVMCI compiler initialization:
jdk.vm.ci.common.JVMCIError: VM config values not expected to be present in JDK 8 jvmci-20.0-b03 windows-amd64 (java.home=C:\Users\Administrator\source\graal\sdk\mxbuild\windows-amd64\GRAALVM_0945E895A1_JAVA8_STAGE1\graalvm-0945e895a1-java8-20.1.0-dev\jre, java.vm.name=OpenJDK 64-Bit Server VM GraalVM 20.1.0-dev, java.vm.version=25.252-b05-jvmci-20.0-b03):
    VM_Version::_has_intel_jcc_erratum at org.graalvm.compiler.hotspot.GraalHotSpotVMConfig.<init>(GraalHotSpotVMConfig.java:900) [value: Field[name=VM_Version::_has_intel_jcc_erratum, type=bool, offset=0, address=0x536fd638, value=true]]

        at org.graalvm.compiler.hotspot.GraalHotSpotVMConfigAccess.reportErrors(GraalHotSpotVMConfigAccess.java:224)
        at org.graalvm.compiler.hotspot.GraalHotSpotVMConfig.<init>(GraalHotSpotVMConfig.java:67)
        at org.graalvm.compiler.hotspot.HotSpotGraalRuntime.<init>(HotSpotGraalRuntime.java:161)
        at org.graalvm.compiler.hotspot.HotSpotGraalCompilerFactory.createCompiler(HotSpotGraalCompilerFactory.java:156)
        at org.graalvm.compiler.hotspot.HotSpotGraalCompilerFactory.createCompiler(HotSpotGraalCompilerFactory.java:134)
        at org.graalvm.compiler.hotspot.HotSpotGraalCompilerFactory.createCompiler(HotSpotGraalCompilerFactory.java:52)
        at jdk.vm.ci.hotspot.HotSpotJVMCIRuntime.getCompiler(HotSpotJVMCIRuntime.java:599)
        at jdk.vm.ci.hotspot.HotSpotJVMCIRuntime.compileMethod(HotSpotJVMCIRuntime.java:667)
```

Once I had it built, I tested the example code and I realized the bug does not exist for JDK 8 based native-image in the current GraalVM codebase, hence ```JavaVersionUtil.JAVA_SPEC >= 11``` in the commit.

## Output :heavy_check_mark: 

```
C:\Users\Administrator\source\UUID\src\com\company
λ main
Hello, UUID: a7fe8786-3494-4a56-93d6-494e4d777a7f
Hello, secureRandom: [32, 0, 11, 49, 33, 55, 28, 24, 76, 28]

C:\Users\Administrator\source\UUID\src\com\company
λ main
Hello, UUID: ccd42f3f-530a-4a7d-9b87-1ed6b2f24085
Hello, secureRandom: [49, 3, 27, 10, 80, 38, 59, 73, 27, 21]
```
