### PR TITLE
Travis: Update Ubuntu distribution

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ addons:
 
 # Use Trusty to get enough RAM
 sudo: required
-dist: trusty
+dist: xenial
 
 jdk:
     - openjdk11


### PR DESCRIPTION
Trusty's EOL was April 2019

Related to #2608 