### PR TITLE
Added ProloGraal to the experiment list

### DIFF
--- a/truffle/docs/Languages.md
+++ b/truffle/docs/Languages.md
@@ -35,5 +35,6 @@ The following language implementations exist already:
 * [bf](https://github.com/chumer/bf/), an experimental Brainfuck programming language implementation.
 * [brainfuck-jvm](https://github.com/mthmulders/brainfuck-jvm), another Brainfuck language implementation.
 * [Heap Language](https://github.com/jaroslavtulach/heapdump) tutorial showing embedding of Truffle languages via interoperability.
+* [ProloGraal](https://gitlab.forge.hefr.ch/tony.licata/prolog-truffle) a Prolog language implementation supporting interoperability.
 
 Submit a [pull request](https://help.github.com/articles/using-pull-requests/) to add/remove from this list.


### PR DESCRIPTION
Dear GraalVM Developers,

During several student projects at the [School of Engineering and Architecture of Fribourg in Switzerland](https://www.heia-fr.ch/en/), a basic Prolog interpreter has been developed for GraalVM, named ProloGraal. ProloGraal is currently in an experimental state, and new features and modifications will be brought with time.

Tony Licata - School of Engineering and Architecture of Fribourg