### PR TITLE
Support dynamic class loading

### DIFF
--- a/substratevm/src/com.oracle.svm.agent/src/com/oracle/svm/agent/ClassLoaderDefineClassSupport.java
+++ b/substratevm/src/com.oracle.svm.agent/src/com/oracle/svm/agent/ClassLoaderDefineClassSupport.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2021, Alibaba Group Holding Limited. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package com.oracle.svm.agent;
+
+import com.oracle.svm.core.util.JavaClassUtil;
+import com.oracle.svm.jni.nativeapi.JNIEnvironment;
+
+import java.security.NoSuchAlgorithmException;
+
+import static com.oracle.svm.jvmtiagentbase.Support.getMethodFullNameAtFrame;
+
+/**
+ * Support dynamic class loading that is implemented by java.lang.ClassLoader.defineClass.
+ */
+public class ClassLoaderDefineClassSupport {
+
+    private static String calculateGeneratedClassSHA(byte[] values) {
+        String generatedClassHashCode;
+        try {
+            generatedClassHashCode = JavaClassUtil.getSHAWithoutSourceFileInfo(values);
+        } catch (NoSuchAlgorithmException e) {
+            generatedClassHashCode = null;
+        }
+        return generatedClassHashCode;
+    }
+
+    public static void trace(TraceWriter traceWriter, byte[] classContents, String generatedClassName, Object result) {
+        assert classContents != null;
+        if (generatedClassName != null && result != null) {
+            // Trace dynamically generated class in config file
+            traceWriter.traceCall("classDefiner", "onClassFileLoadHook", null, null, null, result, generatedClassName.replace('/', '.'), calculateGeneratedClassSHA(classContents), classContents);
+        }
+    }
+
+    public static StringBuilder getStackTrace(JNIEnvironment jni) {
+        StringBuilder trace = new StringBuilder();
+        int i = 0;
+        int maxDepth = 20;
+        while (i < maxDepth) {
+            String methodName = getMethodFullNameAtFrame(jni, i++);
+            if (methodName == null) {
+                break;
+            }
+            trace.append("    ").append(methodName).append("\n");
+        }
+        if (i >= maxDepth) {
+            trace.append("    ").append("...").append("\n");
+        }
+        return trace;
+    }
+}

--- a/substratevm/src/com.oracle.svm.agent/src/com/oracle/svm/agent/NativeImageAgentJNIHandleSet.java
+++ b/substratevm/src/com.oracle.svm.agent/src/com/oracle/svm/agent/NativeImageAgentJNIHandleSet.java
@@ -39,17 +39,15 @@ public class NativeImageAgentJNIHandleSet extends JNIHandleSet {
     final JNIObjectHandle javaLangClass;
     final JNIMethodId javaLangClassForName3;
     final JNIMethodId javaUtilEnumerationNextElement;
+    final JNIMethodId javaLangReflectMemberGetName;
+    final JNIMethodId javaLangReflectMemberGetDeclaringClass;
+    final JNIMethodId javaUtilEnumerationHasMoreElements;
+    final JNIMethodId javaLangClassLoaderGetResource;
+    final JNIObjectHandle javaLangClassLoader;
     final JNIMethodId javaLangClassGetDeclaredMethod;
     final JNIMethodId javaLangClassGetDeclaredConstructor;
     final JNIMethodId javaLangClassGetDeclaredField;
     final JNIMethodId javaLangClassGetName;
-
-    final JNIMethodId javaLangReflectMemberGetName;
-    final JNIMethodId javaLangReflectMemberGetDeclaringClass;
-
-    final JNIMethodId javaUtilEnumerationHasMoreElements;
-
-    final JNIObjectHandle javaLangClassLoader;
 
     final JNIMethodId javaLangObjectGetClass;
 
@@ -78,6 +76,7 @@ public class NativeImageAgentJNIHandleSet extends JNIHandleSet {
         javaLangClassGetDeclaredField = getMethodId(env, javaLangClass, "getDeclaredField", "(Ljava/lang/String;)Ljava/lang/reflect/Field;", false);
         javaLangClassGetName = getMethodId(env, javaLangClass, "getName", "()Ljava/lang/String;", false);
 
+        javaLangClassLoaderGetResource = getMethodId(env, findClass(env, "java/lang/ClassLoader"), "getResource", "(Ljava/lang/String;)Ljava/net/URL;", false);
         JNIObjectHandle javaLangReflectMember = findClass(env, "java/lang/reflect/Member");
         javaLangReflectMemberGetName = getMethodId(env, javaLangReflectMember, "getName", "()Ljava/lang/String;", false);
         javaLangReflectMemberGetDeclaringClass = getMethodId(env, javaLangReflectMember, "getDeclaringClass", "()Ljava/lang/Class;", false);

--- a/substratevm/src/com.oracle.svm.configure/src/com/oracle/svm/configure/ConfigurationTool.java
+++ b/substratevm/src/com.oracle.svm.configure/src/com/oracle/svm/configure/ConfigurationTool.java
@@ -195,6 +195,12 @@ public class ConfigurationTool {
                     set.getSerializationConfigPaths().add(requirePathUri(current, value));
                     break;
 
+                case "--dynamic-classes-input":
+                    set = inputSet; // fall through
+                case "--dynamic-classes-output":
+                    set.getDynamicClassesConfigPaths().add(requirePathUri(current, value));
+                    break;
+
                 case "--trace-input":
                     traceInputs.add(requirePathUri(current, value));
                     break;
@@ -256,7 +262,8 @@ public class ConfigurationTool {
         try {
             p = new TraceProcessor(advisor, inputSet.loadJniConfig(ConfigurationSet.FAIL_ON_EXCEPTION), inputSet.loadReflectConfig(ConfigurationSet.FAIL_ON_EXCEPTION),
                             inputSet.loadProxyConfig(ConfigurationSet.FAIL_ON_EXCEPTION), inputSet.loadResourceConfig(ConfigurationSet.FAIL_ON_EXCEPTION),
-                            inputSet.loadSerializationConfig(ConfigurationSet.FAIL_ON_EXCEPTION));
+                            inputSet.loadSerializationConfig(ConfigurationSet.FAIL_ON_EXCEPTION),
+                            inputSet.loadDynamicClassesConfig(ConfigurationSet.FAIL_ON_EXCEPTION));
         } catch (IOException e) {
             throw e;
         } catch (Throwable t) {
@@ -297,6 +304,11 @@ public class ConfigurationTool {
         for (URI uri : outputSet.getSerializationConfigPaths()) {
             try (JsonWriter writer = new JsonWriter(Paths.get(uri))) {
                 p.getSerializationConfiguration().printJson(writer);
+            }
+        }
+        for (URI uri : outputSet.getDynamicClassesConfigPaths()) {
+            try (JsonWriter writer = new JsonWriter(Paths.get(uri))) {
+                p.getDynamicClassesConfiguration().printJson(writer);
             }
         }
     }

--- a/substratevm/src/com.oracle.svm.configure/src/com/oracle/svm/configure/config/ConfigurationDynamicClass.java
+++ b/substratevm/src/com.oracle.svm.configure/src/com/oracle/svm/configure/config/ConfigurationDynamicClass.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2021, Alibaba Group Holding Limited. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package com.oracle.svm.configure.config;
+
+import com.oracle.svm.configure.json.JsonPrintable;
+import com.oracle.svm.configure.json.JsonWriter;
+import com.oracle.svm.core.configure.ConfigurationFiles;
+
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+public final class ConfigurationDynamicClass implements JsonPrintable {
+
+    private final String qualifiedJavaName;
+    private final String checksum;
+    private final Path classFilePath;
+    private final byte[] classContents;
+
+    public static ConfigurationDynamicClass newAgentTraceTimeConfig(String qualifiedJavaName, String checksum, byte[] classContents) {
+        return new ConfigurationDynamicClass(qualifiedJavaName, checksum, classContents, null);
+    }
+
+    public static ConfigurationDynamicClass newAgentMergeTimeConfig(String qualifiedJavaName, String checksum, Path classFile) {
+        return new ConfigurationDynamicClass(qualifiedJavaName, checksum, null, classFile);
+    }
+
+    private ConfigurationDynamicClass(String qualifiedJavaName, String checksum, byte[] classContents, Path classFilePath) {
+        assert qualifiedJavaName.indexOf('/') == -1 : "Requires qualified Java name, not internal representation";
+        assert !qualifiedJavaName.startsWith("[") : "Requires Java source array syntax, for example java.lang.String[]";
+        assert !(classContents == null && classFilePath == null) : "classContents and classFilePath can't be null at the same time";
+        this.qualifiedJavaName = qualifiedJavaName;
+        this.checksum = checksum;
+        this.classContents = classContents;
+        this.classFilePath = classFilePath;
+    }
+
+    public boolean contains(String definedClassName, String checksum2Match) {
+        return definedClassName != null && definedClassName.equals(qualifiedJavaName) && checksum2Match.equals(this.checksum);
+    }
+
+    @Override
+    public void printJson(JsonWriter writer) throws IOException {
+        // Mangle class' qualified name into a system independent format
+        String internalName = qualifiedJavaName.replace(".", ConfigurationFiles.MANGLE_SLASH);
+        Path basePath = writer.getPath().getParent();
+        Path dumpDir = basePath.resolve(ConfigurationFiles.DUMP_CLASSES_DIR);
+        Path dumpFile = dumpDir.resolve(internalName + ".class");
+        checkAndMkDir(dumpDir);
+        if (classContents != null) {
+            try (FileOutputStream stream = new FileOutputStream(dumpFile.toFile());) {
+                stream.write(classContents);
+            }
+        }
+        if (classFilePath != null) {
+            Files.copy(classFilePath, dumpFile);
+        }
+        writer.append('{').newline();
+        writer.quote("name").append(':').quote(qualifiedJavaName).append(',').newline();
+        writer.quote("classFile").append(":").quote(basePath.relativize(dumpFile).toString()).append(',').newline();
+        writer.quote("checksum").append(":").quote(checksum).newline();
+        writer.append("}");
+    }
+
+    private static void checkAndMkDir(Path dumpDirs) throws IOException {
+        if (!Files.exists(dumpDirs)) {
+            Files.createDirectories(dumpDirs);
+        } else if (!Files.isDirectory(dumpDirs)) {
+            throw new IOException("Existing " + dumpDirs + " is a file, but a directory is expected.");
+        }
+    }
+}

--- a/substratevm/src/com.oracle.svm.configure/src/com/oracle/svm/configure/config/DynamicClassesConfiguration.java
+++ b/substratevm/src/com.oracle.svm.configure/src/com/oracle/svm/configure/config/DynamicClassesConfiguration.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2021, Alibaba Group Holding Limited. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package com.oracle.svm.configure.config;
+
+import com.oracle.svm.configure.json.JsonPrintable;
+import com.oracle.svm.configure.json.JsonWriter;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class DynamicClassesConfiguration implements JsonPrintable {
+
+    private final ConcurrentHashMap<String, ConfigurationDynamicClass> dynamicDefinedClasses = new ConcurrentHashMap<>();
+
+    /**
+     * Collect dynamic class configuration elements to create a new ConfigurationDynamicClass at
+     * agent collecting time.
+     *
+     * @param definedClassName dynamically generated class' full qualified name
+     * @param classContents class contents in byte array
+     * @param checksum dynamically generated class' SHA checksum. The "source" attribute is ignored
+     *            when calculating the checksum.
+     */
+    public void add(String definedClassName, byte[] classContents, String checksum) {
+        ConfigurationDynamicClass configuration = ConfigurationDynamicClass.newAgentTraceTimeConfig(definedClassName, checksum, classContents);
+        dynamicDefinedClasses.put(definedClassName, configuration);
+    }
+
+    /**
+     * Collect dynamic class configuration elements to create a new ConfigurationDynamicClass at
+     * agent merging or configuration tool generating time. In this scenario, the class contents
+     * have been dumped to the file, we need to record its location for later moving usage.
+     *
+     * @param definedClassName class name read from original configuration
+     * @param originalClassPath originally dumped class file's path
+     * @param checksum class checksum read from original configuration
+     */
+    public void add(String definedClassName, Path originalClassPath, String checksum) {
+        ConfigurationDynamicClass configuration = ConfigurationDynamicClass.newAgentMergeTimeConfig(definedClassName, checksum, originalClassPath);
+        dynamicDefinedClasses.put(definedClassName, configuration);
+    }
+
+    @Override
+    public void printJson(JsonWriter writer) throws IOException {
+        writer.append('[').indent();
+        String prefix = "";
+        for (ConfigurationDynamicClass value : dynamicDefinedClasses.values()) {
+            writer.append(prefix);
+            writer.newline();
+            value.printJson(writer);
+            prefix = ",";
+        }
+        writer.unindent().newline();
+        writer.append(']').newline();
+    }
+}

--- a/substratevm/src/com.oracle.svm.configure/src/com/oracle/svm/configure/config/TypeConfiguration.java
+++ b/substratevm/src/com.oracle.svm.configure/src/com/oracle/svm/configure/config/TypeConfiguration.java
@@ -66,6 +66,7 @@ public class TypeConfiguration implements JsonPrintable {
             } else {
                 throw new IllegalArgumentException();
             }
+
             for (int i = 0; i < n; i++) {
                 sb.append("[]");
             }

--- a/substratevm/src/com.oracle.svm.configure/src/com/oracle/svm/configure/json/JsonWriter.java
+++ b/substratevm/src/com.oracle.svm.configure/src/com/oracle/svm/configure/json/JsonWriter.java
@@ -38,8 +38,11 @@ public class JsonWriter implements AutoCloseable {
 
     private int indentation = 0;
 
+    private Path path;
+
     public JsonWriter(Path path, OpenOption... options) throws IOException {
         this(Files.newBufferedWriter(path, StandardCharsets.UTF_8, options));
+        this.path = path;
     }
 
     public JsonWriter(Writer writer) {
@@ -118,4 +121,9 @@ public class JsonWriter implements AutoCloseable {
     public void close() throws IOException {
         writer.close();
     }
+
+    public Path getPath() {
+        return path;
+    }
+
 }

--- a/substratevm/src/com.oracle.svm.configure/src/com/oracle/svm/configure/trace/TraceProcessor.java
+++ b/substratevm/src/com.oracle.svm.configure/src/com/oracle/svm/configure/trace/TraceProcessor.java
@@ -29,6 +29,7 @@ import java.io.Reader;
 import java.util.List;
 import java.util.Map;
 
+import com.oracle.svm.configure.config.DynamicClassesConfiguration;
 import com.oracle.svm.configure.config.ProxyConfiguration;
 import com.oracle.svm.configure.config.ResourceConfiguration;
 import com.oracle.svm.configure.config.SerializationConfiguration;
@@ -40,13 +41,16 @@ public class TraceProcessor extends AbstractProcessor {
     private final JniProcessor jniProcessor;
     private final ReflectionProcessor reflectionProcessor;
     private final SerializationProcessor serializationProcessor;
+    private final DynamicClassesProcessor dynamicClassesProcessor;
 
     public TraceProcessor(AccessAdvisor accessAdvisor, TypeConfiguration jniConfiguration, TypeConfiguration reflectionConfiguration,
-                    ProxyConfiguration proxyConfiguration, ResourceConfiguration resourceConfiguration, SerializationConfiguration serializationConfiguration) {
+                    ProxyConfiguration proxyConfiguration, ResourceConfiguration resourceConfiguration, SerializationConfiguration serializationConfiguration,
+                    DynamicClassesConfiguration dynamicClassesConfiguration) {
         advisor = accessAdvisor;
         jniProcessor = new JniProcessor(this.advisor, jniConfiguration, reflectionConfiguration);
         reflectionProcessor = new ReflectionProcessor(this.advisor, reflectionConfiguration, proxyConfiguration, resourceConfiguration);
         serializationProcessor = new SerializationProcessor(this.advisor, serializationConfiguration);
+        dynamicClassesProcessor = new DynamicClassesProcessor(dynamicClassesConfiguration);
     }
 
     public TypeConfiguration getJniConfiguration() {
@@ -67,6 +71,10 @@ public class TraceProcessor extends AbstractProcessor {
 
     public SerializationConfiguration getSerializationConfiguration() {
         return serializationProcessor.getSerializationConfiguration();
+    }
+
+    public DynamicClassesConfiguration getDynamicClassesConfiguration() {
+        return dynamicClassesProcessor.getDynamicClassesConfiguration();
     }
 
     @SuppressWarnings("unchecked")
@@ -107,6 +115,9 @@ public class TraceProcessor extends AbstractProcessor {
                     break;
                 case "serialization":
                     serializationProcessor.processEntry(entry);
+                    break;
+                case "classDefiner":
+                    dynamicClassesProcessor.processEntry(entry);
                     break;
                 default:
                     logWarning("Unknown tracer, ignoring: " + tracer);

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/configure/ConfigurationFiles.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/configure/ConfigurationFiles.java
@@ -57,6 +57,9 @@ public final class ConfigurationFiles {
     public static final String REFLECTION_NAME = "reflect" + SUFFIX;
     public static final String SERIALIZATION_NAME = "serialization" + SUFFIX;
     public static final String SERIALIZATION_DENY_NAME = "serialization-deny" + SUFFIX;
+    public static final String DYNAMIC_CLASSES_NAME = "dynamicClasses" + SUFFIX;
+    public static final String DUMP_CLASSES_DIR = "dynClasses";
+    public static final String MANGLE_SLASH = "_2F_"; // "/" is \u002F
 
     public static final class Options {
         @Option(help = "Directories directly containing configuration files for dynamic features at runtime.", type = OptionType.User)//
@@ -94,6 +97,11 @@ public final class ConfigurationFiles {
         public static final HostedOptionKey<LocatableMultiOptionValue.Strings> JNIConfigurationFiles = new HostedOptionKey<>(new LocatableMultiOptionValue.Strings());
         @Option(help = "Resources describing program elements to be made accessible via JNI (see JNIConfigurationFiles).", type = OptionType.User)//
         public static final HostedOptionKey<LocatableMultiOptionValue.Strings> JNIConfigurationResources = new HostedOptionKey<>(new LocatableMultiOptionValue.Strings());
+
+        @Option(help = "Files describing dynamically generated classes during program runtime", type = OptionType.User)//
+        public static final HostedOptionKey<LocatableMultiOptionValue.Strings> DynamicClassesConfigurationFiles = new HostedOptionKey<>(new LocatableMultiOptionValue.Strings());
+        @Option(help = "Resources describing dynamically generated classes during program runtime.", type = OptionType.User)//
+        public static final HostedOptionKey<LocatableMultiOptionValue.Strings> DynamicClassesConfigurationResources = new HostedOptionKey<>(new LocatableMultiOptionValue.Strings());
 
         @Option(help = "Comma-separated list of file names with declarative substitutions", type = OptionType.User)//
         public static final HostedOptionKey<LocatableMultiOptionValue.Strings> SubstitutionFiles = new HostedOptionKey<>(new LocatableMultiOptionValue.Strings());

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/configure/DynamicClassesConfigurationParser.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/configure/DynamicClassesConfigurationParser.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2021, Alibaba Group Holding Limited. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package com.oracle.svm.core.configure;
+
+import com.oracle.svm.core.util.VMError;
+import com.oracle.svm.core.util.json.JSONParser;
+import com.oracle.svm.core.util.json.JSONParserException;
+
+import java.io.IOException;
+import java.io.Reader;
+import java.net.URL;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Map;
+
+public class DynamicClassesConfigurationParser extends ConfigurationParser {
+
+    DynamicClassesParserFunction consumer;
+
+    public DynamicClassesConfigurationParser(DynamicClassesParserFunction consumer) {
+        this.consumer = consumer;
+    }
+
+    private Path configurationFileLocation;
+
+    public void setConfigurationFileLocation(Object location) {
+        if (location instanceof URL) {
+            configurationFileLocation = Paths.get(((URL) location).getPath());
+        } else if (location instanceof Path) {
+            configurationFileLocation = (Path) location;
+        } else {
+            VMError.shouldNotReachHere("Input location of setConfigurationFileLocation must be either Path or URL, but is " + location.getClass().getName());
+        }
+    }
+
+    @Override
+    public void parseAndRegister(Reader reader) throws IOException {
+        JSONParser parser = new JSONParser(reader);
+        Object json = parser.parse();
+        for (Object dynamicDefinedClass : asList(json, "first level of document must be an array of dynamic defined classes")) {
+            Map<String, Object> data = asMap(dynamicDefinedClass, "second level of document must be dynamic defined class descriptor objects ");
+            String definedClassName = asString(data.get("name"));
+            if (definedClassName == null) {
+                throw new JSONParserException("Missing attribute 'name' in dynamic class descriptor object");
+            }
+            String dumpedFileName = asString(data.get("classFile"));
+            if (dumpedFileName == null) {
+                throw new JSONParserException("Missing attribute 'classFile' in dynamic class descriptor object");
+            }
+            if (dumpedFileName.length() == 0) {
+                throw new IOException("The value of attribute 'classFile' in dynamic class descriptor must not be empty");
+            }
+            String checksum = asString(data.get("checksum"));
+            Path dumpedFile = configurationFileLocation.getParent().resolve(dumpedFileName);
+            consumer.accept(definedClassName, dumpedFile, checksum);
+        }
+    }
+
+    @FunctionalInterface
+    public interface DynamicClassesParserFunction {
+        void accept(String definedClassName, Path dumpedFileName, String checksum);
+    }
+}

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/util/JavaClassUtil.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/util/JavaClassUtil.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2021, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2021, Alibaba Group Holding Limited. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package com.oracle.svm.core.util;
+
+import jdk.internal.org.objectweb.asm.ClassReader;
+import jdk.internal.org.objectweb.asm.ClassVisitor;
+import jdk.internal.org.objectweb.asm.ClassWriter;
+
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+
+public class JavaClassUtil {
+
+    private static final String CONSTANT_PLACE_HOLDER = "CONSTANT_PLACE_HOLDER";
+
+    /**
+     * Get SHA -256 value of the class for verification usage. But the name of SourceFile attribute
+     * is set to empty, because it might get changed from run to run and it's not really used in the
+     * class.
+     *
+     * @return byte array SHA value without SourceFile name
+     * @throws NoSuchAlgorithmException
+     */
+    public static String getSHAWithoutSourceFileInfo(byte[] classDefinition) throws NoSuchAlgorithmException {
+        ClassReader cr = new ClassReader(classDefinition);
+        ClassWriter writer = new ClassWriter(0);
+        ClassVisitor cv = new ClassVisitor(jdk.internal.org.objectweb.asm.Opcodes.ASM5, writer) {
+            @Override
+            public void visitSource(String source, String debug) {
+                // Set constant value to SourceFIle attribute
+                super.visitSource(CONSTANT_PLACE_HOLDER, null);
+            }
+        };
+        cr.accept(cv, 0);
+        byte[] classBytes = writer.toByteArray();
+        MessageDigest digest = MessageDigest.getInstance("SHA-256");
+        return fingerPrint(digest.digest(classBytes), false);
+    }
+
+    public static String getClassName(byte[] classDefinition) {
+        ClassReader cr = new ClassReader(classDefinition);
+        return cr.getClassName().replace('/', '.');
+    }
+
+    /**
+     * Copied from org.graalvm.component.installer.SystemUtils.
+     *
+     */
+    public static String fingerPrint(byte[] digest, boolean delimiter) {
+        if (digest == null) {
+            return null;
+        }
+        StringBuilder sb = new StringBuilder(digest.length * 3);
+        for (int i = 0; i < digest.length; i++) {
+            if (delimiter && i > 0) {
+                sb.append(':');
+            }
+            // Checkstyle: stop
+            sb.append(String.format("%02x", (digest[i] & 0xff)));
+            // Checkstyle: resume
+        }
+        return sb.toString();
+    }
+}

--- a/substratevm/src/com.oracle.svm.driver/src/com/oracle/svm/driver/NativeImage.java
+++ b/substratevm/src/com.oracle.svm.driver/src/com/oracle/svm/driver/NativeImage.java
@@ -941,7 +941,8 @@ public class NativeImage {
         ResourceConfiguration(ConfigurationFiles.Options.ResourceConfigurationResources, ConfigurationFiles.RESOURCES_NAME),
         ProxyConfiguration(ConfigurationFiles.Options.DynamicProxyConfigurationResources, ConfigurationFiles.DYNAMIC_PROXY_NAME),
         SerializationConfiguration(ConfigurationFiles.Options.SerializationConfigurationResources, ConfigurationFiles.SERIALIZATION_NAME),
-        SerializationDenyConfiguration(ConfigurationFiles.Options.SerializationDenyConfigurationResources, ConfigurationFiles.SERIALIZATION_DENY_NAME);
+        SerializationDenyConfiguration(ConfigurationFiles.Options.SerializationDenyConfigurationResources, ConfigurationFiles.SERIALIZATION_DENY_NAME),
+        DynamicClassesConfiguration(ConfigurationFiles.Options.DynamicClassesConfigurationResources, ConfigurationFiles.DYNAMIC_CLASSES_NAME);
 
         final OptionKey<?> optionKey;
         final String fileName;

--- a/substratevm/src/com.oracle.svm.jni/src/com/oracle/svm/jni/nativeapi/JNIFunctionPointerTypes.java
+++ b/substratevm/src/com.oracle.svm.jni/src/com/oracle/svm/jni/nativeapi/JNIFunctionPointerTypes.java
@@ -27,6 +27,7 @@ package com.oracle.svm.jni.nativeapi;
 import org.graalvm.nativeimage.c.function.CFunctionPointer;
 import org.graalvm.nativeimage.c.function.InvokeCFunctionPointer;
 import org.graalvm.nativeimage.c.type.CCharPointer;
+import org.graalvm.nativeimage.c.type.VoidPointer;
 import org.graalvm.word.PointerBase;
 
 public final class JNIFunctionPointerTypes {
@@ -70,6 +71,11 @@ public final class JNIFunctionPointerTypes {
         void invoke(JNIEnvironment env, JNIObjectHandle objOrClass, JNIMethodId methodId, JNIValue args);
     }
 
+    public interface CallObjectMethod0FunctionPointer extends CFunctionPointer {
+        @InvokeCFunctionPointer
+        JNIObjectHandle invoke(JNIEnvironment env, JNIObjectHandle objOrClass, JNIMethodId methodID);
+    }
+
     public interface CallObjectMethodAFunctionPointer extends CFunctionPointer {
         @InvokeCFunctionPointer
         JNIObjectHandle invoke(JNIEnvironment env, JNIObjectHandle objOrClass, JNIMethodId methodID, JNIValue args);
@@ -88,6 +94,11 @@ public final class JNIFunctionPointerTypes {
     public interface CallIntMethodAFunctionPointer extends CFunctionPointer {
         @InvokeCFunctionPointer
         int invoke(JNIEnvironment env, JNIObjectHandle objOrClass, JNIMethodId methodId, JNIValue args);
+    }
+
+    public interface CallIntMethodFunctionPointer extends CFunctionPointer {
+        @InvokeCFunctionPointer
+        int invoke(JNIEnvironment env, JNIObjectHandle objOrClass, JNIMethodId methodID);
     }
 
     public interface NewObjectAFunctionPointer extends CFunctionPointer {
@@ -138,6 +149,16 @@ public final class JNIFunctionPointerTypes {
     public interface GetObjectArrayElementFunctionPointer extends CFunctionPointer {
         @InvokeCFunctionPointer
         JNIObjectHandle invoke(JNIEnvironment env, JNIObjectHandle array, int index);
+    }
+
+    public interface GetByteArrayElementsFunctionPointer extends CFunctionPointer {
+        @InvokeCFunctionPointer
+        CCharPointer invoke(JNIEnvironment env, JNIObjectHandle array, JNIObjectHandle isCopy);
+    }
+
+    public interface ReleaseByteArrayElementsFunctionPointer extends CFunctionPointer {
+        @InvokeCFunctionPointer
+        CCharPointer invoke(JNIEnvironment env, JNIObjectHandle array, CCharPointer elems, int mode);
     }
 
     public interface SetObjectArrayElementFunctionPointer extends CFunctionPointer {
@@ -205,16 +226,9 @@ public final class JNIFunctionPointerTypes {
         JNIObjectHandle invoke(JNIEnvironment env, int length);
     }
 
-    public interface GetByteArrayElementsFunctionPointer extends CFunctionPointer {
-        // isCopy is actually a boolean
+    public interface GetDirectBufferAddress extends CFunctionPointer {
         @InvokeCFunctionPointer
-        CCharPointer invoke(JNIEnvironment env, JNIObjectHandle byteArray, CCharPointer isCopy);
-    }
-
-    public interface ReleaseByteArrayElementsFunctionPointer extends CFunctionPointer {
-        // isCopy is actually a boolean
-        @InvokeCFunctionPointer
-        CCharPointer invoke(JNIEnvironment env, JNIObjectHandle byteArray, CCharPointer elements, int mode);
+        VoidPointer invoke(JNIEnvironment env, JNIObjectHandle directBuf);
     }
 
     public interface GetObjectFieldFunctionPointer extends CFunctionPointer {

--- a/substratevm/src/com.oracle.svm.jni/src/com/oracle/svm/jni/nativeapi/JNINativeInterface.java
+++ b/substratevm/src/com.oracle.svm.jni/src/com/oracle/svm/jni/nativeapi/JNINativeInterface.java
@@ -33,6 +33,7 @@ import org.graalvm.word.PointerBase;
 
 import com.oracle.svm.jni.nativeapi.JNIFunctionPointerTypes.CallBooleanMethodAFunctionPointer;
 import com.oracle.svm.jni.nativeapi.JNIFunctionPointerTypes.CallIntMethodAFunctionPointer;
+import com.oracle.svm.jni.nativeapi.JNIFunctionPointerTypes.CallIntMethodFunctionPointer;
 import com.oracle.svm.jni.nativeapi.JNIFunctionPointerTypes.CallLongMethodAFunctionPointer;
 import com.oracle.svm.jni.nativeapi.JNIFunctionPointerTypes.CallObjectMethodAFunctionPointer;
 import com.oracle.svm.jni.nativeapi.JNIFunctionPointerTypes.CallStaticLongMethodAFunctionPointer;
@@ -49,6 +50,7 @@ import com.oracle.svm.jni.nativeapi.JNIFunctionPointerTypes.FromReflectedMethodF
 import com.oracle.svm.jni.nativeapi.JNIFunctionPointerTypes.GetArrayLengthFunctionPointer;
 import com.oracle.svm.jni.nativeapi.JNIFunctionPointerTypes.GetBooleanFieldFunctionPointer;
 import com.oracle.svm.jni.nativeapi.JNIFunctionPointerTypes.GetByteArrayElementsFunctionPointer;
+import com.oracle.svm.jni.nativeapi.JNIFunctionPointerTypes.GetDirectBufferAddress;
 import com.oracle.svm.jni.nativeapi.JNIFunctionPointerTypes.GetFieldIDFunctionPointer;
 import com.oracle.svm.jni.nativeapi.JNIFunctionPointerTypes.GetMethodIDFunctionPointer;
 import com.oracle.svm.jni.nativeapi.JNIFunctionPointerTypes.GetObjectArrayElementFunctionPointer;
@@ -271,7 +273,7 @@ public interface JNINativeInterface extends PointerBase {
     void setGetMethodID(GetMethodIDFunctionPointer p);
 
     @CField
-    CFunctionPointer getCallObjectMethod();
+    <T extends CFunctionPointer> T getCallObjectMethod();
 
     @CField
     void setCallObjectMethod(CFunctionPointer p);
@@ -361,10 +363,10 @@ public interface JNINativeInterface extends PointerBase {
     void setCallShortMethodA(CFunctionPointer p);
 
     @CField
-    CFunctionPointer getCallIntMethod();
+    <T extends CallIntMethodFunctionPointer> T getCallIntMethod();
 
     @CField
-    void setCallIntMethod(CFunctionPointer p);
+    void setCallIntMethod(CallIntMethodFunctionPointer p);
 
     @CField
     CFunctionPointer getCallIntMethodV();
@@ -1447,7 +1449,7 @@ public interface JNINativeInterface extends PointerBase {
     void setNewDirectByteBuffer(CFunctionPointer p);
 
     @CField
-    CFunctionPointer getGetDirectBufferAddress();
+    GetDirectBufferAddress getGetDirectBufferAddress();
 
     @CField
     void setGetDirectBufferAddress(CFunctionPointer p);

--- a/substratevm/src/com.oracle.svm.jvmtiagentbase/src/com/oracle/svm/jvmtiagentbase/Support.java
+++ b/substratevm/src/com.oracle.svm.jvmtiagentbase/src/com/oracle/svm/jvmtiagentbase/Support.java
@@ -173,12 +173,29 @@ public final class Support {
         return nullPointer();
     }
 
-    public static JNIObjectHandle getObjectArgument(int slot) {
+    public static JNIObjectHandle getObjectArgument(int depth, int slot) {
         WordPointer handlePtr = StackValue.get(WordPointer.class);
-        if (jvmtiFunctions().GetLocalObject().invoke(jvmtiEnv(), nullHandle(), 0, slot, handlePtr) != JvmtiError.JVMTI_ERROR_NONE) {
+        if (jvmtiFunctions().GetLocalObject().invoke(jvmtiEnv(), nullHandle(), depth, slot, handlePtr) != JvmtiError.JVMTI_ERROR_NONE) {
             return nullHandle();
         }
         return handlePtr.read();
+    }
+
+    public static JNIObjectHandle getObjectArgument(int slot) {
+        return getObjectArgument(0, slot);
+    }
+
+    public static int getIntArgument(int depth, int slot) {
+        CIntPointer handlePtr = StackValue.get(CIntPointer.class);
+        JvmtiError error = jvmtiFunctions().GetLocalInt().invoke(jvmtiEnv(), nullHandle(), depth, slot, handlePtr);
+        if (error != JvmtiError.JVMTI_ERROR_NONE) {
+            throw new RuntimeException(error.toString());
+        }
+        return handlePtr.read();
+    }
+
+    public static int getIntArgument(int slot) {
+        return getIntArgument(0, slot);
     }
 
     public static String getClassNameOr(JNIEnvironment env, JNIObjectHandle clazz, String forNullHandle, String forNullNameOrException) {
@@ -211,6 +228,76 @@ public final class Support {
             declaringClass.write(nullPointer());
         }
         return declaringClass.read();
+    }
+
+    /**
+     * Get method's name at specified frame. Return null if fails, e.g. at a not existed depth.
+     *
+     * @param depth frame depth
+     * @param withSignature should the method name returned with signature
+     * @return method name or null if failed
+     */
+    public static String getMethodNameAtFrame(int depth, boolean withSignature) {
+        JNIMethodId mID = getCallerMethod(depth);
+        if (mID.isNonNull()) {
+            return getMethodNameAndSignature(mID, withSignature);
+        } else {
+            return null;
+        }
+    }
+
+    /**
+     * Get class' name at specified frame. Return null if fails, e.g. at a not existed depth.
+     *
+     * @param env
+     * @param depth frame depth
+     * @return full qualified class name
+     */
+    public static String getClassNameAtFrame(JNIEnvironment env, int depth) {
+        JNIObjectHandle classHandle = getCallerClass(depth);
+        if (classHandle.notEqual(nullHandle())) {
+            return getClassNameOr(env, classHandle, "null", "null");
+        } else {
+            return null;
+        }
+    }
+
+    /**
+     * Get method's name with full qualified class name and method signature. Return null if fails,
+     * e.g. at a not existed depth.
+     *
+     * @param env
+     * @param depth frame depth
+     * @return method name with class name and signature.
+     */
+    public static String getMethodFullNameAtFrame(JNIEnvironment env, int depth) {
+        StringBuilder sb = new StringBuilder();
+        String methodName = getMethodNameAtFrame(depth, true);
+        // Didn't get method at specified depth, return null.
+        if (methodName == null) {
+            return null;
+        }
+        sb.append(getClassNameAtFrame(env, depth)).append(".").append(methodName);
+        return sb.toString();
+    }
+
+    public static String getMethodName(JNIMethodId method) {
+        return getMethodNameAndSignature(method, false);
+    }
+
+    public static String getMethodNameAndSignature(JNIMethodId method, boolean witSignature) {
+        String ret = null;
+        CCharPointerPointer namePtr = StackValue.get(CCharPointerPointer.class);
+        CCharPointerPointer sigPtr = witSignature ? StackValue.get(CCharPointerPointer.class) : nullPointer();
+        if (jvmtiFunctions().GetMethodName().invoke(jvmtiEnv(), method, namePtr, sigPtr, nullPointer()) == JvmtiError.JVMTI_ERROR_NONE) {
+            ret = fromCString(namePtr.read());
+            jvmtiFunctions().Deallocate().invoke(jvmtiEnv(), namePtr.read());
+            if (witSignature) {
+                ret = ret + fromCString(sigPtr.read());
+                jvmtiFunctions().Deallocate().invoke(jvmtiEnv(), sigPtr.read());
+            }
+        }
+        return ret;
     }
 
     public static String getFieldName(JNIObjectHandle clazz, JNIFieldId field) {

--- a/substratevm/src/com.oracle.svm.reflect/src/com/oracle/svm/reflect/MultiClassLoaderReporter.java
+++ b/substratevm/src/com.oracle.svm.reflect/src/com/oracle/svm/reflect/MultiClassLoaderReporter.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2021, Alibaba Group Holding Limited. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package com.oracle.svm.reflect;
+
+import com.oracle.graal.pointsto.BigBang;
+import com.oracle.svm.core.option.SubstrateOptionsParser;
+import com.oracle.svm.hosted.NativeImageOptions;
+
+public class MultiClassLoaderReporter {
+    public static final String MULTIPLE_CHECKSUMS = "MULTIPLE_CHECKSUM";
+    public static final String CHECKSUM_VERIFY_FAIL = "CHECKSUM_VERIFY_FAIL";
+
+    public static void reportError(BigBang bb, String msgKey, String exceptionsMsg) {
+        // Checkstyle: stop
+        String option = SubstrateOptionsParser.commandArgument(NativeImageOptions.ReportUnsupportedElementsAtRuntime, "+");
+        if (!NativeImageOptions.ReportUnsupportedElementsAtRuntime.getValue()) {
+            bb.getUnsupportedFeatures().addMessage(msgKey, null,
+                            exceptionsMsg + "\n" + "To allow continuing compilation with above unsupported features, set " + option);
+        } else {
+            System.out.println(exceptionsMsg);
+            System.out.println("Compilation will continue because " + option +
+                            " was set. But the program may behave unexpectedly at runtime.");
+        }
+        // Checkstyle: resume
+    }
+}

--- a/substratevm/src/com.oracle.svm.reflect/src/com/oracle/svm/reflect/dynamicclasses/hosted/DynamicClassesFeature.java
+++ b/substratevm/src/com.oracle.svm.reflect/src/com/oracle/svm/reflect/dynamicclasses/hosted/DynamicClassesFeature.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2021, Alibaba Group Holding Limited. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package com.oracle.svm.reflect.dynamicclasses.hosted;
+
+// Checkstyle: allow reflection
+
+import com.oracle.svm.core.annotate.AutomaticFeature;
+import com.oracle.svm.core.configure.ConfigurationFiles;
+import com.oracle.svm.core.configure.DynamicClassesConfigurationParser;
+import com.oracle.svm.core.hub.ClassForNameSupport;
+import com.oracle.svm.core.util.UserError;
+import com.oracle.svm.core.util.VMError;
+import com.oracle.svm.hosted.FeatureImpl;
+import com.oracle.svm.hosted.config.ConfigurationParserUtils;
+import com.oracle.svm.reflect.MultiClassLoaderReporter;
+import com.oracle.svm.util.ReflectionUtil;
+import org.graalvm.nativeimage.hosted.Feature;
+
+import java.io.FileInputStream;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@AutomaticFeature
+public class DynamicClassesFeature implements Feature {
+
+    class DynamicClassContainer {
+        Class<?> clazz;
+        String name;
+        String checksum;
+
+        DynamicClassContainer(Class<?> clazz, String name, String checksum) {
+            this.clazz = clazz;
+            this.name = name;
+            this.checksum = checksum;
+        }
+    }
+
+    private Map<String, DynamicClassContainer> dynamicClassContainers = new HashMap<>();
+    private List<StringBuilder> errMsgs = new ArrayList<>();
+
+    /**
+     * Reflectively call protected method ClassLoader.defineClass(String. byte[], int, int)
+     *
+     * @param name target class name
+     * @param classLoader the class loader
+     * @param classData class data byte array
+     * @return the class defined with the given name
+     */
+    private static Class<?> callDefineClass(String name, ClassLoader classLoader, byte[] classData) throws IllegalAccessException, InvocationTargetException {
+        Method defineClass = ReflectionUtil.lookupMethod(ClassLoader.class, "defineClass", String.class, byte[].class, int.class, int.class);
+        return (Class<?>) defineClass.invoke(classLoader, name, classData, 0, classData.length);
+    }
+
+    @Override
+    public void afterRegistration(AfterRegistrationAccess a) {
+        FeatureImpl.AfterRegistrationAccessImpl access = (FeatureImpl.AfterRegistrationAccessImpl) a;
+        ClassLoader imageClassLoader = access.getImageClassLoader().getClassLoader();
+        DynamicClassesConfigurationParser.DynamicClassesParserFunction adapter = (definedClassName, dumpedFilePath, checksum) -> {
+            try (
+                            FileInputStream fio = new FileInputStream(dumpedFilePath.toFile());
+                            FileChannel fileChannel = fio.getChannel();) {
+                ByteBuffer byteBuffer = ByteBuffer.allocate((int) fileChannel.size());
+                while (fileChannel.read(byteBuffer) > 0) {
+                    // Reading file. Do nothing
+                }
+                Class<?> generatedClass = callDefineClass(definedClassName, imageClassLoader, byteBuffer.array());
+                UserError.guarantee(generatedClass != null,
+                                "Cannot find pre-dumped class file %s for dynamic generated class %s. The missing of this class can't be ignored even if -H:+AllowIncompleteClasspath is set." +
+                                                " Please make sure it is in the classpath",
+                                dumpedFilePath, definedClassName);
+                UserError.guarantee(generatedClass.getName().equals(definedClassName), "Pre-dumped generated class file %s's class name is %s, which does not match with configured name %s",
+                                dumpedFilePath, generatedClass.getName(), definedClassName);
+                DynamicClassContainer exitingEntity = dynamicClassContainers.putIfAbsent(definedClassName, new DynamicClassContainer(generatedClass, definedClassName, checksum));
+                if (exitingEntity != null && !exitingEntity.checksum.equals(checksum)) {
+                    StringBuilder sb = new StringBuilder();
+                    sb.append("Suspicious multiple-classloader usage is detected from dynamicClasses configurations:\n");
+                    sb.append("Dynamically defined class (name=").append(definedClassName).append(", checksum=").append(checksum).append(")");
+                    sb.append(" is already registered with checksum ").append(exitingEntity.checksum);
+                    errMsgs.add(sb);
+                }
+            } catch (Exception e) {
+                VMError.shouldNotReachHere("Cannot load required class " + definedClassName, e);
+            }
+        };
+
+        DynamicClassesConfigurationParser parser = new DynamicClassesConfigurationParser(adapter);
+        ConfigurationParserUtils.parseAndRegisterConfigurations(parser, access.getImageClassLoader(), "dynamicClasses",
+                        ConfigurationFiles.Options.DynamicClassesConfigurationFiles, ConfigurationFiles.Options.DynamicClassesConfigurationResources,
+                        ConfigurationFiles.DYNAMIC_CLASSES_NAME);
+    }
+
+    @Override
+    public void duringSetup(DuringSetupAccess access) {
+        if (errMsgs.size() > 0) {
+            for (StringBuilder sb : errMsgs) {
+                MultiClassLoaderReporter.reportError(((FeatureImpl.DuringSetupAccessImpl) access).getBigBang(), MultiClassLoaderReporter.MULTIPLE_CHECKSUMS, sb.toString());
+            }
+        }
+        for (DynamicClassContainer d : dynamicClassContainers.values()) {
+            ClassForNameSupport.registerDynamicGeneratedClass(d.clazz, d.name, d.checksum);
+        }
+    }
+}


### PR DESCRIPTION
**Overview**
This patch supports `java.lang.ClassLoader.defineClass(String name, byte[] b, int off, int len)` based dynamic class loading in native image. It is separated from the previous PR (https://github.com/oracle/graal/pull/2323). 
The basic idea for supporting dynamic class loading is dumping classes generated at run time in a beforehand run with native-image-agent to a specified directory which is added to the classpath for building native image. 
This is implemented in 3 steps:

1. Intercept `java.lang.ClassLoader.postDefineClass` by native-image-agent to dump the dynamically generated class to file system.
2. User should make sure the generated classes' names are fixed through Hotspot version runtime and native-image version runtime.
3. Substitute relevant classes in SubstrateVM to load the previously dumped classes at native image runtime.

**Features:**

- Add new agent option `-agentlib:native-image-agent=dynamic-class-dump-dir=` to specify where to dump the dynamically generated classes, the default value is "dynClass" if not specified.
- Both dynamically generated class and its stack trace are dumped.
- Dynamically generated class's name could be decided at runtime (e.g. runtime sequence number as post-fix) or null when `java.lang.ClassLoader.defineClass` is invoked. It is the user's job to make sure the dynamic generated class' name is constant through Agent runtime and native image runtime. The patch has supported the null name scenario.
- Different classloaders can dynamically define same name class at runtime. SubstrateVM doesn't support multiple classloaders yet. This patch will report error at Agent runtime if same name classes  are defined by multiple classloaders.
- All unsupported dynamic class loading usages shall be reported at the end of Agent run.

**Limitations:**
- This patch does not support defineClass with specified ProtectionDomain.
- It is possible the jar on classpath has a different signature file from dynamically generated class and fail the check in `java.lang.ClassLoader.checkCerts(String name, CodeSource cs)` at native-image build time. Current solution is to manually delete jar's signature file before building. This limitation can be shown by test: [testWithSignedJar.zip](https://github.com/oracle/graal/files/4770502/testWithSignedJar.zip)

- It is possible the dynamically generated class contents are changing from run to run. We make a class contents check at runtime based on the byte array's hash code to assure the runtime defined class is the same as the previously prepared one. But this check excludes SourceFile attribute because it often varies from runs but doesn't affect runtime behavior. This limitation can be shown by test: [testChangedClass.zip](https://github.com/oracle/graal/files/4770579/testChangedClass.zip)



**Tests:**
This patch can be tested by 
[testDynamicLoading.zip](https://github.com/oracle/graal/files/4626450/testDynamicLoading.zip)

