### PR TITLE
Add initial support for Bionic LibC

### DIFF
--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/SubstrateOptions.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/SubstrateOptions.java
@@ -435,6 +435,9 @@ public class SubstrateOptions {
     @Option(help = "file:doc-files/UseMuslCHelp.txt", type = OptionType.Expert)//
     public static final HostedOptionKey<String> UseMuslC = new HostedOptionKey<>(null);
 
+    @Option(help = "When set to true, sets the internally used libc to Bionic. Note that this does not currently download and link against Bionic libc, but serves as a workaround that makes it possible externally", type = OptionType.Expert)//
+    public static final HostedOptionKey<Boolean> UseBionicC = new HostedOptionKey<>(false);
+
     @Option(help = "When set to true, the image generator verifies that the image heap does not contain a home directory as a substring", type = User)//
     public static final HostedOptionKey<Boolean> DetectUserDirectoriesInImageHeap = new HostedOptionKey<>(false);
 

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/c/libc/BionicLibc.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/c/libc/BionicLibc.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2020, 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package com.oracle.svm.core.c.libc;
+
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.List;
+
+public class BionicLibc implements LibCBase {
+
+    @Override
+    public String getJDKStaticLibsPath() {
+        return LibCBase.PATH_DEFAULT;
+    }
+
+    @Override
+    public void prepare(Path directory) {
+    }
+
+    @Override
+    public List<String> getAdditionalQueryCodeCompilerOptions() {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public List<String> getCCompilerOptions() {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public boolean hasIsolatedNamespaces() {
+        return false;
+    }
+}

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/NativeImageGenerator.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/NativeImageGenerator.java
@@ -161,6 +161,7 @@ import com.oracle.svm.core.c.function.CEntryPointOptions;
 import com.oracle.svm.core.c.libc.GLibc;
 import com.oracle.svm.core.c.libc.LibCBase;
 import com.oracle.svm.core.c.libc.MuslLibc;
+import com.oracle.svm.core.c.libc.BionicLibc;
 import com.oracle.svm.core.code.RuntimeCodeCache;
 import com.oracle.svm.core.config.ConfigurationValues;
 import com.oracle.svm.core.graal.GraalConfiguration;
@@ -875,6 +876,8 @@ public class NativeImageGenerator {
         LibCBase libc;
         if (SubstrateOptions.UseMuslC.hasBeenSet()) {
             libc = new MuslLibc();
+        } else if (SubstrateOptions.UseBionicC.hasBeenSet()) {
+            libc = new BionicLibc();
         } else {
             libc = new GLibc();
         }


### PR DESCRIPTION
This PR fixes https://github.com/oracle/graal/issues/2466

Note that unlike MuslC, path to LibC isn't required here since all linking is done externally in Gluon Substrate using native Android toolchain.