### PR TITLE
AArch64 Debug Info fixes

### DIFF
--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfDebugInfo.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfDebugInfo.java
@@ -163,7 +163,7 @@ public class DwarfDebugInfo extends DebugInfoBase {
     private DwarfARangesSectionImpl dwarfARangesSection;
     private DwarfLineSectionImpl dwarfLineSection;
     private DwarfFrameSectionImpl dwarfFameSection;
-    private ELFMachine elfMachine;
+    public final ELFMachine elfMachine;
 
     public DwarfDebugInfo(ELFMachine elfMachine, ByteOrder byteOrder) {
         super(byteOrder);
@@ -202,9 +202,5 @@ public class DwarfDebugInfo extends DebugInfoBase {
 
     public DwarfLineSectionImpl getLineSectionImpl() {
         return dwarfLineSection;
-    }
-
-    public ELFMachine getELFMachine() {
-        return elfMachine;
     }
 }

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfDebugInfo.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfDebugInfo.java
@@ -140,7 +140,7 @@ public class DwarfDebugInfo extends DebugInfoBase {
     /* Values encoded in high 2 bits. */
     public static final byte DW_CFA_advance_loc = 0x1;
     public static final byte DW_CFA_offset = 0x2;
-    @SuppressWarnings("unused") public static final byte DW_CFA_restore = 0x3;
+    public static final byte DW_CFA_restore = 0x3;
 
     /* Values encoded in low 6 bits. */
     public static final byte DW_CFA_nop = 0x0;
@@ -163,9 +163,11 @@ public class DwarfDebugInfo extends DebugInfoBase {
     private DwarfARangesSectionImpl dwarfARangesSection;
     private DwarfLineSectionImpl dwarfLineSection;
     private DwarfFrameSectionImpl dwarfFameSection;
+    private ELFMachine elfMachine;
 
     public DwarfDebugInfo(ELFMachine elfMachine, ByteOrder byteOrder) {
         super(byteOrder);
+        this.elfMachine = elfMachine;
         dwarfStrSection = new DwarfStrSectionImpl(this);
         dwarfAbbrevSection = new DwarfAbbrevSectionImpl(this);
         dwarfInfoSection = new DwarfInfoSectionImpl(this);
@@ -200,5 +202,9 @@ public class DwarfDebugInfo extends DebugInfoBase {
 
     public DwarfLineSectionImpl getLineSectionImpl() {
         return dwarfLineSection;
+    }
+
+    public ELFMachine getELFMachine() {
+        return elfMachine;
     }
 }

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfFrameSectionImpl.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfFrameSectionImpl.java
@@ -32,6 +32,8 @@ import com.oracle.objectfile.debugentry.PrimaryEntry;
 import com.oracle.objectfile.debuginfo.DebugInfoProvider;
 import org.graalvm.compiler.debug.DebugContext;
 
+import java.util.List;
+
 import static com.oracle.objectfile.elf.dwarf.DwarfDebugInfo.DW_CFA_CIE_id;
 import static com.oracle.objectfile.elf.dwarf.DwarfDebugInfo.DW_CFA_CIE_version;
 import static com.oracle.objectfile.elf.dwarf.DwarfDebugInfo.DW_CFA_advance_loc;
@@ -43,6 +45,7 @@ import static com.oracle.objectfile.elf.dwarf.DwarfDebugInfo.DW_CFA_def_cfa_offs
 import static com.oracle.objectfile.elf.dwarf.DwarfDebugInfo.DW_CFA_nop;
 import static com.oracle.objectfile.elf.dwarf.DwarfDebugInfo.DW_CFA_offset;
 import static com.oracle.objectfile.elf.dwarf.DwarfDebugInfo.DW_CFA_register;
+import static com.oracle.objectfile.elf.dwarf.DwarfDebugInfo.DW_CFA_restore;
 import static com.oracle.objectfile.elf.dwarf.DwarfDebugInfo.DW_FRAME_SECTION_NAME;
 import static com.oracle.objectfile.elf.dwarf.DwarfDebugInfo.DW_LINE_SECTION_NAME;
 
@@ -172,32 +175,17 @@ public abstract class DwarfFrameSectionImpl extends DwarfSectionImpl {
             for (PrimaryEntry primaryEntry : classEntry.getPrimaryEntries()) {
                 long lo = primaryEntry.getPrimary().getLo();
                 long hi = primaryEntry.getPrimary().getHi();
-                int frameSize = primaryEntry.getFrameSize();
-                int currentOffset = 0;
                 int lengthPos = pos;
                 pos = writeFDEHeader((int) lo, (int) hi, buffer, pos);
-                for (DebugInfoProvider.DebugFrameSizeChange debugFrameSizeInfo : primaryEntry.getFrameSizeInfos()) {
-                    int advance = debugFrameSizeInfo.getOffset() - currentOffset;
-                    currentOffset += advance;
-                    pos = writeAdvanceLoc(advance, buffer, pos);
-                    if (debugFrameSizeInfo.getType() == DebugInfoProvider.DebugFrameSizeChange.Type.EXTEND) {
-                        /*
-                         * SP has been extended so rebase CFA using full frame.
-                         */
-                        pos = writeDefCFAOffset(frameSize, buffer, pos);
-                    } else {
-                        /*
-                         * SP has been contracted so rebase CFA using empty frame.
-                         */
-                        pos = writeDefCFAOffset(8, buffer, pos);
-                    }
-                }
+                pos = writeFDEs(primaryEntry.getFrameSize(), primaryEntry.getFrameSizeInfos(), buffer, pos);
                 pos = writePaddingNops(buffer, pos);
                 patchLength(lengthPos, buffer, pos);
             }
         }
         return pos;
     }
+
+    protected abstract int writeFDEs(int frameSize, List<DebugInfoProvider.DebugFrameSizeChange> frameSizeInfos, byte[] buffer, int pos);
 
     private int writeFDEHeader(int lo, int hi, byte[] buffer, int p) {
         /*
@@ -346,6 +334,17 @@ public abstract class DwarfFrameSectionImpl extends DwarfSectionImpl {
         }
     }
 
+    protected int writeRestore(int register, byte[] buffer, int p) {
+        byte op = restoreOp(register);
+        int pos = p;
+        if (buffer == null) {
+            return pos + putByte(op, scratch, 0);
+        } else {
+            return putByte(op, buffer, pos);
+        }
+    }
+
+    @SuppressWarnings("unused")
     protected int writeRegister(int savedReg, int savedToReg, byte[] buffer, int p) {
         int pos = p;
         if (buffer == null) {
@@ -389,6 +388,11 @@ public abstract class DwarfFrameSectionImpl extends DwarfSectionImpl {
     private static byte offsetOp(int register) {
         assert (register >> 6) == 0;
         return (byte) ((DW_CFA_offset << 6) | register);
+    }
+
+    private static byte restoreOp(int register) {
+        assert (register >> 6) == 0;
+        return (byte) ((DW_CFA_restore << 6) | register);
     }
 
     private static byte advanceLoc0Op(int offset) {

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfFrameSectionImpl.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfFrameSectionImpl.java
@@ -117,7 +117,7 @@ public abstract class DwarfFrameSectionImpl extends DwarfSectionImpl {
          *
          * <li><code>ULEB : data_alignment_factor ... == -8</code>
          *
-         * <li><code>byte : ret_addr reg id ......... x86_64 => 16 AArch64 => 32</code>
+         * <li><code>byte : ret_addr reg id ......... x86_64 => 16 AArch64 => 30</code>
          *
          * <li><code>byte[] : initial_instructions .. includes pad to 8-byte boundary</code>
          *
@@ -131,7 +131,7 @@ public abstract class DwarfFrameSectionImpl extends DwarfSectionImpl {
             pos += putAsciiStringBytes("", scratch, 0);
             pos += putULEB(1, scratch, 0);
             pos += putSLEB(-8, scratch, 0);
-            pos += putByte((byte) getPCIdx(), scratch, 0);
+            pos += putByte((byte) getReturnPCIdx(), scratch, 0);
             /*
              * Write insns to set up empty frame.
              */
@@ -152,7 +152,7 @@ public abstract class DwarfFrameSectionImpl extends DwarfSectionImpl {
             pos = putAsciiStringBytes("", buffer, pos);
             pos = putULEB(1, buffer, pos);
             pos = putSLEB(-8, buffer, pos);
-            pos = putByte((byte) getPCIdx(), buffer, pos);
+            pos = putByte((byte) getReturnPCIdx(), buffer, pos);
             /*
              * write insns to set up empty frame
              */
@@ -359,7 +359,7 @@ public abstract class DwarfFrameSectionImpl extends DwarfSectionImpl {
         }
     }
 
-    protected abstract int getPCIdx();
+    protected abstract int getReturnPCIdx();
 
     @SuppressWarnings("unused")
     protected abstract int getSPIdx();

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfFrameSectionImplAArch64.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfFrameSectionImplAArch64.java
@@ -73,7 +73,8 @@ public class DwarfFrameSectionImplAArch64 extends DwarfFrameSectionImpl {
     }
 
     @Override
-    protected int writeFDEs(int frameSize, List<DebugInfoProvider.DebugFrameSizeChange> frameSizeInfos, byte[] buffer, int pos) {
+    protected int writeFDEs(int frameSize, List<DebugInfoProvider.DebugFrameSizeChange> frameSizeInfos, byte[] buffer, int p) {
+        int pos = p;
         int currentOffset = 0;
         for (DebugInfoProvider.DebugFrameSizeChange debugFrameSizeInfo : frameSizeInfos) {
             int advance = debugFrameSizeInfo.getOffset() - currentOffset;

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfFrameSectionImplAArch64.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfFrameSectionImplAArch64.java
@@ -34,15 +34,15 @@ public class DwarfFrameSectionImplAArch64 extends DwarfFrameSectionImpl {
     // public static final int DW_CFA_FP_IDX = 29;
     private static final int DW_CFA_LR_IDX = 30;
     private static final int DW_CFA_SP_IDX = 31;
-    private static final int DW_CFA_PC_IDX = 32;
+    // private static final int DW_CFA_PC_IDX = 32;
 
     public DwarfFrameSectionImplAArch64(DwarfDebugInfo dwarfSections) {
         super(dwarfSections);
     }
 
     @Override
-    public int getPCIdx() {
-        return DW_CFA_PC_IDX;
+    public int getReturnPCIdx() {
+        return DW_CFA_LR_IDX;
     }
 
     @Override
@@ -54,15 +54,15 @@ public class DwarfFrameSectionImplAArch64 extends DwarfFrameSectionImpl {
     public int writeInitialInstructions(byte[] buffer, int p) {
         int pos = p;
         /*
-         * Register rsp has not been updated and caller pc is in lr:
+         * Register rsp points at the frame base so cfa is at rsp + 0:
          *
          * <ul>
          *
-         * <li><code>register r32 (rpc), r30 (lr)</code>
+         * <li><code>def_cfa r31 (sp) offset 0</code>
          *
          * </ul>
          */
-        pos = writeRegister(DW_CFA_PC_IDX, DW_CFA_LR_IDX, buffer, pos);
+        pos = writeDefCFA(DW_CFA_SP_IDX, 0, buffer, pos);
         return pos;
     }
 }

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfFrameSectionImplAArch64.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfFrameSectionImplAArch64.java
@@ -26,12 +26,16 @@
 
 package com.oracle.objectfile.elf.dwarf;
 
+import com.oracle.objectfile.debuginfo.DebugInfoProvider;
+
+import java.util.List;
+
 /**
  * AArch64-specific section generator for debug_frame section that knows details of AArch64
  * registers and frame layout.
  */
 public class DwarfFrameSectionImplAArch64 extends DwarfFrameSectionImpl {
-    // public static final int DW_CFA_FP_IDX = 29;
+    public static final int DW_CFA_FP_IDX = 29;
     private static final int DW_CFA_LR_IDX = 30;
     private static final int DW_CFA_SP_IDX = 31;
     // private static final int DW_CFA_PC_IDX = 32;
@@ -54,7 +58,9 @@ public class DwarfFrameSectionImplAArch64 extends DwarfFrameSectionImpl {
     public int writeInitialInstructions(byte[] buffer, int p) {
         int pos = p;
         /*
-         * Register rsp points at the frame base so cfa is at rsp + 0:
+         * Invariant: CFA identifies last word of caller stack.
+         *
+         * So initial cfa is at rsp + 0:
          *
          * <ul>
          *
@@ -63,6 +69,44 @@ public class DwarfFrameSectionImplAArch64 extends DwarfFrameSectionImpl {
          * </ul>
          */
         pos = writeDefCFA(DW_CFA_SP_IDX, 0, buffer, pos);
+        return pos;
+    }
+
+    @Override
+    protected int writeFDEs(int frameSize, List<DebugInfoProvider.DebugFrameSizeChange> frameSizeInfos, byte[] buffer, int pos) {
+        int currentOffset = 0;
+        for (DebugInfoProvider.DebugFrameSizeChange debugFrameSizeInfo : frameSizeInfos) {
+            int advance = debugFrameSizeInfo.getOffset() - currentOffset;
+            currentOffset += advance;
+            pos = writeAdvanceLoc(advance, buffer, pos);
+            if (debugFrameSizeInfo.getType() == DebugInfoProvider.DebugFrameSizeChange.Type.EXTEND) {
+                /*
+                 * SP has been extended so rebase CFA using full frame.
+                 *
+                 * Invariant: CFA identifies last word of caller stack.
+                 */
+                pos = writeDefCFAOffset(frameSize, buffer, pos);
+                /*
+                 * Notify push of lr and fp to stack slots 1 and 2.
+                 *
+                 * Scaling by -8 is automatic.
+                 */
+                pos = writeOffset(DW_CFA_LR_IDX, 1, buffer, pos);
+                pos = writeOffset(DW_CFA_FP_IDX, 2, buffer, pos);
+            } else {
+                /*
+                 * SP will have been contracted so rebase CFA using empty frame.
+                 *
+                 * Invariant: CFA identifies last word of caller stack.
+                 */
+                pos = writeDefCFAOffset(0, buffer, pos);
+                /*
+                 * notify restore of fp and lr
+                 */
+                pos = writeRestore(DW_CFA_FP_IDX, buffer, pos);
+                pos = writeRestore(DW_CFA_LR_IDX, buffer, pos);
+            }
+        }
         return pos;
     }
 }

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfFrameSectionImplX86_64.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfFrameSectionImplX86_64.java
@@ -84,7 +84,8 @@ public class DwarfFrameSectionImplX86_64 extends DwarfFrameSectionImpl {
     }
 
     @Override
-    protected int writeFDEs(int frameSize, List<DebugInfoProvider.DebugFrameSizeChange> frameSizeInfos, byte[] buffer, int pos) {
+    protected int writeFDEs(int frameSize, List<DebugInfoProvider.DebugFrameSizeChange> frameSizeInfos, byte[] buffer, int p) {
+        int pos = p;
         int currentOffset = 0;
         for (DebugInfoProvider.DebugFrameSizeChange debugFrameSizeInfo : frameSizeInfos) {
             int advance = debugFrameSizeInfo.getOffset() - currentOffset;

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfFrameSectionImplX86_64.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfFrameSectionImplX86_64.java
@@ -39,7 +39,7 @@ public class DwarfFrameSectionImplX86_64 extends DwarfFrameSectionImpl {
     }
 
     @Override
-    public int getPCIdx() {
+    public int getReturnPCIdx() {
         return DW_CFA_RIP_IDX;
     }
 

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfLineSectionImpl.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfLineSectionImpl.java
@@ -502,6 +502,7 @@ public class DwarfLineSectionImpl extends DwarfSectionImpl {
                     assert opcode != DW_LNS_undefined;
                     pos = writeSpecialOpcode(context, opcode, buffer, pos);
                     pos = writeCopyOp(context, buffer, pos);
+                    address += addressDelta;
                 }
             }
             /*

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfLineSectionImpl.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfLineSectionImpl.java
@@ -480,23 +480,23 @@ public class DwarfLineSectionImpl extends DwarfSectionImpl {
             pos = writeCopyOp(context, buffer, pos);
 
             /*
-             * On AArch64 gdb expects to see a line record at the start of the method
-             * and a second one at the end of the prologue marking the point where the
-             * method code begins for real. If we don't provide it then gdb will skip
-             * to the second line record when we place a breakpoint on the method.
+             * On AArch64 gdb expects to see a line record at the start of the method and a second
+             * one at the end of the prologue marking the point where the method code begins for
+             * real. If we don't provide it then gdb will skip to the second line record when we
+             * place a breakpoint on the method.
              *
-             * We can identify the end of the prologue for normal methods by noting
-             * where the stack frame height is first adjusted. This should normally
-             * be no more a few instructions in total.
+             * We can identify the end of the prologue for normal methods by noting where the stack
+             * frame height is first adjusted. This should normally be no more a few instructions in
+             * total.
              */
             if (isAArch64() && !primaryEntry.getFrameSizeInfos().isEmpty()) {
                 DebugFrameSizeChange frameSizeChange = primaryEntry.getFrameSizeInfos().get(0);
-                assert frameSizeChange.getType() ==  DebugFrameSizeChange.Type.EXTEND;
+                assert frameSizeChange.getType() == DebugFrameSizeChange.Type.EXTEND;
                 long addressDelta = frameSizeChange.getOffset();
                 if (addressDelta < 16 && (primaryRange.getLo() + addressDelta) < primaryRange.getHi()) {
                     /*
-                     * we should be able to write this with a special opcode as the prologue
-                     * should only be a few instructions
+                     * we should be able to write this with a special opcode as the prologue should
+                     * only be a few instructions
                      */
                     byte opcode = isSpecialOpcode(addressDelta, 0);
                     assert opcode != DW_LNS_undefined;

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfLineSectionImpl.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfLineSectionImpl.java
@@ -34,6 +34,7 @@ import com.oracle.objectfile.debugentry.DirEntry;
 import com.oracle.objectfile.debugentry.FileEntry;
 import com.oracle.objectfile.debugentry.PrimaryEntry;
 import com.oracle.objectfile.debugentry.Range;
+import com.oracle.objectfile.debuginfo.DebugInfoProvider.DebugFrameSizeChange;
 import org.graalvm.compiler.debug.DebugContext;
 
 import java.util.Map;
@@ -478,6 +479,31 @@ public class DwarfLineSectionImpl extends DwarfSectionImpl {
             }
             pos = writeCopyOp(context, buffer, pos);
 
+            /*
+             * On AArch64 gdb expects to see a line record at the start of the method
+             * and a second one at the end of the prologue marking the point where the
+             * method code begins for real. If we don't provide it then gdb will skip
+             * to the second line record when we place a breakpoint on the method.
+             *
+             * We can identify the end of the prologue for normal methods by noting
+             * where the stack frame height is first adjusted. This should normally
+             * be no more a few instructions in total.
+             */
+            if (isAArch64() && !primaryEntry.getFrameSizeInfos().isEmpty()) {
+                DebugFrameSizeChange frameSizeChange = primaryEntry.getFrameSizeInfos().get(0);
+                assert frameSizeChange.getType() ==  DebugFrameSizeChange.Type.EXTEND;
+                long addressDelta = frameSizeChange.getOffset();
+                if (addressDelta < 16 && (primaryRange.getLo() + addressDelta) < primaryRange.getHi()) {
+                    /*
+                     * we should be able to write this with a special opcode as the prologue
+                     * should only be a few instructions
+                     */
+                    byte opcode = isSpecialOpcode(addressDelta, 0);
+                    assert opcode != DW_LNS_undefined;
+                    pos = writeSpecialOpcode(context, opcode, buffer, pos);
+                    pos = writeCopyOp(context, buffer, pos);
+                }
+            }
             /*
              * Now write a row for each subrange lo and hi.
              */

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfSectionImpl.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfSectionImpl.java
@@ -32,6 +32,7 @@ import com.oracle.objectfile.LayoutDecision;
 import com.oracle.objectfile.LayoutDecisionMap;
 import com.oracle.objectfile.ObjectFile;
 import com.oracle.objectfile.debugentry.ClassEntry;
+import com.oracle.objectfile.elf.ELFMachine;
 import com.oracle.objectfile.elf.ELFObjectFile;
 import org.graalvm.compiler.debug.DebugContext;
 
@@ -53,6 +54,10 @@ public abstract class DwarfSectionImpl extends BasicProgbitsSectionImpl {
 
     public DwarfSectionImpl(DwarfDebugInfo dwarfSections) {
         this.dwarfSections = dwarfSections;
+    }
+
+    public boolean isAArch64() {
+        return dwarfSections.getELFMachine() == ELFMachine.AArch64;
     }
 
     /**

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfSectionImpl.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfSectionImpl.java
@@ -57,7 +57,7 @@ public abstract class DwarfSectionImpl extends BasicProgbitsSectionImpl {
     }
 
     public boolean isAArch64() {
-        return dwarfSections.getELFMachine() == ELFMachine.AArch64;
+        return dwarfSections.elfMachine == ELFMachine.AArch64;
     }
 
     /**


### PR DESCRIPTION
This patch fixes several problems with debug info on AArch64. Associated issue is https://github.com/oracle/graal/issues/2378.

Fixed functionality includes

.debug_frame section CIE records:
  establish correct stack call frame address at entry 

.debug_line section:
  restate initial line position at end of method prologue  -- workaround for bad gdb behaviour

.debug_frame section FDE records:
  notify gdb of save/restore for frame and link register 

In terms of user experience what this achieves is that gdb now
    - places method breaks at the first rather than the second line of a method
    - does not crash when you try to display a stack backtrace
    - correctly identifies the return address and stack top for the previous frame
