### PR TITLE
Fix SimpleLanguage readMember implementation

### DIFF
--- a/truffle/src/com.oracle.truffle.sl/src/com/oracle/truffle/sl/runtime/FunctionsObject.java
+++ b/truffle/src/com.oracle.truffle.sl/src/com/oracle/truffle/sl/runtime/FunctionsObject.java
@@ -49,6 +49,7 @@ import com.oracle.truffle.api.dsl.Cached;
 import com.oracle.truffle.api.interop.InteropLibrary;
 import com.oracle.truffle.api.interop.InvalidArrayIndexException;
 import com.oracle.truffle.api.interop.TruffleObject;
+import com.oracle.truffle.api.interop.UnknownIdentifierException;
 import com.oracle.truffle.api.library.ExportLibrary;
 import com.oracle.truffle.api.library.ExportMessage;
 import com.oracle.truffle.api.profiles.BranchProfile;
@@ -80,8 +81,12 @@ final class FunctionsObject implements TruffleObject {
 
     @ExportMessage
     @TruffleBoundary
-    Object readMember(String member) {
-        return functions.get(member);
+    Object readMember(String member) throws UnknownIdentifierException {
+        Object value = functions.get(member);
+        if (value != null) {
+            return value;
+        }
+        throw UnknownIdentifierException.create(member);
     }
 
     @ExportMessage


### PR DESCRIPTION
As far as I can tell, `readMember` implementations must assume that they may be called with invalid keys (i. e., the caller is not responsible for calling `isMemberReadable` first), and should themselves throw an `UnknownIdentifierException` if necessary rather than return `null`.

The specific pattern used here – return the value if it is not `null`, unconditional `throw` at the end – is based on the `readMember` implementations of [`WasmModule`](https://github.com/oracle/graal/blob/5cdf18908cf604f2d69a3bb523dd4123602cd30e/wasm/src/org.graalvm.wasm/src/org/graalvm/wasm/WasmModule.java#L109) and [`PythonAbstractObject`](https://github.com/graalvm/graalpython/blob/f9e72166e24221cf23d51547923ce620eb57882b/graalpython/com.oracle.graal.python/src/com/oracle/graal/python/builtins/objects/PythonAbstractObject.java#L233) (though both of them have more than one potential return before the `throw`).

---

I’m not sure how to test this – improvements to the pull request are welcome.