### PR TITLE
Support WithExceptionNode in IntrinsicGraphBuilder

### DIFF
--- a/compiler/src/org.graalvm.compiler.replacements/src/org/graalvm/compiler/replacements/IntrinsicGraphBuilder.java
+++ b/compiler/src/org.graalvm.compiler.replacements/src/org/graalvm/compiler/replacements/IntrinsicGraphBuilder.java
@@ -35,6 +35,7 @@ import org.graalvm.compiler.debug.DebugCloseable;
 import org.graalvm.compiler.debug.DebugContext;
 import org.graalvm.compiler.debug.GraalError;
 import org.graalvm.compiler.graph.NodeSourcePosition;
+import org.graalvm.compiler.nodes.AbstractBeginNode;
 import org.graalvm.compiler.nodes.CallTargetNode;
 import org.graalvm.compiler.nodes.CallTargetNode.InvokeKind;
 import org.graalvm.compiler.nodes.FixedNode;
@@ -46,11 +47,14 @@ import org.graalvm.compiler.nodes.ReturnNode;
 import org.graalvm.compiler.nodes.StateSplit;
 import org.graalvm.compiler.nodes.StructuredGraph;
 import org.graalvm.compiler.nodes.StructuredGraph.AllowAssumptions;
+import org.graalvm.compiler.nodes.UnwindNode;
 import org.graalvm.compiler.nodes.ValueNode;
+import org.graalvm.compiler.nodes.WithExceptionNode;
 import org.graalvm.compiler.nodes.graphbuilderconf.GraphBuilderContext;
 import org.graalvm.compiler.nodes.graphbuilderconf.IntrinsicContext;
 import org.graalvm.compiler.nodes.graphbuilderconf.InvocationPlugin;
 import org.graalvm.compiler.nodes.graphbuilderconf.InvocationPlugin.Receiver;
+import org.graalvm.compiler.nodes.java.ExceptionObjectNode;
 import org.graalvm.compiler.nodes.spi.CoreProviders;
 import org.graalvm.compiler.nodes.spi.Replacements;
 import org.graalvm.compiler.nodes.spi.StampProvider;
@@ -80,6 +84,8 @@ public class IntrinsicGraphBuilder implements GraphBuilderContext, Receiver {
     protected FixedWithNextNode lastInstr;
     protected ValueNode[] arguments;
     protected ValueNode returnValue;
+
+    private boolean unwindCreated;
 
     public IntrinsicGraphBuilder(OptionValues options, DebugContext debug, CoreProviders providers, Bytecode code, int invokeBci) {
         this(options, debug, providers, code, invokeBci, AllowAssumptions.YES);
@@ -134,10 +140,36 @@ public class IntrinsicGraphBuilder implements GraphBuilderContext, Receiver {
                 FixedWithNextNode fixedWithNextNode = (FixedWithNextNode) fixedNode;
                 assert fixedWithNextNode.next() == null : "cannot append instruction to instruction which isn't end";
                 lastInstr = fixedWithNextNode;
+
+            } else if (fixedNode instanceof WithExceptionNode) {
+                WithExceptionNode withExceptionNode = (WithExceptionNode) fixedNode;
+                AbstractBeginNode normalSuccessor = graph.add(withExceptionNode.createNextBegin());
+                ExceptionObjectNode exceptionSuccessor = graph.add(new ExceptionObjectNode(getMetaAccess()));
+                setExceptionState(exceptionSuccessor);
+                exceptionSuccessor.setNext(graph.add(new UnwindNode(exceptionSuccessor)));
+
+                if (unwindCreated) {
+                    throw GraalError.shouldNotReachHere("Intrinsic graph can only have one node with an exception edge");
+                }
+                unwindCreated = true;
+
+                withExceptionNode.setNext(normalSuccessor);
+                withExceptionNode.setExceptionEdge(exceptionSuccessor);
+                lastInstr = normalSuccessor;
+
             } else {
                 lastInstr = null;
             }
         }
+    }
+
+    /**
+     * Currently unimplemented here, but implemented in subclasses that need it.
+     *
+     * @param exceptionObject The node that needs an exception state.
+     */
+    protected void setExceptionState(ExceptionObjectNode exceptionObject) {
+        throw GraalError.shouldNotReachHere("unsupported by this IntrinsicGraphBuilder");
     }
 
     @Override
@@ -276,6 +308,7 @@ public class IntrinsicGraphBuilder implements GraphBuilderContext, Receiver {
             Receiver receiver = method.isStatic() ? null : this;
             if (plugin.execute(this, method, receiver, arguments)) {
                 assert (returnValue != null) == (method.getSignature().getReturnKind() != JavaKind.Void) : method;
+                assert lastInstr != null : "ReturnNode must be linked into control flow";
                 append(new ReturnNode(returnValue));
                 return graph;
             }

--- a/substratevm/src/com.oracle.graal.pointsto/src/com/oracle/graal/pointsto/phases/SubstrateIntrinsicGraphBuilder.java
+++ b/substratevm/src/com.oracle.graal.pointsto/src/com/oracle/graal/pointsto/phases/SubstrateIntrinsicGraphBuilder.java
@@ -35,6 +35,7 @@ import org.graalvm.compiler.nodes.StateSplit;
 import org.graalvm.compiler.nodes.StructuredGraph.AllowAssumptions;
 import org.graalvm.compiler.nodes.ValueNode;
 import org.graalvm.compiler.nodes.graphbuilderconf.GeneratedInvocationPlugin;
+import org.graalvm.compiler.nodes.java.ExceptionObjectNode;
 import org.graalvm.compiler.nodes.spi.CoreProviders;
 import org.graalvm.compiler.options.OptionValues;
 import org.graalvm.compiler.replacements.IntrinsicGraphBuilder;
@@ -64,6 +65,17 @@ public class SubstrateIntrinsicGraphBuilder extends IntrinsicGraphBuilder {
 
         FrameState stateAfter = getGraph().add(new FrameState(null, code, bci, values, arguments.length, stackSize, false, false, null, null));
         sideEffect.setStateAfter(stateAfter);
+        bci++;
+    }
+
+    @Override
+    protected void setExceptionState(ExceptionObjectNode exceptionObject) {
+        List<ValueNode> values = new ArrayList<>(Arrays.asList(arguments));
+        values.add(exceptionObject);
+        int stackSize = 1;
+
+        FrameState stateAfter = getGraph().add(new FrameState(null, code, bci, values, arguments.length, stackSize, true, false, null, null));
+        exceptionObject.setStateAfter(stateAfter);
         bci++;
     }
 


### PR DESCRIPTION
Fixes a problem introduced by the recent addition of ArrayCopyWithExceptionNode. When System.arraycopy is compiled as a root method, the IntrinsicGraphBuilder needs to properly link the control flow and also create the exception unwind nodes.