### PR TITLE
Tweak compiler assertion

### DIFF
--- a/sulong/projects/com.oracle.truffle.llvm.runtime/src/com/oracle/truffle/llvm/runtime/nodes/control/LLVMDispatchBasicBlockNode.java
+++ b/sulong/projects/com.oracle.truffle.llvm.runtime/src/com/oracle/truffle/llvm/runtime/nodes/control/LLVMDispatchBasicBlockNode.java
@@ -81,7 +81,7 @@ public abstract class LLVMDispatchBasicBlockNode extends LLVMExpressionNode {
     public Object doDispatch(VirtualFrame frame) {
         Object returnValue = null;
 
-        CompilerAsserts.compilationConstant(bodyNodes.length);
+        CompilerAsserts.partialEvaluationConstant(bodyNodes.length);
         int basicBlockIndex = 0;
         int backEdgeCounter = 0;
         outer: while (basicBlockIndex != LLVMBasicBlockNode.RETURN_FROM_FUNCTION) {


### PR DESCRIPTION
AFAICT, there's no reason to use `#compilationConstant` here. `#partialEvaluationConstant` is to be preferred.
See https://github.com/oracle/graal/blob/8fb8fc502411b3c84308ff5cda4d6c1f775f3920/truffle/src/com.oracle.truffle.api/src/com/oracle/truffle/api/CompilerAsserts.java#L102-L113