### PR TITLE
Expect AVX3Threshold on all JDKs >= 11

### DIFF
--- a/compiler/src/org.graalvm.compiler.hotspot/src/org/graalvm/compiler/hotspot/GraalHotSpotVMConfig.java
+++ b/compiler/src/org.graalvm.compiler.hotspot/src/org/graalvm/compiler/hotspot/GraalHotSpotVMConfig.java
@@ -154,7 +154,7 @@ public class GraalHotSpotVMConfig extends GraalHotSpotVMConfigAccess {
     private final boolean useSquareToLenIntrinsic = getFlag("UseSquareToLenIntrinsic", Boolean.class, false, isJDK8OrJDK11Plus);
     public final boolean useVectorizedMismatchIntrinsic = getFlag("UseVectorizedMismatchIntrinsic", Boolean.class, false, isJDK11Plus);
     public final boolean useFMAIntrinsics = getFlag("UseFMA", Boolean.class, false, JDK >= 9);
-    public final int useAVX3Threshold = getFlag("AVX3Threshold", Integer.class, 4096, osArch.equals("amd64") && (JVMCI ? JDK >= 11 : JDK >= 14));
+    public final int useAVX3Threshold = getFlag("AVX3Threshold", Integer.class, 4096, osArch.equals("amd64") && (JDK >= 14 || (JDK == 11 && JDK_UPDATE >= 6)));
 
     public final boolean preserveFramePointer = getFlag("PreserveFramePointer", Boolean.class);
 

--- a/compiler/src/org.graalvm.compiler.hotspot/src/org/graalvm/compiler/hotspot/GraalHotSpotVMConfigAccess.java
+++ b/compiler/src/org.graalvm.compiler.hotspot/src/org/graalvm/compiler/hotspot/GraalHotSpotVMConfigAccess.java
@@ -36,6 +36,7 @@ import org.graalvm.compiler.debug.Assertions;
 import org.graalvm.compiler.hotspot.JVMCIVersionCheck.Version;
 import org.graalvm.compiler.hotspot.JVMCIVersionCheck.Version2;
 import org.graalvm.compiler.hotspot.JVMCIVersionCheck.Version3;
+import org.graalvm.compiler.serviceprovider.GraalServices;
 import org.graalvm.compiler.serviceprovider.JavaVersionUtil;
 
 import jdk.vm.ci.common.JVMCIError;
@@ -137,6 +138,7 @@ public class GraalHotSpotVMConfigAccess {
     }
 
     public static final int JDK = JavaVersionUtil.JAVA_SPEC;
+    public static final int JDK_UPDATE = GraalServices.getJavaUpdateVersion();
     public static final boolean IS_OPENJDK = getProperty("java.vm.name", "").startsWith("OpenJDK");
     public static final Version JVMCI_VERSION;
     public static final boolean JVMCI;

--- a/compiler/src/org.graalvm.compiler.serviceprovider.jdk11/src/org/graalvm/compiler/serviceprovider/GraalServices.java
+++ b/compiler/src/org.graalvm.compiler.serviceprovider.jdk11/src/org/graalvm/compiler/serviceprovider/GraalServices.java
@@ -437,4 +437,8 @@ public final class GraalServices {
         }
         return VirtualObject.get(type, id);
     }
+
+    public static int getJavaUpdateVersion() {
+        return Runtime.version().update();
+    }
 }

--- a/compiler/src/org.graalvm.compiler.serviceprovider.jdk13/src/org/graalvm/compiler/serviceprovider/GraalServices.java
+++ b/compiler/src/org.graalvm.compiler.serviceprovider.jdk13/src/org/graalvm/compiler/serviceprovider/GraalServices.java
@@ -554,4 +554,8 @@ public final class GraalServices {
     public static VirtualObject createVirtualObject(ResolvedJavaType type, int id, boolean isAutoBox) {
         return VirtualObject.get(type, id, isAutoBox);
     }
+
+    public static int getJavaUpdateVersion() {
+        return Runtime.version().update();
+    }
 }

--- a/compiler/src/org.graalvm.compiler.serviceprovider.jdk8/src/org/graalvm/compiler/serviceprovider/GraalServices.java
+++ b/compiler/src/org.graalvm.compiler.serviceprovider.jdk8/src/org/graalvm/compiler/serviceprovider/GraalServices.java
@@ -36,6 +36,8 @@ import java.util.List;
 import java.util.ServiceConfigurationError;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Supplier;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import jdk.vm.ci.code.VirtualObject;
 import jdk.vm.ci.meta.ResolvedJavaField;
@@ -433,5 +435,18 @@ public final class GraalServices {
     @SuppressWarnings("unused")
     public static VirtualObject createVirtualObject(ResolvedJavaType type, int id, boolean isAutoBox) {
         return VirtualObject.get(type, id, isAutoBox);
+    }
+
+    public static int getJavaUpdateVersion() {
+        // JDK 8: Only simplified patterns like 25.242-b08 or 25.241-b07-jvmci-20.1-b01
+        // are being recognized. Update represents the numerical value after the first
+        // dot and before the first dash
+        Pattern p = Pattern.compile("\\d+\\.([^-]+)-.*");
+        String vmVersion = Services.getSavedProperties().get("java.vm.version");
+        Matcher matcher = p.matcher(vmVersion);
+        if (!matcher.matches()) {
+            throw new InternalError("Unexpected java.vm.version value: " + vmVersion);
+        }
+        return Integer.parseInt(matcher.group(1));
     }
 }

--- a/compiler/src/org.graalvm.compiler.serviceprovider/src/org/graalvm/compiler/serviceprovider/GraalServices.java
+++ b/compiler/src/org.graalvm.compiler.serviceprovider/src/org/graalvm/compiler/serviceprovider/GraalServices.java
@@ -244,4 +244,13 @@ public final class GraalServices {
     public static VirtualObject createVirtualObject(ResolvedJavaType type, int id, boolean isAutoBox) {
         throw shouldNotReachHere();
     }
+
+    /**
+     * Gets the update-release counter for the current Java runtime.
+     *
+     * @see "https://download.java.net/java/GA/jdk14/docs/api/java.base/java/lang/Runtime.Version.html"
+     */
+    public static int getJavaUpdateVersion() {
+        throw shouldNotReachHere();
+    }
 }


### PR DESCRIPTION
Instead of conditionalizing flag AVX3Threshold on a JVMCI-versioned
JDK 11, expect it for any JDK >= 11

Closes #2402