### PR TITLE
Generate correct debug info for deoptimization target methods

### DIFF
--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/ClassEntry.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/ClassEntry.java
@@ -75,6 +75,10 @@ public class ClassEntry {
      */
     private int cuIndex;
     /**
+     * index of debug_info section compilation unit for deopt target methods.
+     */
+    private int deoptCUIndex;
+    /**
      * index into debug_line section for associated compilation unit.
      */
     private int lineIndex;
@@ -86,6 +90,11 @@ public class ClassEntry {
      * total size of line number info region for associated compilation unit.
      */
     private int totalSize;
+
+    /**
+     * true iff the entry includes methods that are deopt targets.
+     */
+    private boolean includesDeoptTarget;
 
     public ClassEntry(String className, FileEntry fileEntry) {
         this.className = className;
@@ -106,9 +115,11 @@ public class ClassEntry {
             }
         }
         this.cuIndex = -1;
+        this.deoptCUIndex = -1;
         this.lineIndex = -1;
         this.linePrologueSize = -1;
         this.totalSize = -1;
+        this.includesDeoptTarget = false;
     }
 
     public void addPrimary(Range primary, List<DebugFrameSizeChange> frameSizeInfos, int frameSize) {
@@ -116,6 +127,12 @@ public class ClassEntry {
             PrimaryEntry primaryEntry = new PrimaryEntry(primary, frameSizeInfos, frameSize, this);
             primaryEntries.add(primaryEntry);
             primaryIndex.put(primary, primaryEntry);
+            if (primary.isDeoptTarget()) {
+                includesDeoptTarget = true;
+            } else {
+                /* deopt targets should all come after normal methods */
+                assert includesDeoptTarget == false;
+            }
         }
     }
 
@@ -196,6 +213,19 @@ public class ClassEntry {
         return cuIndex;
     }
 
+    public void setDeoptCUIndex(int cuIndex) {
+        // Should only get set once to a non-negative value.
+        assert deoptCUIndex >= 0;
+        assert this.deoptCUIndex == -1;
+        this.deoptCUIndex = deoptCUIndex;
+    }
+
+    public int getDeoptCUIndex() {
+        // Should have been set before being read.
+        assert deoptCUIndex >= 0;
+        return deoptCUIndex;
+    }
+
     public int getLineIndex() {
         return lineIndex;
     }
@@ -242,5 +272,9 @@ public class ClassEntry {
 
     public LinkedList<FileEntry> getLocalFiles() {
         return localFiles;
+    }
+
+    public boolean includesDeoptTarget() {
+        return includesDeoptTarget;
     }
 }

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/ClassEntry.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/ClassEntry.java
@@ -213,7 +213,7 @@ public class ClassEntry {
         return cuIndex;
     }
 
-    public void setDeoptCUIndex(int cuIndex) {
+    public void setDeoptCUIndex(int deoptCUIndex) {
         // Should only get set once to a non-negative value.
         assert deoptCUIndex >= 0;
         assert this.deoptCUIndex == -1;

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/DebugInfoBase.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/DebugInfoBase.java
@@ -137,8 +137,9 @@ public abstract class DebugInfoBase {
             int lo = debugCodeInfo.addressLo();
             int hi = debugCodeInfo.addressHi();
             int primaryLine = debugCodeInfo.line();
+            boolean isDeoptTarget = debugCodeInfo.isDeoptTarget();
 
-            Range primaryRange = new Range(fileName, filePath, className, methodName, paramNames, returnTypeName, stringTable, lo, hi, primaryLine);
+            Range primaryRange = new Range(fileName, filePath, className, methodName, paramNames, returnTypeName, stringTable, lo, hi, primaryLine, isDeoptTarget);
             debugContext.log(DebugContext.INFO_LEVEL, "PrimaryRange %s.%s %s %s:%d [0x%x, 0x%x]", className, methodName, filePath, fileName, primaryLine, lo, hi);
             addRange(primaryRange, debugCodeInfo.getFrameSizeChanges(), debugCodeInfo.getFrameSize());
             debugCodeInfo.lineInfoProvider().forEach(debugLineInfo -> {

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/Range.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/Range.java
@@ -55,7 +55,8 @@ public class Range {
     /*
      * Create a primary range.
      */
-    public Range(String fileName, Path filePath, String className, String methodName, String paramNames, String returnTypeName, StringTable stringTable, int lo, int hi, int line, boolean isDeoptTarget) {
+    public Range(String fileName, Path filePath, String className, String methodName, String paramNames, String returnTypeName, StringTable stringTable, int lo, int hi, int line,
+                    boolean isDeoptTarget) {
         this(fileName, filePath, className, methodName, paramNames, returnTypeName, stringTable, lo, hi, line, isDeoptTarget, null);
     }
 
@@ -65,10 +66,12 @@ public class Range {
     public Range(String fileName, Path filePath, String className, String methodName, String paramNames, String returnTypeName, StringTable stringTable, int lo, int hi, int line, Range primary) {
         this(fileName, filePath, className, methodName, paramNames, returnTypeName, stringTable, lo, hi, line, false, primary);
     }
+
     /*
      * Create a primary or secondary range.
      */
-    private Range(String fileName, Path filePath, String className, String methodName, String paramNames, String returnTypeName, StringTable stringTable, int lo, int hi, int line, boolean isDeoptTarget, Range primary) {
+    private Range(String fileName, Path filePath, String className, String methodName, String paramNames, String returnTypeName, StringTable stringTable, int lo, int hi, int line,
+                    boolean isDeoptTarget, Range primary) {
         /*
          * Currently file name and full method name need to go into the debug_str section other
          * strings just need to be deduplicated to save space.

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/Range.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/Range.java
@@ -46,6 +46,7 @@ public class Range {
     private int lo;
     private int hi;
     private int line;
+    private boolean isDeoptTarget;
     /*
      * This is null for a primary range.
      */
@@ -54,14 +55,20 @@ public class Range {
     /*
      * Create a primary range.
      */
-    public Range(String fileName, Path filePath, String className, String methodName, String paramNames, String returnTypeName, StringTable stringTable, int lo, int hi, int line) {
-        this(fileName, filePath, className, methodName, paramNames, returnTypeName, stringTable, lo, hi, line, null);
+    public Range(String fileName, Path filePath, String className, String methodName, String paramNames, String returnTypeName, StringTable stringTable, int lo, int hi, int line, boolean isDeoptTarget) {
+        this(fileName, filePath, className, methodName, paramNames, returnTypeName, stringTable, lo, hi, line, isDeoptTarget, null);
     }
 
     /*
-     * Create a primary or secondary range.
+     * Create a secondary range.
      */
     public Range(String fileName, Path filePath, String className, String methodName, String paramNames, String returnTypeName, StringTable stringTable, int lo, int hi, int line, Range primary) {
+        this(fileName, filePath, className, methodName, paramNames, returnTypeName, stringTable, lo, hi, line, false, primary);
+    }
+    /*
+     * Create a primary or secondary range.
+     */
+    private Range(String fileName, Path filePath, String className, String methodName, String paramNames, String returnTypeName, StringTable stringTable, int lo, int hi, int line, boolean isDeoptTarget, Range primary) {
         /*
          * Currently file name and full method name need to go into the debug_str section other
          * strings just need to be deduplicated to save space.
@@ -76,6 +83,7 @@ public class Range {
         this.lo = lo;
         this.hi = hi;
         this.line = line;
+        this.isDeoptTarget = isDeoptTarget;
         this.primary = primary;
     }
 
@@ -134,7 +142,7 @@ public class Range {
     }
 
     public boolean isDeoptTarget() {
-        return methodName.endsWith("**");
+        return isDeoptTarget;
     }
 
     private String getExtendedMethodName(boolean includeParams, boolean includeReturnType) {

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/Range.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/Range.java
@@ -133,6 +133,10 @@ public class Range {
         return fullMethodName;
     }
 
+    public boolean isDeoptTarget() {
+        return methodName.endsWith("**");
+    }
+
     private String getExtendedMethodName(boolean includeParams, boolean includeReturnType) {
         StringBuilder builder = new StringBuilder();
         if (includeReturnType && returnTypeName.length() > 0) {

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debuginfo/DebugInfoProvider.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debuginfo/DebugInfoProvider.java
@@ -114,6 +114,11 @@ public interface DebugInfoProvider {
          *         to an empty frame
          */
         List<DebugFrameSizeChange> getFrameSizeChanges();
+
+        /**
+         * @return true if this method has been compiled in as a deoptimization target
+         */
+        boolean isDeoptTarget();
     }
 
     /**

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfInfoSectionImpl.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfInfoSectionImpl.java
@@ -115,14 +115,27 @@ public class DwarfInfoSectionImpl extends DwarfSectionImpl {
         byte[] buffer = null;
         int pos = 0;
 
+        /* CUs for normal methods */
         for (ClassEntry classEntry : getPrimaryClasses()) {
             int lengthPos = pos;
             pos = writeCUHeader(buffer, pos);
             assert pos == lengthPos + DW_DIE_HEADER_SIZE;
-            pos = writeCU(null, classEntry, buffer, pos);
+            pos = writeCU(null, classEntry, false, buffer, pos);
             /*
              * No need to backpatch length at lengthPos.
              */
+        }
+        /* CUs for deopt targets */
+        for (ClassEntry classEntry : getPrimaryClasses()) {
+            if (classEntry.includesDeoptTarget()) {
+                int lengthPos = pos;
+                pos = writeCUHeader(buffer, pos);
+                assert pos == lengthPos + DW_DIE_HEADER_SIZE;
+                pos = writeCU(null, classEntry, true, buffer, pos);
+                /*
+                 * No need to backpatch length at lengthPos.
+                 */
+            }
         }
         buffer = new byte[pos];
         super.setContent(buffer);
@@ -138,6 +151,7 @@ public class DwarfInfoSectionImpl extends DwarfSectionImpl {
 
         log(context, "  [0x%08x] DEBUG_INFO", pos);
         log(context, "  [0x%08x] size = 0x%08x", pos, size);
+        /* write CUs for normal methods */
         for (ClassEntry classEntry : getPrimaryClasses()) {
             /*
              * Save the offset of this file's CU so it can be used when writing the aranges section.
@@ -147,11 +161,30 @@ public class DwarfInfoSectionImpl extends DwarfSectionImpl {
             pos = writeCUHeader(buffer, pos);
             log(context, "  [0x%08x] Compilation Unit", pos, size);
             assert pos == lengthPos + DW_DIE_HEADER_SIZE;
-            pos = writeCU(context, classEntry, buffer, pos);
+            pos = writeCU(context, classEntry, false, buffer, pos);
             /*
              * Backpatch length at lengthPos (excluding length field).
              */
             patchLength(lengthPos, buffer, pos);
+        }
+        /* write CUs for deopt targets */
+        for (ClassEntry classEntry : getPrimaryClasses()) {
+            if (classEntry.includesDeoptTarget()) {
+                /*
+                 * Save the offset of this file's CU so it can be used when writing the aranges
+                 * section.
+                 */
+                classEntry.setDeoptCUIndex(pos);
+                int lengthPos = pos;
+                pos = writeCUHeader(buffer, pos);
+                log(context, "  [0x%08x] Compilation Unit (deopt targets)", pos, size);
+                assert pos == lengthPos + DW_DIE_HEADER_SIZE;
+                pos = writeCU(context, classEntry, true, buffer, pos);
+                /*
+                 * Backpatch length at lengthPos (excluding length field).
+                 */
+                patchLength(lengthPos, buffer, pos);
+            }
         }
         assert pos == size;
     }
@@ -179,7 +212,46 @@ public class DwarfInfoSectionImpl extends DwarfSectionImpl {
         }
     }
 
-    private int writeCU(DebugContext context, ClassEntry classEntry, byte[] buffer, int p) {
+    private int findLo(LinkedList<PrimaryEntry> classPrimaryEntries, boolean isDeoptTargetCU) {
+        if (!isDeoptTargetCU) {
+            /* First entry is the one we want. */
+            return classPrimaryEntries.getFirst().getPrimary().getLo();
+        } else {
+            /* Need the first entry which is a deopt target. */
+            for (PrimaryEntry primaryEntry : classPrimaryEntries) {
+                Range range = primaryEntry.getPrimary();
+                if (range.isDeoptTarget()) {
+                    return range.getLo();
+                }
+            }
+        }
+        // we should never get here
+        assert false;
+        return 0;
+    }
+
+    private int findHi(LinkedList<PrimaryEntry> classPrimaryEntries, boolean includesDeoptTarget, boolean isDeoptTargetCU) {
+        if (isDeoptTargetCU || !includesDeoptTarget) {
+            /* Either way the last entry is the one we want. */
+            return classPrimaryEntries.getLast().getPrimary().getHi();
+        } else {
+            /* Need the last entry which is not a deopt target. */
+            int hi = 0;
+            for (PrimaryEntry primaryEntry : classPrimaryEntries) {
+                Range range = primaryEntry.getPrimary();
+                if (!range.isDeoptTarget()) {
+                    hi = range.getHi();
+                } else {
+                    return hi;
+                }
+            }
+        }
+        // should never get here
+        assert false;
+        return 0;
+    }
+
+    private int writeCU(DebugContext context, ClassEntry classEntry, boolean isDeoptTargetCU, byte[] buffer, int p) {
         int pos = p;
         LinkedList<PrimaryEntry> classPrimaryEntries = classEntry.getPrimaryEntries();
         log(context, "  [0x%08x] <0> Abbrev Number %d", pos, DW_ABBREV_CODE_compile_unit);
@@ -188,14 +260,19 @@ public class DwarfInfoSectionImpl extends DwarfSectionImpl {
         pos = writeAttrData1(DW_LANG_Java, buffer, pos);
         log(context, "  [0x%08x]     name  0x%x (%s)", pos, debugStringIndex(classEntry.getFileName()), classEntry.getFileName());
         pos = writeAttrStrp(classEntry.getFileName(), buffer, pos);
-        log(context, "  [0x%08x]     lo_pc  0x%08x", pos, classPrimaryEntries.getFirst().getPrimary().getLo());
-        pos = writeAttrAddress(classPrimaryEntries.getFirst().getPrimary().getLo(), buffer, pos);
-        log(context, "  [0x%08x]     hi_pc  0x%08x", pos, classPrimaryEntries.getLast().getPrimary().getHi());
-        pos = writeAttrAddress(classPrimaryEntries.getLast().getPrimary().getHi(), buffer, pos);
+        int lo = findLo(classPrimaryEntries, isDeoptTargetCU);
+        int hi = findHi(classPrimaryEntries, classEntry.includesDeoptTarget(), isDeoptTargetCU);
+        log(context, "  [0x%08x]     lo_pc  0x%08x", pos, lo);
+        pos = writeAttrAddress(lo, buffer, pos);
+        log(context, "  [0x%08x]     hi_pc  0x%08x", pos, hi);
+        pos = writeAttrAddress(hi, buffer, pos);
         log(context, "  [0x%08x]     stmt_list  0x%08x", pos, classEntry.getLineIndex());
         pos = writeAttrData4(classEntry.getLineIndex(), buffer, pos);
         for (PrimaryEntry primaryEntry : classPrimaryEntries) {
-            pos = writePrimary(context, primaryEntry, buffer, pos);
+            Range range = primaryEntry.getPrimary();
+            if (isDeoptTargetCU == range.isDeoptTarget()) {
+                pos = writePrimary(context, range, buffer, pos);
+            }
         }
         /*
          * Write a terminating null attribute for the the level 2 primaries.
@@ -204,17 +281,16 @@ public class DwarfInfoSectionImpl extends DwarfSectionImpl {
 
     }
 
-    private int writePrimary(DebugContext context, PrimaryEntry primaryEntry, byte[] buffer, int p) {
+    private int writePrimary(DebugContext context, Range range, byte[] buffer, int p) {
         int pos = p;
-        Range primary = primaryEntry.getPrimary();
         verboseLog(context, "  [0x%08x] <1> Abbrev Number  %d", pos, DW_ABBREV_CODE_subprogram);
         pos = writeAbbrevCode(DW_ABBREV_CODE_subprogram, buffer, pos);
-        verboseLog(context, "  [0x%08x]     name  0x%X (%s)", pos, debugStringIndex(primary.getFullMethodName()), primary.getFullMethodName());
-        pos = writeAttrStrp(primary.getFullMethodName(), buffer, pos);
-        verboseLog(context, "  [0x%08x]     lo_pc  0x%08x", pos, primary.getLo());
-        pos = writeAttrAddress(primary.getLo(), buffer, pos);
-        verboseLog(context, "  [0x%08x]     hi_pc  0x%08x", pos, primary.getHi());
-        pos = writeAttrAddress(primary.getHi(), buffer, pos);
+        verboseLog(context, "  [0x%08x]     name  0x%X (%s)", pos, debugStringIndex(range.getFullMethodName()), range.getFullMethodName());
+        pos = writeAttrStrp(range.getFullMethodName(), buffer, pos);
+        verboseLog(context, "  [0x%08x]     lo_pc  0x%08x", pos, range.getLo());
+        pos = writeAttrAddress(range.getLo(), buffer, pos);
+        verboseLog(context, "  [0x%08x]     hi_pc  0x%08x", pos, range.getHi());
+        pos = writeAttrAddress(range.getHi(), buffer, pos);
         /*
          * Need to pass true only if method is public.
          */

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfInfoSectionImpl.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfInfoSectionImpl.java
@@ -212,7 +212,7 @@ public class DwarfInfoSectionImpl extends DwarfSectionImpl {
         }
     }
 
-    private int findLo(LinkedList<PrimaryEntry> classPrimaryEntries, boolean isDeoptTargetCU) {
+    private static int findLo(LinkedList<PrimaryEntry> classPrimaryEntries, boolean isDeoptTargetCU) {
         if (!isDeoptTargetCU) {
             /* First entry is the one we want. */
             return classPrimaryEntries.getFirst().getPrimary().getLo();
@@ -230,7 +230,7 @@ public class DwarfInfoSectionImpl extends DwarfSectionImpl {
         return 0;
     }
 
-    private int findHi(LinkedList<PrimaryEntry> classPrimaryEntries, boolean includesDeoptTarget, boolean isDeoptTargetCU) {
+    private static int findHi(LinkedList<PrimaryEntry> classPrimaryEntries, boolean includesDeoptTarget, boolean isDeoptTargetCU) {
         if (isDeoptTargetCU || !includesDeoptTarget) {
             /* Either way the last entry is the one we want. */
             return classPrimaryEntries.getLast().getPrimary().getHi();

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/image/NativeImageDebugInfoProvider.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/image/NativeImageDebugInfoProvider.java
@@ -203,6 +203,11 @@ class NativeImageDebugInfoProvider implements DebugInfoProvider {
             }
             return frameSizeChanges;
         }
+
+        @Override
+        public boolean isDeoptTarget() {
+            return methodName().endsWith(HostedMethod.METHOD_NAME_DEOPT_SUFFIX);
+        }
     }
 
     /**

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/meta/HostedMethod.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/meta/HostedMethod.java
@@ -65,6 +65,8 @@ import jdk.vm.ci.meta.SpeculationLog;
 
 public class HostedMethod implements SharedMethod, WrappedJavaMethod, GraphProvider, JavaMethodContext, Comparable<HostedMethod>, OriginalMethodProvider {
 
+    public static final String METHOD_NAME_DEOPT_SUFFIX = "**";
+
     public final AnalysisMethod wrapped;
 
     private final HostedType holder;
@@ -244,7 +246,7 @@ public class HostedMethod implements SharedMethod, WrappedJavaMethod, GraphProvi
     @Override
     public String getName() {
         if (compilationInfo.isDeoptTarget()) {
-            return wrapped.getName() + "**";
+            return wrapped.getName() + METHOD_NAME_DEOPT_SUFFIX;
         }
         return wrapped.getName();
     }


### PR DESCRIPTION
This is a proposed fix for issue #2587. It handles the case where deopt target methods are included in a native image. Compiled code for these methods is generated after the compiled code for normal compiled methods . In consequence, a class which contains deopt targets has code occupying two distinct code cache address ranges and code form different classes may be interleaved.

This is a problem because DWARF debug data (info, ranges, frame) must be generated as a sequence of entries associated with non-overlapping address ranges ordered low to high. So, a class containing deopt target methods must be processed twice, generating DWARF entries first for the normal methods and then for the deopt targets.
