### PR TITLE
JDK15 java.lang.invoke.MemberName is reachable.

### DIFF
--- a/common.hocon
+++ b/common.hocon
@@ -34,6 +34,7 @@ openjdk8 :          { downloads : { JAVA_HOME : ${jdks.openjdk8} }}
 oraclejdk11 :       { downloads : { JAVA_HOME : ${jdks.oraclejdk11} }}
 oraclejdk15 :       { downloads : { JAVA_HOME : ${jdks.oraclejdk15} }}
 openjdk11 :         { downloads : { JAVA_HOME : ${jdks.openjdk11} }}
+openjdk15 :         { downloads : { JAVA_HOME : ${jdks.openjdk15} }}
 
 labsjdk-ce-11 :         { downloads : { JAVA_HOME : ${jdks.labsjdk-ce-11} }}
 labsjdk-ee-11 :         { downloads : { JAVA_HOME : ${jdks.labsjdk-ee-11} }}

--- a/common.json
+++ b/common.json
@@ -6,8 +6,9 @@
     "openjdk8":        {"name": "openjdk",   "version": "8u262+10-jvmci-20.2-b03", "platformspecific": true },
     "oraclejdk8Debug": {"name": "oraclejdk", "version": "8u261+33-jvmci-20.2-b03-fastdebug", "platformspecific": true },
     "oraclejdk11":     {"name": "oraclejdk", "version": "11.0.6+8", "platformspecific": true },
-    "oraclejdk15":     {"name": "oraclejdk", "version": "15+27", "platformspecific": true },
+    "oraclejdk15":     {"name": "oraclejdk", "version": "15+30", "platformspecific": true },
     "openjdk11":       {"name": "openjdk",   "version": "11.0.3+7", "platformspecific": true },
+    "openjdk15":       {"name": "openjdk",   "version": "15+30", "platformspecific": true },
     "labsjdk-ce-11":   {"name": "labsjdk",   "version": "ce-11.0.8+10-jvmci-20.2-b03", "platformspecific": true },
     "labsjdk-ee-11":   {"name": "labsjdk",   "version": "ee-11.0.8.0.2+1-jvmci-20.2-b03", "platformspecific": true }
   },

--- a/substratevm/mx.substratevm/suite.py
+++ b/substratevm/mx.substratevm/suite.py
@@ -227,6 +227,8 @@ suite = {
             "requiresConcealed" : {
                 "java.base" : [
                     "jdk.internal.loader",
+                    "jdk.internal.misc",
+                    "sun.invoke.util",
                 ],
             },
             "javaCompliance": "15+",

--- a/substratevm/src/com.oracle.svm.core.jdk15/src/com/oracle/svm/core/jdk15/Target_java_lang_invoke_MethodHandles_JDK15.java
+++ b/substratevm/src/com.oracle.svm.core.jdk15/src/com/oracle/svm/core/jdk15/Target_java_lang_invoke_MethodHandles_JDK15.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2020, 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package com.oracle.svm.core.jdk15;
+
+import java.lang.invoke.MethodHandles;
+// Checkstyle: stop
+import sun.invoke.util.VerifyAccess;
+// Checkstyle: resume
+import jdk.internal.misc.Unsafe;
+
+import com.oracle.svm.core.jdk.JDK15OrLater;
+import com.oracle.svm.core.jdk.JDK15OrEarlier;
+import com.oracle.svm.core.SubstrateUtil;
+import com.oracle.svm.core.annotate.Alias;
+import com.oracle.svm.core.annotate.Substitute;
+import com.oracle.svm.core.annotate.TargetClass;
+
+@TargetClass(className = "java.lang.invoke.MethodHandles", innerClass = "Lookup", onlyWith = {JDK15OrLater.class, JDK15OrEarlier.class})
+final class Target_java_lang_invoke_MethodHandles_Lookup_JDK15 {
+
+    @Alias //
+    private Class<?> lookupClass;
+
+    @Alias //
+    private Class<?> prevLookupClass;
+
+    @Alias //
+    private int allowedModes;
+
+    @Substitute
+    public Class<?> lookupClass() {
+        return lookupClass;
+    }
+
+    /**
+     * Eliminate the dependencies on MemberName.
+     */
+    @Substitute
+    public Class<?> ensureInitialized(Class<?> targetClass) throws IllegalAccessException {
+        if (targetClass.isPrimitive()) {
+            throw new IllegalArgumentException(targetClass + " is a primitive class");
+        }
+        if (targetClass.isArray()) {
+            throw new IllegalArgumentException(targetClass + " is an array class");
+        }
+        if (!VerifyAccess.isClassAccessible(targetClass, lookupClass, prevLookupClass, allowedModes)) {
+            // throw new MemberName(targetClass).makeAccessException("access violation", this);
+            String message = "access violation: " + targetClass;
+            if (this == SubstrateUtil.cast(MethodHandles.publicLookup(), Target_java_lang_invoke_MethodHandles_Lookup_JDK15.class)) {
+                message += ", from public Lookup";
+            } else {
+                Module m = lookupClass().getModule();
+                message += ", from " + lookupClass() + " (" + m + ")";
+                if (prevLookupClass != null) {
+                    message += ", previous lookup " +
+                                    prevLookupClass.getName() + " (" + prevLookupClass.getModule() + ")";
+                }
+            }
+            throw new IllegalAccessException(message);
+        }
+
+        // This call is a noop without the security manager
+        // checkSecurityManager(targetClass, null);
+
+        // ensure class initialization
+        Unsafe.getUnsafe().ensureClassInitialized(targetClass);
+        return targetClass;
+    }
+
+}
+
+public class Target_java_lang_invoke_MethodHandles_JDK15 {
+}

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/aarch64/AArch64CPUFeatureAccess.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/aarch64/AArch64CPUFeatureAccess.java
@@ -98,7 +98,11 @@ public class AArch64CPUFeatureAccess implements CPUFeatureAccess {
             features.add(AArch64.CPUFeature.A53MAC);
         }
         if (cpuFeatures.fDMBATOMICS()) {
-            features.add(AArch64.CPUFeature.DMB_ATOMICS);
+            try {
+                features.add(AArch64.CPUFeature.valueOf("DMB_ATOMICS"));
+            } catch (IllegalArgumentException e) {
+                // This JVMCI CPU feature is not available in all JDKs (JDK-8243339)
+            }
         }
 
         return features;

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/JDK15OrEarlier.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/JDK15OrEarlier.java
@@ -24,30 +24,13 @@
  */
 package com.oracle.svm.core.jdk;
 
-import com.oracle.svm.core.annotate.NeverInline;
-import com.oracle.svm.core.annotate.Substitute;
-import com.oracle.svm.core.annotate.TargetClass;
+import java.util.function.BooleanSupplier;
 
-@TargetClass(className = "java.lang.StringConcatHelper", onlyWith = JDK11OrLater.class)
-final class Target_java_lang_StringConcatHelper {
+import org.graalvm.compiler.serviceprovider.JavaVersionUtil;
 
-    /**
-     * The original implementation allocates the OutOfMemoryError in this method. This is OK with
-     * JIT compilation, but bad for AOT compilation because there is no profiling information that
-     * replaces the allocation with a deopt.
-     */
-    @Substitute
-    private static int checkOverflow(int len) {
-        if (len < 0) {
-            throw StringConcatHelperSupport.throwOutOfMemoryError();
-        }
-        return len;
-    }
-}
-
-class StringConcatHelperSupport {
-    @NeverInline("slow path")
-    static OutOfMemoryError throwOutOfMemoryError() {
-        throw new OutOfMemoryError("Overflow: String length out of range");
+public class JDK15OrEarlier implements BooleanSupplier {
+    @Override
+    public boolean getAsBoolean() {
+        return JavaVersionUtil.JAVA_SPEC <= 15;
     }
 }

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/NativeImageGeneratorRunner.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/NativeImageGeneratorRunner.java
@@ -532,6 +532,9 @@ public class NativeImageGeneratorRunner implements ImageBuildTask {
             ModuleSupport.exportAndOpenAllPackagesToUnnamed("jdk.internal.vm.compiler.management", true);
             ModuleSupport.exportAndOpenAllPackagesToUnnamed("com.oracle.graal.graal_enterprise", true);
             ModuleSupport.exportAndOpenPackageToUnnamed("java.base", "jdk.internal.loader", false);
+            if (JavaVersionUtil.JAVA_SPEC >= 15) {
+                ModuleSupport.exportAndOpenPackageToUnnamed("java.base", "jdk.internal.misc", false);
+            }
             ModuleSupport.exportAndOpenPackageToUnnamed("java.base", "sun.text.spi", false);
             ModuleSupport.exportAndOpenPackageToUnnamed("java.base", "jdk.internal.org.objectweb.asm", false);
             NativeImageGeneratorRunner.main(args);

--- a/vm/ci_common/common.hocon
+++ b/vm/ci_common/common.hocon
@@ -250,6 +250,27 @@ full_vm_build_linux: ${svm-common-linux-amd64} ${sulong_linux} ${truffleruby_lin
 full_vm_build_linux_aarch64: ${svm-common-linux-aarch64} ${sulong_linux} ${custom_vm_linux}
 full_vm_build_darwin: ${svm-common-darwin} ${sulong_darwin} ${truffleruby_darwin} ${fastr_darwin} ${graalpython_darwin} ${custom_vm_darwin}
 
+libgraal_compiler: ${svm-common-linux-amd64} ${custom_vm_linux} ${vm_linux} {
+  run: [
+    # enable asserts in the JVM building the image and enable asserts in the resulting native image
+    [mx, --env, ${libgraal_env}, "--extra-image-builder-argument=-J-esa",  "--extra-image-builder-argument=-J-ea", "--extra-image-builder-argument=-ea", build]
+    [mx, --env, ${libgraal_env}, gate, --task, "LibGraal Compiler"]
+  ]
+  timelimit: "1:00:00"
+  targets: [gate]
+}
+
+libgraal_truffle: ${svm-common-linux-amd64} ${custom_vm_linux} ${vm_linux} {
+  run: [
+    # enable asserts in the JVM building the image and enable asserts in the resulting native image
+    [mx, --env, ${libgraal_env}, "--extra-image-builder-argument=-J-esa", "--extra-image-builder-argument=-J-ea", "--extra-image-builder-argument=-ea", build]
+    [mx, --env, ${libgraal_env}, gate, --task, "LibGraal Truffle"]
+  ]
+  logs: ${common_vm.logs} ["*/graal-compiler.log"]
+  timelimit: "45:00"
+  targets: [gate]
+}
+
 builds += [
   #
   # Gates
@@ -260,27 +281,14 @@ builds += [
     ]
     name: gate-vm-style-linux-amd64
   }
-  ${vm_java_8} ${svm-common-linux-amd64} ${custom_vm_linux} ${vm_linux} {
-    run: [
-      # enable asserts in the JVM building the image and enable asserts in the resulting native image
-      [mx, --env, ${libgraal_env}, "--extra-image-builder-argument=-J-esa",  "--extra-image-builder-argument=-J-ea", "--extra-image-builder-argument=-ea", build]
-      [mx, --env, ${libgraal_env}, gate, --task, "LibGraal Compiler"]
-    ]
-    timelimit: "1:00:00"
-    targets: [gate]
-    name: gate-vm-libgraal-compiler
-  }
-  ${vm_java_8} ${svm-common-linux-amd64} ${custom_vm_linux} ${vm_linux} {
-    run: [
-      # enable asserts in the JVM building the image and enable asserts in the resulting native image
-      [mx, --env, ${libgraal_env}, "--extra-image-builder-argument=-J-esa", "--extra-image-builder-argument=-J-ea", "--extra-image-builder-argument=-ea", build]
-      [mx, --env, ${libgraal_env}, gate, --task, "LibGraal Truffle"]
-    ]
-    logs: ${common_vm.logs} ["*/graal-compiler.log"]
-    timelimit: "45:00"
-    targets: [gate]
-    name: gate-vm-libgraal-truffle
-  }
+  ${libgraal_compiler} ${vm_java_8}  { name: gate-vm-libgraal-compiler-8-linux-amd64 }
+# Blocked JDK-8249880
+#  ${libgraal_compiler} ${vm_java_15} { name: gate-vm-libgraal-compiler-15-linux-amd64 }
+
+  ${libgraal_truffle} ${vm_java_8}  { name: gate-vm-libgraal-truffle-8-linux-amd64 }
+# Blocked JDK-8249880
+#  ${libgraal_truffle} ${vm_java_15} { name: gate-vm-libgraal-truffle-15-linux-amd64 }
+
   ${vm_java_8} ${svm-common-linux-amd64} ${sulong_linux} ${custom_vm_linux} ${gate_vm_linux} {
     run: [
       [export, "SVM_SUITE="${svm_suite}]

--- a/vm/ci_includes/vm.hocon
+++ b/vm/ci_includes/vm.hocon
@@ -4,6 +4,9 @@ vm_java_8: ${openjdk8} {
 vm_java_11: ${labsjdk-ce-11} {
   environment: { BASE_JDK_VERSION: "11" }
 }
+vm_java_15: ${openjdk15} {
+  environment: { BASE_JDK_VERSION: "15" }
+}
 svm_suite: /substratevm
 vm_extra_suites: "truffleruby,graalpython,fastr,/wasm"
 vm_extra_suites_aarch64: "/wasm,truffleruby"


### PR DESCRIPTION
Two JDK15 fixes needed to be able to build libjvmcicompiler.so.

1. Fix ints to long in StringConcatHelper
2. Eliminate use of MemberName in MethodHandles.ensureInitialized