### PR TITLE
Remote attach options are not only ports #2532

### DIFF
--- a/substratevm/src/com.oracle.svm.driver/resources/HelpExtra.txt
+++ b/substratevm/src/com.oracle.svm.driver/resources/HelpExtra.txt
@@ -11,7 +11,7 @@ Non-standard options help:
     --configurations-path <search path of option-configuration directories>
                           A %pathsep% separated list of directories to be treated as
                           option-configuration directories.
-    --debug-attach[=<port>]
+    --debug-attach[=<port or host:port (* can be used as host meaning bind to all interfaces)>]
                           attach to debugger during image building (default port is 8000)
     --dry-run             output the command line that would be used for building
 

--- a/substratevm/src/com.oracle.svm.driver/src/com/oracle/svm/driver/DefaultOptionHandler.java
+++ b/substratevm/src/com.oracle.svm.driver/src/com/oracle/svm/driver/DefaultOptionHandler.java
@@ -158,17 +158,10 @@ class DefaultOptionHandler extends NativeImage.OptionHandler<NativeImage> {
             }
             useDebugAttach = true;
             String debugAttachArg = args.poll();
-            String portSuffix = debugAttachArg.substring(debugAttach.length());
-            int debugPort = 8000;
-            if (!portSuffix.isEmpty()) {
-                try {
-                    debugPort = Integer.parseInt(portSuffix.substring(1));
-                } catch (NumberFormatException e) {
-                    NativeImage.showError("Invalid " + debugAttach + " option: " + debugAttachArg);
-                }
-            }
+            String addressSuffix = debugAttachArg.substring(debugAttach.length());
+            String address = addressSuffix.isEmpty() ? "8000" : addressSuffix.substring(1);
             /* Using agentlib to allow interoperability with other agents */
-            nativeImage.addImageBuilderJavaArgs("-agentlib:jdwp=transport=dt_socket,server=y,address=" + debugPort + ",suspend=y");
+            nativeImage.addImageBuilderJavaArgs("-agentlib:jdwp=transport=dt_socket,server=y,address=" + address + ",suspend=y");
             /* Disable watchdog mechanism */
             nativeImage.addPlainImageBuilderArg(nativeImage.oHDeadlockWatchdogInterval + "0");
             return true;


### PR DESCRIPTION
* It can also be a combination of `<host>:<port>`, and host can also be `*`.
* Let the JDK itself validate and throw the appropiate the error if needed.
* Avoids duplicating JDK validation code.