### PR TITLE
Add API for callback arguments which are allocated dynamically

### DIFF
--- a/substratevm/src/org.graalvm.polyglot.nativeapi/src/org/graalvm/polyglot/nativeapi/PolyglotNativeAPI.java
+++ b/substratevm/src/org.graalvm.polyglot.nativeapi/src/org/graalvm/polyglot/nativeapi/PolyglotNativeAPI.java
@@ -84,12 +84,14 @@ import org.graalvm.polyglot.nativeapi.types.PolyglotNativeAPITypes.PolyglotExcep
 import org.graalvm.polyglot.nativeapi.types.PolyglotNativeAPITypes.PolyglotExceptionHandlePointer;
 import org.graalvm.polyglot.nativeapi.types.PolyglotNativeAPITypes.PolyglotExtendedErrorInfo;
 import org.graalvm.polyglot.nativeapi.types.PolyglotNativeAPITypes.PolyglotExtendedErrorInfoPointer;
+import org.graalvm.polyglot.nativeapi.types.PolyglotNativeAPITypes.PolyglotHandle;
 import org.graalvm.polyglot.nativeapi.types.PolyglotNativeAPITypes.PolyglotIsolateThread;
 import org.graalvm.polyglot.nativeapi.types.PolyglotNativeAPITypes.PolyglotLanguage;
 import org.graalvm.polyglot.nativeapi.types.PolyglotNativeAPITypes.PolyglotLanguagePointer;
 import org.graalvm.polyglot.nativeapi.types.PolyglotNativeAPITypes.PolyglotStatus;
 import org.graalvm.polyglot.nativeapi.types.PolyglotNativeAPITypes.PolyglotValue;
 import org.graalvm.polyglot.nativeapi.types.PolyglotNativeAPITypes.PolyglotValuePointer;
+import org.graalvm.polyglot.nativeapi.types.PolyglotNativeAPITypes.PolyglotValuePointerPointer;
 import org.graalvm.polyglot.nativeapi.types.PolyglotNativeAPITypes.SizeTPointer;
 import org.graalvm.polyglot.proxy.ProxyArray;
 import org.graalvm.polyglot.proxy.ProxyExecutable;
@@ -1486,16 +1488,44 @@ public final class PolyglotNativeAPI {
                     " @since 19.0",
     })
     public static PolyglotStatus poly_get_callback_info(PolyglotIsolateThread thread, PolyglotCallbackInfo callback_info, SizeTPointer argc, PolyglotValuePointer argv, WordPointer data) {
+        return poly_get_callback_info_internal(thread, callback_info, argc, argv, data, false);
+    }
+
+    @CEntryPoint(name = "poly_get_callback_info_dynamic", documentation = {
+                    "Retrieves details about the call within a callback (e.g., the arguments from a given callback info).",
+                    "This function would allocate memory for argv, so the caller has responsibility to release it via free().",
+                    "",
+                    " @param callback_info from the callback.",
+                    " @param argc number of arguments to the callback.",
+                    " @param argv double pointer of poly_value for arguments for the callback. If the call succeed, memory for arguments is allocated dynamically.",
+                    " @param the data pointer for the callback.",
+                    " @since 20.2",
+    })
+    public static PolyglotStatus poly_get_callback_info_dynamic(PolyglotIsolateThread thread, PolyglotCallbackInfo callback_info, SizeTPointer argc, PolyglotValuePointerPointer argv, WordPointer data) {
+        return poly_get_callback_info_internal(thread, callback_info, argc, argv, data, true);
+    }
+
+    private static PolyglotStatus poly_get_callback_info_internal(PolyglotIsolateThread thread, PolyglotCallbackInfo callback_info, SizeTPointer argc, PolyglotHandle argv, WordPointer data, boolean needAlloc) {
         return withHandledErrors(() -> {
             PolyglotCallbackInfoInternal callbackInfo = fetchHandle(callback_info);
             UnsignedWord numberOfArguments = WordFactory.unsigned(callbackInfo.arguments.length);
-            UnsignedWord bufferSize = argc.read();
-            UnsignedWord size = bufferSize.belowThan(numberOfArguments) ? bufferSize : numberOfArguments;
-            argc.write(size);
-            for (UnsignedWord i = WordFactory.zero(); i.belowThan(size); i = i.add(1)) {
+            PolyglotValuePointer arglist;
+            if (needAlloc) { // argv instanceof PolyglotValuePointer: "Cannot use instanceof for word a type"
+                arglist = UnmanagedMemory.malloc(numberOfArguments.multiply(SizeOf.unsigned(PolyglotValue.class)));
+                ((PolyglotValuePointerPointer)argv).write(arglist);
+            } else {
+                arglist = (PolyglotValuePointer)argv;
+                UnsignedWord bufferSize = argc.read();
+                if (bufferSize.belowThan(numberOfArguments)) {
+                    numberOfArguments = bufferSize;
+                }
+            }
+            argc.write(numberOfArguments);
+
+            for (UnsignedWord i = WordFactory.zero(); i.belowThan(numberOfArguments); i = i.add(1)) {
                 int index = (int) i.rawValue();
                 ObjectHandle argument = callbackInfo.arguments[index];
-                argv.write(index, argument);
+                arglist.write(index, argument);
             }
             data.write(callbackInfo.data);
         });

--- a/substratevm/src/org.graalvm.polyglot.nativeapi/src/org/graalvm/polyglot/nativeapi/types/PolyglotNativeAPITypes.java
+++ b/substratevm/src/org.graalvm.polyglot.nativeapi/src/org/graalvm/polyglot/nativeapi/types/PolyglotNativeAPITypes.java
@@ -200,6 +200,11 @@ public class PolyglotNativeAPITypes {
         void write(int index, ObjectHandle value);
     }
 
+    @CPointerTo(PolyglotValuePointer.class)
+    public interface PolyglotValuePointerPointer extends PointerBase, PolyglotHandle {
+        void write(ObjectHandle value);
+    }
+
     @CPointerTo(nameOfCType = "poly_callback_info")
     @CTypedef(name = "poly_callback_info")
     public interface PolyglotCallbackInfo extends PointerBase, PolyglotHandle {


### PR DESCRIPTION
This PR is for issue #2632

`poly_get_callback_info()` requires pointer to store arguments for callback functions.  
Currently `argc` would be stored, however we need to pass pointer to `argv` , so it is difficult to handle varargs.

I want to introduce new API `poly_get_callback_info_dynamic()` for it. It would allocate memory for `argv`, so the caller does not need to consider length and memory allocation for `argv`. Of course the caller has a responsibility to release it.

You can see difference between `poly_get_callback_info()` and `poly_get_callback_info_dynamic()` in following example with `TEST_DYNAMIC` macro:

```
#ifdef TEST_DYNAMIC
  poly_value *argv;
#else
  poly_value argv[2];
#endif

  char buf[1024];
  int first_arg;
  int argc;

  /* Get callback info from caller */
#ifdef TEST_DYNAMIC
  poly_get_callback_info_dynamic(thread, info, &argc, &argv, (void **)&data);
#else
  argc = 2;
  poly_get_callback_info(thread, info, &argc, argv, (void **)&data);
#endif

  printf("argc: %d\n", argc);

  poly_value_as_int32(thread, argv[0], &first_arg);
  printf("1st argument: %d\n", first_arg);

  poly_value_to_string_utf8(thread, argv[1], buf, 1024, &len);
  printf("2nd argument: %s\n", buf);

#ifdef TEST_DYNAMIC
  /* Free arguments */
  free(argv);
#endif
```