### PR TITLE
Add compilation directory to debug info

### DIFF
--- a/substratevm/DEBUGINFO.md
+++ b/substratevm/DEBUGINFO.md
@@ -174,31 +174,38 @@ configure extra source search paths (see below).
 Configuring source paths in gdb
 -------------------------------
 
-In order for gdb to be able to locate the source files for your app
-classes, Graal classes and JDK runtime classes you need to provide gdb
-with a list of source root dirs using the 'set directories' command:
+By default gdb will employ the three local directory roots
+`sources/{jdk,graal,src}` to locate the source files for your app classes, Graal
+classes and JDK runtime classes. If the sources cache is not located in the
+directory in which you run gdb you can configure the required paths using the
+following command:
 
     (gdb) set directories /path/to/sources/jdk:/path/to/sources/graal:/path/to/sources/src
 
-Directory .../sources/jdk should contain source files for all JDK runtime
+Directory `/path/to/sources/jdk` should contain source files for all JDK runtime
 classes referenced from debug records.
 
-Directory .../sources/graal should contain source files for all GraalVM
+Directory `/path/to/sources/graal` should contain source files for all GraalVM
 classes referenced from debug records. Note that the current
 implementation does not yet find some sources for the GraalVM JIT
 compiler in the org.graalvm.compiler* package subspace.
 
-Directory .../sources/src should contain source files for all
+Directory `/path/to/sources/src` should contain source files for all
 application classes referenced from debug records, assuming they can
 be located using the lookup strategy described above.
 
-You can supplement the files cached in sources/src by unzipping
+You can supplement the files cached in `sources/src` by unzipping
 application source jars or copying application source trees into the
 cache. You need to ensure that any new subdirectory you add to
-sources/src corresponds to the top level package for the classes whose
+`sources/src` corresponds to the top level package for the classes whose
 sources are being included.
 
-You can also add extra directories to the search path. Note that gdb
+You can also add extra directories to the search path using the 'set
+directories' command:
+
+    (gdb) set directories /path/to/my/sources/:/path/to/my/other/sources
+
+Note that gdb
 does not understand zip format file systems so any extra entries you
 add must identify a directory tree containing the relevant
 sources. Once again. top level entries in the directory added to the

--- a/substratevm/mx.substratevm/mx_substratevm.py
+++ b/substratevm/mx.substratevm/mx_substratevm.py
@@ -800,7 +800,7 @@ def _debuginfotest(native_image, path, build_only, args):
     native_image(native_image_args)
 
     if mx.get_os() == 'linux' and not build_only:
-        mx.run(['gdb', '-d', join(sourcecache, 'src'), '-d', join(sourcecache, 'graal'), '-d', join(sourcecache, 'jdk'), '-x', join(parent, 'mx.substratevm/testhello.py'), join(path, 'hello.hello')])
+        mx.run(['gdb', '-x', join(parent, 'mx.substratevm/testhello.py'), join(path, 'hello.hello')])
 
 
 def _javac_image(native_image, path, args=None):

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/ClassEntry.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/ClassEntry.java
@@ -277,4 +277,12 @@ public class ClassEntry {
     public boolean includesDeoptTarget() {
         return includesDeoptTarget;
     }
+
+    public String getCachePath() {
+        if (fileEntry != null) {
+            return fileEntry.getCachePath();
+        } else {
+            return "";
+        }
+    }
 }

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/DebugInfoBase.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/DebugInfoBase.java
@@ -129,6 +129,7 @@ public abstract class DebugInfoBase {
              */
             String fileName = debugCodeInfo.fileName();
             Path filePath = debugCodeInfo.filePath();
+            Path cachePath = debugCodeInfo.cachePath();
             // switch '$' in class names for '.'
             String className = debugCodeInfo.className().replaceAll("\\$", ".");
             String methodName = debugCodeInfo.methodName();
@@ -139,7 +140,7 @@ public abstract class DebugInfoBase {
             int primaryLine = debugCodeInfo.line();
             boolean isDeoptTarget = debugCodeInfo.isDeoptTarget();
 
-            Range primaryRange = new Range(fileName, filePath, className, methodName, paramNames, returnTypeName, stringTable, lo, hi, primaryLine, isDeoptTarget);
+            Range primaryRange = new Range(fileName, filePath, cachePath, className, methodName, paramNames, returnTypeName, stringTable, lo, hi, primaryLine, isDeoptTarget);
             debugContext.log(DebugContext.INFO_LEVEL, "PrimaryRange %s.%s %s %s:%d [0x%x, 0x%x]", className, methodName, filePath, fileName, primaryLine, lo, hi);
             addRange(primaryRange, debugCodeInfo.getFrameSizeChanges(), debugCodeInfo.getFrameSize());
             debugCodeInfo.lineInfoProvider().forEach(debugLineInfo -> {
@@ -151,11 +152,12 @@ public abstract class DebugInfoBase {
                 int loAtLine = lo + debugLineInfo.addressLo();
                 int hiAtLine = lo + debugLineInfo.addressHi();
                 int line = debugLineInfo.line();
+                Path cachePathAtLine = debugLineInfo.cachePath();
                 /*
                  * Record all subranges even if they have no line or file so we at least get a
                  * symbol for them.
                  */
-                Range subRange = new Range(fileNameAtLine, filePathAtLine, classNameAtLine, methodNameAtLine, "", "", stringTable, loAtLine, hiAtLine, line, primaryRange);
+                Range subRange = new Range(fileNameAtLine, filePathAtLine, cachePathAtLine, classNameAtLine, methodNameAtLine, "", "", stringTable, loAtLine, hiAtLine, line, primaryRange);
                 addSubRange(primaryRange, subRange);
                 try (DebugContext.Scope s = debugContext.scope("Subranges")) {
                     debugContext.log(DebugContext.VERBOSE_LEVEL, "SubRange %s.%s %s %s:%d 0x%x, 0x%x]", classNameAtLine, methodNameAtLine, filePathAtLine, fileNameAtLine, line, loAtLine, hiAtLine);
@@ -203,7 +205,7 @@ public abstract class DebugInfoBase {
         FileEntry fileEntry = filesIndex.get(fileAsPath);
         if (fileEntry == null) {
             DirEntry dirEntry = ensureDirEntry(filePath);
-            fileEntry = new FileEntry(fileName, dirEntry);
+            fileEntry = new FileEntry(fileName, dirEntry, range.getCachePath());
             files.add(fileEntry);
             /*
              * Index the file entry by file path.

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/FileEntry.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/FileEntry.java
@@ -32,10 +32,12 @@ package com.oracle.objectfile.debugentry;
 public class FileEntry {
     private String fileName;
     private DirEntry dirEntry;
+    private String cachePath;
 
-    public FileEntry(String fileName, DirEntry dirEntry) {
+    public FileEntry(String fileName, DirEntry dirEntry, String cachePath) {
         this.fileName = fileName;
         this.dirEntry = dirEntry;
+        this.cachePath = cachePath;
     }
 
     /**
@@ -58,5 +60,12 @@ public class FileEntry {
      */
     public DirEntry getDirEntry() {
         return dirEntry;
+    }
+
+    /**
+     * The compilation directory in which to look for source files as a {@link String}.
+     */
+    public String getCachePath() {
+        return cachePath;
     }
 }

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/Range.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/Range.java
@@ -36,6 +36,7 @@ import java.nio.file.Paths;
  */
 
 public class Range {
+    private final String cachePath;
     private String fileName;
     private Path filePath;
     private String className;
@@ -55,22 +56,23 @@ public class Range {
     /*
      * Create a primary range.
      */
-    public Range(String fileName, Path filePath, String className, String methodName, String paramNames, String returnTypeName, StringTable stringTable, int lo, int hi, int line,
+    public Range(String fileName, Path filePath, Path cachePath, String className, String methodName, String paramNames, String returnTypeName, StringTable stringTable, int lo, int hi, int line,
                     boolean isDeoptTarget) {
-        this(fileName, filePath, className, methodName, paramNames, returnTypeName, stringTable, lo, hi, line, isDeoptTarget, null);
+        this(fileName, filePath, cachePath, className, methodName, paramNames, returnTypeName, stringTable, lo, hi, line, isDeoptTarget, null);
     }
 
     /*
      * Create a secondary range.
      */
-    public Range(String fileName, Path filePath, String className, String methodName, String paramNames, String returnTypeName, StringTable stringTable, int lo, int hi, int line, Range primary) {
-        this(fileName, filePath, className, methodName, paramNames, returnTypeName, stringTable, lo, hi, line, false, primary);
+    public Range(String fileName, Path filePath, Path cachePath, String className, String methodName, String paramNames, String returnTypeName, StringTable stringTable, int lo, int hi, int line,
+                    Range primary) {
+        this(fileName, filePath, cachePath, className, methodName, paramNames, returnTypeName, stringTable, lo, hi, line, false, primary);
     }
 
     /*
      * Create a primary or secondary range.
      */
-    private Range(String fileName, Path filePath, String className, String methodName, String paramNames, String returnTypeName, StringTable stringTable, int lo, int hi, int line,
+    private Range(String fileName, Path filePath, Path cachePath, String className, String methodName, String paramNames, String returnTypeName, StringTable stringTable, int lo, int hi, int line,
                     boolean isDeoptTarget, Range primary) {
         /*
          * Currently file name and full method name need to go into the debug_str section other
@@ -78,6 +80,7 @@ public class Range {
          */
         this.fileName = (fileName == null ? null : stringTable.uniqueDebugString(fileName));
         this.filePath = filePath;
+        this.cachePath = (cachePath == null ? "" : stringTable.uniqueDebugString(cachePath.toString()));
         this.className = stringTable.uniqueString(className);
         this.methodName = stringTable.uniqueString(methodName);
         this.paramNames = stringTable.uniqueString(paramNames);
@@ -169,5 +172,12 @@ public class Range {
 
     private String constructClassAndMethodNameWithParams() {
         return getExtendedMethodName(true, false);
+    }
+
+    /**
+     * Get the compilation directory in which to look for source files as a {@link String}.
+     */
+    public String getCachePath() {
+        return cachePath;
     }
 }

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debuginfo/DebugInfoProvider.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debuginfo/DebugInfoProvider.java
@@ -62,6 +62,12 @@ public interface DebugInfoProvider {
         Path filePath();
 
         /**
+         * @return a relative path to the source cache containing the sources of a compiled method
+         *         or {@code null} if sources are not available.
+         */
+        Path cachePath();
+
+        /**
          * @return the fully qualified name of the class owning the compiled method.
          */
         String className();
@@ -142,6 +148,12 @@ public interface DebugInfoProvider {
          *         its package name or null if the method is in the empty package.
          */
         Path filePath();
+
+        /**
+         * @return a relative path to the source cache containing the sources of a compiled method
+         *         or {@code null} if sources are not available.
+         */
+        Path cachePath();
 
         /**
          * @return the fully qualified name of the class owning the outer or inlined method.

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfAbbrevSectionImpl.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfAbbrevSectionImpl.java
@@ -32,6 +32,7 @@ import org.graalvm.compiler.debug.DebugContext;
 import static com.oracle.objectfile.elf.dwarf.DwarfDebugInfo.DW_ABBREV_CODE_compile_unit;
 import static com.oracle.objectfile.elf.dwarf.DwarfDebugInfo.DW_ABBREV_CODE_subprogram;
 import static com.oracle.objectfile.elf.dwarf.DwarfDebugInfo.DW_ABBREV_SECTION_NAME;
+import static com.oracle.objectfile.elf.dwarf.DwarfDebugInfo.DW_AT_comp_dir;
 import static com.oracle.objectfile.elf.dwarf.DwarfDebugInfo.DW_AT_external;
 import static com.oracle.objectfile.elf.dwarf.DwarfDebugInfo.DW_AT_hi_pc;
 import static com.oracle.objectfile.elf.dwarf.DwarfDebugInfo.DW_AT_language;
@@ -184,6 +185,8 @@ public class DwarfAbbrevSectionImpl extends DwarfSectionImpl {
         pos = writeAttrType(DW_AT_language, buffer, pos);
         pos = writeAttrForm(DW_FORM_data1, buffer, pos);
         pos = writeAttrType(DW_AT_name, buffer, pos);
+        pos = writeAttrForm(DW_FORM_strp, buffer, pos);
+        pos = writeAttrType(DW_AT_comp_dir, buffer, pos);
         pos = writeAttrForm(DW_FORM_strp, buffer, pos);
         pos = writeAttrType(DW_AT_low_pc, buffer, pos);
         pos = writeAttrForm(DW_FORM_addr, buffer, pos);

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfDebugInfo.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfDebugInfo.java
@@ -72,7 +72,7 @@ public class DwarfDebugInfo extends DebugInfoBase {
      */
     public static final int DW_AT_null = 0x0;
     public static final int DW_AT_name = 0x3;
-    @SuppressWarnings("unused") public static final int DW_AT_comp_dir = 0x1b;
+    public static final int DW_AT_comp_dir = 0x1b;
     public static final int DW_AT_stmt_list = 0x10;
     public static final int DW_AT_low_pc = 0x11;
     public static final int DW_AT_hi_pc = 0x12;

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfInfoSectionImpl.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfInfoSectionImpl.java
@@ -260,6 +260,9 @@ public class DwarfInfoSectionImpl extends DwarfSectionImpl {
         pos = writeAttrData1(DW_LANG_Java, buffer, pos);
         log(context, "  [0x%08x]     name  0x%x (%s)", pos, debugStringIndex(classEntry.getFileName()), classEntry.getFileName());
         pos = writeAttrStrp(classEntry.getFileName(), buffer, pos);
+        String compilationDirectory = classEntry.getCachePath();
+        log(context, "  [0x%08x]     comp_dir  0x%x (%s)", pos, debugStringIndex(compilationDirectory), compilationDirectory);
+        pos = writeAttrStrp(compilationDirectory, buffer, pos);
         int lo = findLo(classPrimaryEntries, isDeoptTargetCU);
         int hi = findHi(classPrimaryEntries, classEntry.includesDeoptTarget(), isDeoptTargetCU);
         log(context, "  [0x%08x]     lo_pc  0x%08x", pos, lo);


### PR DESCRIPTION
This PR adds the DW_AT_comp_dir attribute to debug info, making it
point to the appropriate source file cache. This removes the need of
using `set directores sources/jdk:sources/graal:sources/src` in gdb.

At the moment there are 3 directories that might contain sources:
1. `sources/jdk`
2. `sources/graal`
3. `sources/src`

This patch detects the corresponding path for each compilation unit and adds it to the `DW_AT_comp_dir` attribute.
For instance for `java.base/java/lang/Shutdown.java` it sets `DW_AT_comp_dir` to `sources/jdk`, and for `com/oracle/svm/core/RegisterDumper.java` it sets it to `sources/graal`.