### PR TITLE
Enforce consistent lookup of class and file names

### DIFF
--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/image/NativeImageDebugInfoProvider.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/image/NativeImageDebugInfoProvider.java
@@ -99,7 +99,12 @@ class NativeImageDebugInfoProvider implements DebugInfoProvider {
             this.method = method;
             HostedType declaringClass = method.getDeclaringClass();
             Class<?> clazz = declaringClass.getJavaClass();
-            this.javaType = declaringClass.getWrapped();
+            /*
+             * HostedType wraps an AnalysisType and both HostedType and AnalysisType punt calls to
+             * getSourceFilename to the wrapped class so for consistency we need to do the path
+             * lookup relative to the doubly unwrapped HostedType.
+             */
+            this.javaType = declaringClass.getWrapped().getWrapped();
             this.compilation = compilation;
             SourceManager sourceManager = ImageSingletons.lookup(SourceManager.class);
             try (DebugContext.Scope s = debugContext.scope("DebugCodeInfo", declaringClass)) {
@@ -309,8 +314,9 @@ class NativeImageDebugInfoProvider implements DebugInfoProvider {
                 clazz = ((OriginalClassProvider) declaringClass).getJavaClass();
             }
             /*
-             * HostedType and AnalysisType punt calls to getSourceFilename to the wrapped class so
-             * for consistency we need to do the path lookup relative to the wrapped class.
+             * HostedType wraps an AnalysisType and both HostedType and AnalysisType punt calls to
+             * getSourceFilename to the wrapped class so for consistency we need to do the path
+             * lookup relative to the doubly unwrapped HostedType or singly unwrapped AnalysisType.
              */
             if (declaringClass instanceof HostedType) {
                 declaringClass = ((HostedType) declaringClass).getWrapped();

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/image/sources/SourceManager.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/image/sources/SourceManager.java
@@ -110,6 +110,9 @@ public class SourceManager {
      * @return the file name or null if it the class cannot be associated with a source file
      */
     private static String computeBaseName(ResolvedJavaType resolvedType) {
+        if (resolvedType.isPrimitive()) {
+            return null;
+        }
         String fileName = resolvedType.getSourceFileName();
         if (fileName == null) {
             /* ok, try to construct it from the class name */


### PR DESCRIPTION
This patch fixes issue  #2693. It ensures that the NativeImageDebugInfoProvider hands out consistent source file names and class names when providing info about types compiled into a native image.
