### PR TITLE
Apply trapping nullcheck to the uncompressed target for compressed po…

### DIFF
--- a/compiler/src/org.graalvm.compiler.core.common/src/org/graalvm/compiler/core/common/type/AbstractPointerStamp.java
+++ b/compiler/src/org.graalvm.compiler.core.common/src/org/graalvm/compiler/core/common/type/AbstractPointerStamp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -160,5 +160,9 @@ public abstract class AbstractPointerStamp extends Stamp {
     @Override
     public JavaKind getStackKind() {
         return JavaKind.Illegal;
+    }
+
+    public boolean isCompressed() {
+        return false;
     }
 }

--- a/compiler/src/org.graalvm.compiler.core/src/org/graalvm/compiler/core/phases/LowTier.java
+++ b/compiler/src/org.graalvm.compiler.core/src/org/graalvm/compiler/core/phases/LowTier.java
@@ -70,9 +70,9 @@ public class LowTier extends BaseTier<LowTierContext> {
         appendPhase(new FixReadsPhase(true,
                         new SchedulePhase(GraalOptions.StressTestEarlyReads.getValue(options) ? SchedulingStrategy.EARLIEST : SchedulingStrategy.LATEST_OUT_OF_LOOPS_IMPLICIT_NULL_CHECKS)));
 
-        appendPhase(canonicalizerWithoutGVN);
-
         appendPhase(new UseTrappingNullChecksPhase());
+
+        appendPhase(canonicalizerWithoutGVN);
 
         appendPhase(new DeadCodeEliminationPhase(Required));
 

--- a/compiler/src/org.graalvm.compiler.hotspot/src/org/graalvm/compiler/hotspot/meta/AddressLoweringHotSpotSuitesProvider.java
+++ b/compiler/src/org.graalvm.compiler.hotspot/src/org/graalvm/compiler/hotspot/meta/AddressLoweringHotSpotSuitesProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2017, Red Hat Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -56,11 +56,13 @@ public class AddressLoweringHotSpotSuitesProvider extends HotSpotSuitesProvider 
         Suites suites = super.createSuites(options);
 
         ListIterator<BasePhase<? super LowTierContext>> findPhase = suites.getLowTier().findPhase(UseTrappingNullChecksPhase.class);
-        if (findPhase == null) {
+        if (findPhase != null) {
+            findPhase.add(addressLowering);
+        } else {
             findPhase = suites.getLowTier().findPhase(SchedulePhase.class);
+            findPhase.previous();
+            findPhase.add(addressLowering);
         }
-        findPhase.previous();
-        findPhase.add(addressLowering);
 
         return suites;
     }

--- a/compiler/src/org.graalvm.compiler.hotspot/src/org/graalvm/compiler/hotspot/nodes/type/KlassPointerStamp.java
+++ b/compiler/src/org.graalvm.compiler.hotspot/src/org/graalvm/compiler/hotspot/nodes/type/KlassPointerStamp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -146,6 +146,7 @@ public final class KlassPointerStamp extends MetaspacePointerStamp {
         }
     }
 
+    @Override
     public boolean isCompressed() {
         return encoding != null;
     }

--- a/compiler/src/org.graalvm.compiler.nodes/src/org/graalvm/compiler/nodes/memory/address/OffsetAddressNode.java
+++ b/compiler/src/org.graalvm.compiler.nodes/src/org/graalvm/compiler/nodes/memory/address/OffsetAddressNode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -58,13 +58,18 @@ public class OffsetAddressNode extends AddressNode implements Canonicalizable {
         super(TYPE);
         this.base = base;
         this.offset = offset;
-
         assert base != null && (base.stamp(NodeView.DEFAULT) instanceof AbstractPointerStamp || IntegerStamp.getBits(base.stamp(NodeView.DEFAULT)) == 64) &&
                         offset != null && IntegerStamp.getBits(offset.stamp(NodeView.DEFAULT)) == 64 : "both values must have 64 bits";
     }
 
     public static OffsetAddressNode create(ValueNode base) {
-        return new OffsetAddressNode(base, ConstantNode.forIntegerBits(PrimitiveStamp.getBits(base.stamp(NodeView.DEFAULT)), 0));
+        ValueNode offset;
+        if (base.stamp(NodeView.DEFAULT) instanceof AbstractPointerStamp) {
+            offset = ConstantNode.forIntegerBits(64, 0);
+        } else {
+            offset = ConstantNode.forIntegerBits(PrimitiveStamp.getBits(base.stamp(NodeView.DEFAULT)), 0);
+        }
+        return new OffsetAddressNode(base, offset);
     }
 
     @Override

--- a/compiler/src/org.graalvm.compiler.nodes/src/org/graalvm/compiler/nodes/type/NarrowOopStamp.java
+++ b/compiler/src/org.graalvm.compiler.nodes/src/org/graalvm/compiler/nodes/type/NarrowOopStamp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -115,4 +115,9 @@ public abstract class NarrowOopStamp extends AbstractObjectStamp {
 
     @Override
     public abstract boolean isCompatible(Constant other);
+
+    @Override
+    public boolean isCompressed() {
+        return true;
+    }
 }

--- a/compiler/src/org.graalvm.compiler.phases.common/src/org/graalvm/compiler/phases/common/UseTrappingNullChecksPhase.java
+++ b/compiler/src/org.graalvm.compiler.phases.common/src/org/graalvm/compiler/phases/common/UseTrappingNullChecksPhase.java
@@ -274,7 +274,7 @@ public class UseTrappingNullChecksPhase extends BasePhase<LowTierContext> {
 
         if (trappingNullCheck == null) {
             // Need to add a null check node.
-            trappingNullCheck = graph.add(new NullCheckNode(value, deoptReasonAndAction, deoptSpeculation));
+            trappingNullCheck = graph.add(NullCheckNode.create(value, deoptReasonAndAction, deoptSpeculation));
             graph.replaceSplit(ifNode, trappingNullCheck, nonTrappingContinuation);
             debug.log("Inserted NullCheckNode %s", trappingNullCheck);
         }

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/NativeImageGenerator.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/NativeImageGenerator.java
@@ -89,10 +89,10 @@ import org.graalvm.compiler.phases.PhaseSuite;
 import org.graalvm.compiler.phases.common.CanonicalizerPhase;
 import org.graalvm.compiler.phases.common.DeoptimizationGroupingPhase;
 import org.graalvm.compiler.phases.common.ExpandLogicPhase;
-import org.graalvm.compiler.phases.common.FixReadsPhase;
 import org.graalvm.compiler.phases.common.FrameStateAssignmentPhase;
 import org.graalvm.compiler.phases.common.LoopSafepointInsertionPhase;
 import org.graalvm.compiler.phases.common.LoweringPhase;
+import org.graalvm.compiler.phases.common.UseTrappingNullChecksPhase;
 import org.graalvm.compiler.phases.common.inlining.InliningPhase;
 import org.graalvm.compiler.phases.tiers.HighTierContext;
 import org.graalvm.compiler.phases.tiers.LowTierContext;
@@ -1345,7 +1345,7 @@ public class NativeImageGenerator {
         if (firstTier) {
             lowTier.findPhase(ExpandLogicPhase.class, true).add(addressLoweringPhase);
         } else {
-            lowTier.findPhase(FixReadsPhase.class).add(addressLoweringPhase);
+            lowTier.findPhase(UseTrappingNullChecksPhase.class).add(addressLoweringPhase);
         }
 
         if (SubstrateOptions.MultiThreaded.getValue()) {


### PR DESCRIPTION
…inter.

Trapping nullcheck might generate two uncompress instructions for the same compressed oop in Graal. One is inserted by the backend when it emits nullcheck. If the pointer is a compressed object, it should be uncompressed before the nullcheck is emitted. And another one is generated by the normal uncompressing operation. These two instructions are duplicated with each other.
The generated codes on AArch64 like:

      ldr   w0, [x0,#112]
      lsl   x2, x0, #3      ; uncompressing (first)
      ldr   xzr, [x2]       ; implicit exception: deoptimizes
      ......                ; fixed operations
      lsl   x0, x0, #3      ; uncompressing (second)
      str   w1, [x0,#12]

A simple way to avoid this is to creat a new uncompression node for the nullcheck, and let the value numbering remove the duplicated one if possible. Since the address lowering of AMD64 can handle the uncompressing computation for address, the created uncompression node is wrapped to an address node and the nullcheck is finally applied on the address.

With the modification, the codes above could be optimized to:

      ldr   w0, [x0,#112]
      lsl   x0, x0, #3      ; uncompressing
      ldr   xzr, [x0]       ; implicit exception: deoptimizes
      ......                ; fixed operations
      str   w1, [x0,#12]

Change-Id: Iabfe47bbf984ed11c42555f84bdd0ccf2a5bdddb