### PR TITLE
Fix broken links in documentation files

### DIFF
--- a/truffle/docs/InteropMigration.md
+++ b/truffle/docs/InteropMigration.md
@@ -110,7 +110,7 @@ The following interop messages were changed:
 READ, WRITE, REMOVE, HAS_SIZE, GET_SIZE, HAS_KEYS, KEYS
 ```
 
-The updated protocol with separate member and array namespace in [InteropLibrary](TODO) looks like this:
+The updated protocol with separate member and array namespace in [InteropLibrary](http://www.graalvm.org/truffle/javadoc/com/oracle/truffle/api/interop/InteropLibrary.html) looks like this:
 
 #### Object namespace:
 

--- a/truffle/docs/README.md
+++ b/truffle/docs/README.md
@@ -27,7 +27,7 @@ It simplifies language implementation by automatically deriving high-performance
 
 ### Getting started
 
-Information on how to get starting building your language can be found in the Truffle language implementation [tutorial](./docs/LanguageTutorial.md).
+Information on how to get starting building your language can be found in the Truffle language implementation [tutorial](./LanguageTutorial.md).
 The reference API documentation is available as part of the [Truffle javadoc](http://graalvm.org/truffle/javadoc/).
 Start with looking at the [TruffleLanguage](http://www.graalvm.org/truffle/javadoc/com/oracle/truffle/api/TruffleLanguage.html) class, which one should subclass to start developing a language.
 Truffle comes prebuilt with Graal and several language implementations as as part of [GraalVM](https://www.oracle.com/downloads/graalvm-downloads.html).


### PR DESCRIPTION
Super tiny changes to fix broken links in those files:
- `truffle/docs/InteropMigration.md`
- `truffle/docs/README.md`