### PR TITLE
[GR-25560] Allow optional CodeObserver installation.

### DIFF
--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/code/InstalledCodeObserverSupport.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/code/InstalledCodeObserverSupport.java
@@ -58,12 +58,14 @@ public final class InstalledCodeObserverSupport {
     }
 
     public InstalledCodeObserver[] createObservers(DebugContext debug, SharedMethod method, CompilationResult compilation, Pointer code) {
-        InstalledCodeObserver[] observers = new InstalledCodeObserver[observerFactories.size()];
-        int index = 0;
+        List<InstalledCodeObserver> observers = new ArrayList<>();
         for (InstalledCodeObserver.Factory factory : observerFactories) {
-            observers[index++] = factory.create(debug, method, compilation, code);
+            InstalledCodeObserver observer = factory.create(debug, method, compilation, code);
+            if (observer != null) {
+                observers.add(observer);
+            }
         }
-        return observers;
+        return observers.toArray(new InstalledCodeObserver[0]);
     }
 
     public static NonmovableArray<InstalledCodeObserverHandle> installObservers(InstalledCodeObserver[] observers) {


### PR DESCRIPTION
This change gives `InstalledCodeObserver.Factory` the flexibility to make installing a `InstalledCodeObserver` optional.