### PR TITLE
Enable to rebuild multiple images at once on Windows

### DIFF
--- a/substratevm/mx.substratevm/rebuild-images.cmd
+++ b/substratevm/mx.substratevm/rebuild-images.cmd
@@ -120,7 +120,7 @@ for %%f in (%to_build%) do (
   )
   echo Building %%f...
   if defined verbose echo !cmd_line!
-  !cmd_line!
+  call !cmd_line!
 )
 
 goto :eof


### PR DESCRIPTION
I saw the following error message when I ran `rebuild-images` to rebuild multiple images at once on Windows.

```
>gu rebuild-images polyglot libpolyglot
Building polyglot...
...
C:\temp\graalvm-ce-java11-20.2.0-dev>(
set "cmd_line="C:\temp\graalvm-ce-java11-20.2.0-dev\lib\svm\bin\..\..\..\bin\native-image""
 if "libpolyglot" == "polyglot" (call :launcher polyglot cmd_line )  else if "libpolyglot" == "libpolyglot" (call :libpolyglot cmd_line )  else if "libpolyglot" == "js" (call :launcher js cmd_line )  else if "libpolyglot" == "llvm" (call :launcher lli cmd_line )  else if "libpolyglot" == "python" (call :launcher graalpython cmd_line )  else if "libpolyglot" == "ruby" (call :launcher truffleruby cmd_line )  else (
echo Should not reach here
 exit /b 1
)
 echo Building libpolyglot...
 if defined verbose echo !cmd_line!
 !cmd_line!
)
Invalid attempt to call batch label outside of batch script.
Building libpolyglot...
'!cmd_line!' is not recognized as an internal or external command,
operable program or batch file.
```

The same error happened when I changed the order of components. I think it should rebuild multiple images at once. On Linux and MacOS this command works. 

Here is the environment.
* OS: Windows 10
* GraalVM version: GraalVM CE 20.2.0-dev-20200620_0159 (both Java 11 and Java 8)

Of course I can rebuild the only one image.

```
> gu rebuild-images polyglot
Building polyglot...
[polyglot:92868]    classlist:   4,134.73 ms,  0.96 GB
[polyglot:92868]        (cap):   3,008.52 ms,  0.96 GB
[polyglot:92868]        setup:   5,637.66 ms,  0.96 GB
[engine::PolyglotContextImpl] WARNING: Language wasm cannot be pre-initialized as it does not override TruffleLanguage.patchContext method.
[polyglot:92868]     (clinit):   1,324.11 ms,  4.39 GB
[polyglot:92868]   (typeflow):  38,166.55 ms,  4.39 GB
[polyglot:92868]    (objects):  18,851.42 ms,  4.39 GB
[polyglot:92868]   (features):   7,221.23 ms,  4.39 GB
[polyglot:92868]     analysis:  68,074.87 ms,  4.39 GB
[polyglot:92868]     universe:   2,461.33 ms,  4.64 GB
10109 method(s) included for runtime compilation
[polyglot:92868]      (parse):  16,664.52 ms,  5.32 GB
[polyglot:92868]     (inline):   8,721.93 ms,  5.75 GB
[polyglot:92868]    (compile):  46,663.13 ms,  5.37 GB
[polyglot:92868]      compile:  76,136.54 ms,  5.37 GB
[polyglot:92868]        image:  10,776.70 ms,  5.48 GB
[polyglot:92868]        write:     903.20 ms,  5.48 GB
[polyglot:92868]      [total]: 170,713.81 ms,  5.48 GB
```

I can resolve them with the code of this pull request. I believe it fixes the bug, so I'd like to contribute it. This fix works on both the Java 8 version and Java 11 version of GraalVM.

Here is the result of the execution after the patch was applied.
```
> gu rebuild-images polyglot libpolyglot                                                                                                                                                    Building polyglot...
[polyglot:83560]    classlist:   4,137.48 ms,  0.96 GB
[polyglot:83560]        (cap):   2,941.75 ms,  0.96 GB
[polyglot:83560]        setup:   5,517.13 ms,  0.96 GB
[engine::PolyglotContextImpl] WARNING: Language wasm cannot be pre-initialized as it does not override TruffleLanguage.patchContext method.
[polyglot:83560]     (clinit):   1,395.23 ms,  4.37 GB
[polyglot:83560]   (typeflow):  36,992.06 ms,  4.37 GB
[polyglot:83560]    (objects):  18,807.74 ms,  4.37 GB
[polyglot:83560]   (features):   7,282.82 ms,  4.37 GB
[polyglot:83560]     analysis:  67,052.30 ms,  4.37 GB
[polyglot:83560]     universe:   2,543.24 ms,  4.60 GB
10109 method(s) included for runtime compilation
[polyglot:83560]      (parse):   8,740.16 ms,  4.60 GB
[polyglot:83560]     (inline):  15,465.23 ms,  5.83 GB
[polyglot:83560]    (compile):  46,189.83 ms,  5.47 GB
[polyglot:83560]      compile:  74,454.22 ms,  5.47 GB
[polyglot:83560]        image:  10,709.21 ms,  4.84 GB
[polyglot:83560]        write:     816.86 ms,  4.84 GB
[polyglot:83560]      [total]: 167,533.24 ms,  4.84 GB
Building libpolyglot...
-H:IncludeAllTimeZones and -H:IncludeTimeZones are now deprecated. Native-image includes all timezones by default.
[polyglot:92888]    classlist:  14,120.96 ms,  0.96 GB
[polyglot:92888]        (cap):   3,417.39 ms,  0.96 GB
[polyglot:92888]        setup:   6,164.95 ms,  0.96 GB
[engine::PolyglotContextImpl] WARNING: Language wasm cannot be pre-initialized as it does not override TruffleLanguage.patchContext method.
[polyglot:92888]     (clinit):   1,322.45 ms,  5.41 GB
[polyglot:92888]   (typeflow):  38,825.37 ms,  5.41 GB
[polyglot:92888]    (objects):  17,954.25 ms,  5.41 GB
[polyglot:92888]   (features):   7,426.34 ms,  5.41 GB
[polyglot:92888]     analysis:  67,967.90 ms,  5.41 GB
[polyglot:92888]     universe:   2,442.74 ms,  5.41 GB
10633 method(s) included for runtime compilation
[polyglot:92888]      (parse):   8,701.64 ms,  5.43 GB
[polyglot:92888]     (inline):  15,527.50 ms,  6.19 GB
[polyglot:92888]    (compile):  47,281.64 ms,  6.04 GB
[polyglot:92888]      compile:  75,711.63 ms,  6.04 GB
[polyglot:92888]        image:  11,305.17 ms,  6.21 GB
[polyglot:92888]        write:     919.49 ms,  6.21 GB
[polyglot:92888]      [total]: 180,938.60 ms,  6.21 GB
```

For your information, our company (NTT Data Corporation) has signed OCA already.