### PR TITLE
Fix code that assumes suites are under a vcs repository

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -80,6 +80,8 @@ matrix:
   - os: linux
     arch: arm64
     env: JDK="jdk11" GATE="build,bootstraplite" PRIMARY="compiler"
+  - os: linux
+    env: JDK="jdk11" WITHOUT_VCS=true
 # GR-16977
 #  - env: JDK="jdk11" GATE="build,test,helloworld" PRIMARY="substratevm"
 
@@ -135,7 +137,14 @@ install:
 script:
   - echo ${JAVA_HOME}
   - ${JAVA_HOME}/bin/java -version
-  - mx --primary-suite-path ${TRAVIS_BUILD_DIR}/${PRIMARY} --J @"-Xmx2g" --java-home=${JAVA_HOME} gate --strict-mode --tags ${GATE}
+  - |
+      if [[ ${WITHOUT_VCS} ]]
+      then
+        rm -rf .git
+        mx --primary-suite-path ${TRAVIS_BUILD_DIR}/substratevm native-image --help
+      else
+        mx --primary-suite-path ${TRAVIS_BUILD_DIR}/${PRIMARY} --J @"-Xmx2g" --java-home=${JAVA_HOME} gate --strict-mode --tags ${GATE}
+      fi
 after_failure:
   - cat hs_err*
 notifications:

--- a/compiler/mx.compiler/mx_compiler.py
+++ b/compiler/mx.compiler/mx_compiler.py
@@ -1273,7 +1273,10 @@ def _update_graaljdk(src_jdk, dst_jdk_dir=None, root_module_names=None, export_t
 
         vm_name = 'Server VM Graal'
         for d in _graal_config().jvmci_dists:
-            s = ':' + d.suite.name + '_' + d.suite.version()
+            version = d.suite.version()
+            s = ':' + d.suite.name
+            if version:
+                s += '_' + d.suite.version()
             if s not in vm_name:
                 vm_name = vm_name + s
 
@@ -1341,10 +1344,12 @@ def _update_graaljdk(src_jdk, dst_jdk_dir=None, root_module_names=None, export_t
         with open(join(tmp_dst_jdk_dir, 'release.jvmci'), 'w') as fp:
             for d in _graal_config().jvmci_dists:
                 s = d.suite
-                print('{}={}'.format(d.name, s.vc.parent(s.dir)), file=fp)
+                if s.vc:
+                    print('{}={}'.format(d.name, s.vc.parent(s.dir)), file=fp)
             for d in _graal_config().boot_dists + _graal_config().truffle_dists:
                 s = d.suite
-                print('{}={}'.format(d.name, s.vc.parent(s.dir)), file=fp)
+                if s.vc:
+                    print('{}={}'.format(d.name, s.vc.parent(s.dir)), file=fp)
 
         assert exists(jvmlib), jvmlib + ' does not exist'
         out = mx.LinesOutputCapture()

--- a/compiler/mx.compiler/suite.py
+++ b/compiler/mx.compiler/suite.py
@@ -1,5 +1,5 @@
 suite = {
-  "mxversion" : "5.267.0",
+  "mxversion" : "5.270.0",
   "name" : "compiler",
   "sourceinprojectwhitelist" : [],
 

--- a/sdk/mx.sdk/mx_sdk.py
+++ b/sdk/mx.sdk/mx_sdk.py
@@ -72,8 +72,12 @@ def build_oracle_compliant_javadoc_args(suite, product_name, feature_name):
     :type feature_name: str
     """
     version = suite.release_version()
-    revision = suite.vc.parent(suite.vc_dir)
-    copyright_year = str(datetime.datetime.fromtimestamp(suite.vc.parent_info(suite.vc_dir)['committer-ts']).year)
+    if suite.vc:
+        revision = suite.vc.parent(suite.vc_dir)
+        copyright_year = str(datetime.datetime.fromtimestamp(suite.vc.parent_info(suite.vc_dir)['committer-ts']).year)
+    else:
+        revision = None
+        copyright_year = datetime.datetime.now().year
     return ['--arg', '@-header', '--arg', '<b>%s %s Java API Reference<br>%s</b><br>%s' % (product_name, feature_name, version, revision),
             '--arg', '@-bottom', '--arg', '<center>Copyright &copy; 2012, %s, Oracle and/or its affiliates. All rights reserved.</center>' % (copyright_year),
             '--arg', '@-windowtitle', '--arg', '%s %s Java API Reference' % (product_name, feature_name)]

--- a/sdk/mx.sdk/mx_sdk_vm_impl.py
+++ b/sdk/mx.sdk/mx_sdk_vm_impl.py
@@ -817,7 +817,10 @@ x-GraalVM-Component-Distribution=bundled
             catalog = _release_catalog()
         else:
             snapshot_catalog = _snapshot_catalog()
-            catalog = "{}/{}".format(snapshot_catalog, _suite.vc.parent(_suite.vc_dir)) if snapshot_catalog else None
+            if snapshot_catalog and _suite.vc:
+                catalog = "{}/{}".format(snapshot_catalog, _suite.vc.parent(_suite.vc_dir))
+            else:
+                catalog = None
         if catalog:
             _metadata_dict['component_catalog'] = quote(catalog)
 

--- a/sdk/mx.sdk/suite.py
+++ b/sdk/mx.sdk/suite.py
@@ -39,7 +39,7 @@
 # SOFTWARE.
 #
 suite = {
-  "mxversion" : "5.251.0",
+  "mxversion" : "5.270.0",
   "name" : "sdk",
   "version" : "20.3.0",
   "release" : False,

--- a/substratevm/mx.substratevm/mx_substratevm.py
+++ b/substratevm/mx.substratevm/mx_substratevm.py
@@ -1452,16 +1452,20 @@ def _ensure_vm_built(config):
             vm_linkname = os.path.relpath(_vm_home(config), dirname(vm_link))
             os.symlink(vm_linkname, vm_link)
     rev_file_name = join(svmbuild_dir(), 'vm-rev')
-    rev_value = svm_suite().vc.parent(svm_suite().vc_dir)
+    if svm_suite().vc:
+        rev_value = svm_suite().vc.parent(svm_suite().vc_dir)
+    else:
+        rev_value = None
     if not os.path.exists(rev_file_name):
         rebuild_vm = True
     else:
         with open(rev_file_name, 'r') as f:
-            if f.read() != rev_value:
+            if not rev_value or f.read() != rev_value:
                 rebuild_vm = True
     if rebuild_vm:
-        with open(rev_file_name, 'w') as f:
-            f.write(rev_value)
+        if rev_value:
+            with open(rev_file_name, 'w') as f:
+                f.write(rev_value)
         build_native_image_image(config)
 
 @mx.command(suite.name, 'native-image')

--- a/substratevm/mx.substratevm/suite.py
+++ b/substratevm/mx.substratevm/suite.py
@@ -1,5 +1,5 @@
 suite = {
-    "mxversion": "5.265.3",
+    "mxversion": "5.270.0",
     "name": "substratevm",
     "version" : "20.3.0",
     "release" : False,


### PR DESCRIPTION
As of mx 5.270.0 (https://github.com/graalvm/mx/pull/221), mx projects can be built even outside a vcs repository.
This patch makes the necessary changes to allow graal to be built outside a vcs repository.