### PR TITLE
Optimizing VolatileReadNode out causes wrong memory state to propagate

### DIFF
--- a/compiler/src/org.graalvm.compiler.core.test/src/org/graalvm/compiler/core/test/LateMembarInsertionTest.java
+++ b/compiler/src/org.graalvm.compiler.core.test/src/org/graalvm/compiler/core/test/LateMembarInsertionTest.java
@@ -195,45 +195,6 @@ public class LateMembarInsertionTest extends GraalCompilerTest {
         verifyMembars("volatileFieldStore", membarsExpected());
     }
 
-    // Unused field load should be optimized out and leave no barrier behind
-    @SuppressWarnings("unused")
-    public static void volatileFieldStoreUnusedVolatileFieldLoadVolatileFieldStore(int v2) {
-        VolatileAccess2.field = v2;
-        int v1 = VolatileAccess.field;
-        VolatileAccess2.field = v2;
-    }
-
-    @Test
-    public void test09() {
-        StructuredGraph graph = getFinalGraph(getResolvedJavaMethod("volatileFieldStoreUnusedVolatileFieldLoadVolatileFieldStore"));
-        List<TypePair> accesses = getAccesses(graph);
-
-        Assert.assertEquals(accesses.size(), 2);
-        Assert.assertEquals(accesses.get(0).getType(), volatileAccess2Type);
-        Assert.assertEquals(accesses.get(1).getType(), volatileAccess2Type);
-        Assert.assertTrue(accesses.get(0).isWrite());
-        Assert.assertTrue(accesses.get(1).isWrite());
-        Assert.assertEquals(membarsExpected() ? 4 : 0, getMembars(graph).size());
-    }
-
-    // Unused field load should be optimized out and leave no barrier behind
-    @SuppressWarnings("unused")
-    public static void unusedVolatileFieldLoadVolatileFieldStore(int v2) {
-        int v1 = VolatileAccess.field;
-        VolatileAccess2.field = v2;
-    }
-
-    @Test
-    public void test10() {
-        StructuredGraph graph = getFinalGraph(getResolvedJavaMethod("unusedVolatileFieldLoadVolatileFieldStore"));
-        List<TypePair> accesses = getAccesses(graph);
-
-        Assert.assertEquals(accesses.size(), 1);
-        Assert.assertEquals(accesses.get(0).getType(), volatileAccess2Type);
-        Assert.assertTrue(accesses.get(0).isWrite());
-        Assert.assertEquals(membarsExpected() ? 2 : 0, getMembars(graph).size());
-    }
-
     public static int unsafeVolatileFieldLoad(Object o, long offset) {
         return UNSAFE.getIntVolatile(o, offset);
     }

--- a/compiler/src/org.graalvm.compiler.core.test/src/org/graalvm/compiler/core/test/VolatileReadEliminateWrongMemoryStateTest.java
+++ b/compiler/src/org.graalvm.compiler.core.test/src/org/graalvm/compiler/core/test/VolatileReadEliminateWrongMemoryStateTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, Red Hat Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.graalvm.compiler.core.test;
+
+import org.junit.Test;
+
+// See https://bugs.openjdk.java.net/browse/JDK-8247832
+public class VolatileReadEliminateWrongMemoryStateTest extends GraalCompilerTest {
+
+    private static volatile int volatileField;
+    private static int field;
+
+    @SuppressWarnings("unused")
+    public static int testMethod() {
+        field = 0;
+        int v = volatileField;
+        field += 1;
+        v = volatileField;
+        field += 1;
+        return field;
+    }
+
+    @Test
+    public void test1() {
+        test("testMethod");
+    }
+
+    public static void testMethod2(Object obj) {
+        synchronized (obj) {
+            volatileField++;
+        }
+    }
+
+    @Test
+    public void test2() {
+        test("testMethod2", new Object());
+    }
+}

--- a/compiler/src/org.graalvm.compiler.nodes/src/org/graalvm/compiler/nodes/memory/VolatileReadNode.java
+++ b/compiler/src/org.graalvm.compiler.nodes/src/org/graalvm/compiler/nodes/memory/VolatileReadNode.java
@@ -43,20 +43,11 @@ import org.graalvm.compiler.nodes.spi.NodeLIRBuilderTool;
 import org.graalvm.word.LocationIdentity;
 
 @NodeInfo(nameTemplate = "VolatileRead#{p#location/s}", allowedUsageTypes = Memory, cycles = CYCLES_2, size = SIZE_1)
-public class VolatileReadNode extends ReadNode implements SingleMemoryKill, Lowerable, Simplifiable {
+public class VolatileReadNode extends ReadNode implements SingleMemoryKill, Lowerable {
     public static final NodeClass<VolatileReadNode> TYPE = NodeClass.create(VolatileReadNode.class);
 
-    public VolatileReadNode(AddressNode address, LocationIdentity location, Stamp stamp, BarrierType barrierType) {
-        super(TYPE, address, location, stamp, null, barrierType, false, null);
-    }
-
-    @Override
-    public void simplify(SimplifierTool tool) {
-        if (lastLocationAccess != null && hasOnlyUsagesOfType(Memory)) {
-            replaceAtUsages(lastLocationAccess.asNode(), Memory);
-            assert hasNoUsages();
-            graph().removeFixed(this);
-        }
+    public VolatileReadNode(AddressNode address, Stamp stamp, BarrierType barrierType) {
+        super(TYPE, address, LocationIdentity.any(), stamp, null, barrierType, false, null);
     }
 
     @Override

--- a/compiler/src/org.graalvm.compiler.replacements/src/org/graalvm/compiler/replacements/DefaultJavaLoweringProvider.java
+++ b/compiler/src/org.graalvm.compiler.replacements/src/org/graalvm/compiler/replacements/DefaultJavaLoweringProvider.java
@@ -475,7 +475,7 @@ public abstract class DefaultJavaLoweringProvider implements LoweringProvider {
         ReadNode memoryRead = null;
         BarrierType barrierType = barrierSet.fieldLoadBarrierType(field, getStorageKind(field));
         if (loadField.isVolatile()) {
-            memoryRead = graph.add(new VolatileReadNode(address, fieldLocationIdentity(field), loadStamp, barrierType));
+            memoryRead = graph.add(new VolatileReadNode(address, loadStamp, barrierType));
         } else {
             memoryRead = graph.add(new ReadNode(address, fieldLocationIdentity(field), loadStamp, barrierType));
         }
@@ -767,7 +767,7 @@ public abstract class DefaultJavaLoweringProvider implements LoweringProvider {
         AddressNode address = createUnsafeAddress(graph, load.object(), load.offset());
         ReadNode memoryRead = null;
         if (load.isVolatile()) {
-            memoryRead = new VolatileReadNode(address, load.getLocationIdentity(), loadStamp, barrierSet.readBarrierType(load));
+            memoryRead = new VolatileReadNode(address, loadStamp, barrierSet.readBarrierType(load));
         } else {
             memoryRead = new ReadNode(address, load.getLocationIdentity(), loadStamp, barrierSet.readBarrierType(load));
         }


### PR DESCRIPTION
This is bug https://bugs.openjdk.java.net/browse/JDK-8247832

VolatileReadNode.simplify() removes VolatileReadNodes that have no use other than Memory uses. The current logic updates the uses' Memory input with the VolatileReadNode's lastLocationAccess. That's broken as the LocationIdentity of the VolatileReadNode and the one of its uses likely differ. To make that optimization possible, I suggest the VolatileReadNode keeps track of the entire memory state in its lastLocationAccess input with a MemoryMapNode.