### PR TITLE
native-image - Register String.getBytes() for JNI access at runtime

### DIFF
--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/jdk/JNIRegistrationJava.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/jdk/JNIRegistrationJava.java
@@ -129,6 +129,7 @@ class JNIRegistrationJava extends JNIRegistrationUtil implements GraalFeature {
         JNIRuntimeAccess.register(method(a, "java.nio.charset.Charset", "isSupported", String.class));
         JNIRuntimeAccess.register(constructor(a, "java.lang.String", byte[].class, String.class));
         JNIRuntimeAccess.register(method(a, "java.lang.String", "getBytes", String.class));
+        JNIRuntimeAccess.register(method(a, "java.lang.String", "getBytes"));
         JNIRuntimeAccess.register(method(a, "java.lang.String", "concat", String.class));
         if (JavaVersionUtil.JAVA_SPEC >= 11) {
             JNIRuntimeAccess.register(fields(a, "java.lang.String", "coder", "value"));


### PR DESCRIPTION
`String.getBytes()` gets used through JNI, for example[1]. The commit in this PR registers it for JNI runtime access to avoid issues like the one reported in Quarkus here[2]

[1] https://github.com/openjdk/jdk/blob/master/src/java.base/share/native/libjava/jni_util.c#L831
[2] https://github.com/quarkusio/quarkus/issues/10682