### PR TITLE
Support MaxDirectMemorySize

### DIFF
--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/SubstrateOptions.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/SubstrateOptions.java
@@ -24,6 +24,7 @@
  */
 package com.oracle.svm.core;
 
+import static org.graalvm.compiler.core.common.GraalOptions.TrackNodeSourcePosition;
 import static org.graalvm.compiler.core.common.SpeculativeExecutionAttacksMitigations.None;
 import static org.graalvm.compiler.core.common.SpeculativeExecutionAttacksMitigations.Options.MitigateSpeculativeExecutionAttacks;
 import static org.graalvm.compiler.options.OptionType.User;
@@ -51,8 +52,6 @@ import com.oracle.svm.core.option.HostedOptionValues;
 import com.oracle.svm.core.option.OptionUtils;
 import com.oracle.svm.core.option.RuntimeOptionKey;
 import com.oracle.svm.core.option.XOptions;
-
-import static org.graalvm.compiler.core.common.GraalOptions.TrackNodeSourcePosition;
 
 public class SubstrateOptions {
 
@@ -192,6 +191,10 @@ public class SubstrateOptions {
             }
         }
     };
+
+    /* Same option name and specification as the Java HotSpot VM. */
+    @Option(help = "Maximum total size of NIO direct-buffer allocations")//
+    public static final RuntimeOptionKey<Long> MaxDirectMemorySize = new RuntimeOptionKey<>(0L);
 
     @Option(help = "Verify naming conventions during image construction.")//
     public static final HostedOptionKey<Boolean> VerifyNamingConventions = new HostedOptionKey<>(false);

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/heap/Target_java_lang_ref_Reference.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/heap/Target_java_lang_ref_Reference.java
@@ -136,7 +136,25 @@ public final class Target_java_lang_ref_Reference<T> {
     @TargetElement(onlyWith = JDK8OrEarlier.class)
     @SuppressWarnings("unused")
     static boolean tryHandlePending(boolean waitForNotify) {
-        throw VMError.unimplemented();
+        /*
+         * This method in JDK 8 was replaced by waitForReferenceProcessing in JDK 11. On JDK 8, it
+         * helped with reference handling by handling a single reference (if one is available). The
+         * only caller (apart from the reference handling thread itself) in the JDK is
+         * `Bits.reserveMemory`, which passes `false` as the parameter `waitForNotify`. So our
+         * substitution, which always waits, is a considerable change in semantics. However, since
+         * `Bits.reserveMemory` did not change much between JDK 8 and JDK 11, this is OK.
+         */
+        try {
+            return ReferenceInternals.waitForReferenceProcessing();
+        } catch (InterruptedException ex) {
+            Thread.currentThread().interrupt();
+            /*
+             * The caller might loop until "there is no more progress", i.e., until this method
+             * returns false. So returning true could lead to an infinite loop in the caller that is
+             * not interruptible.
+             */
+            return false;
+        }
     }
 
     /** May be used by {@code JavaLangRefAccess} via {@code SharedSecrets}. */


### PR DESCRIPTION
Do not inherit the maximum direct memory size from image generator, and provide same runtime option `-XX:MaxDirectMemorySize` as the Java HotSpot VM.

