### PR TITLE
Fix static image IPv6 support.

### DIFF
--- a/substratevm/src/com.oracle.svm.native.jvm.posix/src/JvmFuncs.c
+++ b/substratevm/src/com.oracle.svm.native.jvm.posix/src/JvmFuncs.c
@@ -44,6 +44,16 @@
 #define OS_OK 0
 #define OS_ERR -1
 
+/* Set by native-image during image build time. Indicates whether the built image is a static binary. */
+extern int __svm_vm_is_static_binary;
+/*
+    The way JDK checks IPv6 support on Linux involves checking if this function exists using JVM_FindLibraryEntry. That
+    function in turn calls dlsym, which is a bad idea in a static binary. Since this function is guaranteed to exist on
+    every POSIX platform we support, we ask the linker to provide us with the symbol value, which we will then return to
+    the test code.
+*/
+int inet_pton(int af, const char *src, void *dst);
+
 #ifdef JNI_VERSION_9
     #define JVM_INTERFACE_VERSION 6
 #else
@@ -78,7 +88,24 @@ JNIEXPORT int JNICALL JVM_Connect(int fd, struct sockaddr* him, socklen_t len) {
 }
 
 JNIEXPORT void* JNICALL JVM_FindLibraryEntry(void* handle, const char* name) {
-    return dlsym(handle, name);
+    /*
+        Calls to this function from a static binary are inherently unsafe. On some libc implementations, it may result
+        in a segfault, while on others, the symbol could be wrongly not found. As of JDK11, this function is invoked in
+        only one place: IPv6 support checking.
+        As a safeguard, we restrict access to only known used symbols from the JDK code. If a future version introduces
+        a dependency on another symbol, it could result in hard-to-find bugs. Therefore, calling this function from a
+        static binary with an unknown symbol terminates the program.
+    */
+    if (__svm_vm_is_static_binary) {
+        if (strcmp(name, "inet_pton") == 0) {
+            return inet_pton;
+        }
+        fprintf(stderr, "Internal error: JVM_FindLibraryEntry called from a static native image. Results may be unpredictable. Please report this issue to the SubstrateVM team.");
+        fflush(stderr);
+        exit(1);
+    } else {
+        return dlsym(handle, name);
+    }
 }
 
 JNIEXPORT int JNICALL JVM_GetHostName(char* name, int namelen) {


### PR DESCRIPTION
The issue is described in more detail here: [#2373 comment](https://github.com/oracle/graal/issues/2373#issuecomment-619147560 )

This PR fixes support for IPv6 in static native-images. It also adds a check to see whether the `JVM_FindLibraryEntry` has been called while running a static native-image binary, and force the program to exit if that is the case, instead of allowing implementation specific behavior.

JDK 11 call that checks for IPv6 support can be located at: https://github.com/graalvm/labs-openjdk-11/blob/master/src/java.base/unix/native/libnet/net_util_md.c, function `jint  IPv6_supported()`, called during `libnet` initialization.

Closes #2373 