### PR TITLE
Fix reachability checks in the presence of @GenerateUncached.

### DIFF
--- a/truffle/src/com.oracle.truffle.api.dsl.test/src/com/oracle/truffle/api/dsl/test/ReachabilityTest.java
+++ b/truffle/src/com.oracle.truffle.api.dsl.test/src/com/oracle/truffle/api/dsl/test/ReachabilityTest.java
@@ -304,7 +304,7 @@ public class ReachabilityTest {
 
     }
 
-    static abstract class ReachabilityUncached extends Node {
+    abstract static class ReachabilityUncached extends Node {
         abstract int execute();
 
         int foo() {
@@ -313,7 +313,7 @@ public class ReachabilityTest {
     }
 
     @GenerateUncached
-    static abstract class ReachabilityUncached1 extends ReachabilityUncached {
+    abstract static class ReachabilityUncached1 extends ReachabilityUncached {
         @Specialization
         int doCached(@Cached("foo()") int cached) {
             return cached;
@@ -326,7 +326,7 @@ public class ReachabilityTest {
     }
 
     @GenerateUncached
-    static abstract class ReachabilityUncached2 extends ReachabilityUncached {
+    abstract static class ReachabilityUncached2 extends ReachabilityUncached {
         @Specialization
         int doCached(@Cached("foo()") int cached) {
             return cached;
@@ -345,7 +345,7 @@ public class ReachabilityTest {
     }
 
     @GenerateUncached
-    static abstract class ReachabilityUncached3 extends ReachabilityUncached {
+    abstract static class ReachabilityUncached3 extends ReachabilityUncached {
         @Specialization
         int doCached1(@Cached("foo()") int cached) {
             return cached;

--- a/truffle/src/com.oracle.truffle.api.dsl.test/src/com/oracle/truffle/api/dsl/test/ReachabilityTest.java
+++ b/truffle/src/com.oracle.truffle.api.dsl.test/src/com/oracle/truffle/api/dsl/test/ReachabilityTest.java
@@ -42,12 +42,15 @@ package com.oracle.truffle.api.dsl.test;
 
 import java.math.BigInteger;
 
+import com.oracle.truffle.api.dsl.Cached;
+import com.oracle.truffle.api.dsl.GenerateUncached;
 import com.oracle.truffle.api.dsl.NodeChild;
 import com.oracle.truffle.api.dsl.NodeChildren;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.dsl.test.TypeSystemTest.Abstract;
 import com.oracle.truffle.api.dsl.test.TypeSystemTest.BExtendsAbstract;
 import com.oracle.truffle.api.dsl.test.TypeSystemTest.ValueNode;
+import com.oracle.truffle.api.nodes.Node;
 
 public class ReachabilityTest {
 
@@ -301,4 +304,62 @@ public class ReachabilityTest {
 
     }
 
+    static abstract class ReachabilityUncached extends Node {
+        abstract int execute();
+
+        int foo() {
+            return 0;
+        }
+    }
+
+    @GenerateUncached
+    static abstract class ReachabilityUncached1 extends ReachabilityUncached {
+        @Specialization
+        int doCached(@Cached("foo()") int cached) {
+            return cached;
+        }
+
+        @Specialization(replaces = "doCached")
+        int doUncached() {
+            return 1;
+        }
+    }
+
+    @GenerateUncached
+    static abstract class ReachabilityUncached2 extends ReachabilityUncached {
+        @Specialization
+        int doCached(@Cached("foo()") int cached) {
+            return cached;
+        }
+
+        @Specialization(replaces = "doCached")
+        int doUncached1() {
+            return 1;
+        }
+
+        @ExpectError("Specialization is not reachable. It is shadowed by doUncached1().")
+        @Specialization
+        int doUncached2() {
+            return 2;
+        }
+    }
+
+    @GenerateUncached
+    static abstract class ReachabilityUncached3 extends ReachabilityUncached {
+        @Specialization
+        int doCached1(@Cached("foo()") int cached) {
+            return cached;
+        }
+
+        @ExpectError("Specialization is not reachable. It is shadowed by doCached1(int).")
+        @Specialization(replaces = "doCached1")
+        int doCached2(@Cached("foo()") int cached) {
+            return cached + 1;
+        }
+
+        @Specialization(replaces = "doCached2")
+        int doUncached() {
+            return 1;
+        }
+    }
 }

--- a/truffle/src/com.oracle.truffle.dsl.processor/src/com/oracle/truffle/dsl/processor/model/SpecializationData.java
+++ b/truffle/src/com.oracle.truffle.dsl.processor/src/com/oracle/truffle/dsl/processor/model/SpecializationData.java
@@ -81,6 +81,7 @@ public final class SpecializationData extends TemplateMethod {
     private final Set<SpecializationData> excludedBy = new LinkedHashSet<>();
     private String insertBeforeName;
     private SpecializationData insertBefore;
+    private boolean isUncached;
     private boolean reachable;
     private boolean reachesFallback;
     private int index;
@@ -104,6 +105,7 @@ public final class SpecializationData extends TemplateMethod {
         copy.guards.addAll(guards);
         copy.caches = new ArrayList<>(caches);
         copy.assumptionExpressions = new ArrayList<>(assumptionExpressions);
+        copy.isUncached = isUncached;
         copy.replaces.addAll(replaces);
         copy.replacesNames.addAll(replacesNames);
         copy.excludedBy.addAll(excludedBy);
@@ -353,8 +355,16 @@ public final class SpecializationData extends TemplateMethod {
         this.reachable = reachable;
     }
 
+    public void setUncached(boolean uncached) {
+        isUncached = uncached;
+    }
+
     public boolean isReachable() {
         return reachable;
+    }
+
+    public boolean isUncached() {
+        return isUncached;
     }
 
     public boolean isPolymorphic() {
@@ -618,6 +628,11 @@ public final class SpecializationData extends TemplateMethod {
 
         if (prev.isGuardBindsCache()) {
             // may fallthrough due to limit
+            return true;
+        }
+
+        if (node.isGenerateUncached() && isUncached() && !prev.isUncached()) {
+            // becomes reachable in the uncached node
             return true;
         }
 

--- a/truffle/src/com.oracle.truffle.dsl.processor/src/com/oracle/truffle/dsl/processor/model/SpecializationData.java
+++ b/truffle/src/com.oracle.truffle.dsl.processor/src/com/oracle/truffle/dsl/processor/model/SpecializationData.java
@@ -81,7 +81,7 @@ public final class SpecializationData extends TemplateMethod {
     private final Set<SpecializationData> excludedBy = new LinkedHashSet<>();
     private String insertBeforeName;
     private SpecializationData insertBefore;
-    private boolean isUncached;
+    private boolean replaced;
     private boolean reachable;
     private boolean reachesFallback;
     private int index;
@@ -105,7 +105,7 @@ public final class SpecializationData extends TemplateMethod {
         copy.guards.addAll(guards);
         copy.caches = new ArrayList<>(caches);
         copy.assumptionExpressions = new ArrayList<>(assumptionExpressions);
-        copy.isUncached = isUncached;
+        copy.replaced = replaced;
         copy.replaces.addAll(replaces);
         copy.replacesNames.addAll(replacesNames);
         copy.excludedBy.addAll(excludedBy);
@@ -355,16 +355,16 @@ public final class SpecializationData extends TemplateMethod {
         this.reachable = reachable;
     }
 
-    public void setUncached(boolean uncached) {
-        isUncached = uncached;
+    public void setReplaced(boolean replaced) {
+        this.replaced = replaced;
     }
 
     public boolean isReachable() {
         return reachable;
     }
 
-    public boolean isUncached() {
-        return isUncached;
+    public boolean isReplaced() {
+        return replaced;
     }
 
     public boolean isPolymorphic() {
@@ -631,7 +631,7 @@ public final class SpecializationData extends TemplateMethod {
             return true;
         }
 
-        if (node.isGenerateUncached() && isUncached() && !prev.isUncached()) {
+        if (node.isGenerateUncached() && !isReplaced() && prev.isReplaced()) {
             // becomes reachable in the uncached node
             return true;
         }

--- a/truffle/src/com.oracle.truffle.dsl.processor/src/com/oracle/truffle/dsl/processor/parser/NodeParser.java
+++ b/truffle/src/com.oracle.truffle.dsl.processor/src/com/oracle/truffle/dsl/processor/parser/NodeParser.java
@@ -1576,6 +1576,7 @@ public final class NodeParser extends AbstractParser<NodeData> {
         initializeUninitialized(node);
         initializeOrder(node);
         initializePolymorphism(node); // requires specializations
+        initializeUncached(node);
         initializeReachability(node);
         initializeFallbackReachability(node);
         initializeCheckedExceptions(node);
@@ -1745,6 +1746,13 @@ public final class NodeParser extends AbstractParser<NodeData> {
         for (SpecializationData included : specialization.getReplaces()) {
             collectIncludes(included, found, new HashSet<>(visited));
             found.add(included);
+        }
+    }
+
+    private static void initializeUncached(final NodeData node) {
+        Collection<SpecializationData> uncachedSpecializations = node.computeUncachedSpecializations(node.getSpecializations());
+        for (SpecializationData specialization : uncachedSpecializations) {
+            specialization.setUncached(true);
         }
     }
 

--- a/truffle/src/com.oracle.truffle.dsl.processor/src/com/oracle/truffle/dsl/processor/parser/NodeParser.java
+++ b/truffle/src/com.oracle.truffle.dsl.processor/src/com/oracle/truffle/dsl/processor/parser/NodeParser.java
@@ -1576,11 +1576,10 @@ public final class NodeParser extends AbstractParser<NodeData> {
         initializeUninitialized(node);
         initializeOrder(node);
         initializePolymorphism(node); // requires specializations
-        initializeUncached(node);
+        resolveReplaces(node);
         initializeReachability(node);
         initializeFallbackReachability(node);
         initializeCheckedExceptions(node);
-        resolveReplaces(node);
 
         List<SpecializationData> specializations = node.getSpecializations();
         for (SpecializationData cur : specializations) {
@@ -1719,6 +1718,11 @@ public final class NodeParser extends AbstractParser<NodeData> {
             if (specialization.getReplaces().isEmpty()) {
                 continue;
             }
+
+            for (SpecializationData replaced : specialization.getReplaces()) {
+                replaced.setReplaced(true);
+            }
+
             Set<SpecializationData> foundSpecializations = new HashSet<>();
             collectIncludes(specialization, foundSpecializations, new HashSet<SpecializationData>());
             specialization.getReplaces().addAll(foundSpecializations);
@@ -1746,13 +1750,6 @@ public final class NodeParser extends AbstractParser<NodeData> {
         for (SpecializationData included : specialization.getReplaces()) {
             collectIncludes(included, found, new HashSet<>(visited));
             found.add(included);
-        }
-    }
-
-    private static void initializeUncached(final NodeData node) {
-        Collection<SpecializationData> uncachedSpecializations = node.computeUncachedSpecializations(node.getSpecializations());
-        for (SpecializationData specialization : uncachedSpecializations) {
-            specialization.setUncached(true);
         }
     }
 


### PR DESCRIPTION
Fixes a behavior of the Truffle specialization DSL, where uncached specializations would be marked unreachable, even if they are reachable in the node generated with `@GenerateUncached`.

The logic implemented here is: if `@GenerateUncached` is present, an uncached specialization cannot be shadowed by a cached one.