### PR TITLE
Debug info test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,6 +44,12 @@ matrix:
         packages:
           - libc++1
           - libc++abi1
+  - os: linux
+    env: JDK="jdk8" GATE="build,debuginfotest" PRIMARY="substratevm"
+    addons:
+      apt:
+        packages:
+          - gdb
   - env: JDK="jdk11" GATE="style,fullbuild" PRIMARY="compiler"
   - env: JDK="jdk11" GATE="build,test" PRIMARY="compiler"
   - env: JDK="jdk11" GATE="build,bootstraplite" PRIMARY="compiler"

--- a/substratevm/DEBUGINFO.md
+++ b/substratevm/DEBUGINFO.md
@@ -16,14 +16,16 @@ argument to the GenerateDebugInfo option.
 
 The GenerateDebugInfo option also enables caching of sources for any
 JDK runtime classes, GraalVM classes and application classes which can
-be located during native image generation. The cache is created under
-local subdirectory sources. It is used to configure source file search
-path roots for the debugger. Files in the cache are located in a
-directory hierarchy that matches the file path information included in
-the native image debug records. The source cache should contain all
-the files needed to debug the generated image and nothing more. This
-local cache provides a convenient way of making just the necessary
-sources available to the debugger/IDE when debugging a native image.
+be located during native image generation. By default the cache is
+created under local subdirectory sources (a command line option can be
+use dot specifiy an alternative location). It is used to configure
+source file search path roots for the debugger. Files in the cache are
+located in a directory hierarchy that matches the file path
+information included in the native image debug records. The source
+cache should contain all the files needed to debug the generated image
+and nothing more. This local cache provides a convenient way of making
+just the necessary sources available to the debugger/IDE when
+debugging a native image.
 
 The implementation tries to be smart about locating source files. It
 uses the current JAVA_HOME to locate the JDK src.zip when searching
@@ -57,7 +59,23 @@ separator:
         -cp apps/target/hello.jar:apps/target/greeter.jar \
         org.my.Hello
 
-Note that in both the examples above the DebugInfoSourceSearchPath
+By default the cache of application, GraalVM and JDK sources is
+located under local directory sources. Option DebugInfoSourceCacheRoot
+can be used to specify an alternative location for the top level
+directory. As an example, the following variant of the previous
+command specifies the same target but employs an absolute path:
+
+    $ SOURCE_CACHE_ROOT=$PWD/sources
+    $ mx native-image -H:GenerateDebugInfo=1 \
+        -H:DebugInfoSourceCacheRoot=$SOURCE_CACHE_ROOT \
+        -H:DebugInfoSourceSearchPath=apps/hello/target/hello-sources.jar,apps/greeter/target/greeter-sources.jar \
+        -cp apps/target/hello.jar:apps/target/greeter.jar \
+        org.my.Hello
+
+If you specify a root directory that does not yet exist it will be
+created during population of the cache.
+
+Note that in all the examples above the DebugInfoSourceSearchPath
 options are actually redundant. In the first case the classpath
 entries for apps/hello/classes and apps/greeter/classes will be used
 to derive the default search roots apps/hello/src and
@@ -65,6 +83,7 @@ apps/greeter/src. In the second case classpath entries
 apps/target/hello.jar and apps/target/greeter.jar will be used to
 derive the default search roots apps/target/hello-sources.jar and
 apps/target/greeter-sources.jar.
+
 
 What is currently implemented
 -----------------------------

--- a/substratevm/DEBUGINFO.md
+++ b/substratevm/DEBUGINFO.md
@@ -18,7 +18,7 @@ The GenerateDebugInfo option also enables caching of sources for any
 JDK runtime classes, GraalVM classes and application classes which can
 be located during native image generation. By default the cache is
 created under local subdirectory sources (a command line option can be
-use dot specifiy an alternative location). It is used to configure
+used to specifiy an alternative location). It is used to configure
 source file search path roots for the debugger. Files in the cache are
 located in a directory hierarchy that matches the file path
 information included in the native image debug records. The source

--- a/substratevm/mx.substratevm/mx_substratevm.py
+++ b/substratevm/mx.substratevm/mx_substratevm.py
@@ -245,6 +245,7 @@ class Tags(set):
 GraalTags = Tags([
     'helloworld',
     'helloworld_debug',
+    'debuginfotest',
     'test',
     'maven',
     'js',
@@ -367,6 +368,16 @@ def svm_gate_body(args, tasks):
                 helloworld(['--output-path', svmbuild_dir(), '--shared', '-H:GenerateDebugInfo=1'])  # Build and run helloworld as shared library
                 cinterfacetutorial(['-H:GenerateDebugInfo=1'])
                 clinittest([])
+
+        with Task('image debuginfotest', tasks, tags=[GraalTags.debuginfotest]) as t:
+            if t:
+                if svm_java8():
+                    javac_image(['--output-path', svmbuild_dir()])
+                    javac_command = ['--javac-command', ' '.join(javac_image_command(svmbuild_dir()))]
+                else:
+                    # Building javac image currently only supported for Java 8
+                    javac_command = []
+                debuginfotest(['--output-path', svmbuild_dir()] + javac_command)
 
         with Task('native unittests', tasks, tags=[GraalTags.test]) as t:
             if t:
@@ -700,6 +711,36 @@ def _helloworld(native_image, javac_command, path, build_only, args):
         if actual_output != expected_output:
             raise Exception('Unexpected output: ' + str(actual_output) + "  !=  " + str(expected_output))
 
+def _debuginfotest(native_image, javac_command, path, build_only, args):
+    mkpath(path)
+    parent = os.path.dirname(path)
+    print("parent=%s"%parent)
+    sourcepath = join(parent, 'src/com.oracle.svm.test/src/')
+    print("sourcepath=%s"%sourcepath)
+    sourcecache = join(path, 'sources')
+    print("sourcecache=%s"%sourcecache)
+    hello_source = join(sourcepath, 'hello/Hello.java')
+    print('javac %s'%(['-sourcepath', sourcepath, '-d', path, hello_source]))
+    mx.run(javac_command + ['-sourcepath', sourcepath, '-d', path, hello_source])
+
+    javaProperties = {}
+    for dist in suite.dists:
+        if isinstance(dist, mx.ClasspathDependency):
+            for cpEntry in mx.classpath_entries(dist):
+                if hasattr(cpEntry, "getJavaProperties"):
+                    for key, value in cpEntry.getJavaProperties().items():
+                        javaProperties[key] = value
+    for key, value in javaProperties.items():
+        args.append("-D" + key + "=" + value)
+
+    native_image_args = ["--native-image-info", "-H:Path=" + path, '-H:+VerifyNamingConventions', '-cp', path, '-Dgraal.LogFile=graal.log', '-H:GenerateDebugInfo=1', '-H:DebugInfoSourceSearchPath=' + sourcepath, '-H:DebugInfoSourceCacheRoot=' + join(path, 'sources'), 'hello.Hello'] + args
+    print('native_image {}'.format(native_image_args))
+    native_image(native_image_args)
+
+    if mx.get_os() == 'linux' and not build_only:
+        mx.run(['gdb', '-d', join(sourcecache, 'src'), '-d', join(sourcecache, 'graal'), '-d', join(sourcecache, 'jdk'), '-x', join(parent, 'mx.substratevm/testhello.py'), join(path, 'hello.hello')])
+
+
 def _javac_image(native_image, path, args=None):
     args = [] if args is None else args
     mkpath(path)
@@ -1007,6 +1048,29 @@ def helloworld(args, config=None):
         build_if_missing=True
     )
 
+
+@mx.command(suite_name=suite.name, command_name='debuginfotest', usage_msg='[options]')
+def debuginfotest(args, config=None):
+    """
+    builds a debuginfo Hello native image and tests it with gdb.
+    """
+    parser = ArgumentParser(prog='mx debuginfotest')
+    all_args = ['--output-path', '--javac-command', '--build-only']
+    masked_args = [_mask(arg, all_args) for arg in args]
+    parser.add_argument(all_args[0], metavar='<output-path>', nargs=1, help='Path of the generated image', default=[svmbuild_dir(suite)])
+    parser.add_argument(all_args[1], metavar='<javac-command>', help='A javac command to be used', default=mx.get_jdk().javac)
+    parser.add_argument(all_args[2], action='store_true', help='Only build the native image', default=False)
+    parser.add_argument('image_args', nargs='*', default=[])
+    parsed = parser.parse_args(masked_args)
+    javac_command = unmask(parsed.javac_command.split())
+    output_path = unmask(parsed.output_path)[0]
+    build_only = parsed.build_only
+    native_image_context_run(
+        lambda native_image, a:
+            _debuginfotest(native_image, javac_command, output_path, build_only, a), unmask(parsed.image_args),
+        config=config,
+        build_if_missing=True
+    )
 
 @mx.command(suite.name, 'cinterfacetutorial', 'Runs the ')
 def cinterfacetutorial(args):

--- a/substratevm/mx.substratevm/testhello.py
+++ b/substratevm/mx.substratevm/testhello.py
@@ -1,3 +1,26 @@
+# Copyright (c) 2020, 2020, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2020, 2020, Red Hat Inc. All rights reserved.
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+#
+# This code is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 only, as
+# published by the Free Software Foundation.
+#
+# This code is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+# version 2 for more details (a copy is included in the LICENSE file that
+# accompanied this code).
+#
+# You should have received a copy of the GNU General Public License version
+# 2 along with this work; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+# or visit www.oracle.com if you need additional information or have any
+# questions.
+#
+# ----------------------------------------------------------------------------------------------------
 # pylint: skip-file
 #
 # A test script for use from gdb. It can be used to drive execution of

--- a/substratevm/mx.substratevm/testhello.py
+++ b/substratevm/mx.substratevm/testhello.py
@@ -1,0 +1,227 @@
+# pylint: skip-file
+#
+# A test script for use from gdb. It can be sued to drive execution of
+# a native image version of test app Hello and check that the debug
+# info is valid.
+#
+# Assumes you have already executed
+#
+# $ javac hello/Hello.java
+# $ mx native-image -H:GenerateDebugInfo=1 hello.hello
+#
+# Run test
+#
+# gdb -d /path/to/sources/src -d /path/to/sources/graal -d /path/to/sources/jdk -x testhello.py /path/to/hello
+#
+# exit status 0 means all is well 1 means test failed
+#
+# n.b. assumes the sourcefile cache is in local dir sources
+
+import re
+import sys
+
+# A helper class which checks that a sequence of lines of output
+# from a gdb command matches a sequence of per-line regular
+# expressions
+
+class Checker:
+    # Create a checker to check gdb command output text.
+    # name - string to help identify the check if we have a failure.
+    # regexps - a list of regular expressions which must match.
+    # successive lines of checked
+    def __init__(self, name, regexps):
+        self.name = name
+        compiled = []
+        if not isinstance(regexps, list):
+            regexps = [regexps]
+        for regexp in regexps:
+            compiled.append(re.compile(regexp))
+        self.rexps = compiled
+
+    # Check that successive lines of a gdb command's output text
+    # match the corresponding regexp patterns provided when this
+    # Checker was created.
+    # text - the full output of a gdb comand run by calling
+    # gdb.execute and passing to_string = True.
+    # Exits with status 1 if there are less lines in the text
+    # than regexp patterns or if any line fails to match the
+    # corresponding pattern otherwise prints the text and returns
+    # the set of matches.
+    def check(self, text, skip_fails=True):
+        lines = text.split('\n')
+        rexps = self.rexps
+        num_lines = len(lines)
+        num_rexps = len(rexps)
+        line_idx = 0
+        matches = []
+        for i in range(0, (num_rexps)):
+            rexp = rexps[i]
+            match = None
+            while line_idx < num_lines and match is None:
+                line = lines[line_idx]
+                match = rexp.match(line)
+                if  match is None:
+                    if not skip_fails:
+                        print('Checker %s: match %d failed at line %d %s\n'%(self.name, i, line_idx, line))
+                        print(self)
+                        print(text)
+                        sys.exit(1)
+                else:
+                    matches.append(match)
+                line_idx += 1
+        if len(matches) < num_rexps:
+            print('Checker %s: insufficient matching lines %d for regular expressions %d'%(self.name, len(matches), num_rexps))
+            print(self)
+            print(text)
+            sys.exit(1)
+        print(text)
+        return matches
+
+    # Format a Checker as a string
+    def __str__(self):
+        rexps = self.rexps
+        result = 'Checker %s '%(self.name)
+        result += '{\n'
+        for rexp in rexps:
+            result += '  %s\n'%(rexp)
+        result += '}\n'
+        return result
+
+def execute(command):
+    print('(gdb) %s'%(command))
+    return gdb.execute(command, to_string=True)
+
+# Configure this gdb session
+
+# ensure file listings show only the current line
+execute("set listsize 1")
+
+# Start of actual test code
+#
+
+def test():
+
+    # disable prompting to continue output
+    execute("set pagination off")
+    # set a break point at hello.Hello::main
+    # expect "Breakpoint 1 at 0x[0-9a-f]+: file hello.Hello.java, line 64."
+    exec_string = execute("break hello.Hello::main")
+    rexp = "Breakpoint 1 at 0x([0-9a-f]+): file hello/Hello\\.java, line 64\\."
+    checker = Checker('break main', rexp)
+    checker.check(exec_string)
+
+    # run the program
+    execute("run")
+
+    # list the line at the breakpoint
+    # expect "64	        Greeter greeter = Greeter.greeter(args);"
+    exec_string = execute("list")
+    checker = Checker("list bp 1", "64[ \t]+Greeter greeter = Greeter\\.greeter\\(args\\);")
+    checker.check(exec_string, skip_fails=False)
+
+    # run a backtrace
+    # expect "#0  hello.Hello::main(java.lang.String[]).* at hello.Hello.java:64"
+    # expect "#1  0x[0-9a-f]+ in com.oracle.svm.core.code.IsolateEnterStub::JavaMainWrapper_run_.* at [a-z/]+/JavaMainWrapper.java:[0-9]+"
+    exec_string = execute("backtrace")
+    checker = Checker("backtrace hello.Hello::main",
+                      ["#0[ \t]+hello\\.Hello::main\\(java\\.lang\\.String\\[\\]\\).* at hello/Hello\\.java:64",
+                       "#1[ \t]+0x[0-9a-f]+ in com\\.oracle\\.svm\\.core\\.code\\.IsolateEnterStub::JavaMainWrapper_run_.* at [a-z/]+/JavaMainWrapper\\.java:[0-9]+"
+                      ])
+    checker.check(exec_string, skip_fails=False)
+
+    # look up PrintStream::println methods
+    # expect "All functions matching regular expression "java.io.PrintStream::println":"
+    # expect ""
+    # expect "File java.base/java/io/PrintStream.java:"
+    # expect "      void java.io.PrintStream::println(java.lang.Object)(void);"
+    # expect "      void java.io.PrintStream::println(java.lang.String)(void);"
+    exec_string = execute("info func java.io.PrintStream::println")
+#    checker = Checker("info func java.io.PrintStream::println",
+#                      ["All functions matching regular expression \"java\\.io\\.PrintStream::println\":",
+#                       "",
+#                       "File .*java/io/PrintStream.java:",
+#                       "[ \t]*void java.io.PrintStream::println\\(java\\.lang\\.Object\\)\\(void\\);",
+#                       "[ \t]*void java.io.PrintStream::println\\(java\\.lang\\.String\\)\\(void\\);",
+#                      ])
+    checker = Checker("info func java.io.PrintStream::println",
+                      "[ \t]*void java.io.PrintStream::println\\(java\\.lang\\.String\\)")
+    checker.check(exec_string)
+
+    # set a break point at PrintStream::println(String)
+    # expect "Breakpoint 2 at 0x[0-9a-f]+: java.base/java/io/PrintStream.java, line [0-9]+."
+    exec_string = execute("break java.io.PrintStream::println(java.lang.String)")
+    rexp = "Breakpoint 2 at 0x([0-9a-f]+): file .*java/io/PrintStream\\.java, line [0-9]+\\."
+    checker = Checker('break println', rexp)
+    checker.check(exec_string, skip_fails=False)
+
+    # step into method call
+    execute("step")
+
+    # list current line
+    # expect "31	            if (args.length == 0) {"
+    exec_string = execute("list")
+    rexp = "31[ \t]+if \\(args\\.length == 0\\) {"
+    checker = Checker('list hello.Hello.Greeter::greeter', rexp)
+    checker.check(exec_string, skip_fails=False)
+
+    # run a backtrace
+    # expect "#0  hello.Hello.greeter::greeter(java.lang.String[]).* at hello.Hello.java:31"
+    # expect "#1  0x[0-9a-f]+ in hello.Hello::main(java.lang.String[]).* at hello.Hello.java:64"
+    # expect "#2  0x[0-9a-f]+ in com.oracle.svm.core.code.IsolateEnterStub::JavaMainWrapper_run_.* at [a-z/]+/JavaMainWrapper.java:[0-9]+"
+    exec_string = execute("backtrace")
+    checker = Checker("backtrace hello.Hello.Greeter::greeter",
+                      ["#0[ \t]+hello\\.Hello\\.Greeter::greeter\\(java\\.lang\\.String\\[\\]\\).* at hello/Hello\\.java:31",
+                       "#1[ \t]+0x[0-9a-f]+ in hello\\.Hello::main\\(java\\.lang\\.String\\[\\]\\).* at hello/Hello\\.java:64",
+                       "#2[ \t]+0x[0-9a-f]+ in com\\.oracle\\.svm\\.core\\.code\\.IsolateEnterStub::JavaMainWrapper_run_.* at [a-z/]+/JavaMainWrapper\\.java:[0-9]+"
+                      ])
+    checker.check(exec_string, skip_fails=False)
+
+    # now step into inlined code
+    execute("next")
+
+    # check we are still in hello.Hello.Greeter::greeter but no longer in hello.Hello.java
+    exec_string = execute("backtrace 1")
+    checker = Checker("backtrace inline",
+                      ["#0[ \t]+hello\\.Hello\\.Greeter::greeter\\(java\\.lang\\.String\\[\\]\\).* at ([a-zA-Z0-9/]+\\.java):[0-9]+"])
+    matches = checker.check(exec_string, skip_fails=False)
+    # n.b. can only get back here with one match
+    match = matches[0]
+    if match.group(1) == "hello.Hello.java":
+        line = exec_string.replace("\n", "")
+        print('bad match for output %d\n'%(line))
+        print(checker)
+        sys.exit(1)
+
+    # continue to next breakpoint
+    execute("continue")
+
+    # run backtrace to check we are in java.io.PrintStream::println(java.lang.String)
+    # expect "#0  java.io.PrintStream::println(java.lang.String).* at java.base/java/io/PrintStream.java:[0-9]+"
+    exec_string = execute("backtrace 1")
+    checker = Checker("backtrace 1 PrintStream::println",
+                      ["#0[ \t]+java\\.io\\.PrintStream::println\\(java\\.lang\\.String\\).* at .*java/io/PrintStream.java:[0-9]+"])
+    checker.check(exec_string, skip_fails=False)
+
+    # list current line
+    # expect "[0-9]+        synchronized (this) {"
+    exec_string = execute("list")
+    rexp = "([0-9]+)[ \t]+synchronized \\(this\\) {"
+    checker = Checker('list println 1', rexp)
+    matches = checker.check(exec_string, skip_fails=False)
+
+    # n.b. can only get back here with one match
+    match = matches[0]
+    prev_line_num = int(match.group(1)) - 1
+
+    # check the previous line is the declaration for println(String)
+    # list {prev_line_num}
+    # expect "{prev_line_num}        public void println(String [a-zA-Z0-9_]+) {"
+    exec_string = execute("list %d"%prev_line_num)
+    rexp = "%d[ \t]+public void println\\(String [a-zA-Z0-9_]+\\) {"%prev_line_num
+    checker = Checker('list println 2', rexp)
+    checker.check(exec_string, skip_fails=False)
+
+    # continue to next breakpoint
+    print(execute("quit 0"))
+
+test()

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/SubstrateOptions.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/SubstrateOptions.java
@@ -29,9 +29,13 @@ import static org.graalvm.compiler.core.common.SpeculativeExecutionAttacksMitiga
 import static org.graalvm.compiler.core.common.SpeculativeExecutionAttacksMitigations.Options.MitigateSpeculativeExecutionAttacks;
 import static org.graalvm.compiler.options.OptionType.User;
 
+import java.nio.file.InvalidPathException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.List;
 import java.util.function.Predicate;
 
+import com.oracle.svm.core.util.UserError;
 import org.graalvm.collections.EconomicMap;
 import org.graalvm.collections.UnmodifiableEconomicMap;
 import org.graalvm.compiler.api.replacements.Fold;
@@ -470,13 +474,14 @@ public class SubstrateOptions {
     public static final HostedOptionKey<String[]> DebugInfoSourceSearchPath = new HostedOptionKey<String[]>(null) {
     };
     @Option(help = "Directory under which to create source file cache for Application or GraalVM classes")//
-    public static final HostedOptionKey<String> DebugInfoSourceCacheRoot = new HostedOptionKey<String>("sources") {
-        @Override
-        protected void onValueUpdate(EconomicMap<OptionKey<?>, Object> values, String oldValue, String newValue) {
-            // disallow null or empty string
-            if (newValue == null || newValue.length() == 0) {
-                DebugInfoSourceCacheRoot.update(values, oldValue);
-            }
+    public static final HostedOptionKey<String> DebugInfoSourceCacheRoot = new HostedOptionKey<String>("sources");
+
+    public static Path getDebugInfoSourceCacheRoot() {
+        try {
+            Path sourceRoot = Paths.get(DebugInfoSourceCacheRoot.getValue());
+            return sourceRoot;
+        } catch (InvalidPathException ipe) {
+            throw UserError.abort("Invalid path provided for option DebugInfoSourceCacheRoot " + DebugInfoSourceCacheRoot.getValue());
         }
-    };
+    }
 }

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/SubstrateOptions.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/SubstrateOptions.java
@@ -474,7 +474,7 @@ public class SubstrateOptions {
     public static final HostedOptionKey<String[]> DebugInfoSourceSearchPath = new HostedOptionKey<String[]>(null) {
     };
     @Option(help = "Directory under which to create source file cache for Application or GraalVM classes")//
-    public static final HostedOptionKey<String> DebugInfoSourceCacheRoot = new HostedOptionKey<String>("sources");
+    public static final HostedOptionKey<String> DebugInfoSourceCacheRoot = new HostedOptionKey<>("sources");
 
     public static Path getDebugInfoSourceCacheRoot() {
         try {

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/SubstrateOptions.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/SubstrateOptions.java
@@ -469,4 +469,14 @@ public class SubstrateOptions {
     @Option(help = "Search path for source files for Application or GraalVM classes (list of comma-separated directories or jar files)")//
     public static final HostedOptionKey<String[]> DebugInfoSourceSearchPath = new HostedOptionKey<String[]>(null) {
     };
+    @Option(help = "Directory under which to create source file cache for Application or GraalVM classes")//
+    public static final HostedOptionKey<String> DebugInfoSourceCacheRoot = new HostedOptionKey<String>("sources") {
+        @Override
+        protected void onValueUpdate(EconomicMap<OptionKey<?>, Object> values, String oldValue, String newValue) {
+            // disallow null or empty string
+            if (newValue == null || newValue.length() == 0) {
+                DebugInfoSourceCacheRoot.update(values, oldValue);
+            }
+        }
+    };
 }

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/image/sources/JDKSourceCache.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/image/sources/JDKSourceCache.java
@@ -58,7 +58,7 @@ public class JDKSourceCache extends SourceCache {
         Path srcZipPath;
         String javaSpecVersion = System.getProperty(JAVA_SPEC_VERSION_PROP);
         if (javaSpecVersion.equals("1.8")) {
-            srcZipPath = javaHomePath.resolve("src.zip");
+            srcZipPath = javaHomePath.getParent().resolve("src.zip");
         } else {
             assert javaSpecVersion.matches("[1-9][0-9]");
             srcZipPath = javaHomePath.resolve("lib").resolve("src.zip");

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/image/sources/JDKSourceCache.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/image/sources/JDKSourceCache.java
@@ -58,7 +58,11 @@ public class JDKSourceCache extends SourceCache {
         Path srcZipPath;
         String javaSpecVersion = System.getProperty(JAVA_SPEC_VERSION_PROP);
         if (javaSpecVersion.equals("1.8")) {
-            srcZipPath = javaHomePath.getParent().resolve("src.zip");
+            Path srcZipDir = javaHomePath.getParent();
+            if (srcZipDir == null) {
+                VMError.shouldNotReachHere("Cannot resolve parent directory of " + javaHome);
+            }
+            srcZipPath = srcZipDir.resolve("src.zip");
         } else {
             assert javaSpecVersion.matches("[1-9][0-9]");
             srcZipPath = javaHomePath.resolve("lib").resolve("src.zip");

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/image/sources/SourceCache.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/image/sources/SourceCache.java
@@ -109,7 +109,7 @@ public abstract class SourceCache {
      * A local directory serving as the root for all source trees maintained by the different
      * available source caches.
      */
-    private static final String SOURCE_CACHE_ROOT_DIR = "sources";
+    private static final String SOURCE_CACHE_ROOT_DIR = SubstrateOptions.DebugInfoSourceCacheRoot.getValue();
 
     /**
      * The top level path relative to the root directory under which files belonging to this

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/image/sources/SourceCache.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/image/sources/SourceCache.java
@@ -73,7 +73,7 @@ public abstract class SourceCache {
      * Create some flavour of source cache.
      */
     protected SourceCache() {
-        basePath = Paths.get(SOURCE_CACHE_ROOT_DIR).resolve(getType().getSubdir());
+        basePath = SOURCE_CACHE_ROOT_DIR.resolve(getType().getSubdir());
         srcRoots = new ArrayList<>();
         initSrcRoots();
     }
@@ -109,7 +109,7 @@ public abstract class SourceCache {
      * A local directory serving as the root for all source trees maintained by the different
      * available source caches.
      */
-    private static final String SOURCE_CACHE_ROOT_DIR = SubstrateOptions.DebugInfoSourceCacheRoot.getValue();
+    private static final Path SOURCE_CACHE_ROOT_DIR = SubstrateOptions.getDebugInfoSourceCacheRoot();
 
     /**
      * The top level path relative to the root directory under which files belonging to this

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/image/sources/SourceCache.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/image/sources/SourceCache.java
@@ -73,7 +73,7 @@ public abstract class SourceCache {
      * Create some flavour of source cache.
      */
     protected SourceCache() {
-        basePath = SOURCE_CACHE_ROOT_DIR.resolve(getType().getSubdir());
+        basePath = SubstrateOptions.getDebugInfoSourceCacheRoot().resolve(getType().getSubdir());
         srcRoots = new ArrayList<>();
         initSrcRoots();
     }
@@ -104,12 +104,6 @@ public abstract class SourceCache {
      * @return the source cache type
      */
     protected abstract SourceCacheType getType();
-
-    /**
-     * A local directory serving as the root for all source trees maintained by the different
-     * available source caches.
-     */
-    private static final Path SOURCE_CACHE_ROOT_DIR = SubstrateOptions.getDebugInfoSourceCacheRoot();
 
     /**
      * The top level path relative to the root directory under which files belonging to this

--- a/substratevm/src/com.oracle.svm.test/src/hello/Hello.java
+++ b/substratevm/src/com.oracle.svm.test/src/hello/Hello.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2020, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, Red Hat Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package hello;
+
+public class Hello {
+    public static abstract class Greeter {
+        static Greeter greeter(String[] args) {
+            if (args.length == 0) {
+                return new DefaultGreeter();
+            } else if (args.length == 1) {
+                return new NamedGreeter(args[0]);
+            } else {
+                throw new RuntimeException("zero or one args expected");
+            }
+        }
+
+        public abstract void greet();
+    }
+
+    public static class DefaultGreeter extends Greeter {
+        @Override
+        public void greet() {
+            System.out.println("Hello, world!");
+        }
+    }
+
+    public static class NamedGreeter extends Greeter {
+        private String name;
+
+        NamedGreeter(String name) {
+            this.name = name;
+        }
+
+        @Override
+        public void greet() {
+            System.out.println("Hello, " + name + "!");
+        }
+    }
+
+    public static void main(String[] args) {
+        Greeter greeter = Greeter.greeter(args);
+        greeter.greet();
+        System.exit(0);
+    }
+}

--- a/substratevm/src/com.oracle.svm.test/src/hello/Hello.java
+++ b/substratevm/src/com.oracle.svm.test/src/hello/Hello.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2020, 2020, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2020, Red Hat Inc. All rights reserved.
+ * Copyright (c) 2020, 2020, Red Hat Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,10 +23,13 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+
 package hello;
 
+// Checkstyle: stop
+
 public class Hello {
-    public static abstract class Greeter {
+    public abstract static class Greeter {
         static Greeter greeter(String[] args) {
             if (args.length == 0) {
                 return new DefaultGreeter();


### PR DESCRIPTION
This PR provides a test of the debuginfo capability on Linux. The patch provides an mx command.

    $ mx debuginfotest

which compiles a sample program to a native image and scripts a run of the image under gdb, checking that breaks, backtraces, stepping and line listing work as expected.

n.b. for the command to work it requires gdb to be in the path.

The test succeeds on my Linux x86_64 and AArch64 boxes.

I have also modified the travis config to run this test automatically on Linux aarch64 and x86_64. I have no idea if that works or not (yet :-)