### PR TITLE
Remove AArch64 feature fDMBATOMICS in SVM

### DIFF
--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/aarch64/AArch64CPUFeatureAccess.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/aarch64/AArch64CPUFeatureAccess.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -96,10 +96,6 @@ public class AArch64CPUFeatureAccess implements CPUFeatureAccess {
         }
         if (cpuFeatures.fA53MAC()) {
             features.add(AArch64.CPUFeature.A53MAC);
-        }
-        if (cpuFeatures.fDMBATOMICS()) {
-            // JDK-8243339
-            features.add(AArch64.CPUFeature.valueOf("DMB_ATOMICS"));
         }
 
         return features;

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/aarch64/AArch64LibCHelper.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/aarch64/AArch64LibCHelper.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2019, 2019, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2019, 2019, Arm Limited. All rights reserved.
+ * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2020, Arm Limited. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -89,9 +89,5 @@ public class AArch64LibCHelper {
         @AllowNarrowingCast
         @CField
         boolean fA53MAC();
-
-        @AllowNarrowingCast
-        @CField
-        boolean fDMBATOMICS();
     }
 }

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/NativeImageOptions.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/NativeImageOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -53,7 +53,7 @@ public class NativeImageOptions {
                     "BMI2, RTM, ADX, AVX512F, AVX512DQ, AVX512PF, AVX512ER, AVX512CD, AVX512BW. " +
                     "On AArch64, no features are enabled by default. Available features are: " +
                     "FP, ASIMD, EVTSTRM, AES, PMULL, SHA1, SHA2, CRC32, LSE, STXR_PREFETCH, " +
-                    "A53MAC, DMB_ATOMICS", type = User)//
+                    "A53MAC", type = User)//
     public static final HostedOptionKey<String[]> CPUFeatures = new HostedOptionKey<>(null);
 
     @Option(help = "Overrides CPUFeatures and uses the native architecture, i.e., the architecture of a machine that builds an image. NativeArchitecture takes precedence over CPUFeatures", type = User)//

--- a/substratevm/src/com.oracle.svm.native.libchelper/include/aarch64cpufeatures.h
+++ b/substratevm/src/com.oracle.svm.native.libchelper/include/aarch64cpufeatures.h
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2019, 2019, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2019, 2019, Arm Limited. All rights reserved.
+ * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2020, Arm Limited. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,5 +36,4 @@ typedef struct {
   char fLSE;
   char fSTXRPREFETCH;
   char fA53MAC;
-  char fDMBATOMICS;
 } CPUFeatures;

--- a/substratevm/src/com.oracle.svm.native.libchelper/src/cpuid.c
+++ b/substratevm/src/com.oracle.svm.native.libchelper/src/cpuid.c
@@ -214,12 +214,8 @@ void determineCPUFeatures(CPUFeatures* features) {
 #ifndef HWCAP_A53MAC
 #define HWCAP_A53MAC        (1L << 30)
 #endif
-#ifndef HWCAP_DMB_ATOMICS
-#define HWCAP_DMB_ATOMICS   (1L << 31)
-#endif
 
 #define CPU_ARM 'A'
-#define CPU_CAVIUM 'C'
 
 /*
  * Extracts the CPU features by both reading the hwcaps as well as
@@ -239,7 +235,6 @@ void determineCPUFeatures(CPUFeatures* features) {
   features->fLSE = !!(auxv & HWCAP_LSE);
   features->fSTXRPREFETCH = !!(auxv & HWCAP_STXR_PREFETCH);
   features->fA53MAC = !!(auxv & HWCAP_A53MAC);
-  features->fDMBATOMICS = !!(auxv & HWCAP_DMB_ATOMICS);
 
   //checking for features signaled in another way
 
@@ -274,7 +269,6 @@ void determineCPUFeatures(CPUFeatures* features) {
   if (_cpu == CPU_ARM && _cpu_lines == 1 && _model == 0xd07) features->fA53MAC = !!(1);
   if (_cpu == CPU_ARM && (_model == 0xd03 || _model2 == 0xd03)) features->fA53MAC = !!(1);
   if (_cpu == CPU_ARM && (_model == 0xd07 || _model2 == 0xd07)) features->fSTXRPREFETCH = !!(1);
-  if (_cpu == CPU_CAVIUM && _model == 0xA1 && _variant == 0) features->fDMBATOMICS = !!(1);
 }
 
 #else


### PR DESCRIPTION
The fDMBATOMICS CPU feature was only ever implemented on a
prototype CPU and never made it into a production CPU.

See https://bugs.openjdk.java.net/browse/JDK-8242469