### PR TITLE
Implement proper behaviour for POSIX Truffle NFI feature for different libc implementations.

### DIFF
--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/c/libc/GLibc.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/c/libc/GLibc.java
@@ -48,4 +48,9 @@ public class GLibc implements LibCBase {
     public List<String> getCCompilerOptions() {
         return Collections.emptyList();
     }
+
+    @Override
+    public boolean hasIsolatedNamespaces() {
+        return true;
+    }
 }

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/c/libc/LibCBase.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/c/libc/LibCBase.java
@@ -99,4 +99,6 @@ public interface LibCBase {
     default boolean isLibC(Class<? extends LibCBase> libC) {
         return getClass().equals(libC);
     }
+
+    boolean hasIsolatedNamespaces();
 }

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/c/libc/MuslLibc.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/c/libc/MuslLibc.java
@@ -97,4 +97,9 @@ public class MuslLibc implements LibCBase {
         VMError.guarantee(specFilePath != null);
         return specFilePath.toAbsolutePath();
     }
+
+    @Override
+    public boolean hasIsolatedNamespaces() {
+        return false;
+    }
 }

--- a/substratevm/src/com.oracle.svm.truffle.nfi.posix/src/com/oracle/svm/truffle/nfi/posix/PosixTruffleNFIFeature.java
+++ b/substratevm/src/com.oracle.svm.truffle.nfi.posix/src/com/oracle/svm/truffle/nfi/posix/PosixTruffleNFIFeature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,7 +26,6 @@ package com.oracle.svm.truffle.nfi.posix;
 
 import static com.oracle.svm.core.posix.headers.Dlfcn.GNUExtensions.LM_ID_NEWLM;
 
-import com.oracle.svm.core.c.libc.GLibc;
 import com.oracle.svm.core.c.libc.LibCBase;
 import org.graalvm.nativeimage.ImageSingletons;
 import org.graalvm.nativeimage.Platform;
@@ -63,9 +62,13 @@ public final class PosixTruffleNFIFeature implements Feature {
 
 final class PosixTruffleNFISupport extends TruffleNFISupport {
 
-    static final int ISOLATED_NAMESPACE_FLAG = 0x10000;
+    private static final int ISOLATED_NAMESPACE_FLAG = 0x10000;
+    private static final int ISOLATED_NAMESPACE_NOT_SUPPORTED_FLAG = 0;
+
+    static int isolatedNamespaceFlag;
 
     static void initialize() {
+        isolatedNamespaceFlag = LibCBase.singleton().hasIsolatedNamespaces() ? ISOLATED_NAMESPACE_FLAG : ISOLATED_NAMESPACE_NOT_SUPPORTED_FLAG;
         ImageSingletons.add(TruffleNFISupport.class, new PosixTruffleNFISupport());
     }
 
@@ -99,7 +102,7 @@ final class PosixTruffleNFISupport extends TruffleNFISupport {
      * A single linking namespace is created lazily and registered on the NFI context instance.
      */
     private static PointerBase loadLibraryInNamespace(long nativeContext, String name, int mode) {
-        assert (mode & ISOLATED_NAMESPACE_FLAG) == 0;
+        assert (mode & isolatedNamespaceFlag) == 0;
         Target_com_oracle_truffle_nfi_impl_NFIContextLinux context = //
                         KnownIntrinsics.convertUnknownValue(getContext(nativeContext), Target_com_oracle_truffle_nfi_impl_NFIContextLinux.class);
 
@@ -138,8 +141,8 @@ final class PosixTruffleNFISupport extends TruffleNFISupport {
     @Override
     protected long loadLibraryImpl(long nativeContext, String name, int flags) {
         PointerBase handle;
-        if (Platform.includedIn(Platform.LINUX.class) && (flags & ISOLATED_NAMESPACE_FLAG) != 0 && LibCBase.singleton().isLibC(GLibc.class)) {
-            handle = loadLibraryInNamespace(nativeContext, name, flags & ~ISOLATED_NAMESPACE_FLAG);
+        if (Platform.includedIn(Platform.LINUX.class) && (flags & isolatedNamespaceFlag) != 0) {
+            handle = loadLibraryInNamespace(nativeContext, name, flags & ~isolatedNamespaceFlag);
         } else {
             handle = PosixUtils.dlopen(name, flags);
         }

--- a/substratevm/src/com.oracle.svm.truffle.nfi.posix/src/com/oracle/svm/truffle/nfi/posix/Target_com_oracle_truffle_nfi_impl_NFIContextLinux.java
+++ b/substratevm/src/com.oracle.svm.truffle.nfi.posix/src/com/oracle/svm/truffle/nfi/posix/Target_com_oracle_truffle_nfi_impl_NFIContextLinux.java
@@ -43,7 +43,7 @@ final class Target_com_oracle_truffle_nfi_impl_NFIContextLinux {
 
     static class IsolatedAccessor {
         static int getISOLATED_NAMESPACE(@SuppressWarnings("unused") Target_com_oracle_truffle_nfi_impl_NFIContextLinux ctx) {
-            return PosixTruffleNFISupport.ISOLATED_NAMESPACE_FLAG;
+            return PosixTruffleNFISupport.isolatedNamespaceFlag;
         }
     }
     // Checkstyle: resume


### PR DESCRIPTION
Currently, isolated namespaces in a context are silently disregarded if compiled native-image uses musl-c.
This PR makes each libc return whether it supports isolated namespaces.