### PR TITLE
correct computation of prologue size

### DIFF
--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfLineSectionImpl.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfLineSectionImpl.java
@@ -320,7 +320,7 @@ public class DwarfLineSectionImpl extends DwarfSectionImpl {
         /*
          * 4 ubyte prologue length includes rest of header and dir + file table section.
          */
-        int prologueSize = classEntry.getLinePrologueSize() - 6;
+        int prologueSize = classEntry.getLinePrologueSize() - (4 + 2 + 4);
         pos = putInt(prologueSize, buffer, pos);
         /*
          * 1 ubyte min instruction length is always 1.


### PR DESCRIPTION
This fixes the problem found when using gdb 9.1 that was raised in issue #2431

The computation of the value for the prologue size field was incorrectly including that field in the byte count for remaining header + dir & file tables, meaning it was identifying a point 4 bytes into the line state machine instructions. With gdb 9.1 the debugger adds the prologue size to the prologue offset to identify the start of those instructions. With 8.3 it simply starts reading instructions from the point where the header + dir & file tables end which is why it went undetected.