### PR TITLE
look for app sources in correct locations

### DIFF
--- a/substratevm/DEBUGINFO.md
+++ b/substratevm/DEBUGINFO.md
@@ -140,9 +140,11 @@ what is found in each classpath entry. Given a jar file entry like
 /path/to/foo.jar, the corresponding jar /path/to/foo-sources.jar is
 considered as a candidate zip file system from which source files may
 be extracted. When the entry specifies a dir like /path/to/bar/classes
-or /path/to/bar/target/classes then directory /path/to/bar/src is
-considered as a candidate. Finally, the current directory in which the
-native image program is being run is also considered as a candidate.
+or /path/to/bar/target/classes then one of the directories
+/path/to/bar/src/main/java, /path/to/bar/src/java or /path/to/bar/src
+is selected as a candidate (in that order of preference). Finally, the
+current directory in which the native image program is being run is
+also considered as a candidate.
 
 These lookup strategies are only provisional and may need extending in
 future. Note however that it is possible to make missing sources

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/image/sources/ApplicationSourceCache.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/image/sources/ApplicationSourceCache.java
@@ -114,6 +114,7 @@ public class ApplicationSourceCache extends SourceCache {
                         sourcePath = subPath;
                     } else {
                         subPath = sourcePath.resolve("java");
+                        file = subPath.toFile();
                         if (file.exists() && file.isDirectory()) {
                             sourcePath = subPath;
                         }

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/image/sources/ApplicationSourceCache.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/image/sources/ApplicationSourceCache.java
@@ -77,7 +77,7 @@ public class ApplicationSourceCache extends SourceCache {
                      * application jar /path/to/xxx.jar should have sources /path/to/xxx-sources.jar
                      */
                     int length = fileNameString.length();
-                    fileNameString = fileNameString.substring(0, length - 4) + "-sources.zip";
+                    fileNameString = fileNameString.substring(0, length - 4) + "-sources.jar";
                 }
                 sourcePath = sourcePath.getParent().resolve(fileNameString);
                 if (sourcePath.toFile().exists()) {
@@ -107,6 +107,17 @@ public class ApplicationSourceCache extends SourceCache {
                 // try the path as provided
                 File file = sourcePath.toFile();
                 if (file.exists() && file.isDirectory()) {
+                    // see if we have src/main/java or src/java
+                    Path subPath = sourcePath.resolve("main").resolve("java");
+                    file = subPath.toFile();
+                    if (file.exists() && file.isDirectory()) {
+                        sourcePath = subPath;
+                    } else {
+                        subPath = sourcePath.resolve("java");
+                        if (file.exists() && file.isDirectory()) {
+                            sourcePath = subPath;
+                        }
+                    }
                     srcRoots.add(sourcePath);
                 }
             }


### PR DESCRIPTION
Correction to ensure app source roots are computed correctly relative to a jar or directory in the classpath.
