### PR TITLE
ClassValue substitution: Fix computeValue usage

### DIFF
--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/JavaLangSubstitutions.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/JavaLangSubstitutions.java
@@ -569,7 +569,7 @@ final class Target_java_lang_ClassValue {
     @RecomputeFieldValue(kind = RecomputeFieldValue.Kind.Custom, declClass = JavaLangSubstitutions.ClassValueInitializer.class)//
     private final ConcurrentMap<Class<?>, Object> values;
 
-    private static final Object dummyNull = new Object();
+    private static final Object NULL_MARKER = new Object();
 
     @Substitute
     private Target_java_lang_ClassValue() {
@@ -589,14 +589,14 @@ final class Target_java_lang_ClassValue {
         if (result == null) {
             Object newValue = computeValue(type);
             if (newValue == null) {
-                /* values can't store null, replace with dummyNull */
-                newValue = dummyNull;
+                /* values can't store null, replace with NULL_MARKER */
+                newValue = NULL_MARKER;
             }
             Object oldValue = values.putIfAbsent(type, newValue);
             result = oldValue != null ? oldValue : newValue;
         }
-        if (result == dummyNull) {
-            /* replace dummyNull back to real null */
+        if (result == NULL_MARKER) {
+            /* replace NULL_MARKER back to real null */
             result = null;
         }
         return result;


### PR DESCRIPTION
This PR fixes #2421.

The "get" method of ClassValue  has the special property that racing threads must return the same value.
In the substitution this is ensured by using a ConcurrentHashMap. The problem is, that this map can't handle null values - but null is a valid response. Without the PR a NPE occurs if null is a response.

To support null we can use a dummy null. This dummy null can be store in the map.
The dummy null is also here to distinguish between "value was computed = null" and "value was not yet computed".
Because a simple `if (newValue == null) return null;` is not correct. 
If we would do this simple check, instead of using a dummy null, the next time the "get" method is called for the same type, "computeValue" would be called again. This is not correct.