### PR TITLE
AArch64: Add integer Math.abs intrinsics

### DIFF
--- a/compiler/src/org.graalvm.compiler.hotspot.test/src/org/graalvm/compiler/hotspot/test/CheckGraalIntrinsics.java
+++ b/compiler/src/org.graalvm.compiler.hotspot.test/src/org/graalvm/compiler/hotspot/test/CheckGraalIntrinsics.java
@@ -398,9 +398,12 @@ public class CheckGraalIntrinsics extends GraalTest {
         }
 
         if (isJDK13OrHigher()) {
+            if (!(arch instanceof AArch64)) {
+                add(toBeInvestigated,
+                                "java/lang/Math.abs(I)I",
+                                "java/lang/Math.abs(J)J");
+            }
             add(toBeInvestigated,
-                            "java/lang/Math.abs(I)I",
-                            "java/lang/Math.abs(J)J",
                             "java/lang/Math.max(DD)D",
                             "java/lang/Math.max(FF)F",
                             "java/lang/Math.min(DD)D",

--- a/compiler/src/org.graalvm.compiler.jtt/src/org/graalvm/compiler/jtt/lang/Math_abs.java
+++ b/compiler/src/org.graalvm.compiler.jtt/src/org/graalvm/compiler/jtt/lang/Math_abs.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,12 +32,11 @@ import jdk.vm.ci.meta.ResolvedJavaMethod;
 /*
  */
 public class Math_abs extends UnaryMath {
-
     @SuppressWarnings("serial")
     public static class NaN extends Throwable {
     }
 
-    public static double test(double arg) throws NaN {
+    public static double testAbsD(double arg) throws NaN {
         double v = Math.abs(arg);
         if (Double.isNaN(v)) {
             // NaN can't be tested against itself
@@ -48,43 +47,73 @@ public class Math_abs extends UnaryMath {
 
     @Test
     public void run0() throws Throwable {
-        runTest("test", 5.0d);
+        runTest("testAbsD", 5.0d);
     }
 
     @Test
     public void run1() throws Throwable {
-        runTest("test", -5.0d);
+        runTest("testAbsD", -5.0d);
     }
 
     @Test
     public void run2() throws Throwable {
-        runTest("test", 0.0d);
+        runTest("testAbsD", 0.0d);
     }
 
     @Test
     public void run3() throws Throwable {
-        runTest("test", -0.0d);
+        runTest("testAbsD", -0.0d);
     }
 
     @Test
     public void run4() throws Throwable {
-        runTest("test", java.lang.Double.NEGATIVE_INFINITY);
+        runTest("testAbsD", java.lang.Double.NEGATIVE_INFINITY);
     }
 
     @Test
     public void run5() throws Throwable {
-        runTest("test", java.lang.Double.POSITIVE_INFINITY);
+        runTest("testAbsD", java.lang.Double.POSITIVE_INFINITY);
     }
 
     @Test
     public void run6() throws Throwable {
-        runTest("test", java.lang.Double.NaN);
+        runTest("testAbsD", java.lang.Double.NaN);
     }
 
     @Test
     public void run7() {
         OptionValues options = getInitialOptions();
-        ResolvedJavaMethod method = getResolvedJavaMethod("test");
+        ResolvedJavaMethod method = getResolvedJavaMethod("testAbsD");
         testManyValues(options, method);
+    }
+
+    public static int testAbsI(int arg) {
+        return Math.abs(arg);
+    }
+
+    public static long testAbsL(long arg) {
+        return Math.abs(arg);
+    }
+
+    @Test
+    public void run8() {
+        runTest("testAbsI", Integer.MIN_VALUE);
+        runTest("testAbsI", -326543323);
+        runTest("testAbsI", -21325);
+        runTest("testAbsI", -0);
+        runTest("testAbsI", 5432);
+        runTest("testAbsI", 352438548);
+        runTest("testAbsI", Integer.MAX_VALUE);
+    }
+
+    @Test
+    public void run9() {
+        runTest("testAbsL", Long.MIN_VALUE);
+        runTest("testAbsL", -425423654342L);
+        runTest("testAbsL", -21543224L);
+        runTest("testAbsL", -0L);
+        runTest("testAbsL", 1325488L);
+        runTest("testAbsL", 313567897765L);
+        runTest("testAbsL", Long.MAX_VALUE);
     }
 }

--- a/compiler/src/org.graalvm.compiler.replacements.aarch64/src/org/graalvm/compiler/replacements/aarch64/AArch64GraphBuilderPlugins.java
+++ b/compiler/src/org.graalvm.compiler.replacements.aarch64/src/org/graalvm/compiler/replacements/aarch64/AArch64GraphBuilderPlugins.java
@@ -34,6 +34,7 @@ import static org.graalvm.compiler.replacements.nodes.UnaryMathIntrinsicNode.Una
 
 import org.graalvm.compiler.lir.aarch64.AArch64ArithmeticLIRGeneratorTool.RoundingMode;
 import org.graalvm.compiler.nodes.ValueNode;
+import org.graalvm.compiler.nodes.calc.AbsNode;
 import org.graalvm.compiler.nodes.graphbuilderconf.GraphBuilderConfiguration.Plugins;
 import org.graalvm.compiler.nodes.graphbuilderconf.GraphBuilderContext;
 import org.graalvm.compiler.nodes.graphbuilderconf.InvocationPlugin;
@@ -147,6 +148,7 @@ public class AArch64GraphBuilderPlugins implements TargetGraphBuilderPlugins {
         if (useFMAIntrinsics && JavaVersionUtil.JAVA_SPEC > 8) {
             registerFMA(r);
         }
+        registerIntegerAbs(r);
     }
 
     private static void registerFMA(Registration r) {
@@ -171,6 +173,25 @@ public class AArch64GraphBuilderPlugins implements TargetGraphBuilderPlugins {
                             ValueNode nb,
                             ValueNode nc) {
                 b.push(JavaKind.Float, b.append(new FusedMultiplyAddNode(na, nb, nc)));
+                return true;
+            }
+        });
+    }
+
+    private static void registerIntegerAbs(Registration r) {
+        r.register1("abs", Integer.TYPE, new InvocationPlugin() {
+
+            @Override
+            public boolean apply(GraphBuilderContext b, ResolvedJavaMethod targetMethod, Receiver receiver, ValueNode value) {
+                b.push(JavaKind.Int, b.append(new AbsNode(value).canonical(null)));
+                return true;
+            }
+        });
+        r.register1("abs", Long.TYPE, new InvocationPlugin() {
+
+            @Override
+            public boolean apply(GraphBuilderContext b, ResolvedJavaMethod targetMethod, Receiver receiver, ValueNode value) {
+                b.push(JavaKind.Long, b.append(new AbsNode(value).canonical(null)));
                 return true;
             }
         });


### PR DESCRIPTION
Math.abs for int/long type could be implemented with "cmp+cneg" on AArch64, which has a better performance than the current pattern:
```
    tbnz w1, #31, label
    mov w0, w1
    ...
  label:
    neg w0, w1
```
This patch adds the intrinsic support for the integer Math.abs to generate the `"AbsNode"` that will emit `"cmp+cneg"` finally.

Here is the main code of two micro benchmarks:
```
  @Benchmark
  public void jmhAbsInt() {
    int res = 0;
    for (int i = 0; i < NUM_INVOKES; ++i) {
      int a = rand_int[(i) % NUM_RANDS];
      res += Math.abs(a) * Math.abs(a);
    }
    res_int = res;
  }

  @Benchmark
  public void jmhAbsLong() {
    long res = 0;
    for (int i = 0; i < NUM_INVOKES; ++i) {
      long a = rand_long[i % NUM_RANDS];
      res += Math.abs(a) * Math.abs(a);
    }
    res_long = res;
  }
```
And the performance results on an A72 AArch64 machine:
Before:
```
Benchmark   Mode  Cnt    Score    Error  Units
jmhAbsInt   avgt   25  335.121 ±  8.971  ns/op
jmhAbsLong  avgt   25  327.854 ± 15.797  ns/op
```

After:
```
Benchmark   Mode  Cnt    Score   Error  Units
jmhAbsInt   avgt   25   59.390 ± 0.256  ns/op
jmhAbsLong  avgt   25  104.772 ± 0.459  ns/op
```
Change-Id: I73a3aa66153fc2f023d6151a82f199d73824f04b