### PR TITLE
Add intrinsics for floating point Math.min/Math.max on AArch64

### DIFF
--- a/compiler/src/org.graalvm.compiler.asm.aarch64/src/org/graalvm/compiler/asm/aarch64/AArch64Assembler.java
+++ b/compiler/src/org.graalvm.compiler.asm.aarch64/src/org/graalvm/compiler/asm/aarch64/AArch64Assembler.java
@@ -71,6 +71,8 @@ import static org.graalvm.compiler.asm.aarch64.AArch64Assembler.Instruction.FCVT
 import static org.graalvm.compiler.asm.aarch64.AArch64Assembler.Instruction.FCVTZS;
 import static org.graalvm.compiler.asm.aarch64.AArch64Assembler.Instruction.FDIV;
 import static org.graalvm.compiler.asm.aarch64.AArch64Assembler.Instruction.FMADD;
+import static org.graalvm.compiler.asm.aarch64.AArch64Assembler.Instruction.FMAX;
+import static org.graalvm.compiler.asm.aarch64.AArch64Assembler.Instruction.FMIN;
 import static org.graalvm.compiler.asm.aarch64.AArch64Assembler.Instruction.FMOV;
 import static org.graalvm.compiler.asm.aarch64.AArch64Assembler.Instruction.FMSUB;
 import static org.graalvm.compiler.asm.aarch64.AArch64Assembler.Instruction.FMUL;
@@ -2790,6 +2792,30 @@ public abstract class AArch64Assembler extends Assembler {
         assert src1.getRegisterCategory().equals(SIMD);
         assert src2.getRegisterCategory().equals(SIMD);
         emitInt(type.encoding | instr.encoding | Fp2SourceOp | rd(dst) | rs1(src1) | rs2(src2));
+    }
+
+    /**
+     * dst = src1 > src2 ? src1 : src2.
+     *
+     * @param size register size.
+     * @param dst floating point register. May not be null.
+     * @param src1 floating point register. May not be null.
+     * @param src2 floating point register. May not be null.
+     */
+    public void fmax(int size, Register dst, Register src1, Register src2) {
+        fpDataProcessing2Source(FMAX, dst, src1, src2, floatFromSize(size));
+    }
+
+    /**
+     * dst = src1 < src2 ? src1 : src2.
+     *
+     * @param size register size.
+     * @param dst floating point register. May not be null.
+     * @param src1 floating point register. May not be null.
+     * @param src2 floating point register. May not be null.
+     */
+    public void fmin(int size, Register dst, Register src1, Register src2) {
+        fpDataProcessing2Source(FMIN, dst, src1, src2, floatFromSize(size));
     }
 
     /* Floating-point Multiply-Add (5.7.9) */

--- a/compiler/src/org.graalvm.compiler.core.aarch64/src/org/graalvm/compiler/core/aarch64/AArch64ArithmeticLIRGenerator.java
+++ b/compiler/src/org.graalvm.compiler.core.aarch64/src/org/graalvm/compiler/core/aarch64/AArch64ArithmeticLIRGenerator.java
@@ -452,6 +452,22 @@ public class AArch64ArithmeticLIRGenerator extends ArithmeticLIRGenerator implem
     }
 
     @Override
+    public Value emitMathMax(Value a, Value b) {
+        assert a.getPlatformKind() == b.getPlatformKind();
+        assert a.getPlatformKind() == AArch64Kind.DOUBLE ||
+                        a.getPlatformKind() == AArch64Kind.SINGLE;
+        return emitBinary(LIRKind.combine(a, b), AArch64ArithmeticOp.FMAX, true, a, b);
+    }
+
+    @Override
+    public Value emitMathMin(Value a, Value b) {
+        assert a.getPlatformKind() == b.getPlatformKind();
+        assert a.getPlatformKind() == AArch64Kind.DOUBLE ||
+                        a.getPlatformKind() == AArch64Kind.SINGLE;
+        return emitBinary(LIRKind.combine(a, b), AArch64ArithmeticOp.FMIN, true, a, b);
+    }
+
+    @Override
     public Value emitMathSqrt(Value input) {
         assert input.getPlatformKind() == AArch64Kind.DOUBLE ||
                         input.getPlatformKind() == AArch64Kind.SINGLE;

--- a/compiler/src/org.graalvm.compiler.core.common/src/org/graalvm/compiler/core/common/type/FloatStamp.java
+++ b/compiler/src/org.graalvm.compiler.core.common/src/org/graalvm/compiler/core/common/type/FloatStamp.java
@@ -910,6 +910,77 @@ public class FloatStamp extends PrimitiveStamp {
 
                     null, null, null,
 
+                    new BinaryOp.Max(true, true) {
+
+                        @Override
+                        public Constant foldConstant(Constant const1, Constant const2) {
+                            PrimitiveConstant a = (PrimitiveConstant) const1;
+                            PrimitiveConstant b = (PrimitiveConstant) const2;
+                            assert a.getJavaKind() == b.getJavaKind();
+                            switch (a.getJavaKind()) {
+                                case Float:
+                                    return JavaConstant.forFloat(Math.max(a.asFloat(), b.asFloat()));
+                                case Double:
+                                    return JavaConstant.forDouble(Math.max(a.asDouble(), b.asDouble()));
+                                default:
+                                    throw GraalError.shouldNotReachHere();
+                            }
+                        }
+
+                        @Override
+                        public Stamp foldStamp(Stamp s1, Stamp s2) {
+                            if (s1.isEmpty()) {
+                                return s1;
+                            }
+                            if (s2.isEmpty()) {
+                                return s2;
+                            }
+                            FloatStamp stamp1 = (FloatStamp) s1;
+                            FloatStamp stamp2 = (FloatStamp) s2;
+                            Stamp folded = maybeFoldConstant(this, stamp1, stamp2);
+                            if (folded != null) {
+                                return folded;
+                            }
+
+                            return new FloatStamp(stamp1.getBits(), Math.max(stamp1.lowerBound, stamp2.lowerBound), Math.max(stamp1.upperBound, stamp2.upperBound), false);
+                        }
+                    },
+
+                    new BinaryOp.Min(true, true) {
+
+                        @Override
+                        public Constant foldConstant(Constant const1, Constant const2) {
+                            PrimitiveConstant a = (PrimitiveConstant) const1;
+                            PrimitiveConstant b = (PrimitiveConstant) const2;
+                            assert a.getJavaKind() == b.getJavaKind();
+                            switch (a.getJavaKind()) {
+                                case Float:
+                                    return JavaConstant.forFloat(Math.min(a.asFloat(), b.asFloat()));
+                                case Double:
+                                    return JavaConstant.forDouble(Math.min(a.asDouble(), b.asDouble()));
+                                default:
+                                    throw GraalError.shouldNotReachHere();
+                            }
+                        }
+
+                        @Override
+                        public Stamp foldStamp(Stamp s1, Stamp s2) {
+                            if (s1.isEmpty()) {
+                                return s1;
+                            }
+                            if (s2.isEmpty()) {
+                                return s2;
+                            }
+                            FloatStamp stamp1 = (FloatStamp) s1;
+                            FloatStamp stamp2 = (FloatStamp) s2;
+                            Stamp folded = maybeFoldConstant(this, stamp1, stamp2);
+                            if (folded != null) {
+                                return folded;
+                            }
+                            return new FloatStamp(stamp1.getBits(), Math.min(stamp1.lowerBound, stamp2.lowerBound), Math.min(stamp1.upperBound, stamp2.upperBound), false);
+                        }
+                    },
+
                     new FloatConvertOp(F2I) {
 
                         @Override

--- a/compiler/src/org.graalvm.compiler.core.common/src/org/graalvm/compiler/core/common/type/IntegerStamp.java
+++ b/compiler/src/org.graalvm.compiler.core.common/src/org/graalvm/compiler/core/common/type/IntegerStamp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1619,6 +1619,10 @@ public final class IntegerStamp extends PrimitiveStamp {
                             return result;
                         }
                     },
+
+                    null,   // BinaryOp.max
+
+                    null,   // BinaryOp.min
 
                     new FloatConvertOp(I2F) {
 

--- a/compiler/src/org.graalvm.compiler.core.test/src/org/graalvm/compiler/core/test/ReassociateAndCanonicalTest.java
+++ b/compiler/src/org.graalvm.compiler.core.test/src/org/graalvm/compiler/core/test/ReassociateAndCanonicalTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,19 +24,26 @@
  */
 package org.graalvm.compiler.core.test;
 
+import java.util.Random;
+
 import org.graalvm.compiler.graph.IterableNodeType;
 import org.graalvm.compiler.graph.Node;
 import org.graalvm.compiler.nodes.StructuredGraph;
 import org.graalvm.compiler.nodes.StructuredGraph.AllowAssumptions;
 import org.junit.Test;
 
+import jdk.vm.ci.aarch64.AArch64;
+
 public class ReassociateAndCanonicalTest extends GraalCompilerTest {
 
-    public static int rnd = (int) (Math.random() * 100);
+    private static final Random random = new Random(11);
+    public static int rnd = random.nextInt();
+    private static float rndF = random.nextFloat();
+    private static double rndD = random.nextDouble();
 
     @Test
     public void test1() {
-        test("test1Snippet", "ref1Snippet");
+        compareGraphs("test1Snippet", "ref1Snippet");
     }
 
     public static int test1Snippet() {
@@ -49,7 +56,7 @@ public class ReassociateAndCanonicalTest extends GraalCompilerTest {
 
     @Test
     public void test2() {
-        test("test2Snippet", "ref2Snippet");
+        compareGraphs("test2Snippet", "ref2Snippet");
     }
 
     public static int test2Snippet() {
@@ -62,7 +69,7 @@ public class ReassociateAndCanonicalTest extends GraalCompilerTest {
 
     @Test
     public void test3() {
-        test("test3Snippet", "ref3Snippet");
+        compareGraphs("test3Snippet", "ref3Snippet");
     }
 
     public static int test3Snippet() {
@@ -75,7 +82,7 @@ public class ReassociateAndCanonicalTest extends GraalCompilerTest {
 
     @Test
     public void test4() {
-        test("test4Snippet", "ref4Snippet");
+        compareGraphs("test4Snippet", "ref4Snippet");
     }
 
     public static int test4Snippet() {
@@ -88,7 +95,7 @@ public class ReassociateAndCanonicalTest extends GraalCompilerTest {
 
     @Test
     public void test5() {
-        test("test5Snippet", "ref5Snippet");
+        compareGraphs("test5Snippet", "ref5Snippet");
     }
 
     public static int test5Snippet() {
@@ -101,7 +108,7 @@ public class ReassociateAndCanonicalTest extends GraalCompilerTest {
 
     @Test
     public void test6() {
-        test("test6Snippet", "ref6Snippet");
+        compareGraphs("test6Snippet", "ref6Snippet");
     }
 
     public static int test6Snippet() {
@@ -114,7 +121,7 @@ public class ReassociateAndCanonicalTest extends GraalCompilerTest {
 
     @Test
     public void test7() {
-        test("test7Snippet", "ref7Snippet");
+        compareGraphs("test7Snippet", "ref7Snippet");
     }
 
     public static int test7Snippet() {
@@ -127,7 +134,7 @@ public class ReassociateAndCanonicalTest extends GraalCompilerTest {
 
     @Test
     public void test8() {
-        test("test8Snippet", "ref8Snippet");
+        compareGraphs("test8Snippet", "ref8Snippet");
     }
 
     public static int test8Snippet() {
@@ -140,7 +147,7 @@ public class ReassociateAndCanonicalTest extends GraalCompilerTest {
 
     @Test
     public void test9() {
-        test("test9Snippet", "ref9Snippet");
+        compareGraphs("test9Snippet", "ref9Snippet");
     }
 
     public static int test9Snippet() {
@@ -153,7 +160,7 @@ public class ReassociateAndCanonicalTest extends GraalCompilerTest {
 
     @Test
     public void test10() {
-        test("test10Snippet", "ref10Snippet");
+        compareGraphs("test10Snippet", "ref10Snippet");
     }
 
     public static int test10Snippet() {
@@ -166,7 +173,7 @@ public class ReassociateAndCanonicalTest extends GraalCompilerTest {
 
     @Test
     public void test11() {
-        test("test11Snippet", "ref11Snippet");
+        compareGraphs("test11Snippet", "ref11Snippet");
     }
 
     public static int test11Snippet() {
@@ -179,7 +186,7 @@ public class ReassociateAndCanonicalTest extends GraalCompilerTest {
 
     @Test
     public void test12() {
-        test("test12Snippet", "ref12Snippet");
+        compareGraphs("test12Snippet", "ref12Snippet");
     }
 
     public static int test12Snippet() {
@@ -192,7 +199,7 @@ public class ReassociateAndCanonicalTest extends GraalCompilerTest {
 
     @Test
     public void test13() {
-        test("test13Snippet", "ref13Snippet");
+        compareGraphs("test13Snippet", "ref13Snippet");
     }
 
     public static int test13Snippet() {
@@ -205,7 +212,7 @@ public class ReassociateAndCanonicalTest extends GraalCompilerTest {
 
     @Test
     public void test14() {
-        test("test14Snippet", "ref14Snippet");
+        compareGraphs("test14Snippet", "ref14Snippet");
     }
 
     public static int test14Snippet() {
@@ -218,7 +225,7 @@ public class ReassociateAndCanonicalTest extends GraalCompilerTest {
 
     @Test
     public void test15() {
-        test("test15Snippet", "ref15Snippet");
+        compareGraphs("test15Snippet", "ref15Snippet");
     }
 
     public static int test15Snippet() {
@@ -231,7 +238,7 @@ public class ReassociateAndCanonicalTest extends GraalCompilerTest {
 
     @Test
     public void test16() {
-        test("test16Snippet", "ref16Snippet");
+        compareGraphs("test16Snippet", "ref16Snippet");
     }
 
     public static int test16Snippet() {
@@ -242,10 +249,55 @@ public class ReassociateAndCanonicalTest extends GraalCompilerTest {
         return (2 - rnd) - 1;
     }
 
-    private <T extends Node & IterableNodeType> void test(String test, String ref) {
-        StructuredGraph testGraph = parseEager(test, AllowAssumptions.NO);
+    @Test
+    public void testMathMax() {
+        if (getTarget().arch instanceof AArch64) {
+            // Test only on AArch64 as it uses MinNode/MaxNode to intrinsify Math.min/max with
+            // float/double types that can be re-associated.
+            compareGraphs("testMathMaxFloatSnippet", "refMathMaxFloatSnippet");
+            compareGraphs("testMathMinFloatSnippet", "refMathMinFloatSnippet");
+            compareGraphs("testMathMaxDoubleSnippet", "refMathMaxDoubleSnippet");
+            compareGraphs("testMathMinDoubleSnippet", "refMathMinDoubleSnippet");
+        }
+    }
+
+    public static float testMathMaxFloatSnippet() {
+        return Math.max(Math.max(3.0f, rndF), 2.0f);
+    }
+
+    public static float refMathMaxFloatSnippet() {
+        return Math.max(rndF, 3.0f);
+    }
+
+    public static float testMathMinFloatSnippet() {
+        return Math.min(Math.min(3.0f, rndF), 2.0f);
+    }
+
+    public static float refMathMinFloatSnippet() {
+        return Math.min(rndF, 2.0f);
+    }
+
+    public static double testMathMaxDoubleSnippet() {
+        return Math.max(Math.max(3.0d, rndD), 2.0d);
+    }
+
+    public static double refMathMaxDoubleSnippet() {
+        return Math.max(rndD, 3.0d);
+    }
+
+    public static double testMathMinDoubleSnippet() {
+        return Math.min(Math.min(3.0d, rndD), 2.0d);
+    }
+
+    public static double refMathMinDoubleSnippet() {
+        return Math.min(rndD, 2.0d);
+    }
+
+    private <T extends Node & IterableNodeType> void compareGraphs(String testMethodName, String refMethodName) {
+        test(testMethodName);
+        StructuredGraph testGraph = parseEager(testMethodName, AllowAssumptions.NO);
         createCanonicalizerPhase().apply(testGraph, getProviders());
-        StructuredGraph refGraph = parseEager(ref, AllowAssumptions.NO);
+        StructuredGraph refGraph = parseEager(refMethodName, AllowAssumptions.NO);
         createCanonicalizerPhase().apply(refGraph, getProviders());
         assertEquals(testGraph, refGraph);
     }

--- a/compiler/src/org.graalvm.compiler.hotspot.test/src/org/graalvm/compiler/hotspot/test/CheckGraalIntrinsics.java
+++ b/compiler/src/org.graalvm.compiler.hotspot.test/src/org/graalvm/compiler/hotspot/test/CheckGraalIntrinsics.java
@@ -405,13 +405,12 @@ public class CheckGraalIntrinsics extends GraalTest {
             if (!(arch instanceof AArch64)) {
                 add(toBeInvestigated,
                                 "java/lang/Math.abs(I)I",
-                                "java/lang/Math.abs(J)J");
+                                "java/lang/Math.abs(J)J",
+                                "java/lang/Math.max(DD)D",
+                                "java/lang/Math.max(FF)F",
+                                "java/lang/Math.min(DD)D",
+                                "java/lang/Math.min(FF)F");
             }
-            add(toBeInvestigated,
-                            "java/lang/Math.max(DD)D",
-                            "java/lang/Math.max(FF)F",
-                            "java/lang/Math.min(DD)D",
-                            "java/lang/Math.min(FF)F");
             add(toBeInvestigated,
                             "jdk/internal/misc/Unsafe.writeback0(J)V",
                             "jdk/internal/misc/Unsafe.writebackPostSync0()V",

--- a/compiler/src/org.graalvm.compiler.jtt/src/org/graalvm/compiler/jtt/lang/Math_minMax.java
+++ b/compiler/src/org.graalvm.compiler.jtt/src/org/graalvm/compiler/jtt/lang/Math_minMax.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, Arm Limited. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.graalvm.compiler.jtt.lang;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import org.graalvm.compiler.jtt.JTTTest;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+
+@RunWith(Parameterized.class)
+public class Math_minMax extends JTTTest {
+
+    @Parameters(name = "{0}, {1}")
+    public static Collection<Object[]> testData() {
+        double[] inputs = {0.0d, -0.0d, 4.1d, -4.1d, Double.MIN_VALUE, Double.MAX_VALUE, Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY, Double.NaN};
+
+        List<Object[]> testParameters = new ArrayList<>();
+        for (double a : inputs) {
+            for (double b : inputs) {
+                testParameters.add(new Object[]{a, b});
+            }
+        }
+        return testParameters;
+    }
+
+    @Parameter(value = 0) public double input0;
+    @Parameter(value = 1) public double input1;
+
+    public static double maxDouble(double x, double y) {
+        return Math.max(x, y);
+    }
+
+    public static double minDouble(double x, double y) {
+        return Math.min(x, y);
+    }
+
+    public static float maxFloat(float x, float y) {
+        return Math.max(x, y);
+    }
+
+    public static float minFloat(float x, float y) {
+        return Math.min(x, y);
+    }
+
+    @Test
+    public void testMaxDouble() throws Throwable {
+        runTest("maxDouble", input0, input1);
+    }
+
+    @Test
+    public void testMinDouble() throws Throwable {
+        runTest("minDouble", input0, input1);
+    }
+
+    @Test
+    public void testMaxFloat() throws Throwable {
+        runTest("maxFloat", (float) input0, (float) input1);
+    }
+
+    @Test
+    public void testMinFloat() throws Throwable {
+        runTest("minFloat", (float) input0, (float) input1);
+    }
+}

--- a/compiler/src/org.graalvm.compiler.lir.aarch64/src/org/graalvm/compiler/lir/aarch64/AArch64ArithmeticOp.java
+++ b/compiler/src/org.graalvm.compiler.lir.aarch64/src/org/graalvm/compiler/lir/aarch64/AArch64ArithmeticOp.java
@@ -90,6 +90,8 @@ public enum AArch64ArithmeticOp {
     FRINTM,
     FRINTN,
     FRINTP,
+    FMAX,
+    FMIN,
     SQRT;
 
     /**
@@ -348,6 +350,12 @@ public enum AArch64ArithmeticOp {
                     break;
                 case FDIV:
                     masm.fdiv(size, dst, src1, src2);
+                    break;
+                case FMAX:
+                    masm.fmax(size, dst, src1, src2);
+                    break;
+                case FMIN:
+                    masm.fmin(size, dst, src1, src2);
                     break;
                 case MULVS:
                     masm.mulvs(size, dst, src1, src2);

--- a/compiler/src/org.graalvm.compiler.lir/src/org/graalvm/compiler/lir/gen/ArithmeticLIRGeneratorTool.java
+++ b/compiler/src/org.graalvm.compiler.lir/src/org/graalvm/compiler/lir/gen/ArithmeticLIRGeneratorTool.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -141,4 +141,13 @@ public interface ArithmeticLIRGeneratorTool {
         throw GraalError.unimplemented("No specialized implementation available");
     }
 
+    @SuppressWarnings("unused")
+    default Value emitMathMax(Value x, Value y) {
+        throw GraalError.unimplemented("No specialized implementation available");
+    }
+
+    @SuppressWarnings("unused")
+    default Value emitMathMin(Value x, Value y) {
+        throw GraalError.unimplemented("No specialized implementation available");
+    }
 }

--- a/compiler/src/org.graalvm.compiler.nodes/src/org/graalvm/compiler/nodes/calc/BinaryArithmeticNode.java
+++ b/compiler/src/org.graalvm.compiler.nodes/src/org/graalvm/compiler/nodes/calc/BinaryArithmeticNode.java
@@ -362,6 +362,12 @@ public abstract class BinaryArithmeticNode<OP> extends BinaryNode implements Ari
         } else if (node instanceof XorNode) {
             // Re-association from "x ^ (y ^ C)" to "(x ^ y) ^ C"
             return XorNode.create(matchValue, XorNode.create(otherValue1, otherValue2, view), view);
+        } else if (node instanceof MinNode) {
+            // Re-association from "Math.min(x, Math.min(y, C))" to "Math.min(Math.min(x, y), C)"
+            return MinNode.create(matchValue, MinNode.create(otherValue1, otherValue2, view), view);
+        } else if (node instanceof MaxNode) {
+            // Re-association from "Math.max(x, Math.max(y, C))" to "Math.max(Math.max(x, y), C)"
+            return MaxNode.create(matchValue, MaxNode.create(otherValue1, otherValue2, view), view);
         } else {
             throw GraalError.shouldNotReachHere();
         }
@@ -388,7 +394,7 @@ public abstract class BinaryArithmeticNode<OP> extends BinaryNode implements Ari
      * criterion: {@code (a + 2) + 1 => a + (1 + 2)}
      * <p>
      * This method accepts only {@linkplain BinaryOp#isAssociative() associative} operations such as
-     * +, -, *, &amp;, | and ^
+     * +, -, *, &amp;, |, ^, min, max
      *
      * @param forY
      * @param forX
@@ -466,6 +472,10 @@ public abstract class BinaryArithmeticNode<OP> extends BinaryNode implements Ari
             return OrNode.create(a, OrNode.create(m1, m2, view), view);
         } else if (node instanceof XorNode) {
             return XorNode.create(a, XorNode.create(m1, m2, view), view);
+        } else if (node instanceof MaxNode) {
+            return MaxNode.create(a, MaxNode.create(m1, m2, view), view);
+        } else if (node instanceof MinNode) {
+            return MinNode.create(a, MinNode.create(m1, m2, view), view);
         } else {
             throw GraalError.shouldNotReachHere();
         }

--- a/compiler/src/org.graalvm.compiler.nodes/src/org/graalvm/compiler/nodes/calc/MaxNode.java
+++ b/compiler/src/org.graalvm.compiler.nodes/src/org/graalvm/compiler/nodes/calc/MaxNode.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, Arm Limited. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.graalvm.compiler.nodes.calc;
+
+import org.graalvm.compiler.core.common.type.ArithmeticOpTable;
+import org.graalvm.compiler.core.common.type.ArithmeticOpTable.BinaryOp;
+import org.graalvm.compiler.core.common.type.ArithmeticOpTable.BinaryOp.Max;
+import org.graalvm.compiler.core.common.type.FloatStamp;
+import org.graalvm.compiler.core.common.type.Stamp;
+import org.graalvm.compiler.graph.NodeClass;
+import org.graalvm.compiler.nodeinfo.NodeInfo;
+import org.graalvm.compiler.nodes.ConstantNode;
+import org.graalvm.compiler.nodes.NodeView;
+import org.graalvm.compiler.nodes.ValueNode;
+
+@NodeInfo(shortName = "MAX")
+public class MaxNode extends MinMaxNode<Max> {
+
+    public static final NodeClass<MaxNode> TYPE = NodeClass.create(MaxNode.class);
+
+    protected MaxNode(ValueNode x, ValueNode y) {
+        super(TYPE, getArithmeticOpTable(x).getMax(), x, y);
+    }
+
+    @Override
+    protected BinaryOp<Max> getOp(ArithmeticOpTable table) {
+        return table.getMax();
+    }
+
+    public static ValueNode create(ValueNode x, ValueNode y, NodeView view) {
+        BinaryOp<Max> op = ArithmeticOpTable.forStamp(x.stamp(view)).getMax();
+        Stamp stamp = op.foldStamp(x.stamp(view), y.stamp(view));
+        assert stamp instanceof FloatStamp;
+        ConstantNode tryConstantFold = tryConstantFold(op, x, y, stamp, view);
+        if (tryConstantFold != null) {
+            return tryConstantFold;
+        }
+        return new MaxNode(x, y).maybeCommuteInputs();
+    }
+}

--- a/compiler/src/org.graalvm.compiler.nodes/src/org/graalvm/compiler/nodes/calc/MinMaxNode.java
+++ b/compiler/src/org.graalvm.compiler.nodes/src/org/graalvm/compiler/nodes/calc/MinMaxNode.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, Arm Limited. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package org.graalvm.compiler.nodes.calc;
+
+import org.graalvm.compiler.core.common.type.ArithmeticOpTable.BinaryOp;
+import org.graalvm.compiler.graph.NodeClass;
+import org.graalvm.compiler.graph.spi.Canonicalizable;
+import org.graalvm.compiler.graph.spi.CanonicalizerTool;
+import org.graalvm.compiler.lir.gen.ArithmeticLIRGeneratorTool;
+import org.graalvm.compiler.nodeinfo.NodeInfo;
+import org.graalvm.compiler.nodes.NodeView;
+import org.graalvm.compiler.nodes.ValueNode;
+import org.graalvm.compiler.nodes.spi.NodeLIRBuilderTool;
+
+import jdk.vm.ci.meta.Value;
+
+@NodeInfo(shortName = "MinMax")
+public abstract class MinMaxNode<OP> extends BinaryArithmeticNode<OP> implements NarrowableArithmeticNode, Canonicalizable.BinaryCommutative<ValueNode> {
+
+    @SuppressWarnings("rawtypes") public static final NodeClass<MinMaxNode> TYPE = NodeClass.create(MinMaxNode.class);
+
+    protected MinMaxNode(NodeClass<? extends BinaryArithmeticNode<OP>> c, BinaryOp<OP> opForStampComputation, ValueNode x, ValueNode y) {
+        super(c, opForStampComputation, x, y);
+    }
+
+    @Override
+    public ValueNode canonical(CanonicalizerTool tool, ValueNode forX, ValueNode forY) {
+        ValueNode ret = super.canonical(tool, forX, forY);
+        if (ret != this) {
+            return ret;
+        }
+
+        NodeView view = NodeView.from(tool);
+        return reassociateMatchedValues(this, ValueNode.isConstantPredicate(), forX, forY, view);
+    }
+
+    @Override
+    public void generate(NodeLIRBuilderTool nodeValueMap, ArithmeticLIRGeneratorTool gen) {
+        Value op1 = nodeValueMap.operand(getX());
+        assert op1 != null : getX() + ", this=" + this;
+        Value op2 = nodeValueMap.operand(getY());
+        if (shouldSwapInputs(nodeValueMap)) {
+            Value tmp = op1;
+            op1 = op2;
+            op2 = tmp;
+        }
+        if (this instanceof MaxNode) {
+            nodeValueMap.setResult(this, gen.emitMathMax(op1, op2));
+        } else {
+            nodeValueMap.setResult(this, gen.emitMathMin(op1, op2));
+        }
+    }
+}

--- a/compiler/src/org.graalvm.compiler.nodes/src/org/graalvm/compiler/nodes/calc/MinNode.java
+++ b/compiler/src/org.graalvm.compiler.nodes/src/org/graalvm/compiler/nodes/calc/MinNode.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, Arm Limited. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.graalvm.compiler.nodes.calc;
+
+import org.graalvm.compiler.core.common.type.ArithmeticOpTable;
+import org.graalvm.compiler.core.common.type.ArithmeticOpTable.BinaryOp;
+import org.graalvm.compiler.core.common.type.ArithmeticOpTable.BinaryOp.Min;
+import org.graalvm.compiler.core.common.type.FloatStamp;
+import org.graalvm.compiler.core.common.type.Stamp;
+import org.graalvm.compiler.graph.NodeClass;
+import org.graalvm.compiler.nodeinfo.NodeInfo;
+import org.graalvm.compiler.nodes.ConstantNode;
+import org.graalvm.compiler.nodes.NodeView;
+import org.graalvm.compiler.nodes.ValueNode;
+
+@NodeInfo(shortName = "MIN")
+public class MinNode extends MinMaxNode<Min> {
+
+    public static final NodeClass<MinNode> TYPE = NodeClass.create(MinNode.class);
+
+    protected MinNode(ValueNode x, ValueNode y) {
+        super(TYPE, getArithmeticOpTable(x).getMin(), x, y);
+    }
+
+    @Override
+    protected BinaryOp<Min> getOp(ArithmeticOpTable table) {
+        return table.getMin();
+    }
+
+    public static ValueNode create(ValueNode x, ValueNode y, NodeView view) {
+        BinaryOp<Min> op = ArithmeticOpTable.forStamp(x.stamp(view)).getMin();
+        Stamp stamp = op.foldStamp(x.stamp(view), y.stamp(view));
+        assert stamp instanceof FloatStamp;
+        ConstantNode tryConstantFold = tryConstantFold(op, x, y, stamp, view);
+        if (tryConstantFold != null) {
+            return tryConstantFold;
+        }
+        return new MinNode(x, y).maybeCommuteInputs();
+    }
+}


### PR DESCRIPTION
Emit `fmin/fmax` instructions when `Math.min()/Math.max()` function is called with single or double precision floating point values on AArch64. The existing mechanism emits `cmp+csel` combination for the integer variants of `Math.min()/Math.max()`.

Relevant snippet of the microbenchmark is shown below (only the double variant for `Math.max()` is shown for brevity).

```
@Benchmark
public void jmhTimeMaxDouble() {
    double res = 0.0d;
    for (int i = 0; i < NUM_INVOKES; ++i) {
        double a = rand_double[i % NUM_RANDS];
        double b = rand_double[(i + 1) % NUM_RANDS];
        res += Math.max(a, b);
    }
    res_double = res;
}
```

Performance results on an A72 AArch64 machine

Before:
```
Benchmark         Mode  Cnt    Score   Error  Units
jmhTimeMaxDouble  avgt   15  288.019 ± 5.645  ns/op
jmhTimeMaxFloat   avgt   15  283.060 ± 4.367  ns/op
jmhTimeMinDouble  avgt   15  282.940 ± 3.823  ns/op
jmhTimeMinFloat   avgt   15  279.740 ± 2.278  ns/op
```

After:
```
Benchmark         Mode  Cnt   Score   Error  Units
jmhTimeMaxDouble  avgt   15  98.860 ± 0.010  ns/op
jmhTimeMaxFloat   avgt   15  98.847 ± 0.008  ns/op
jmhTimeMinDouble  avgt   15  98.867 ± 0.024  ns/op
jmhTimeMinFloat   avgt   15  98.855 ± 0.016  ns/op
```

Change-Id: Ic3b9de4aa096a8af699cfe5d0f0b8c83ca86b208