### PR TITLE
UnsafeSubstitutionsTest stores object to int field

### DIFF
--- a/compiler/src/org.graalvm.compiler.replacements.test/src/org/graalvm/compiler/replacements/test/UnsafeSubstitutionsTest.java
+++ b/compiler/src/org.graalvm.compiler.replacements.test/src/org/graalvm/compiler/replacements/test/UnsafeSubstitutionsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -136,7 +136,7 @@ public class UnsafeSubstitutionsTest extends MethodSubstitutionTest {
             test("unsafePutLong", unsafeArg, supply(() -> new Foo()), fooOffset("l"), 4711L);
             test("unsafePutFloat", unsafeArg, supply(() -> new Foo()), fooOffset("f"), 58.0F);
             test("unsafePutDouble", unsafeArg, supply(() -> new Foo()), fooOffset("d"), -28736.243465D);
-            test("unsafePutObject", unsafeArg, supply(() -> new Foo()), fooOffset("i"), "value1", "value2", "value3");
+            test("unsafePutObject", unsafeArg, supply(() -> new Foo()), fooOffset("o"), "value1", "value2", "value3");
 
             test("unsafeGetAddress", unsafeArg, address);
             test("unsafePutAddress", unsafeArg, address, 0xDEAD_BEEF_DEAD_BABEL);


### PR DESCRIPTION
Running this test on AArch64 with -XX:-UseCompressedOops crashes the VM
with a SIGBUS. This is caused by a call to unsafePutObjectVolatile with
a non-64-bit-aligned offset (12). The VM should throw an exception here
rather than crash, and that needs to be fixed separately (it's a variant
of JDK-8246051), but we should also fix the test to use the offset of
the correct field.