### PR TITLE
Add intrinsics for get/put unsafe unaligned methods on AArch64

### DIFF
--- a/compiler/src/org.graalvm.compiler.replacements.aarch64/src/org/graalvm/compiler/replacements/aarch64/AArch64GraphBuilderPlugins.java
+++ b/compiler/src/org.graalvm.compiler.replacements.aarch64/src/org/graalvm/compiler/replacements/aarch64/AArch64GraphBuilderPlugins.java
@@ -295,9 +295,18 @@ public class AArch64GraphBuilderPlugins implements TargetGraphBuilderPlugins {
         registerUnsafePlugins(new Registration(plugins, Unsafe.class), explicitUnsafeNullChecks,
                         new JavaKind[]{JavaKind.Int, JavaKind.Long, JavaKind.Object}, "Object");
         if (JavaVersionUtil.JAVA_SPEC > 8) {
-            registerUnsafePlugins(new Registration(plugins, "jdk.internal.misc.Unsafe", replacements), explicitUnsafeNullChecks,
-                            new JavaKind[]{JavaKind.Int, JavaKind.Long, JavaKind.Object},
+            Registration r = new Registration(plugins, "jdk.internal.misc.Unsafe", replacements);
+            registerUnsafePlugins(r, explicitUnsafeNullChecks, new JavaKind[]{JavaKind.Int, JavaKind.Long, JavaKind.Object},
                             JavaVersionUtil.JAVA_SPEC <= 11 ? "Object" : "Reference");
+            registerUnsafeUnalignedPlugins(r, explicitUnsafeNullChecks);
+        }
+    }
+
+    private static void registerUnsafeUnalignedPlugins(Registration r, boolean explicitUnsafeNullChecks) {
+        for (JavaKind kind : new JavaKind[]{JavaKind.Char, JavaKind.Short, JavaKind.Int, JavaKind.Long}) {
+            Class<?> javaClass = kind.toJavaClass();
+            r.registerOptional3("get" + kind.name() + "Unaligned", Receiver.class, Object.class, long.class, new UnsafeGetPlugin(kind, explicitUnsafeNullChecks));
+            r.registerOptional4("put" + kind.name() + "Unaligned", Receiver.class, Object.class, long.class, javaClass, new UnsafePutPlugin(kind, explicitUnsafeNullChecks));
         }
     }
 
@@ -327,12 +336,6 @@ public class AArch64GraphBuilderPlugins implements TargetGraphBuilderPlugins {
                     }
                 });
             }
-        }
-
-        for (JavaKind kind : new JavaKind[]{JavaKind.Char, JavaKind.Short, JavaKind.Int, JavaKind.Long}) {
-            Class<?> javaClass = kind.toJavaClass();
-            r.registerOptional3("get" + kind.name() + "Unaligned", Receiver.class, Object.class, long.class, new UnsafeGetPlugin(kind, explicitUnsafeNullChecks));
-            r.registerOptional4("put" + kind.name() + "Unaligned", Receiver.class, Object.class, long.class, javaClass, new UnsafePutPlugin(kind, explicitUnsafeNullChecks));
         }
     }
 }


### PR DESCRIPTION
Intrinsics replace the bytewise read/write operations by necessary word sized chunks while performing unaligned memory accesses using the unsafe API. Covers char, short, int and long types.

**Microbenchmarking results:**
Relevant snippet of the microbenchmark is:
```
@Benchmark
    public void jmhTimeUnsafeGetPutInt() {
        int res = 0;
        int pos;
        for (int i = 0; i < NUM_INVOKES; ++i) {
            pos = (i * intSize);
            res += unsafe.getIntUnaligned(intArr, arrBaseOffset + pos + 1);
            unsafe.putIntUnaligned(intArr, arrBaseOffset + pos + 1, res);
        }
    res_int = res;
}
```

Performance results on an A72 AArch64 machine are:
Before:
```
Benchmark                 Mode  Cnt     Score   Error  Units
jmhTimeUnsafeGetPutChar   avgt   10   367.850 ± 0.058  ns/op
jmhTimeUnsafeGetPutShort  avgt   10   321.127 ± 1.524  ns/op
jmhTimeUnsafeGetPutInt    avgt   10   533.823 ± 0.075  ns/op
jmhTimeUnsafeGetPutLong   avgt   10  1718.885 ± 0.193  ns/op
```

After:
```
Benchmark                 Mode  Cnt     Score   Error  Units
jmhTimeUnsafeGetPutChar   avgt   10  225.210 ± 0.043  ns/op
jmhTimeUnsafeGetPutShort  avgt   10  225.435 ± 0.045  ns/op
jmhTimeUnsafeGetPutInt    avgt   10  206.207 ± 0.137  ns/op
jmhTimeUnsafeGetPutLong   avgt   10  205.953 ± 0.135  ns/op
```
