### PR TITLE
Use @ arguments file for running java as part of native-image on Windows

### DIFF
--- a/substratevm/src/com.oracle.svm.driver/src/com/oracle/svm/driver/NativeImage.java
+++ b/substratevm/src/com.oracle.svm.driver/src/com/oracle/svm/driver/NativeImage.java
@@ -73,7 +73,6 @@ import java.util.stream.Collectors;
 
 import org.graalvm.compiler.options.OptionKey;
 import org.graalvm.compiler.serviceprovider.JavaVersionUtil;
-import org.graalvm.nativeimage.Platform;
 import org.graalvm.nativeimage.ProcessProperties;
 
 import com.oracle.graal.pointsto.api.PointstoOptions;
@@ -98,8 +97,6 @@ public class NativeImage {
     private static final String DEFAULT_GENERATOR_CLASS_NAME = "com.oracle.svm.hosted.NativeImageGeneratorRunner";
     private static final String DEFAULT_GENERATOR_9PLUS_SUFFIX = "$JDK9Plus";
     private static final String CUSTOM_SYSTEM_CLASS_LOADER = NativeImageSystemClassLoader.class.getCanonicalName();
-
-    private static final int WINDOWS_MAX_COMMAND_LENGTH = 32768;
 
     static final boolean IS_AOT = Boolean.getBoolean("com.oracle.graalvm.isaot");
 
@@ -1259,17 +1256,15 @@ public class NativeImage {
 
         int exitStatus = 1;
         try {
-            if (Platform.includedIn(Platform.WINDOWS.class)) {
-                int totalLength = command.stream().mapToInt(s -> s.length() + 1).sum();
-                if (totalLength >= WINDOWS_MAX_COMMAND_LENGTH) {
-                    Path argsFile = Files.createTempFile("native-image", "args");
-                    argsFile.toFile().deleteOnExit();
-                    Files.write(argsFile, (Iterable<String>) command.stream().skip(1).map(NativeImage::quoteFileArg)::iterator);
-                    List<String> atCommand = new ArrayList<>();
-                    atCommand.add(command.get(0));
-                    atCommand.add("@" + argsFile);
-                    command = atCommand;
-                }
+            if (config.useJavaModules()) {
+                /* For Java > 8 we use an argument file to pass the options to the builder */
+                Path argsFile = Files.createTempFile("native-image", "args");
+                argsFile.toFile().deleteOnExit();
+                Files.write(argsFile, (Iterable<String>) command.stream().skip(1).map(NativeImage::quoteFileArg)::iterator);
+                List<String> atCommand = new ArrayList<>();
+                atCommand.add(command.get(0));
+                atCommand.add("@" + argsFile);
+                command = atCommand;
             }
             ProcessBuilder pb = new ProcessBuilder();
             pb.command(command);
@@ -1282,11 +1277,11 @@ public class NativeImage {
     }
 
     private static String quoteFileArg(String arg) {
-        String result = arg.replaceAll(Pattern.quote("\\"), Matcher.quoteReplacement("\\\\"));
-        if (result.contains(" ")) {
-            result = "\"" + result + "\"";
+        String resultArg = arg.replaceAll(Pattern.quote("\\"), Matcher.quoteReplacement("\\\\"));
+        if (resultArg.contains(" ")) {
+            resultArg = "\"" + resultArg + "\"";
         }
-        return result;
+        return resultArg;
     }
 
     private static final Function<BuildConfiguration, NativeImage> defaultNativeImageProvider = config -> IS_AOT ? NativeImageServer.create(config) : new NativeImage(config);

--- a/substratevm/src/com.oracle.svm.driver/src/com/oracle/svm/driver/NativeImage.java
+++ b/substratevm/src/com.oracle.svm.driver/src/com/oracle/svm/driver/NativeImage.java
@@ -1274,9 +1274,9 @@ public class NativeImage {
             exitStatus = p.waitFor();
             if (exitStatus != 0 && isVerbose() && argsFile != null) {
                 /* Create a copy of the argument file for failure analysis */
-                Path tmpDir = Paths.get(System.getProperty("java.io.tmpdir"));
-                Path argsFileCopy = tmpDir.resolve("native-image-failure.args");
+                Path argsFileCopy = Paths.get("native-image-failure.args");
                 Files.copy(argsFile, argsFileCopy, StandardCopyOption.REPLACE_EXISTING);
+                showMessage("Argument file: " + argsFileCopy);
             }
         } catch (IOException | InterruptedException e) {
             throw showError(e.getMessage());


### PR DESCRIPTION
A very simple solution to #2387 using the @ argument support added to `java` in version 9.

The other solution offered in the issue seems much more complex just for having it work on Java 8. If that's essential it seems more useful to backport the @ argument support to version 8 instead.

Btw, the code could be simplified a bit more by removing the length check and just always generate the @ file on windows. Not sure what would be preferable though.