### PR TITLE
AArch64: Add Math.multiplyHigh intrinsic on AArch64.

### DIFF
--- a/compiler/mx.compiler/suite.py
+++ b/compiler/mx.compiler/suite.py
@@ -1262,6 +1262,24 @@ suite = {
       "javaCompliance" : "9..11",
     },
 
+    "org.graalvm.compiler.replacements.jdk10.test" : {
+      "testProject" : True,
+      "subDir" : "src",
+      "sourceDirs" : ["src"],
+      "dependencies" : [
+        "org.graalvm.compiler.replacements.test"
+      ],
+      "requiresConcealed" : {
+        "jdk.internal.vm.ci" : [
+          "jdk.vm.ci.meta",
+          "jdk.vm.ci.code",
+          "jdk.vm.ci.aarch64",
+        ],
+      },
+      "checkstyle": "org.graalvm.compiler.graph",
+      "javaCompliance" : "10+",
+    },
+
     "org.graalvm.compiler.replacements.jdk12.test" : {
       "testProject" : True,
       "subDir" : "src",
@@ -2227,6 +2245,7 @@ suite = {
         "org.graalvm.compiler.loop.test",
         "org.graalvm.compiler.replacements.jdk9.test",
         "org.graalvm.compiler.replacements.jdk9_11.test",
+        "org.graalvm.compiler.replacements.jdk10.test",
         "org.graalvm.compiler.replacements.jdk12.test",
         "org.graalvm.compiler.core.jdk9.test",
         "org.graalvm.compiler.hotspot.jdk9.test",

--- a/compiler/src/org.graalvm.compiler.hotspot.test/src/org/graalvm/compiler/hotspot/test/CheckGraalIntrinsics.java
+++ b/compiler/src/org.graalvm.compiler.hotspot.test/src/org/graalvm/compiler/hotspot/test/CheckGraalIntrinsics.java
@@ -378,8 +378,10 @@ public class CheckGraalIntrinsics extends GraalTest {
         }
 
         if (isJDK10OrHigher()) {
-            add(toBeInvestigated,
-                            "java/lang/Math.multiplyHigh(JJ)J");
+            if (!(arch instanceof AArch64)) {
+                add(toBeInvestigated,
+                                "java/lang/Math.multiplyHigh(JJ)J");
+            }
         }
 
         if (isJDK11OrHigher()) {

--- a/compiler/src/org.graalvm.compiler.replacements.aarch64/src/org/graalvm/compiler/replacements/aarch64/AArch64GraphBuilderPlugins.java
+++ b/compiler/src/org.graalvm.compiler.replacements.aarch64/src/org/graalvm/compiler/replacements/aarch64/AArch64GraphBuilderPlugins.java
@@ -35,6 +35,7 @@ import static org.graalvm.compiler.replacements.nodes.UnaryMathIntrinsicNode.Una
 import org.graalvm.compiler.lir.aarch64.AArch64ArithmeticLIRGeneratorTool.RoundingMode;
 import org.graalvm.compiler.nodes.ValueNode;
 import org.graalvm.compiler.nodes.calc.AbsNode;
+import org.graalvm.compiler.nodes.calc.IntegerMulHighNode;
 import org.graalvm.compiler.nodes.graphbuilderconf.GraphBuilderConfiguration.Plugins;
 import org.graalvm.compiler.nodes.graphbuilderconf.GraphBuilderContext;
 import org.graalvm.compiler.nodes.graphbuilderconf.InvocationPlugin;
@@ -149,6 +150,16 @@ public class AArch64GraphBuilderPlugins implements TargetGraphBuilderPlugins {
             registerFMA(r);
         }
         registerIntegerAbs(r);
+
+        if (JavaVersionUtil.JAVA_SPEC >= 10) {
+            r.register2("multiplyHigh", Long.TYPE, Long.TYPE, new InvocationPlugin() {
+                @Override
+                public boolean apply(GraphBuilderContext b, ResolvedJavaMethod targetMethod, Receiver receiver, ValueNode x, ValueNode y) {
+                    b.push(JavaKind.Long, b.append(new IntegerMulHighNode(x, y)));
+                    return true;
+                }
+            });
+        }
     }
 
     private static void registerFMA(Registration r) {

--- a/compiler/src/org.graalvm.compiler.replacements.jdk10.test/src/org/graalvm/compiler/replacements/jdk10/test/MathMultiplyHighTest.java
+++ b/compiler/src/org.graalvm.compiler.replacements.jdk10.test/src/org/graalvm/compiler/replacements/jdk10/test/MathMultiplyHighTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, Arm Limited. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.graalvm.compiler.replacements.jdk10.test;
+
+import org.graalvm.compiler.api.test.Graal;
+import org.graalvm.compiler.nodes.calc.IntegerMulHighNode;
+import org.graalvm.compiler.replacements.test.MethodSubstitutionTest;
+import org.graalvm.compiler.runtime.RuntimeProvider;
+import org.junit.Test;
+
+import jdk.vm.ci.aarch64.AArch64;
+import jdk.vm.ci.code.TargetDescription;
+
+public class MathMultiplyHighTest extends MethodSubstitutionTest {
+    private static final long[] INPUT = {Long.MIN_VALUE, Long.MIN_VALUE + 1, 0XF64543679090840EL, -1L,
+                    0L, 0X5L, 0X100L, 0X4336624L, 0x25842900000L, Long.MAX_VALUE - 1, Long.MAX_VALUE};
+
+    public static long multiplyHigh(long m, long n) {
+        return Math.multiplyHigh(m, n);
+    }
+
+    @Test
+    public void testMultiplyHigh() {
+        TargetDescription target = Graal.getRequiredCapability(RuntimeProvider.class).getHostBackend().getTarget();
+        if (target.arch instanceof AArch64) {
+            assertInGraph(testGraph("multiplyHigh"), IntegerMulHighNode.class);
+        }
+        for (long input1 : INPUT) {
+            for (long input2 : INPUT) {
+                test("multiplyHigh", input1, input2);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Math.multiplyHigh() could be implemented with a single instruction "smulh" on AArch64. This patch adds the intrinsic support for it when the JDK version is greater than 9.

Here is the main code of a JMH benchmark:
```
  @Benchmark
  public void jmhTimeMultiplyHigh() {
    long res = 0;
    for (int i = 0; i < 64; ++i) {
      long a = rand_long[i % 1024];
      long b = rand_long[(i + 1) % 1024];
      res += Math.multiplyHigh(a, b);
    }
    res_long = res;
  }
```

With this patch, it has about` 346% ~ 840%` performance improvement on different AArch64 machines.

Change-Id: I4758849d82895f4df708711af26ec8935949aafe