### PR TITLE
[gu] Ensure errors in Graal Updater are displayed

### DIFF
--- a/vm/src/org.graalvm.component.installer/src/org/graalvm/component/installer/commands/ListInstalledCommand.java
+++ b/vm/src/org.graalvm.component.installer/src/org/graalvm/component/installer/commands/ListInstalledCommand.java
@@ -148,15 +148,15 @@ public class ListInstalledCommand extends QueryCommandBase {
                 exceptions.add(ex);
             }
         }
-        if (components.isEmpty()) {
-            feedback.message("LIST_NoComponentsFound");
-            return false;
-        }
         if (!exceptions.isEmpty()) {
             feedback.error("LIST_ErrorInComponentMetadata", null);
             for (Exception e : exceptions) {
                 feedback.error("LIST_ErrorInComponentMetadataItem", e, e.getLocalizedMessage());
             }
+        }
+        if (components.isEmpty()) {
+            feedback.message("LIST_NoComponentsFound");
+            return false;
         }
         return true;
     }


### PR DESCRIPTION
In case `components.isEmpty()`, errors are not displayed to the user. While debugging, I found out that:
> Unsupported operation in filter. Only = is supported.

is thrown. With this fix in place, I would have seen the error straight away.