### PR TITLE
Prints JDK build number along with  java.version

### DIFF
--- a/substratevm/src/com.oracle.svm.driver/src/com/oracle/svm/driver/DefaultOptionHandler.java
+++ b/substratevm/src/com.oracle.svm.driver/src/com/oracle/svm/driver/DefaultOptionHandler.java
@@ -82,7 +82,7 @@ class DefaultOptionHandler extends NativeImage.OptionHandler<NativeImage> {
                 if (!NativeImage.graalvmConfig.isEmpty()) {
                     message += " " + NativeImage.graalvmConfig;
                 }
-                message += " (Java Version " + System.getProperty("java.version") + ")";
+                message += " (Java Version " + System.getProperty("java.runtime.version") + ")";
                 nativeImage.showMessage(message);
                 System.exit(0);
                 return true;


### PR DESCRIPTION
Since graal is sensitive to JDK changes printing the build number along
with the java version, makes issue reporting and debugging a bit easier.