### PR TITLE
Fix assertion error for debug builds on AArch64

### DIFF
--- a/compiler/mx.compiler/suite.py
+++ b/compiler/mx.compiler/suite.py
@@ -803,7 +803,6 @@ suite = {
         "jdk.internal.vm.ci" : [
           "jdk.vm.ci.meta",
           "jdk.vm.ci.code",
-          "jdk.vm.ci.amd64"
         ],
       },
       "checkstyle": "org.graalvm.compiler.graph",

--- a/compiler/src/org.graalvm.compiler.core.aarch64/src/org/graalvm/compiler/core/aarch64/AArch64ArithmeticLIRGenerator.java
+++ b/compiler/src/org.graalvm.compiler.core.aarch64/src/org/graalvm/compiler/core/aarch64/AArch64ArithmeticLIRGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -238,7 +238,7 @@ public class AArch64ArithmeticLIRGenerator extends ArithmeticLIRGenerator implem
             result = getLIRGen().newVariable(LIRKind.combine(c));
         } else {
             assert a.getPlatformKind() == c.getPlatformKind();
-            if (op == AArch64ArithmeticOp.FADD) {
+            if (op == AArch64ArithmeticOp.FMADD) {
                 // For floating-point Math.fma intrinsic.
                 assert a.getPlatformKind() == AArch64Kind.SINGLE || a.getPlatformKind() == AArch64Kind.DOUBLE;
             } else {

--- a/compiler/src/org.graalvm.compiler.hotspot.jdk9.test/src/org/graalvm/compiler/hotspot/jdk9/test/MathDoubleFMATest.java
+++ b/compiler/src/org.graalvm.compiler.hotspot.jdk9.test/src/org/graalvm/compiler/hotspot/jdk9/test/MathDoubleFMATest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,6 +24,7 @@
  */
 package org.graalvm.compiler.hotspot.jdk9.test;
 
+import static org.junit.Assume.assumeFalse;
 import static org.junit.Assume.assumeTrue;
 
 import java.util.ArrayList;
@@ -41,14 +42,12 @@ import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameter;
 import org.junit.runners.Parameterized.Parameters;
 
-import jdk.vm.ci.amd64.AMD64;
-
 @RunWith(Parameterized.class)
 public final class MathDoubleFMATest extends GraalCompilerTest {
 
     @Before
-    public void checkAMD64() {
-        assumeTrue("skipping AMD64 specific test", getTarget().arch instanceof AMD64);
+    public void checkNotSPARC() {
+        assumeFalse("skipping tests on SPARC", isSPARC(getTarget().arch));
         HotSpotGraalRuntimeProvider rt = (HotSpotGraalRuntimeProvider) Graal.getRequiredCapability(RuntimeProvider.class);
         assumeTrue("skipping FMA specific test", rt.getVMConfig().useFMAIntrinsics);
     }

--- a/compiler/src/org.graalvm.compiler.hotspot.jdk9.test/src/org/graalvm/compiler/hotspot/jdk9/test/MathFMAConstantInputTest.java
+++ b/compiler/src/org.graalvm.compiler.hotspot.jdk9.test/src/org/graalvm/compiler/hotspot/jdk9/test/MathFMAConstantInputTest.java
@@ -24,19 +24,17 @@
  */
 package org.graalvm.compiler.hotspot.jdk9.test;
 
-import static org.junit.Assume.assumeTrue;
+import static org.junit.Assume.assumeFalse;
 
 import org.graalvm.compiler.core.test.GraalCompilerTest;
 import org.junit.Before;
 import org.junit.Test;
 
-import jdk.vm.ci.amd64.AMD64;
-
 public final class MathFMAConstantInputTest extends GraalCompilerTest {
 
     @Before
-    public void checkAMD64() {
-        assumeTrue("skipping AMD64 specific test", getTarget().arch instanceof AMD64);
+    public void checkNotSPARC() {
+        assumeFalse("skipping test on SPARC ", isSPARC(getTarget().arch));
     }
 
     public static float floatFMA() {

--- a/compiler/src/org.graalvm.compiler.hotspot.jdk9.test/src/org/graalvm/compiler/hotspot/jdk9/test/MathFloatFMATest.java
+++ b/compiler/src/org.graalvm.compiler.hotspot.jdk9.test/src/org/graalvm/compiler/hotspot/jdk9/test/MathFloatFMATest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,6 +24,7 @@
  */
 package org.graalvm.compiler.hotspot.jdk9.test;
 
+import static org.junit.Assume.assumeFalse;
 import static org.junit.Assume.assumeTrue;
 
 import java.util.ArrayList;
@@ -41,14 +42,12 @@ import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameter;
 import org.junit.runners.Parameterized.Parameters;
 
-import jdk.vm.ci.amd64.AMD64;
-
 @RunWith(Parameterized.class)
 public final class MathFloatFMATest extends GraalCompilerTest {
 
     @Before
-    public void checkAMD64() {
-        assumeTrue("skipping AMD64 specific test", getTarget().arch instanceof AMD64);
+    public void checkNotSPARC() {
+        assumeFalse("skipping test on SPARC", isSPARC(getTarget().arch));
         HotSpotGraalRuntimeProvider rt = (HotSpotGraalRuntimeProvider) Graal.getRequiredCapability(RuntimeProvider.class);
         assumeTrue("skipping FMA specific tests", rt.getVMConfig().useFMAIntrinsics);
     }


### PR DESCRIPTION
Fix a minor typo in the Arithmetic LIR generator for AArch64 that
avoids assertion errors when they are enabled (using -ea flag).