### PR TITLE
Allow user-defined image inclusion of builtin modules.

### DIFF
--- a/sdk/mx.sdk/mx_sdk_vm.py
+++ b/sdk/mx.sdk/mx_sdk_vm.py
@@ -726,13 +726,6 @@ grant codeBase "jrt:/com.oracle.graal.graal_enterprise" {
                 if isfile(lib_path):
                     shutil.copy2(lib_path, dst_lib_directory)
 
-        # Build the list of modules whose classes might have annotations
-        # to be processed by native-image (GR-15192).
-        with open(join(dst_jdk_dir, 'lib', 'native-image-modules.list'), 'w') as fp:
-            print('# Modules whose classes might have annotations processed by native-image', file=fp)
-            for m in modules:
-                print(m.name, file=fp)
-
     finally:
         if not mx.get_opts().verbose:
             # Preserve build directory so that javac command can be re-executed

--- a/substratevm/src/com.oracle.svm.driver/src/com/oracle/svm/driver/MacroOptionHandler.java
+++ b/substratevm/src/com.oracle.svm.driver/src/com/oracle/svm/driver/MacroOptionHandler.java
@@ -80,6 +80,8 @@ class MacroOptionHandler extends NativeImage.OptionHandler<NativeImage> {
         BuildConfiguration config = nativeImage.config;
         if (!config.useJavaModules()) {
             enabledOption.forEachPropertyValue(config, "ImageBuilderBootClasspath8", entry -> nativeImage.addImageBuilderBootClasspath(ClasspathUtils.stringToClasspath(entry)), PATH_SEPARATOR_REGEX);
+        } else {
+            enabledOption.forEachPropertyValue(config, "ImageIncludeBuiltinModules", entry -> nativeImage.addImageIncludeBuiltinModules(entry), ",");
         }
 
         if (!enabledOption.forEachPropertyValue(config, "ImageBuilderClasspath", entry -> nativeImage.addImageBuilderClasspath(ClasspathUtils.stringToClasspath(entry)), PATH_SEPARATOR_REGEX)) {

--- a/substratevm/src/com.oracle.svm.driver/src/com/oracle/svm/driver/NativeImage.java
+++ b/substratevm/src/com.oracle.svm.driver/src/com/oracle/svm/driver/NativeImage.java
@@ -86,6 +86,7 @@ import com.oracle.svm.core.util.VMError;
 import com.oracle.svm.driver.MacroOption.EnabledOption;
 import com.oracle.svm.driver.MacroOption.MacroOptionKind;
 import com.oracle.svm.driver.MacroOption.Registry;
+import com.oracle.svm.hosted.ImageClassLoader;
 import com.oracle.svm.hosted.NativeImageSystemClassLoader;
 import com.oracle.svm.util.ModuleSupport;
 
@@ -193,6 +194,7 @@ public class NativeImage {
     private final LinkedHashSet<String> imageBuilderArgs = new LinkedHashSet<>();
     private final LinkedHashSet<Path> imageBuilderClasspath = new LinkedHashSet<>();
     private final LinkedHashSet<Path> imageBuilderBootClasspath = new LinkedHashSet<>();
+    private final LinkedHashSet<String> imageIncludeBuiltinModules = new LinkedHashSet<>();
     private final ArrayList<String> imageBuilderJavaArgs = new ArrayList<>();
     private final LinkedHashSet<Path> imageClasspath = new LinkedHashSet<>();
     private final LinkedHashSet<Path> imageProvidedClasspath = new LinkedHashSet<>();
@@ -1051,6 +1053,9 @@ public class NativeImage {
         // The following two are for backwards compatibility reasons. They should be removed.
         imageBuilderJavaArgs.add("-Djdk.internal.lambda.eagerlyInitialize=false");
         imageBuilderJavaArgs.add("-Djava.lang.invoke.InnerClassLambdaMetafactory.initializeLambdas=false");
+        if (!imageIncludeBuiltinModules.isEmpty()) {
+            imageBuilderJavaArgs.add("-D" + ImageClassLoader.PROPERTY_IMAGEINCLUDEBUILTINMODULES + "=" + String.join(",", imageIncludeBuiltinModules));
+        }
 
         /* After JavaArgs consolidation add the user provided JavaArgs */
         addImageBuilderJavaArgs(customJavaArgs.toArray(new String[0]));
@@ -1336,6 +1341,10 @@ public class NativeImage {
 
     void addImageBuilderBootClasspath(Path classpath) {
         imageBuilderBootClasspath.add(canonicalize(classpath));
+    }
+
+    public void addImageIncludeBuiltinModules(String moduleName) {
+        imageIncludeBuiltinModules.add(moduleName);
     }
 
     void addImageBuilderJavaArgs(String... javaArgs) {

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/ImageClassLoader.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/ImageClassLoader.java
@@ -72,6 +72,10 @@ import com.oracle.svm.util.ModuleSupport;
 
 public final class ImageClassLoader {
 
+    /*
+     * This cannot be a HostedOption because all Subclasses of OptionDescriptors from inside builtin
+     * modules need to be initialized prior to option parsing so that they can be found.
+     */
     public static final String PROPERTY_IMAGEINCLUDEBUILTINMODULES = "substratevm.ImageIncludeBuiltinModules";
 
     private static final String CLASS_EXTENSION = ".class";

--- a/substratevm/src/com.oracle.svm.util.jdk11/src/com/oracle/svm/util/ModuleSupport.java
+++ b/substratevm/src/com.oracle.svm.util.jdk11/src/com/oracle/svm/util/ModuleSupport.java
@@ -81,6 +81,10 @@ public final class ModuleSupport {
         return ResourceBundle.getBundle(bundleName, locale, loader);
     }
 
+    public static boolean hasSystemModule(String moduleName) {
+        return ModuleFinder.ofSystem().find(moduleName).isPresent();
+    }
+
     public static List<String> getModuleResources(Collection<String> names) {
         List<String> result = new ArrayList<>();
         for (String name : names) {

--- a/substratevm/src/com.oracle.svm.util/src/com/oracle/svm/util/ModuleSupport.java
+++ b/substratevm/src/com.oracle.svm.util/src/com/oracle/svm/util/ModuleSupport.java
@@ -46,6 +46,16 @@ public final class ModuleSupport {
     }
 
     /**
+     * Checks if the Java run-time image contains a module with the given name.
+     */
+    @SuppressWarnings("unused")
+    public static boolean hasSystemModule(String moduleName) {
+        /* Nothing to do in JDK 8 version. JDK 11 version provides a proper implementation. */
+        assert JavaVersionUtil.JAVA_SPEC <= 8;
+        return false;
+    }
+
+    /**
      * Gets all resources in the modules named by {@code modules} from the Java runtime image.
      */
     @SuppressWarnings("unused")

--- a/truffle/mx.truffle/macro-truffle.properties
+++ b/truffle/mx.truffle/macro-truffle.properties
@@ -1,5 +1,6 @@
 # This file contains support for building truffle images
 ImageBuilderBootClasspath8 = ${.}/../../../truffle/truffle-api.jar
+ImageIncludeBuiltinModules = org.graalvm.truffle
 
 Args = -H:Features=com.oracle.svm.truffle.TruffleFeature,org.graalvm.home.HomeFinderFeature \
        -H:MaxRuntimeCompileMethods=1400 \


### PR DESCRIPTION
This is a proper fix for the workaround added in https://github.com/oracle/graal/commit/4a5f6ae8341071ff9225c93ea82db643a102320a