### PR TITLE
Add missing GraalVM packages present in JDK source cache

### DIFF
--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/image/sources/SourceManager.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/image/sources/SourceManager.java
@@ -172,6 +172,17 @@ public class SourceManager {
                     "org.omg.",
                     "org.w3c.",
                     "org.xml",
+                    "org.graalvm.collections.",
+                    "org.graalvm.compiler.",
+                    "org.graalvm.home.",
+                    "org.graalvm.nativeimage.",
+                    "org.graalvm.options.",
+                    "org.graalvm.polyglot.",
+                    "org.graalvm.word.",
+                    "com.oracle.graalvm.locator.",
+                    "com.oracle.truffe.api.",
+                    "com.oracle.truffe.object.",
+                    "com.oracle.truffe.polyglot.",
     };
     /**
      * A whitelist of packages prefixes used to pre-filter GraalVM class lookups.


### PR DESCRIPTION
Closes #2577.

The sources for the packages added are stored in `lib/src.zip`. Hence, they need to be included as part of the sources that are extracted from there.