### PR TITLE
Fixes inlined code's cache paths for DWARF generation

### DIFF
--- a/substratevm/mx.substratevm/mx_substratevm.py
+++ b/substratevm/mx.substratevm/mx_substratevm.py
@@ -727,7 +727,7 @@ def _debuginfotest(native_image, path, build_only, args):
                          '-H:+VerifyNamingConventions',
                          '-cp', classpath('com.oracle.svm.test'),
                          '-Dgraal.LogFile=graal.log',
-                         '-H:GenerateDebugInfo=1',
+                         '-g',
                          '-H:DebugInfoSourceSearchPath=' + sourcepath,
                          '-H:DebugInfoSourceCacheRoot=' + join(path, 'sources'),
                          'hello.Hello'] + args

--- a/substratevm/mx.substratevm/testhello.py
+++ b/substratevm/mx.substratevm/testhello.py
@@ -30,7 +30,7 @@
 # Assumes you have already executed
 #
 # $ javac hello/Hello.java
-# $ mx native-image -H:GenerateDebugInfo=1 hello.hello
+# $ mx native-image -g hello.hello
 #
 # Run test
 #

--- a/substratevm/mx.substratevm/testhello.py
+++ b/substratevm/mx.substratevm/testhello.py
@@ -34,7 +34,7 @@
 #
 # Run test
 #
-# gdb -d /path/to/sources/src -d /path/to/sources/graal -d /path/to/sources/jdk -x testhello.py /path/to/hello
+# gdb -x testhello.py /path/to/hello
 #
 # exit status 0 means all is well 1 means test failed
 #

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/ClassEntry.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/ClassEntry.java
@@ -28,7 +28,9 @@ package com.oracle.objectfile.debugentry;
 
 import com.oracle.objectfile.debuginfo.DebugInfoProvider.DebugFrameSizeChange;
 
+import java.nio.file.Path;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -70,6 +72,11 @@ public class ClassEntry {
      * a list of the same dirs.
      */
     private LinkedList<DirEntry> localDirs;
+    /**
+     * A {@link java.util.Set Set} of directories containing the source files of the compiled code
+     * in this class.
+     */
+    private HashSet<String> cachePaths;
     /**
      * index of debug_info section compilation unit for this class.
      */
@@ -120,9 +127,10 @@ public class ClassEntry {
         this.linePrologueSize = -1;
         this.totalSize = -1;
         this.includesDeoptTarget = false;
+        this.cachePaths = new HashSet<>();
     }
 
-    public void addPrimary(Range primary, List<DebugFrameSizeChange> frameSizeInfos, int frameSize) {
+    public void addPrimary(Range primary, List<DebugFrameSizeChange> frameSizeInfos, int frameSize, StringTable stringTable) {
         if (primaryIndex.get(primary) == null) {
             PrimaryEntry primaryEntry = new PrimaryEntry(primary, frameSizeInfos, frameSize, this);
             primaryEntries.add(primaryEntry);
@@ -133,10 +141,13 @@ public class ClassEntry {
                 /* deopt targets should all come after normal methods */
                 assert includesDeoptTarget == false;
             }
+            addCachePath(primary, stringTable);
         }
+        assert primary.getCachePath() == null || primary.getCachePath().toString().isEmpty() || cachePaths.contains(primary.getCachePath().toString()) : primary.getCachePath().toString() +
+                        " missing from cache path of " + className;
     }
 
-    public void addSubRange(Range subrange, FileEntry subFileEntry) {
+    public void addSubRange(Range subrange, FileEntry subFileEntry, StringTable stringTable) {
         Range primary = subrange.getPrimary();
         /*
          * the subrange should belong to a primary range
@@ -159,6 +170,15 @@ public class ClassEntry {
                 localDirs.add(dirEntry);
                 localDirsIndex.put(dirEntry, localDirs.size());
             }
+            addCachePath(subrange, stringTable);
+        }
+    }
+
+    private void addCachePath(Range subrange, StringTable stringTable) {
+        Path cachePath = subrange.getCachePath();
+        if (cachePath != null && !cachePath.toString().isEmpty()) {
+            cachePaths.add(cachePath.toString());
+            stringTable.uniqueDebugString(getCachePathsString());
         }
     }
 
@@ -278,11 +298,12 @@ public class ClassEntry {
         return includesDeoptTarget;
     }
 
-    public String getCachePath() {
-        if (fileEntry != null) {
-            return fileEntry.getCachePath();
-        } else {
-            return "";
-        }
+    /**
+     * The compilation directories in which to look for source files as a colon ({@code :})
+     * separated {@link String}.
+     */
+    public String getCachePathsString() {
+        return String.join(":", cachePaths);
     }
+
 }

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/DebugInfoBase.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/DebugInfoBase.java
@@ -205,7 +205,7 @@ public abstract class DebugInfoBase {
         FileEntry fileEntry = filesIndex.get(fileAsPath);
         if (fileEntry == null) {
             DirEntry dirEntry = ensureDirEntry(filePath);
-            fileEntry = new FileEntry(fileName, dirEntry, range.getCachePath());
+            fileEntry = new FileEntry(fileName, dirEntry);
             files.add(fileEntry);
             /*
              * Index the file entry by file path.
@@ -224,7 +224,7 @@ public abstract class DebugInfoBase {
     private void addRange(Range primaryRange, List<DebugInfoProvider.DebugFrameSizeChange> frameSizeInfos, int frameSize) {
         assert primaryRange.isPrimary();
         ClassEntry classEntry = ensureClassEntry(primaryRange);
-        classEntry.addPrimary(primaryRange, frameSizeInfos, frameSize);
+        classEntry.addPrimary(primaryRange, frameSizeInfos, frameSize, stringTable);
     }
 
     private void addSubRange(Range primaryRange, Range subrange) {
@@ -239,7 +239,7 @@ public abstract class DebugInfoBase {
          */
         assert classEntry.primaryIndexFor(primaryRange) != null;
         if (subrangeFileEntry != null) {
-            classEntry.addSubRange(subrange, subrangeFileEntry);
+            classEntry.addSubRange(subrange, subrangeFileEntry, stringTable);
         }
     }
 

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/FileEntry.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/FileEntry.java
@@ -32,12 +32,10 @@ package com.oracle.objectfile.debugentry;
 public class FileEntry {
     private String fileName;
     private DirEntry dirEntry;
-    private String cachePath;
 
-    public FileEntry(String fileName, DirEntry dirEntry, String cachePath) {
+    public FileEntry(String fileName, DirEntry dirEntry) {
         this.fileName = fileName;
         this.dirEntry = dirEntry;
-        this.cachePath = cachePath;
     }
 
     /**
@@ -62,10 +60,4 @@ public class FileEntry {
         return dirEntry;
     }
 
-    /**
-     * The compilation directory in which to look for source files as a {@link String}.
-     */
-    public String getCachePath() {
-        return cachePath;
-    }
 }

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/Range.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/Range.java
@@ -36,7 +36,7 @@ import java.nio.file.Paths;
  */
 
 public class Range {
-    private final String cachePath;
+    private final Path cachePath;
     private String fileName;
     private Path filePath;
     private String className;
@@ -80,7 +80,7 @@ public class Range {
          */
         this.fileName = (fileName == null ? null : stringTable.uniqueDebugString(fileName));
         this.filePath = filePath;
-        this.cachePath = (cachePath == null ? "" : stringTable.uniqueDebugString(cachePath.toString()));
+        this.cachePath = cachePath;
         this.className = stringTable.uniqueString(className);
         this.methodName = stringTable.uniqueString(methodName);
         this.paramNames = stringTable.uniqueString(paramNames);
@@ -177,7 +177,7 @@ public class Range {
     /**
      * Get the compilation directory in which to look for source files as a {@link String}.
      */
-    public String getCachePath() {
+    public Path getCachePath() {
         return cachePath;
     }
 }

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/StringTable.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/StringTable.java
@@ -89,7 +89,7 @@ public class StringTable implements Iterable<StringEntry> {
      */
     public int debugStringIndex(String string) {
         StringEntry stringEntry = table.get(string);
-        assert stringEntry != null;
+        assert stringEntry != null : "\"" + string + "\" not in string table";
         if (stringEntry == null) {
             return -1;
         }

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfInfoSectionImpl.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfInfoSectionImpl.java
@@ -263,7 +263,7 @@ public class DwarfInfoSectionImpl extends DwarfSectionImpl {
         pos = writeAttrData1(DW_LANG_Java, buffer, pos);
         log(context, "  [0x%08x]     name  0x%x (%s)", pos, debugStringIndex(classEntry.getFileName()), classEntry.getFileName());
         pos = writeAttrStrp(classEntry.getFileName(), buffer, pos);
-        String compilationDirectory = classEntry.getCachePath();
+        String compilationDirectory = classEntry.getCachePathsString();
         log(context, "  [0x%08x]     comp_dir  0x%x (%s)", pos, debugStringIndex(compilationDirectory), compilationDirectory);
         pos = writeAttrStrp(compilationDirectory, buffer, pos);
         int lo = findLo(classPrimaryEntries, isDeoptTargetCU);


### PR DESCRIPTION
Since inlined methods may be defined in a different file than the one
defining a compiled method, the cache paths of all the source files
contributing code to the compiled method need to be set as the
compilation directory to make gdb work.

E.g. If:
1. `foo` invokes `bar` and `baz`
2. `bar` and `baz` get inlined in `foo`
3. `foo`'s source file is cached in `sources/src`
4. `bar`'s source file is cached in `sources/jdk`
5. `baz`'s source file is cached in `sources/graal`

then the compilation directory in `foo`'s compilation unit needs to be
set to `sources/src:sources/jdk:sources/graal`