### PR TITLE
Omit stmt_list from CU info record when it has no associated line records

### DIFF
--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfDebugInfo.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfDebugInfo.java
@@ -59,8 +59,9 @@ public class DwarfDebugInfo extends DebugInfoBase {
      * Define all the abbrev section codes we need for our DIEs.
      */
     @SuppressWarnings("unused") public static final int DW_ABBREV_CODE_null = 0;
-    public static final int DW_ABBREV_CODE_compile_unit = 1;
-    public static final int DW_ABBREV_CODE_subprogram = 2;
+    public static final int DW_ABBREV_CODE_compile_unit_1 = 1;
+    public static final int DW_ABBREV_CODE_compile_unit_2 = 2;
+    public static final int DW_ABBREV_CODE_subprogram = 3;
 
     /*
      * Define all the Dwarf tags we need for our DIEs.


### PR DESCRIPTION
This patch fixes issue #2697. It was tested by applying it on top of the patch for #2695 where it resolved the gdb 7.11 crash that is stopping that latter patch pass the debuginfotest gate. The fix allows for two variants of the info Compile Unit record for a top level compiled method, one with a stmt_list and one without. The latter  is used when there are no line records associated with a method.
