### PR TITLE
Default value in ErrorStateHolder::messageHolder might leak

### DIFF
--- a/substratevm/src/org.graalvm.polyglot.nativeapi/src/org/graalvm/polyglot/nativeapi/PolyglotNativeAPI.java
+++ b/substratevm/src/org.graalvm.polyglot.nativeapi/src/org/graalvm/polyglot/nativeapi/PolyglotNativeAPI.java
@@ -134,7 +134,10 @@ public final class PolyglotNativeAPI {
 
     private static class ErrorStateHolder {
         public PolyglotExtendedErrorInfo info = WordFactory.nullPointer();
-        public CCharPointerHolder messageHolder = CTypeConversion.toCString(null); // will be assigned to CTypeConversionSupportImpl::NULL_HOLDER
+
+        // will be assigned to CTypeConversionSupportImpl::NULL_HOLDER by default
+        public CCharPointerHolder messageHolder = CTypeConversion.toCString(null);
+
         public PolyglotException polyglotException = null;
     }
 

--- a/substratevm/src/org.graalvm.polyglot.nativeapi/src/org/graalvm/polyglot/nativeapi/PolyglotNativeAPI.java
+++ b/substratevm/src/org.graalvm.polyglot.nativeapi/src/org/graalvm/polyglot/nativeapi/PolyglotNativeAPI.java
@@ -134,7 +134,7 @@ public final class PolyglotNativeAPI {
 
     private static class ErrorStateHolder {
         public PolyglotExtendedErrorInfo info = WordFactory.nullPointer();
-        public CCharPointerHolder messageHolder = CTypeConversion.toCString("");
+        public CCharPointerHolder messageHolder = CTypeConversion.toCString(null); // will be assigned to CTypeConversionSupportImpl::NULL_HOLDER
         public PolyglotException polyglotException = null;
     }
 


### PR DESCRIPTION
`ErrorStateHolder::messageHolder` holds `CCharPointerHolder` which is instantiated by `CTypeConversionSupportImpl`. If we pass `""` (zero-length string) to `CTypeConversion::toString`, it would be assigned unmanaged memory which have `\0`.

`messageHolder` would be released at `PolyglotNativeAPI::resetErrorState`. `ErrorStateHolder::info` should not be null to happen releasing memory. However `info` is assigned to `WordFactory.nullPointer()` by default, so it would not be happen - default value of `messageHolder` would leak.

`ErrorStateHolder::messageHolder` is overwritten when an error is happen at `PolyglotNativeAPI::handleThrowable`, but it seems to assume all resources in `ErrorStateHolder` are certainly released at `PolyglotNativeAPI::withHandledErrors` (caller of `resetErrorState()`).