### PR TITLE
Debugframesize

### DIFF
--- a/compiler/src/org.graalvm.compiler.hotspot.aarch64/src/org/graalvm/compiler/hotspot/aarch64/AArch64HotSpotBackend.java
+++ b/compiler/src/org.graalvm.compiler.hotspot.aarch64/src/org/graalvm/compiler/hotspot/aarch64/AArch64HotSpotBackend.java
@@ -253,6 +253,11 @@ public class AArch64HotSpotBackend extends HotSpotHostBackend implements LIRGene
         }
 
         @Override
+        public void returned(CompilationResultBuilder crb) {
+            // nothing to do
+        }
+
+        @Override
         public boolean hasFrame() {
             return true;
         }

--- a/compiler/src/org.graalvm.compiler.hotspot.aarch64/src/org/graalvm/compiler/hotspot/aarch64/AArch64HotSpotReturnOp.java
+++ b/compiler/src/org.graalvm.compiler.hotspot.aarch64/src/org/graalvm/compiler/hotspot/aarch64/AArch64HotSpotReturnOp.java
@@ -70,5 +70,6 @@ public final class AArch64HotSpotReturnOp extends AArch64HotSpotEpilogueOp {
         final boolean emitSafepoint = !isStub;
         leaveFrame(crb, masm, emitSafepoint, requiresReservedStackAccessCheck);
         masm.ret(lr);
+        crb.frameContext.returned(crb);
     }
 }

--- a/compiler/src/org.graalvm.compiler.hotspot.amd64/src/org/graalvm/compiler/hotspot/amd64/AMD64HotSpotBackend.java
+++ b/compiler/src/org.graalvm.compiler.hotspot.amd64/src/org/graalvm/compiler/hotspot/amd64/AMD64HotSpotBackend.java
@@ -198,6 +198,11 @@ public class AMD64HotSpotBackend extends HotSpotHostBackend implements LIRGenera
                 }
             }
         }
+
+        @Override
+        public void returned(CompilationResultBuilder crb) {
+            // nothing to do
+        }
     }
 
     @Override

--- a/compiler/src/org.graalvm.compiler.hotspot.amd64/src/org/graalvm/compiler/hotspot/amd64/AMD64HotSpotReturnOp.java
+++ b/compiler/src/org.graalvm.compiler.hotspot.amd64/src/org/graalvm/compiler/hotspot/amd64/AMD64HotSpotReturnOp.java
@@ -118,6 +118,7 @@ final class AMD64HotSpotReturnOp extends AMD64HotSpotEpilogueBlockEndOp implemen
             }
         }
         masm.ret(0);
+        crb.frameContext.returned(crb);
     }
 
 }

--- a/compiler/src/org.graalvm.compiler.hotspot.sparc/src/org/graalvm/compiler/hotspot/sparc/SPARCHotSpotBackend.java
+++ b/compiler/src/org.graalvm.compiler.hotspot.sparc/src/org/graalvm/compiler/hotspot/sparc/SPARCHotSpotBackend.java
@@ -216,6 +216,11 @@ public class SPARCHotSpotBackend extends HotSpotHostBackend implements LIRGenera
             SPARCMacroAssembler masm = (SPARCMacroAssembler) crb.asm;
             masm.restoreWindow();
         }
+
+        @Override
+        public void returned(CompilationResultBuilder crb) {
+            // nothing to do
+        }
     }
 
     @Override

--- a/compiler/src/org.graalvm.compiler.lir.aarch64/src/org/graalvm/compiler/lir/aarch64/AArch64ControlFlow.java
+++ b/compiler/src/org.graalvm.compiler.lir.aarch64/src/org/graalvm/compiler/lir/aarch64/AArch64ControlFlow.java
@@ -76,6 +76,7 @@ public class AArch64ControlFlow {
         protected void emitCode(CompilationResultBuilder crb, AArch64MacroAssembler masm) {
             crb.frameContext.leave(crb);
             masm.ret(lr);
+            crb.frameContext.returned(crb);
         }
     }
 

--- a/compiler/src/org.graalvm.compiler.lir.amd64/src/org/graalvm/compiler/lir/amd64/AMD64ControlFlow.java
+++ b/compiler/src/org.graalvm.compiler.lir.amd64/src/org/graalvm/compiler/lir/amd64/AMD64ControlFlow.java
@@ -95,6 +95,7 @@ public class AMD64ControlFlow {
                 masm.vzeroupper();
             }
             masm.ret(0);
+            crb.frameContext.returned(crb);
         }
     }
 

--- a/compiler/src/org.graalvm.compiler.lir/src/org/graalvm/compiler/lir/asm/FrameContext.java
+++ b/compiler/src/org.graalvm.compiler.lir/src/org/graalvm/compiler/lir/asm/FrameContext.java
@@ -35,6 +35,7 @@ public interface FrameContext {
      * <li>setting up the stack frame</li>
      * <li>saving callee-saved registers</li>
      * <li>stack overflow checking</li>
+     * <li>adding marks to identify the frame push</li>
      * </ul>
      */
     void enter(CompilationResultBuilder crb);
@@ -45,9 +46,20 @@ public interface FrameContext {
      * <li>restoring callee-saved registers</li>
      * <li>performing a safepoint</li>
      * <li>destroying the stack frame</li>
+     * <li>adding marks to identify the frame pop</li>
      * </ul>
      */
     void leave(CompilationResultBuilder crb);
+
+    /**
+     * Allows the frame context to track the point at which a return has been generated.
+     * This callback si not intended to actually generate the retrun instruction itself.
+     * A legitimate action in response to this call may include:
+     * <ul>
+     * <li>adding a mark to identify the end of an epilogue</li>
+     * </ul>
+     */
+    void returned(CompilationResultBuilder crb);
 
     /**
      * Determines if a frame is set up and torn down by this object.

--- a/compiler/src/org.graalvm.compiler.lir/src/org/graalvm/compiler/lir/asm/FrameContext.java
+++ b/compiler/src/org.graalvm.compiler.lir/src/org/graalvm/compiler/lir/asm/FrameContext.java
@@ -52,9 +52,9 @@ public interface FrameContext {
     void leave(CompilationResultBuilder crb);
 
     /**
-     * Allows the frame context to track the point at which a return has been generated.
-     * This callback si not intended to actually generate the retrun instruction itself.
-     * A legitimate action in response to this call may include:
+     * Allows the frame context to track the point at which a return has been generated. This
+     * callback is not intended to actually generate the return instruction itself. A legitimate
+     * action in response to this call may include:
      * <ul>
      * <li>adding a mark to identify the end of an epilogue</li>
      * </ul>

--- a/substratevm/src/com.oracle.svm.core.graal.aarch64/src/com/oracle/svm/core/graal/aarch64/SubstrateAArch64Backend.java
+++ b/substratevm/src/com.oracle.svm.core.graal.aarch64/src/com/oracle/svm/core/graal/aarch64/SubstrateAArch64Backend.java
@@ -572,6 +572,10 @@ public class SubstrateAArch64Backend extends SubstrateBackend implements LIRGene
             if (frameSize != 0) {
                 crb.recordMark(SubstrateMarkId.EPILOGUE_INCD_RSP);
             }
+        }
+
+        @Override
+        public void returned(CompilationResultBuilder crb) {
             crb.recordMark(SubstrateMarkId.EPILOGUE_END);
         }
 

--- a/substratevm/src/com.oracle.svm.core.graal.amd64/src/com/oracle/svm/core/graal/amd64/SubstrateAMD64Backend.java
+++ b/substratevm/src/com.oracle.svm.core.graal.amd64/src/com/oracle/svm/core/graal/amd64/SubstrateAMD64Backend.java
@@ -736,7 +736,11 @@ public class SubstrateAMD64Backend extends SubstrateBackend implements LIRGenera
             }
 
             tasm.recordMark(SubstrateMarkId.EPILOGUE_INCD_RSP);
-            tasm.recordMark(SubstrateMarkId.EPILOGUE_END);
+        }
+
+        @Override
+        public void returned(CompilationResultBuilder crb) {
+            crb.recordMark(SubstrateMarkId.EPILOGUE_END);
         }
 
         @Override

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/image/NativeImageDebugInfoProvider.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/image/NativeImageDebugInfoProvider.java
@@ -198,7 +198,10 @@ class NativeImageDebugInfoProvider implements DebugInfoProvider {
                 } else if (mark.id.equals(SubstrateBackend.SubstrateMarkId.EPILOGUE_INCD_RSP)) {
                     NativeImageDebugFrameSizeChange sizeChange = new NativeImageDebugFrameSizeChange(mark.pcOffset, CONTRACT);
                     frameSizeChanges.add(sizeChange);
-                    // } else if(mark.id.equals("EPILOGUE_END")) {
+                } else if (mark.id.equals(SubstrateBackend.SubstrateMarkId.EPILOGUE_END) && mark.pcOffset < compilation.getTargetCodeSize()) {
+                    // there is code after this return point so notify stack extend again
+                    NativeImageDebugFrameSizeChange sizeChange = new NativeImageDebugFrameSizeChange(mark.pcOffset, EXTEND);
+                    frameSizeChanges.add(sizeChange);
                 }
             }
             return frameSizeChanges;


### PR DESCRIPTION
This PR fixes issue #2624. The changes in the compiler code ensure that a Frame.returned() callback occurs at the end of any basic block that also includes a call to Frame.leave(). This is needed to ensure that marks inserted by the Substrate implementors of Frame are correctly located. Substrate Frame.leave implementations still add marks for EPILOGUE_START and EPILOGUE_INCD_RSP. Generation of EPILOGUE_END occurs in Substrate Frame.returned implementations i.e. at the end of the basic block terminated by the return (or, in certain cases, a method exiting jump to a handler). The current code places the EPILOGUE_END mark before the terminating return (or jump). In deed, in some cases it also precedes safepoint code or other code that operates with the empty frame.

The result of making this compiler change is to allow the debug info frame record generator to decrement the stack frame size at EPILOGUE_INCD_RSP but then restore it again at EPILOGUE_END if it finds there is code that follows the EPILOGUE_END.
