### PR TITLE
Fix #1788 when using native-image-agent to generate config.

### DIFF
--- a/substratevm/src/com.oracle.svm.configure/src/com/oracle/svm/configure/trace/ReflectionProcessor.java
+++ b/substratevm/src/com.oracle.svm.configure/src/com/oracle/svm/configure/trace/ReflectionProcessor.java
@@ -145,7 +145,11 @@ class ReflectionProcessor extends AbstractProcessor {
                 memberKind = ConfigurationMemberKind.DECLARED;
                 // fall through
             case "getField": {
-                configuration.getOrCreateType(clazzOrDeclaringClass).addField(singleElement(args), memberKind, false, unsafeAccess);
+                String theClass = clazzOrDeclaringClass;
+                if (memberKind != ConfigurationMemberKind.DECLARED && !clazzOrDeclaringClass.equals(clazz)) {
+                    theClass = clazz;
+                }
+                configuration.getOrCreateType(theClass).addField(singleElement(args), memberKind, false, unsafeAccess);
                 break;
             }
 
@@ -159,7 +163,11 @@ class ReflectionProcessor extends AbstractProcessor {
                 if (parameterTypes == null) { // tolerated and equivalent to no parameter types
                     parameterTypes = Collections.emptyList();
                 }
-                configuration.getOrCreateType(clazzOrDeclaringClass).addMethod(name, SignatureUtil.toInternalSignature(parameterTypes), memberKind);
+                String theClass = clazzOrDeclaringClass;
+                if (memberKind != ConfigurationMemberKind.DECLARED && !clazzOrDeclaringClass.equals(clazz)) {
+                    theClass = clazz;
+                }
+                configuration.getOrCreateType(theClass).addMethod(name, SignatureUtil.toInternalSignature(parameterTypes), memberKind);
                 break;
             }
 

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/config/ReflectionRegistryAdapter.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/config/ReflectionRegistryAdapter.java
@@ -25,6 +25,7 @@
 package com.oracle.svm.hosted.config;
 
 import java.lang.reflect.Executable;
+import java.lang.reflect.Field;
 import java.util.List;
 
 import org.graalvm.nativeimage.impl.ReflectionRegistry;
@@ -100,7 +101,11 @@ public class ReflectionRegistryAdapter implements ReflectionConfigurationParserD
 
     @Override
     public void registerField(Class<?> type, String fieldName, boolean allowWrite, boolean allowUnsafeAccess) throws NoSuchFieldException {
-        registry.register(allowWrite, allowUnsafeAccess, type.getDeclaredField(fieldName));
+        try {
+            registry.register(allowWrite, allowUnsafeAccess, type.getDeclaredField(fieldName));
+        } catch (NoSuchFieldException e) {
+            registry.register(allowWrite, allowUnsafeAccess, type.getField(fieldName));
+        }
     }
 
     @Override
@@ -128,7 +133,11 @@ public class ReflectionRegistryAdapter implements ReflectionConfigurationParserD
     @Override
     public void registerMethod(Class<?> type, String methodName, List<Class<?>> methodParameterTypes) throws NoSuchMethodException {
         Class<?>[] parameterTypesArray = methodParameterTypes.toArray(new Class<?>[0]);
-        registry.register((Executable) type.getDeclaredMethod(methodName, parameterTypesArray));
+        try {
+            registry.register((Executable) type.getDeclaredMethod(methodName, parameterTypesArray));
+        } catch (NoSuchMethodException e) {
+            registry.register((Executable) type.getMethod(methodName, parameterTypesArray));
+        }
     }
 
     @Override


### PR DESCRIPTION
1. Record the name of the receiver of `getMethod/getField` rather than
`getDeclaringClass` of `Method`/`Field` in `ReflectionProcessor`
2. Use `getMethod` to register method in `ReflectionRegistryAdapter`