### PR TITLE
Provide java.lang.Terminator.setup() via --install-exit-handlers

### DIFF
--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/JavaMainWrapper.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/JavaMainWrapper.java
@@ -51,9 +51,7 @@ import org.graalvm.word.PointerBase;
 import org.graalvm.word.UnsignedWord;
 import org.graalvm.word.WordFactory;
 
-import com.oracle.svm.core.annotate.Alias;
 import com.oracle.svm.core.annotate.AlwaysInline;
-import com.oracle.svm.core.annotate.TargetClass;
 import com.oracle.svm.core.c.CGlobalData;
 import com.oracle.svm.core.c.CGlobalDataFactory;
 import com.oracle.svm.core.c.function.CEntryPointOptions;
@@ -135,10 +133,6 @@ public class JavaMainWrapper {
         int exitCode;
         try {
             if (SubstrateOptions.ParseRuntimeOptions.getValue()) {
-                if (SubstrateOptions.InstallExitHandlers.getValue()) {
-                    Target_java_lang_Terminator.setup();
-                }
-
                 /*
                  * When options are not parsed yet, it is also too early to run the startup hooks
                  * because they often depend on option values. The user is expected to manually run
@@ -292,10 +286,4 @@ public class JavaMainWrapper {
         @RawField
         void setArgv(CCharPointerPointer value);
     }
-}
-
-@TargetClass(className = "java.lang.Terminator")
-final class Target_java_lang_Terminator {
-    @Alias
-    static native void setup();
 }

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/JavaMainWrapper.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/JavaMainWrapper.java
@@ -53,14 +53,12 @@ import org.graalvm.word.WordFactory;
 
 import com.oracle.svm.core.annotate.Alias;
 import com.oracle.svm.core.annotate.AlwaysInline;
-import com.oracle.svm.core.annotate.RecomputeFieldValue;
 import com.oracle.svm.core.annotate.TargetClass;
 import com.oracle.svm.core.c.CGlobalData;
 import com.oracle.svm.core.c.CGlobalDataFactory;
 import com.oracle.svm.core.c.function.CEntryPointOptions;
 import com.oracle.svm.core.c.function.CEntryPointSetup.EnterCreateIsolatePrologue;
 import com.oracle.svm.core.jdk.InternalVMMethod;
-import com.oracle.svm.core.jdk.Package_jdk_internal_misc;
 import com.oracle.svm.core.jdk.RuntimeSupport;
 import com.oracle.svm.core.option.RuntimeOptionParser;
 import com.oracle.svm.core.thread.JavaThreads;
@@ -298,13 +296,6 @@ public class JavaMainWrapper {
 
 @TargetClass(className = "java.lang.Terminator")
 final class Target_java_lang_Terminator {
-    @Alias @RecomputeFieldValue(kind = RecomputeFieldValue.Kind.Reset) //
-    private static Target_jdk_internal_misc_Signal_Handler handler;
-
     @Alias
     static native void setup();
-}
-
-@TargetClass(classNameProvider = Package_jdk_internal_misc.class, className = "Signal$Handler")
-final class Target_jdk_internal_misc_Signal_Handler {
 }

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/SubstrateExitHandlerFeature.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/SubstrateExitHandlerFeature.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2020, 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package com.oracle.svm.core;
+
+import org.graalvm.nativeimage.ImageInfo;
+import org.graalvm.nativeimage.hosted.Feature;
+
+import com.oracle.svm.core.annotate.Alias;
+import com.oracle.svm.core.annotate.AutomaticFeature;
+import com.oracle.svm.core.annotate.TargetClass;
+import com.oracle.svm.core.jdk.RuntimeSupport;
+
+@AutomaticFeature
+public class SubstrateExitHandlerFeature implements Feature {
+    @Override
+    public void beforeAnalysis(BeforeAnalysisAccess access) {
+        if (SubstrateOptions.InstallExitHandlers.getValue() && ImageInfo.isExecutable()) {
+            RuntimeSupport.getRuntimeSupport().addStartupHook(Target_java_lang_Terminator::setup);
+        }
+    }
+}
+
+@TargetClass(className = "java.lang.Terminator")
+final class Target_java_lang_Terminator {
+    @Alias
+    static native void setup();
+}

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/SubstrateOptions.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/SubstrateOptions.java
@@ -24,6 +24,7 @@
  */
 package com.oracle.svm.core;
 
+import static org.graalvm.compiler.core.common.GraalOptions.TrackNodeSourcePosition;
 import static org.graalvm.compiler.core.common.SpeculativeExecutionAttacksMitigations.None;
 import static org.graalvm.compiler.core.common.SpeculativeExecutionAttacksMitigations.Options.MitigateSpeculativeExecutionAttacks;
 import static org.graalvm.compiler.options.OptionType.User;
@@ -51,8 +52,6 @@ import com.oracle.svm.core.option.HostedOptionValues;
 import com.oracle.svm.core.option.OptionUtils;
 import com.oracle.svm.core.option.RuntimeOptionKey;
 import com.oracle.svm.core.option.XOptions;
-
-import static org.graalvm.compiler.core.common.GraalOptions.TrackNodeSourcePosition;
 
 public class SubstrateOptions {
 
@@ -424,6 +423,10 @@ public class SubstrateOptions {
     @APIOption(name = "native-image-info")//
     @Option(help = "Show native-toolchain information and image-build settings", type = User)//
     public static final HostedOptionKey<Boolean> DumpTargetInfo = new HostedOptionKey<>(false);
+
+    @APIOption(name = "install-exit-handlers")//
+    @Option(help = "Provide java.lang.Terminator exit handlers for executable images", type = User)//
+    public static final HostedOptionKey<Boolean> InstallExitHandlers = new HostedOptionKey<>(false);
 
     @Option(help = "file:doc-files/UseMuslCHelp.txt", type = OptionType.Expert)//
     public static final HostedOptionKey<String> UseMuslC = new HostedOptionKey<>(null);

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/jdk/JNIRegistrationJava.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/jdk/JNIRegistrationJava.java
@@ -67,7 +67,7 @@ class JNIRegistrationJava extends JNIRegistrationUtil implements GraalFeature {
     public void duringSetup(DuringSetupAccess a) {
         ImageSingletons.add(JNIRegistrationSupport.class, new JNIRegistrationSupport());
 
-        rerunClassInit(a, "java.io.RandomAccessFile", "java.lang.ProcessEnvironment", "java.io.File$TempDirectory");
+        rerunClassInit(a, "java.io.RandomAccessFile", "java.lang.ProcessEnvironment", "java.io.File$TempDirectory", "java.lang.Terminator");
         if (JavaVersionUtil.JAVA_SPEC <= 8) {
             if (isPosix()) {
                 rerunClassInit(a, "java.lang.UNIXProcess");


### PR DESCRIPTION
This PR provides a fix for #1592

Testing with

```java
public class Main {
    public static void main(String[] args) {
        Runtime.getRuntime().addShutdownHook(new Thread(() -> {
            System.out.println("Shutdown happens!");
        }));
        
        try {
            System.out.println("Zzzzzzz.....");
            Thread.sleep(Long.MAX_VALUE);
        } catch (InterruptedException e) {
            System.out.println("Good morning!");
            e.printStackTrace();
        }
    }
}
```

shows an image size increase of 48Kb when native-image --install-exit-handlers is used (from 6,802,048 bytes to 6,850,976 bytes)