### PR TITLE
Avoid NPE when printing errors in polyglot shell

### DIFF
--- a/sdk/src/org.graalvm.launcher/src/org/graalvm/launcher/MultiLanguageShell.java
+++ b/sdk/src/org.graalvm.launcher/src/org/graalvm/launcher/MultiLanguageShell.java
@@ -249,7 +249,7 @@ class MultiLanguageShell {
                     if (e.isHostException()) {
                         console.println(e.asHostException().toString());
                     } else {
-                        console.println(e.getMessage());
+                        console.println(String.valueOf(e.getMessage()));
                     }
                     // no need to print stack traces with single entry
                     if (trace.size() > 1) {


### PR DESCRIPTION
`e.getMessage()` is allowed to return `null`. In this case, `console.println()` throws an error:
```
org.graalvm.launcher.Launcher$AbortException
Caused by: java.lang.NullPointerException
	at jline.console.ConsoleReader.print(ConsoleReader.java:3482)
	at jline.console.ConsoleReader.println(ConsoleReader.java:3486)
	at org.graalvm.launcher.MultiLanguageShell.readEvalPrint(MultiLanguageShell.java:252)
	at org.graalvm.launcher.PolyglotLauncher.runShell(PolyglotLauncher.java:430)
	at org.graalvm.launcher.PolyglotLauncher.launchImpl(PolyglotLauncher.java:233)
	at org.graalvm.launcher.PolyglotLauncher.launch(PolyglotLauncher.java:186)
	at org.graalvm.launcher.PolyglotLauncher.main(PolyglotLauncher.java:440)
```

*Tested on GraalVM CE 20.1 and macOS Catalina.*