### PR TITLE
Add WebAssembly to rebuild-images files

### DIFF
--- a/substratevm/mx.substratevm/rebuild-images.cmd
+++ b/substratevm/mx.substratevm/rebuild-images.cmd
@@ -63,6 +63,8 @@ if not "%~1"=="" (
     set "_tb=!u_arg!"
   ) else if "!u_arg!"=="ruby" (
     set "_tb=!u_arg!"
+  ) else if "!u_arg!"=="wasm" (
+    set "_tb=!u_arg!"
   ) else if "!u_arg!"=="--help" (
     set "_h=true"
   ) else if "!u_arg!"=="-h" (
@@ -114,6 +116,8 @@ for %%f in (%to_build%) do (
     call :launcher graalpython cmd_line
   ) else if "%%f"=="ruby" (
     call :launcher truffleruby cmd_line
+  ) else if "%%f"=="wasm" (
+    call :launcher wasm cmd_line
   ) else (
     echo Should not reach here
     exit /b 1
@@ -133,7 +137,7 @@ goto :eof
   exit /b 0
 
 :usage
-  echo Usage: "%~nx0 [-v|--verbose] polyglot|libpolyglot|js|llvm|python|ruby... [custom native-image args]..."
+  echo Usage: "%~nx0 [-v|--verbose] polyglot|libpolyglot|js|llvm|python|ruby|wasm... [custom native-image args]..."
   exit /b 0
 
 :common cmd_line

--- a/substratevm/mx.substratevm/rebuild-images.sh
+++ b/substratevm/mx.substratevm/rebuild-images.sh
@@ -43,7 +43,7 @@ location="$( cd -P "$( dirname "$source" )" && pwd )"
 graalvm_home="${location}/../../.."
 
 function usage_and_exit() {
-    echo "Usage: $0 [--verbose] polyglot|libpolyglot|js|llvm|python|ruby|R... [custom native-image args]..."
+    echo "Usage: $0 [--verbose] polyglot|libpolyglot|js|llvm|python|ruby|R|wasm... [custom native-image args]..."
     exit 1
 }
 
@@ -52,7 +52,7 @@ custom_args=()
 
 for opt in "${@:1}"; do
     case "$opt" in
-        polyglot|libpolyglot|js|llvm|python|ruby|R)
+        polyglot|libpolyglot|js|llvm|python|ruby|R|wasm)
            to_build+=("${opt}")
             ;;
         --help|-h)
@@ -130,6 +130,9 @@ for binary in "${to_build[@]}"; do
             ;;
         R)
             launcher RMain
+            ;;
+        wasm)
+            launcher wasm
             ;;
         *)
             echo "shouldNotReachHere()"


### PR DESCRIPTION
I found the following message when I executed the command `rebuild-images wasm` with GraalVM CE 20.1.0 (Java 11) on Ubuntu 18.04.

```
 $ rebuild-images wasm
nothing to build
Usage: /home/jyukutyo/dev/graalvm-ce-java11-20.1.0/bin/rebuild-images [--verbose] polyglot|libpolyglot|js|llvm|python|ruby|R... [custom native-image args]...
```
I've installed wasm via `gu install` already.
```
 $ gu list
ComponentId              Version             Component name      Origin
--------------------------------------------------------------------------------
graalvm                  20.1.0              GraalVM Core
llvm-toolchain           20.1.0              LLVM.org toolchain  github.com
native-image             20.1.0              Native Image        github.com
wasm                     20.1.0              GraalWasm           github.com
```
So `rebuild-images wasm` should be able to rebuild wasm, I think. I fixed the files.
* substratevm/mx.substratevm/rebuild-images.sh
* substratevm/mx.substratevm/rebuild-images.cmd

After do that, I can rebuild wasm.
```
$ ./rebuild-images wasm
Building wasm...
[wasm:13088]    classlist:   3,500.63 ms,  0.96 GB
[wasm:13088]        (cap):     916.99 ms,  0.96 GB
[wasm:13088]        setup:   2,813.82 ms,  0.96 GB
[engine::PolyglotContextImpl] WARNING: Language wasm cannot be pre-initialized as it does not override TruffleLanguage.patchContext method.
[wasm:13088]     (clinit):     651.34 ms,  2.57 GB
[wasm:13088]   (typeflow):  22,247.13 ms,  2.57 GB
[wasm:13088]    (objects):  15,969.75 ms,  2.57 GB
[wasm:13088]   (features):   2,437.33 ms,  2.57 GB
[wasm:13088]     analysis:  42,580.10 ms,  2.57 GB
[wasm:13088]     universe:   1,402.22 ms,  3.64 GB
1598 method(s) included for runtime compilation
[wasm:13088]      (parse):   6,010.48 ms,  3.64 GB
[wasm:13088]     (inline):   8,258.47 ms,  4.85 GB
[wasm:13088]    (compile):  36,677.24 ms,  5.02 GB
[wasm:13088]      compile:  53,205.61 ms,  5.02 GB
[wasm:13088]        image:   3,788.61 ms,  5.02 GB
[wasm:13088]        write:     456.06 ms,  5.02 GB
[wasm:13088]      [total]: 109,374.61 ms,  5.02 GB
```
On Windows 10, rebuild-image.cmd works fine.
```
$ rebuild-images.cmd wasm
Building wasm...
[wasm:104524]    classlist:   2,406.34 ms,  0.96 GB
```

If wasm isn't installed yet, the follwoing message is shown.
```
$ rebuild-images wasm
Building wasm...
Error: Unknown name in option specification: macro:wasm-launcher
Available macro options are:
    --macro:polyglot-launcher
    --macro:junit
    --macro:jvmcicompiler-library
    --macro:native-image-agent-library
    --macro:truffle
    --macro:polyglot-library
    --macro:native-image-configure-launcher
    --macro:native-image-launcher

# Windows
$ rebuild-images.cmd wasm
Building wasm...
Error: Unknown name in option specification: macro:wasm-launcher
Available macro options are:
    --macro:polyglot-launcher
    --macro:js-launcher
    --macro:jvmcicompiler-library
    --macro:gu-launcher
    --macro:native-image-agent-library
    --macro:polyglot-library
    --macro:truffle
    --macro:native-image-launcher
```