### PR TITLE
[GR-22749]: Fix native-image buffer overflow on windows using Chinese Charset.

### DIFF
--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/pecoff/PECoffSymtabStruct.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/pecoff/PECoffSymtabStruct.java
@@ -84,7 +84,7 @@ final class PECoffSymtabStruct {
             sym = new PECoffSymbolStruct(index, type, storageclass, secHdrIndex, offset);
             symbols.add(sym);
         } else {
-            int nameSize = name.getBytes().length;
+            int nameSize = name.getBytes(StandardCharsets.UTF_8).length;
 
             // We can't trust strTabContent.length() since that is
             // chars (UTF16), keep track of bytes on our own.


### PR DESCRIPTION
Use UTF_8 Charset when calculating length of Windows PE Coff symbols.