### PR TITLE
CAP cache improvements

### DIFF
--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/c/CAnnotationProcessor.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/c/CAnnotationProcessor.java
@@ -28,6 +28,7 @@ import static com.oracle.svm.core.util.VMError.shouldNotReachHere;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -58,6 +59,7 @@ public class CAnnotationProcessor {
     private final NativeLibraries nativeLibs;
     private CCompilerInvoker compilerInvoker;
     private Path tempDirectory;
+    private Path queryCodeDirectory;
 
     private NativeCodeInfo codeInfo;
     private QueryCodeWriter writer;
@@ -65,12 +67,19 @@ public class CAnnotationProcessor {
     public CAnnotationProcessor(NativeLibraries nativeLibs, NativeCodeContext codeCtx) {
         this.nativeLibs = nativeLibs;
         this.codeCtx = codeCtx;
-        if (!ImageSingletons.contains(CCompilerInvoker.class)) {
+
+        if (ImageSingletons.contains(CCompilerInvoker.class)) {
+            this.compilerInvoker = ImageSingletons.lookup(CCompilerInvoker.class);
+            this.queryCodeDirectory = compilerInvoker.tempDirectory;
+            this.tempDirectory = compilerInvoker.tempDirectory;
+        } else {
             assert CAnnotationProcessorCache.Options.UseCAPCache.getValue();
-            return;
         }
-        this.compilerInvoker = ImageSingletons.lookup(CCompilerInvoker.class);
-        this.tempDirectory = compilerInvoker.tempDirectory;
+
+        if (CAnnotationProcessorCache.Options.QueryCodeDir.hasBeenSet()) {
+            String queryCodeDir = CAnnotationProcessorCache.Options.QueryCodeDir.getValue();
+            this.queryCodeDirectory = FileSystems.getDefault().getPath(queryCodeDir).toAbsolutePath();
+        }
     }
 
     public NativeCodeInfo process(CAnnotationProcessorCache cache) {
@@ -87,12 +96,17 @@ public class CAnnotationProcessor {
              * Generate C source file (the "Query") that will produce the information needed (e.g.,
              * size of struct/union and offsets to their fields, value of enum/macros etc.).
              */
-            writer = new QueryCodeWriter(tempDirectory);
+            writer = new QueryCodeWriter(queryCodeDirectory);
             Path queryFile = writer.write(codeInfo);
             if (nativeLibs.getErrors().size() > 0) {
                 return codeInfo;
             }
             assert Files.exists(queryFile);
+
+            if (CAnnotationProcessorCache.Options.ExitAfterQueryCodeGeneration.getValue()) {
+                // Only output query code and exit
+                return codeInfo;
+            }
 
             Path binary = compileQueryCode(queryFile);
             if (nativeLibs.getErrors().size() > 0) {
@@ -140,7 +154,7 @@ public class CAnnotationProcessor {
             throw VMError.shouldNotReachHere(queryFile + " invalid queryFile");
         }
         String fileName = fileNamePath.toString();
-        Path binary = queryFile.resolveSibling(compilerInvoker.asExecutableName(fileName.substring(0, fileName.lastIndexOf("."))));
+        Path binary = tempDirectory.resolve(compilerInvoker.asExecutableName(fileName.substring(0, fileName.lastIndexOf("."))));
         ArrayList<String> options = new ArrayList<>();
         options.addAll(codeCtx.getDirectives().getOptions());
         if (Platform.includedIn(Platform.LINUX.class)) {

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/c/CAnnotationProcessorCache.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/c/CAnnotationProcessorCache.java
@@ -76,9 +76,16 @@ public final class CAnnotationProcessorCache {
 
         @Option(help = "Exit image generation after C Annotation Processor Cache creation.")//
         public static final HostedOptionKey<Boolean> ExitAfterCAPCache = new HostedOptionKey<>(false);
+
+        @Option(help = "Output query code for target platform without executing it")//
+        public static final HostedOptionKey<Boolean> ExitAfterQueryCodeGeneration = new HostedOptionKey<>(false);
+
+        @Option(help = "Directory where query code for target platform should be output")//
+        public static final HostedOptionKey<String> QueryCodeDir = new HostedOptionKey<>("");
     }
 
     private File cache;
+    private File query;
 
     public CAnnotationProcessorCache() {
         if ((Options.UseCAPCache.getValue() || Options.NewCAPCache.getValue())) {
@@ -101,6 +108,23 @@ public final class CAnnotationProcessorCache {
             } else if (Options.NewCAPCache.getValue()) {
                 clearCache();
             }
+        }
+
+        if (Options.QueryCodeDir.hasBeenSet()) {
+            Path queryPath = FileSystems.getDefault().getPath(Options.QueryCodeDir.getValue()).toAbsolutePath();
+            query = queryPath.toFile();
+            if (!query.exists()) {
+                try {
+                    query = Files.createDirectories(queryPath).toFile();
+                } catch (IOException e) {
+                    throw UserError.abort("Could not create query code directory: " + e.getMessage());
+                }
+            } else if (!query.isDirectory()) {
+                throw UserError.abort("Path to query code directory is not a directory");
+            }
+        } else if (Options.ExitAfterQueryCodeGeneration.hasBeenSet()) {
+            throw UserError.abort("Query code directory wasn't specified, use  " +
+                            SubstrateOptionsParser.commandArgument(CAnnotationProcessorCache.Options.QueryCodeDir, "PATH") + " option.");
         }
     }
 

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/c/NativeLibraries.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/c/NativeLibraries.java
@@ -324,7 +324,8 @@ public final class NativeLibraries {
         if (staticLibsDir != null) {
             libraryPaths.add(staticLibsDir.toString());
         } else {
-            if (!NativeImageOptions.ExitAfterRelocatableImageWrite.getValue()) {
+            if (!NativeImageOptions.ExitAfterRelocatableImageWrite.getValue() && !CAnnotationProcessorCache.Options.ExitAfterQueryCodeGeneration.getValue() &&
+                            !CAnnotationProcessorCache.Options.ExitAfterCAPCache.getValue()) {
                 /* Fail if we will statically link JDK libraries but do not have them available */
                 String libCMessage = "";
                 if (Platform.includedIn(Platform.LINUX.class)) {

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/c/codegen/QueryCodeWriter.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/c/codegen/QueryCodeWriter.java
@@ -123,11 +123,19 @@ public class QueryCodeWriter extends InfoTreeVisitor {
         writer.appendln("#define IS_CONST_UNSIGNED(a) (a>=0 ? 1 : 0)");
 
         /* Write the main function with all the outputs for the children. */
+        String functionName = nativeCodeInfo.getName().replaceAll("\\W", "_");
         writer.appendln();
-        writer.appendln("int main(void) {");
+        writer.appendln("int " + functionName + "() {");
         writer.indent();
         processChildren(nativeCodeInfo);
         writer.indents().appendln("return 0;");
+        writer.outdent();
+        writer.appendln("}");
+
+        writer.appendln();
+        writer.appendln("int main(void) {");
+        writer.indent();
+        writer.indents().appendln("return " + functionName + "();");
         writer.outdent();
         writer.appendln("}");
     }

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/c/info/InfoTreeVisitor.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/c/info/InfoTreeVisitor.java
@@ -24,11 +24,17 @@
  */
 package com.oracle.svm.hosted.c.info;
 
+import com.oracle.svm.core.util.UserError;
+
 public abstract class InfoTreeVisitor {
 
     protected final void processChildren(ElementInfo info) {
         for (ElementInfo child : info.getChildren()) {
-            child.accept(this);
+            try {
+                child.accept(this);
+            } catch (NumberFormatException e) {
+                throw UserError.abort("Missing CAP cache value for: " + child.getUniqueID());
+            }
         }
     }
 


### PR DESCRIPTION
* Added `ExitAfterQueryCodeGeneration` native-image argument (output query code for target platform without executing it)
* Added `QueryCodeDir` native-image argument (directory where query code for target platform should be output)
* Split query code function and main
* Output which value is missing from CAP cache if CAP cache is corrupted or isn't up to date.