### PR TITLE
Add function name lookup for c++ functions.

### DIFF
--- a/sulong/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/LLVMParser.java
+++ b/sulong/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/LLVMParser.java
@@ -43,7 +43,6 @@ import com.oracle.truffle.llvm.runtime.LLVMAlias;
 import com.oracle.truffle.llvm.runtime.LLVMFunction;
 import com.oracle.truffle.llvm.runtime.LLVMFunctionCode.Function;
 import com.oracle.truffle.llvm.runtime.LLVMFunctionCode.LazyLLVMIRFunction;
-import com.oracle.truffle.llvm.runtime.LLVMLanguage;
 import com.oracle.truffle.llvm.runtime.LLVMSymbol;
 import com.oracle.truffle.llvm.runtime.datalayout.DataLayout;
 import com.oracle.truffle.llvm.runtime.except.LLVMLinkerException;
@@ -52,8 +51,6 @@ import com.oracle.truffle.llvm.runtime.options.SulongEngineOption;
 
 import java.util.ArrayList;
 import java.util.List;
-
-import org.antlr.v4.runtime.ParserRuleContext;
 
 public final class LLVMParser {
     private final Source source;

--- a/sulong/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/LLVMParser.java
+++ b/sulong/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/LLVMParser.java
@@ -126,6 +126,8 @@ public final class LLVMParser {
         LLVMFunction llvmFunction = LLVMFunction.create(functionSymbol.getName(), library, function, functionSymbol.getType(), runtime.getBitcodeID(), functionSymbol.getIndex(),
                         functionDefinition.isExported());
         runtime.getFileScope().register(llvmFunction);
+        lazyConverter.resolveLinkageName();
+
     }
 
     private void defineAlias(GlobalAlias alias) {

--- a/sulong/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/LLVMParser.java
+++ b/sulong/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/LLVMParser.java
@@ -53,6 +53,8 @@ import com.oracle.truffle.llvm.runtime.options.SulongEngineOption;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.antlr.v4.runtime.ParserRuleContext;
+
 public final class LLVMParser {
     private final Source source;
     private final LLVMParserRuntime runtime;
@@ -128,7 +130,7 @@ public final class LLVMParser {
         LLVMFunction llvmFunction = LLVMFunction.create(functionSymbol.getName(), library, function, functionSymbol.getType(), runtime.getBitcodeID(), functionSymbol.getIndex(),
                         functionDefinition.isExported());
         runtime.getFileScope().register(llvmFunction);
-        final boolean cxxInterop = LLVMLanguage.getContext().getEnv().getOptions().get(SulongEngineOption.CXX_INTEROP);
+        final boolean cxxInterop = runtime.getContext().getEnv().getOptions().get(SulongEngineOption.CXX_INTEROP);
         if (cxxInterop) {
             model.getFunctionParser(functionDefinition).parseLinkageName(runtime);
         }

--- a/sulong/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/LLVMParser.java
+++ b/sulong/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/LLVMParser.java
@@ -43,10 +43,12 @@ import com.oracle.truffle.llvm.runtime.LLVMAlias;
 import com.oracle.truffle.llvm.runtime.LLVMFunction;
 import com.oracle.truffle.llvm.runtime.LLVMFunctionCode.Function;
 import com.oracle.truffle.llvm.runtime.LLVMFunctionCode.LazyLLVMIRFunction;
+import com.oracle.truffle.llvm.runtime.LLVMLanguage;
 import com.oracle.truffle.llvm.runtime.LLVMSymbol;
 import com.oracle.truffle.llvm.runtime.datalayout.DataLayout;
 import com.oracle.truffle.llvm.runtime.except.LLVMLinkerException;
 import com.oracle.truffle.llvm.runtime.global.LLVMGlobal;
+import com.oracle.truffle.llvm.runtime.options.SulongEngineOption;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -126,8 +128,10 @@ public final class LLVMParser {
         LLVMFunction llvmFunction = LLVMFunction.create(functionSymbol.getName(), library, function, functionSymbol.getType(), runtime.getBitcodeID(), functionSymbol.getIndex(),
                         functionDefinition.isExported());
         runtime.getFileScope().register(llvmFunction);
-        lazyConverter.resolveLinkageName();
-
+        final boolean cxxInterop = LLVMLanguage.getContext().getEnv().getOptions().get(SulongEngineOption.CXX_INTEROP);
+        if (cxxInterop) {
+            model.getFunctionParser(functionDefinition).parseLinkageName(runtime);
+        }
     }
 
     private void defineAlias(GlobalAlias alias) {

--- a/sulong/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/LazyToTruffleConverterImpl.java
+++ b/sulong/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/LazyToTruffleConverterImpl.java
@@ -508,8 +508,4 @@ public class LazyToTruffleConverterImpl implements LazyToTruffleConverter {
 
         return formalParamInits;
     }
-
-    public void resolveLinkageName() {
-        parser.parseLinkageName(runtime);
-    }
 }

--- a/sulong/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/LazyToTruffleConverterImpl.java
+++ b/sulong/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/LazyToTruffleConverterImpl.java
@@ -508,4 +508,8 @@ public class LazyToTruffleConverterImpl implements LazyToTruffleConverter {
 
         return formalParamInits;
     }
+
+    public void resolveLinkageName() {
+        parser.parseLinkageName(runtime);
+    }
 }

--- a/sulong/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/listeners/FunctionMDOnly.java
+++ b/sulong/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/listeners/FunctionMDOnly.java
@@ -53,6 +53,10 @@ public final class FunctionMDOnly implements ParserListener {
 
     }
 
+    /**
+     * Only to look for an MDSubprogram that is attached to a function. MetadataSubprogramOnly
+     * throws an MDSubprogramParsedException when it is parsed.
+     */
     @Override
     public ParserListener enter(Block block) {
         switch (block) {
@@ -68,7 +72,13 @@ public final class FunctionMDOnly implements ParserListener {
 
     @Override
     public void exit() {
-        // no linkageName found
+        /*
+         * No linkageName found. This method is not called if a linkage name has been found (i.e.,
+         * MDSubprogramOnly has thrown MDSubprogramParsedException), since the information which had
+         * been looked for has already been found, and the state of this parser is not relevant any
+         * more. In case of another parsing step of this function (due to lazy parsing), a different
+         * parser is used.
+         */
         scope.exitLocalScope();
     }
 

--- a/sulong/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/listeners/FunctionMDOnly.java
+++ b/sulong/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/listeners/FunctionMDOnly.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are
+ * permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of
+ * conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of
+ * conditions and the following disclaimer in the documentation and/or other materials provided
+ * with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be used to
+ * endorse or promote products derived from this software without specific prior written
+ * permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS
+ * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+ * GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.oracle.truffle.llvm.parser.listeners;
+
+import com.oracle.truffle.llvm.parser.model.IRScope;
+import com.oracle.truffle.llvm.parser.model.functions.FunctionDefinition;
+import com.oracle.truffle.llvm.parser.scanner.Block;
+import com.oracle.truffle.llvm.parser.scanner.RecordBuffer;
+
+public final class FunctionMDOnly implements ParserListener {
+
+    private final FunctionDefinition function;
+
+    private final Types types;
+
+    private final IRScope scope;
+
+    public FunctionMDOnly(IRScope scope, Types types, FunctionDefinition function) {
+        this.scope = scope;
+        this.types = types;
+        this.function = function;
+    }
+
+    public void setupScope() {
+        scope.startLocalScope(function);
+
+    }
+
+    @Override
+    public ParserListener enter(Block block) {
+        switch (block) {
+            case METADATA:
+            case METADATA_ATTACHMENT:
+            case METADATA_KIND:
+                return new MetadataSubprogramOnly(types, scope);
+
+            default:
+                return ParserListener.DEFAULT;
+        }
+    }
+
+    @Override
+    public void exit() {
+        // no linkageName found
+        scope.exitLocalScope();
+    }
+
+    @Override
+    public void record(RecordBuffer buffer) {
+
+    }
+
+}

--- a/sulong/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/listeners/Metadata.java
+++ b/sulong/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/listeners/Metadata.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2019, Oracle and/or its affiliates.
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates.
  *
  * All rights reserved.
  *

--- a/sulong/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/listeners/Metadata.java
+++ b/sulong/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/listeners/Metadata.java
@@ -75,7 +75,7 @@ import com.oracle.truffle.llvm.parser.scanner.RecordBuffer;
 import com.oracle.truffle.llvm.runtime.except.LLVMParserException;
 import com.oracle.truffle.llvm.runtime.types.Type;
 
-public final class Metadata implements ParserListener {
+public class Metadata implements ParserListener {
 
     private static final int METADATA_STRING = 1;
     private static final int METADATA_VALUE = 2;
@@ -97,7 +97,7 @@ public final class Metadata implements ParserListener {
     private static final int METADATA_COMPOSITE_TYPE = 18;
     private static final int METADATA_SUBROUTINE_TYPE = 19;
     private static final int METADATA_COMPILE_UNIT = 20;
-    private static final int METADATA_SUBPROGRAM = 21;
+    protected static final int METADATA_SUBPROGRAM = 21;
     private static final int METADATA_LEXICAL_BLOCK = 22;
     private static final int METADATA_LEXICAL_BLOCK_FILE = 23;
     private static final int METADATA_NAMESPACE = 24;
@@ -127,7 +127,7 @@ public final class Metadata implements ParserListener {
         return scope;
     }
 
-    private final IRScope scope;
+    protected final IRScope scope;
 
     private final Set<MDCompositeType> compositeTypes;
 
@@ -149,6 +149,10 @@ public final class Metadata implements ParserListener {
     public void record(RecordBuffer buffer) {
         long[] args = buffer.dumpArray();
         final int opCode = buffer.getId();
+        parseOpcode(buffer, args, opCode);
+    }
+
+    protected void parseOpcode(RecordBuffer buffer, long[] args, final int opCode) {
         switch (opCode) {
             case METADATA_STRING:
                 metadata.add(MDString.create(buffer));

--- a/sulong/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/listeners/MetadataSubprogramOnly.java
+++ b/sulong/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/listeners/MetadataSubprogramOnly.java
@@ -35,12 +35,21 @@ import com.oracle.truffle.llvm.parser.metadata.MDSubprogram;
 import com.oracle.truffle.llvm.parser.model.IRScope;
 import com.oracle.truffle.llvm.parser.scanner.RecordBuffer;
 
+/**
+ * This class is used to find an MDSubprogram that has been attached to a LLVM function.
+ */
+
 public class MetadataSubprogramOnly extends Metadata {
 
     MetadataSubprogramOnly(Types types, IRScope scope) {
         super(types, scope);
     }
 
+    /**
+     * Parses the given opCode while looking for an MDSubprogam.
+     *
+     * @throws MDSubprogramParsedException if the MDSubprogram is found.
+     */
     @Override
     protected void parseOpcode(RecordBuffer buffer, long[] args, int opCode) {
         super.parseOpcode(buffer, args, opCode);

--- a/sulong/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/listeners/MetadataSubprogramOnly.java
+++ b/sulong/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/listeners/MetadataSubprogramOnly.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are
+ * permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of
+ * conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of
+ * conditions and the following disclaimer in the documentation and/or other materials provided
+ * with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be used to
+ * endorse or promote products derived from this software without specific prior written
+ * permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS
+ * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+ * GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.oracle.truffle.llvm.parser.listeners;
+
+import com.oracle.truffle.llvm.parser.metadata.MDBaseNode;
+import com.oracle.truffle.llvm.parser.metadata.MDString;
+import com.oracle.truffle.llvm.parser.metadata.MDSubprogram;
+import com.oracle.truffle.llvm.parser.model.IRScope;
+import com.oracle.truffle.llvm.parser.scanner.RecordBuffer;
+
+public class MetadataSubprogramOnly extends Metadata {
+
+    MetadataSubprogramOnly(Types types, IRScope scope) {
+        super(types, scope);
+    }
+
+    @Override
+    protected void parseOpcode(RecordBuffer buffer, long[] args, int opCode) {
+        super.parseOpcode(buffer, args, opCode);
+        if (opCode == METADATA_SUBPROGRAM) {
+            MDBaseNode mdBaseNode = metadata.getOrNull(metadata.size() - 1);
+            if (mdBaseNode instanceof MDSubprogram) {
+                MDSubprogram mdSubprogram = (MDSubprogram) mdBaseNode;
+                String linkageName = MDString.getIfInstance(mdSubprogram.getLinkageName());
+                String displayName = MDString.getIfInstance(mdSubprogram.getName());
+                scope.exitLocalScope();
+                throw new MDSubprogramParsedException(linkageName, displayName);
+            }
+        }
+    }
+
+    public static class MDSubprogramParsedException extends RuntimeException {
+
+        private static final long serialVersionUID = 1L;
+        public final String linkageName;
+        public final String displayName;
+
+        public MDSubprogramParsedException(String linkageName, String displayName) {
+            this.linkageName = linkageName;
+            this.displayName = displayName;
+        }
+
+        @Override
+        public synchronized Throwable fillInStackTrace() {
+            return this;
+        }
+
+    }
+
+}

--- a/sulong/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/model/functions/FunctionDefinition.java
+++ b/sulong/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/model/functions/FunctionDefinition.java
@@ -35,6 +35,8 @@ import java.util.List;
 
 import com.oracle.truffle.api.CompilerAsserts;
 import com.oracle.truffle.llvm.parser.metadata.MDAttachment;
+import com.oracle.truffle.llvm.parser.metadata.MDString;
+import com.oracle.truffle.llvm.parser.metadata.MDSubprogram;
 import com.oracle.truffle.llvm.parser.metadata.MetadataAttachmentHolder;
 import com.oracle.truffle.llvm.parser.metadata.debuginfo.SourceFunction;
 import com.oracle.truffle.llvm.parser.model.SymbolImpl;
@@ -89,6 +91,21 @@ public final class FunctionDefinition extends FunctionSymbol implements Constant
     public String getSourceName() {
         final String scopeName = sourceFunction.getName();
         return SourceFunction.DEFAULT_SOURCE_NAME.equals(scopeName) ? null : scopeName;
+    }
+
+    public String getDisplayName() {
+        // for LLVM from C++, function.name stores the linkage name, but not 'original' C++ name
+        if (mdAttachments != null && mdAttachments.size() > 0) {
+            for (MDAttachment mdAttachment : mdAttachments) {
+                if (mdAttachment.getValue() instanceof MDSubprogram) {
+                    MDSubprogram mdSubprogram = (MDSubprogram) mdAttachment.getValue();
+                    if (mdSubprogram.getName() instanceof MDString) {
+                        return ((MDString) mdSubprogram.getName()).getString();
+                    }
+                }
+            }
+        }
+        return getSourceName();
     }
 
     @Override

--- a/sulong/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/model/functions/FunctionDefinition.java
+++ b/sulong/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/model/functions/FunctionDefinition.java
@@ -94,7 +94,10 @@ public final class FunctionDefinition extends FunctionSymbol implements Constant
     }
 
     public String getDisplayName() {
-        // for LLVM from C++, function.name stores the linkage name, but not 'original' C++ name
+        /*
+         * For LLVM code produced from C++ sources, function.name stores the linkage name, but not
+         * 'original' C++ name.
+         */
         if (mdAttachments != null && mdAttachments.size() > 0) {
             for (MDAttachment mdAttachment : mdAttachments) {
                 if (mdAttachment.getValue() instanceof MDSubprogram) {

--- a/sulong/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/model/functions/LazyFunctionParser.java
+++ b/sulong/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/model/functions/LazyFunctionParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2019, Oracle and/or its affiliates.
+ * Copyright (c) 2018, 2020, Oracle and/or its affiliates.
  *
  * All rights reserved.
  *
@@ -87,8 +87,10 @@ public final class LazyFunctionParser {
                 parser.setupScope();
                 scanner.scanBlock(parser);
             } catch (MDSubprogramParsedException e) {
-                // if linkageName/displayName is found, an exception is thrown (s.t.
-                // parsing/searching does not have to be continued)
+                /*
+                 * If linkageName/displayName is found, an exception is thrown (such that
+                 * parsing/searching does not have to be continued).
+                 */
                 final String displayName = e.displayName;
                 final String linkageName = e.linkageName;
 

--- a/sulong/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/model/functions/LazyFunctionParser.java
+++ b/sulong/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/model/functions/LazyFunctionParser.java
@@ -32,6 +32,8 @@ package com.oracle.truffle.llvm.parser.model.functions;
 import com.oracle.truffle.api.source.Source;
 import com.oracle.truffle.llvm.parser.LLVMParserRuntime;
 import com.oracle.truffle.llvm.parser.listeners.Function;
+import com.oracle.truffle.llvm.parser.listeners.FunctionMDOnly;
+import com.oracle.truffle.llvm.parser.listeners.MetadataSubprogramOnly.MDSubprogramParsedException;
 import com.oracle.truffle.llvm.parser.listeners.ParameterAttributes;
 import com.oracle.truffle.llvm.parser.listeners.Types;
 import com.oracle.truffle.llvm.parser.metadata.debuginfo.DebugInfoFunctionProcessor;
@@ -74,6 +76,25 @@ public final class LazyFunctionParser {
                     llSource.applySourceLocations(parser.getFunction(), runtime);
                 }
                 isParsed = true;
+            }
+        }
+    }
+
+    public void parseLinkageName(LLVMParserRuntime runtime) {
+        synchronized (scope) {
+            FunctionMDOnly parser = new FunctionMDOnly(scope, types, function);
+            try {
+                parser.setupScope();
+                scanner.scanBlock(parser);
+            } catch (MDSubprogramParsedException e) {
+                // if linkageName/displayName is found, an exception is thrown (s.t.
+                // parsing/searching does not have to be continued)
+                final String displayName = e.displayName;
+                final String linkageName = e.linkageName;
+
+                if (linkageName != null && runtime.getFileScope().getFunction(displayName) == null) {
+                    runtime.getFileScope().registerLinkageName(displayName, linkageName);
+                }
             }
         }
     }

--- a/sulong/projects/com.oracle.truffle.llvm.runtime/src/com/oracle/truffle/llvm/runtime/LLVMScope.java
+++ b/sulong/projects/com.oracle.truffle.llvm.runtime/src/com/oracle/truffle/llvm/runtime/LLVMScope.java
@@ -98,7 +98,11 @@ public class LLVMScope implements TruffleObject {
     }
 
     /**
-     * add a tuple of function name and function linkage name to the map
+     * Add a tuple of function name and function linkage name to the map.
+     *
+     * @param name Function name as specified in original (e.g. C/C++) source.
+     * @param linkageName Function name in LLVM code if @param name has been changed during
+     *            compilation to LLVM bitcode.
      */
     public void registerLinkageName(String name, String linkageName) {
         linkageNames.put(name, linkageName);

--- a/sulong/projects/com.oracle.truffle.llvm.runtime/src/com/oracle/truffle/llvm/runtime/LLVMScope.java
+++ b/sulong/projects/com.oracle.truffle.llvm.runtime/src/com/oracle/truffle/llvm/runtime/LLVMScope.java
@@ -55,10 +55,12 @@ public class LLVMScope implements TruffleObject {
 
     private final HashMap<String, LLVMSymbol> symbols;
     private final ArrayList<String> functionKeys;
+    private final HashMap<String, String> linkageNames;
 
     public LLVMScope() {
         this.symbols = new HashMap<>();
         this.functionKeys = new ArrayList<>();
+        this.linkageNames = new HashMap<>();
     }
 
     @TruffleBoundary
@@ -72,7 +74,8 @@ public class LLVMScope implements TruffleObject {
     }
 
     /**
-     * Lookup a function in the scope by name.
+     * Lookup a function in the scope by name. If not found, interpret the name as linkageName and
+     * lookup the function by its original name.
      *
      * @param name Function name to lookup.
      * @return A handle to the function if found, null otherwise.
@@ -83,7 +86,22 @@ public class LLVMScope implements TruffleObject {
         if (symbol != null && symbol.isFunction()) {
             return symbol.asFunction();
         }
+        final String newName = linkageNames.get(name);
+        if (newName != null) {
+            symbol = get(newName);
+            if (symbol != null && symbol.isFunction()) {
+                return symbol.asFunction();
+            }
+        }
+
         return null;
+    }
+
+    /**
+     * add a tuple of function name and function linkage name to the map
+     */
+    public void registerLinkageName(String name, String linkageName) {
+        linkageNames.put(name, linkageName);
     }
 
     /**
@@ -131,6 +149,9 @@ public class LLVMScope implements TruffleObject {
     public void addMissingEntries(LLVMScope other) {
         for (Entry<String, LLVMSymbol> entry : other.symbols.entrySet()) {
             symbols.putIfAbsent(entry.getKey(), entry.getValue());
+        }
+        for (Entry<String, String> entry : other.linkageNames.entrySet()) {
+            linkageNames.putIfAbsent(entry.getKey(), entry.getValue());
         }
     }
 

--- a/sulong/projects/com.oracle.truffle.llvm.runtime/src/com/oracle/truffle/llvm/runtime/options/SulongEngineOption.java
+++ b/sulong/projects/com.oracle.truffle.llvm.runtime/src/com/oracle/truffle/llvm/runtime/options/SulongEngineOption.java
@@ -73,6 +73,12 @@ public final class SulongEngineOption {
                    "dependency on both of them. Thus, the option is off by default.")
     public static final OptionKey<Boolean> LOAD_CXX_LIBRARIES = new OptionKey<>(false);
 
+    public static final String CXX_INTEROP_NAME = "llvm.C++Interop";
+    @Option(name = CXX_INTEROP_NAME,
+            category = OptionCategory.EXPERT,
+            help = "Enables using C++ code and features via interop library")
+    public static final OptionKey<Boolean> CXX_INTEROP = new OptionKey<>(false);
+
     @Option(name = "llvm.enableExternalNativeAccess",
             category = OptionCategory.USER,
             help = "Enable Sulongs native interface.")

--- a/sulong/tests/com.oracle.truffle.llvm.tests.interop.native/interop/membersTest.cpp
+++ b/sulong/tests/com.oracle.truffle.llvm.tests.interop.native/interop/membersTest.cpp
@@ -1,3 +1,25 @@
+/*
+ * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
 #include<stdio.h>
 #include<stdlib.h>
 #include<polyglot.h>

--- a/sulong/tests/com.oracle.truffle.llvm.tests.interop.native/interop/membersTest.cpp
+++ b/sulong/tests/com.oracle.truffle.llvm.tests.interop.native/interop/membersTest.cpp
@@ -1,0 +1,20 @@
+#include<stdio.h>
+#include<stdlib.h>
+#include<polyglot.h>
+
+void hello() {
+	printf("hello() is being called in testfile membersTest.cc");
+}
+
+void bye() {
+	printf("bye() is being called in testfile membersTest.cc");
+}
+
+int gcd(int a, int b) {
+	if(a==0) {return b;}
+	else if(b==0) {return a;}
+	else if(a<0) {return gcd(-a, b);}
+	else if(b<0) {return gcd(a, -b);}
+	else {return gcd(b, a%b);}
+}
+

--- a/sulong/tests/com.oracle.truffle.llvm.tests/src/com/oracle/truffle/llvm/tests/interop/CxxMembersTest.java
+++ b/sulong/tests/com.oracle.truffle.llvm.tests/src/com/oracle/truffle/llvm/tests/interop/CxxMembersTest.java
@@ -38,22 +38,24 @@ import org.junit.runner.RunWith;
 import com.oracle.truffle.tck.TruffleRunner;
 
 @RunWith(TruffleRunner.class)
-public class MembersTest extends InteropTestBase {
+public class CxxMembersTest extends InteropTestBase {
 
-    private static Value testLibrary;
+    private static Value testCppLibrary;
 
     @BeforeClass
     public static void loadTestBitcode() {
-        testLibrary = loadTestBitcodeValue("stringTest.c");
+        testCppLibrary = loadTestBitcodeValue("membersTest.cpp");
     }
 
     @Test
     public void testMemberExists() {
-        Assert.assertTrue(testLibrary.hasMember("test_as_string_utf8"));
+        Assert.assertTrue(testCppLibrary.hasMember("hello"));
+        Assert.assertTrue(testCppLibrary.hasMember("bye"));
+        Assert.assertTrue(testCppLibrary.hasMember("gcd"));
     }
 
     @Test
     public void testMemberDoesNotExist() {
-        Assert.assertFalse(testLibrary.hasMember("abc"));
+        Assert.assertFalse(testCppLibrary.hasMember("abc"));
     }
 }

--- a/sulong/tests/com.oracle.truffle.llvm.tests/src/com/oracle/truffle/llvm/tests/interop/InteropTestBase.java
+++ b/sulong/tests/com.oracle.truffle.llvm.tests/src/com/oracle/truffle/llvm/tests/interop/InteropTestBase.java
@@ -58,7 +58,7 @@ public class InteropTestBase {
 
     public static Context.Builder getContextBuilder() {
         String lib = System.getProperty("test.sulongtest.lib.path");
-        return Context.newBuilder().allowAllAccess(true).option(SulongEngineOption.LIBRARY_PATH_NAME, lib);
+        return Context.newBuilder().allowAllAccess(true).allowExperimentalOptions(true).option(SulongEngineOption.LIBRARY_PATH_NAME, lib).option(SulongEngineOption.CXX_INTEROP_NAME, "true");
     }
 
     private static final Path testBase = Paths.get(TestOptions.TEST_SUITE_PATH, "interop");

--- a/sulong/tests/com.oracle.truffle.llvm.tests/src/com/oracle/truffle/llvm/tests/interop/MembersTest.java
+++ b/sulong/tests/com.oracle.truffle.llvm.tests/src/com/oracle/truffle/llvm/tests/interop/MembersTest.java
@@ -41,19 +41,26 @@ import com.oracle.truffle.tck.TruffleRunner;
 public class MembersTest extends InteropTestBase {
 
     private static Value testLibrary;
+    private static Value testCppLibrary;
 
     @BeforeClass
     public static void loadTestBitcode() {
         testLibrary = loadTestBitcodeValue("stringTest.c");
+        testCppLibrary = loadTestBitcodeValue("membersTest.cpp");
     }
 
     @Test
     public void testMemberExists() {
         Assert.assertTrue(testLibrary.hasMember("test_as_string_utf8"));
+        Assert.assertTrue(testCppLibrary.hasMember("hello"));
+        Assert.assertTrue(testCppLibrary.hasMember("bye"));
+        Assert.assertTrue(testCppLibrary.hasMember("gcd"));
+
     }
 
     @Test
     public void testMemberDoesNotExist() {
         Assert.assertFalse(testLibrary.hasMember("abc"));
+        Assert.assertFalse(testCppLibrary.hasMember("abc"));
     }
 }


### PR DESCRIPTION
**add function name lookup for c++ functions**
When compiled with Clang++, C++ functions have only been resolved by their linkage name (i.e. when calling a C(++) function from javascript, one had to call them by their linkage names). Now, an additional lookup is done to also look for the C++ function name (such that calling a C++ function from javascript/... by its 'real' name is enabled). 