### PR TITLE
Add intrinsics for unsafe atomics on AArch64

### DIFF
--- a/compiler/src/org.graalvm.compiler.asm.aarch64/src/org/graalvm/compiler/asm/aarch64/AArch64Assembler.java
+++ b/compiler/src/org.graalvm.compiler.asm.aarch64/src/org/graalvm/compiler/asm/aarch64/AArch64Assembler.java
@@ -1510,7 +1510,7 @@ public abstract class AArch64Assembler extends Assembler {
      * compares it against a given value rs, and, if equal, stores the value rt to memory. The value
      * read from address rn is stored in register rs.
      *
-     * @param size size of bits read from memory. Must be 32 or 64.
+     * @param size size of bits read from memory. Must be 8, 16, 32 or 64.
      * @param rs general purpose register to be compared and loaded. May not be null.
      * @param rt general purpose register to be conditionally stored. May not be null.
      * @param rn general purpose register containing the address from which to read.
@@ -1518,8 +1518,9 @@ public abstract class AArch64Assembler extends Assembler {
      * @param release boolean value signifying if the store should use release semantics.
      */
     public void cas(int size, Register rs, Register rt, Register rn, boolean acquire, boolean release) {
-        assert size == 32 || size == 64;
-        compareAndSwapInstruction(CAS, rs, rt, rn, getLog2TransferSize(size), acquire, release);
+        assert size == 8 || size == 16 || size == 32 || size == 64;
+        int transferSize = NumUtil.log2Ceil(size / 8);
+        compareAndSwapInstruction(CAS, rs, rt, rn, transferSize, acquire, release);
     }
 
     private void compareAndSwapInstruction(Instruction instr, Register rs, Register rt, Register rn, int log2TransferSize, boolean acquire, boolean release) {

--- a/compiler/src/org.graalvm.compiler.asm.aarch64/src/org/graalvm/compiler/asm/aarch64/AArch64Assembler.java
+++ b/compiler/src/org.graalvm.compiler.asm.aarch64/src/org/graalvm/compiler/asm/aarch64/AArch64Assembler.java
@@ -1519,8 +1519,7 @@ public abstract class AArch64Assembler extends Assembler {
      */
     public void cas(int size, Register rs, Register rt, Register rn, boolean acquire, boolean release) {
         assert size == 8 || size == 16 || size == 32 || size == 64;
-        int transferSize = NumUtil.log2Ceil(size / 8);
-        compareAndSwapInstruction(CAS, rs, rt, rn, transferSize, acquire, release);
+        compareAndSwapInstruction(CAS, rs, rt, rn, getLog2TransferSize(size), acquire, release);
     }
 
     private void compareAndSwapInstruction(Instruction instr, Register rs, Register rt, Register rn, int log2TransferSize, boolean acquire, boolean release) {

--- a/compiler/src/org.graalvm.compiler.core.aarch64/src/org/graalvm/compiler/core/aarch64/AArch64LIRGenerator.java
+++ b/compiler/src/org.graalvm.compiler.core.aarch64/src/org/graalvm/compiler/core/aarch64/AArch64LIRGenerator.java
@@ -152,8 +152,8 @@ public abstract class AArch64LIRGenerator extends LIRGenerator {
     }
 
     @Override
-    public Variable emitLogicCompareAndSwap(LIRKind accessKind, Value address, Value expectedValue, Value newValue, Value trueValue, Value falseValue) {
-        emitCompareAndSwap(accessKind, address, expectedValue, newValue);
+    public Variable emitLogicCompareAndSwap(LIRKind accessKind, Value address, Value expectedValue, Value newValue, Value trueValue, Value falseValue, int memoryBarrier) {
+        emitCompareAndSwap(accessKind, address, expectedValue, newValue, memoryBarrier);
         assert trueValue.getValueKind().equals(falseValue.getValueKind());
         assert isIntConstant(trueValue, 1) && isIntConstant(falseValue, 0);
         Variable result = newVariable(trueValue.getValueKind());
@@ -162,14 +162,14 @@ public abstract class AArch64LIRGenerator extends LIRGenerator {
     }
 
     @Override
-    public Variable emitValueCompareAndSwap(LIRKind accessKind, Value address, Value expectedValue, Value newValue) {
-        return emitCompareAndSwap(accessKind, address, expectedValue, newValue);
+    public Variable emitValueCompareAndSwap(LIRKind accessKind, Value address, Value expectedValue, Value newValue, int memoryBarrier) {
+        return emitCompareAndSwap(accessKind, address, expectedValue, newValue, memoryBarrier);
     }
 
-    private Variable emitCompareAndSwap(LIRKind accessKind, Value address, Value expectedValue, Value newValue) {
+    private Variable emitCompareAndSwap(LIRKind accessKind, Value address, Value expectedValue, Value newValue, int memoryBarrier) {
         Variable result = newVariable(expectedValue.getValueKind());
         Variable scratch = newVariable(LIRKind.value(AArch64Kind.DWORD));
-        append(new CompareAndSwapOp((AArch64Kind) accessKind.getPlatformKind(), result, loadReg(expectedValue), loadReg(newValue), asAllocatable(address), scratch));
+        append(new CompareAndSwapOp((AArch64Kind) accessKind.getPlatformKind(), result, loadReg(expectedValue), loadReg(newValue), asAllocatable(address), scratch, memoryBarrier));
         return result;
     }
 

--- a/compiler/src/org.graalvm.compiler.core.aarch64/src/org/graalvm/compiler/core/aarch64/AArch64LIRGenerator.java
+++ b/compiler/src/org.graalvm.compiler.core.aarch64/src/org/graalvm/compiler/core/aarch64/AArch64LIRGenerator.java
@@ -168,6 +168,8 @@ public abstract class AArch64LIRGenerator extends LIRGenerator {
     }
 
     private Variable emitCompareAndSwap(LIRKind accessKind, Value address, Value expectedValue, Value newValue, MemoryOrderMode memoryOrder) {
+        // FIXME in AMD64 floats and doubles are converted to word types - why is this not happening
+        // here? Are these types never needed?? Should check this
         Variable result = newVariable(expectedValue.getValueKind());
         Variable scratch = newVariable(LIRKind.value(AArch64Kind.DWORD));
         append(new CompareAndSwapOp((AArch64Kind) accessKind.getPlatformKind(), result, loadReg(expectedValue), loadReg(newValue), asAllocatable(address), scratch, memoryOrder));

--- a/compiler/src/org.graalvm.compiler.core.aarch64/src/org/graalvm/compiler/core/aarch64/AArch64LIRGenerator.java
+++ b/compiler/src/org.graalvm.compiler.core.aarch64/src/org/graalvm/compiler/core/aarch64/AArch64LIRGenerator.java
@@ -35,6 +35,7 @@ import org.graalvm.compiler.asm.aarch64.AArch64Assembler.ConditionFlag;
 import org.graalvm.compiler.asm.aarch64.AArch64MacroAssembler;
 import org.graalvm.compiler.core.common.LIRKind;
 import org.graalvm.compiler.core.common.calc.Condition;
+import org.graalvm.compiler.core.common.memory.MemoryOrderMode;
 import org.graalvm.compiler.core.common.spi.LIRKindTool;
 import org.graalvm.compiler.debug.GraalError;
 import org.graalvm.compiler.lir.LIRFrameState;
@@ -152,8 +153,8 @@ public abstract class AArch64LIRGenerator extends LIRGenerator {
     }
 
     @Override
-    public Variable emitLogicCompareAndSwap(LIRKind accessKind, Value address, Value expectedValue, Value newValue, Value trueValue, Value falseValue, int memoryBarrier) {
-        emitCompareAndSwap(accessKind, address, expectedValue, newValue, memoryBarrier);
+    public Variable emitLogicCompareAndSwap(LIRKind accessKind, Value address, Value expectedValue, Value newValue, Value trueValue, Value falseValue, MemoryOrderMode memoryOrder) {
+        emitCompareAndSwap(accessKind, address, expectedValue, newValue, memoryOrder);
         assert trueValue.getValueKind().equals(falseValue.getValueKind());
         assert isIntConstant(trueValue, 1) && isIntConstant(falseValue, 0);
         Variable result = newVariable(trueValue.getValueKind());
@@ -162,14 +163,14 @@ public abstract class AArch64LIRGenerator extends LIRGenerator {
     }
 
     @Override
-    public Variable emitValueCompareAndSwap(LIRKind accessKind, Value address, Value expectedValue, Value newValue, int memoryBarrier) {
-        return emitCompareAndSwap(accessKind, address, expectedValue, newValue, memoryBarrier);
+    public Variable emitValueCompareAndSwap(LIRKind accessKind, Value address, Value expectedValue, Value newValue, MemoryOrderMode memoryOrder) {
+        return emitCompareAndSwap(accessKind, address, expectedValue, newValue, memoryOrder);
     }
 
-    private Variable emitCompareAndSwap(LIRKind accessKind, Value address, Value expectedValue, Value newValue, int memoryBarrier) {
+    private Variable emitCompareAndSwap(LIRKind accessKind, Value address, Value expectedValue, Value newValue, MemoryOrderMode memoryOrder) {
         Variable result = newVariable(expectedValue.getValueKind());
         Variable scratch = newVariable(LIRKind.value(AArch64Kind.DWORD));
-        append(new CompareAndSwapOp((AArch64Kind) accessKind.getPlatformKind(), result, loadReg(expectedValue), loadReg(newValue), asAllocatable(address), scratch, memoryBarrier));
+        append(new CompareAndSwapOp((AArch64Kind) accessKind.getPlatformKind(), result, loadReg(expectedValue), loadReg(newValue), asAllocatable(address), scratch, memoryOrder));
         return result;
     }
 

--- a/compiler/src/org.graalvm.compiler.core.aarch64/src/org/graalvm/compiler/core/aarch64/AArch64LIRGenerator.java
+++ b/compiler/src/org.graalvm.compiler.core.aarch64/src/org/graalvm/compiler/core/aarch64/AArch64LIRGenerator.java
@@ -152,8 +152,8 @@ public abstract class AArch64LIRGenerator extends LIRGenerator {
     }
 
     @Override
-    public Variable emitLogicCompareAndSwap(LIRKind accessKind, Value address, Value expectedValue, Value newValue, Value trueValue, Value falseValue, boolean useBarriers) {
-        emitCompareAndSwap(address, expectedValue, newValue, useBarriers);
+    public Variable emitLogicCompareAndSwap(LIRKind accessKind, Value address, Value expectedValue, Value newValue, Value trueValue, Value falseValue) {
+        emitCompareAndSwap(accessKind, address, expectedValue, newValue);
         assert trueValue.getValueKind().equals(falseValue.getValueKind());
         assert isIntConstant(trueValue, 1) && isIntConstant(falseValue, 0);
         Variable result = newVariable(trueValue.getValueKind());
@@ -162,14 +162,14 @@ public abstract class AArch64LIRGenerator extends LIRGenerator {
     }
 
     @Override
-    public Variable emitValueCompareAndSwap(LIRKind accessKind, Value address, Value expectedValue, Value newValue, boolean useBarriers) {
-        return emitCompareAndSwap(address, expectedValue, newValue, useBarriers);
+    public Variable emitValueCompareAndSwap(LIRKind accessKind, Value address, Value expectedValue, Value newValue) {
+        return emitCompareAndSwap(accessKind, address, expectedValue, newValue);
     }
 
-    private Variable emitCompareAndSwap(Value address, Value expectedValue, Value newValue, boolean useBarriers) {
+    private Variable emitCompareAndSwap(LIRKind accessKind, Value address, Value expectedValue, Value newValue) {
         Variable result = newVariable(expectedValue.getValueKind());
         Variable scratch = newVariable(LIRKind.value(AArch64Kind.DWORD));
-        append(new CompareAndSwapOp(result, loadReg(expectedValue), loadReg(newValue), asAllocatable(address), scratch, useBarriers));
+        append(new CompareAndSwapOp((AArch64Kind) accessKind.getPlatformKind(), result, loadReg(expectedValue), loadReg(newValue), asAllocatable(address), scratch));
         return result;
     }
 

--- a/compiler/src/org.graalvm.compiler.core.amd64/src/org/graalvm/compiler/core/amd64/AMD64LIRGenerator.java
+++ b/compiler/src/org.graalvm.compiler.core.amd64/src/org/graalvm/compiler/core/amd64/AMD64LIRGenerator.java
@@ -266,12 +266,12 @@ public abstract class AMD64LIRGenerator extends LIRGenerator {
     }
 
     @Override
-    public Variable emitLogicCompareAndSwap(LIRKind accessKind, Value address, Value expectedValue, Value newValue, Value trueValue, Value falseValue) {
+    public Variable emitLogicCompareAndSwap(LIRKind accessKind, Value address, Value expectedValue, Value newValue, Value trueValue, Value falseValue, int memoryBarrier) {
         return LIRValueUtil.asVariable(emitCompareAndSwap(true, accessKind, address, expectedValue, newValue, trueValue, falseValue));
     }
 
     @Override
-    public Value emitValueCompareAndSwap(LIRKind accessKind, Value address, Value expectedValue, Value newValue) {
+    public Value emitValueCompareAndSwap(LIRKind accessKind, Value address, Value expectedValue, Value newValue, int memoryBarrier) {
         return emitCompareAndSwap(false, accessKind, address, expectedValue, newValue, null, null);
     }
 

--- a/compiler/src/org.graalvm.compiler.core.amd64/src/org/graalvm/compiler/core/amd64/AMD64LIRGenerator.java
+++ b/compiler/src/org.graalvm.compiler.core.amd64/src/org/graalvm/compiler/core/amd64/AMD64LIRGenerator.java
@@ -266,12 +266,12 @@ public abstract class AMD64LIRGenerator extends LIRGenerator {
     }
 
     @Override
-    public Variable emitLogicCompareAndSwap(LIRKind accessKind, Value address, Value expectedValue, Value newValue, Value trueValue, Value falseValue, boolean useBarriers) {
+    public Variable emitLogicCompareAndSwap(LIRKind accessKind, Value address, Value expectedValue, Value newValue, Value trueValue, Value falseValue) {
         return LIRValueUtil.asVariable(emitCompareAndSwap(true, accessKind, address, expectedValue, newValue, trueValue, falseValue));
     }
 
     @Override
-    public Value emitValueCompareAndSwap(LIRKind accessKind, Value address, Value expectedValue, Value newValue, boolean useBarriers) {
+    public Value emitValueCompareAndSwap(LIRKind accessKind, Value address, Value expectedValue, Value newValue) {
         return emitCompareAndSwap(false, accessKind, address, expectedValue, newValue, null, null);
     }
 

--- a/compiler/src/org.graalvm.compiler.core.amd64/src/org/graalvm/compiler/core/amd64/AMD64LIRGenerator.java
+++ b/compiler/src/org.graalvm.compiler.core.amd64/src/org/graalvm/compiler/core/amd64/AMD64LIRGenerator.java
@@ -55,6 +55,7 @@ import org.graalvm.compiler.asm.amd64.AVXKind.AVXSize;
 import org.graalvm.compiler.core.common.LIRKind;
 import org.graalvm.compiler.core.common.NumUtil;
 import org.graalvm.compiler.core.common.calc.Condition;
+import org.graalvm.compiler.core.common.memory.MemoryOrderMode;
 import org.graalvm.compiler.core.common.spi.ForeignCallLinkage;
 import org.graalvm.compiler.core.common.spi.LIRKindTool;
 import org.graalvm.compiler.debug.GraalError;
@@ -266,12 +267,12 @@ public abstract class AMD64LIRGenerator extends LIRGenerator {
     }
 
     @Override
-    public Variable emitLogicCompareAndSwap(LIRKind accessKind, Value address, Value expectedValue, Value newValue, Value trueValue, Value falseValue, int memoryBarrier) {
+    public Variable emitLogicCompareAndSwap(LIRKind accessKind, Value address, Value expectedValue, Value newValue, Value trueValue, Value falseValue, MemoryOrderMode memoryOrder) {
         return LIRValueUtil.asVariable(emitCompareAndSwap(true, accessKind, address, expectedValue, newValue, trueValue, falseValue));
     }
 
     @Override
-    public Value emitValueCompareAndSwap(LIRKind accessKind, Value address, Value expectedValue, Value newValue, int memoryBarrier) {
+    public Value emitValueCompareAndSwap(LIRKind accessKind, Value address, Value expectedValue, Value newValue, MemoryOrderMode memoryOrder) {
         return emitCompareAndSwap(false, accessKind, address, expectedValue, newValue, null, null);
     }
 

--- a/compiler/src/org.graalvm.compiler.core.common/src/org/graalvm/compiler/core/common/memory/MemoryOrderMode.java
+++ b/compiler/src/org.graalvm.compiler.core.common/src/org/graalvm/compiler/core/common/memory/MemoryOrderMode.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.graalvm.compiler.core.common.memory;
+
+import static jdk.vm.ci.code.MemoryBarriers.JMM_POST_VOLATILE_READ;
+import static jdk.vm.ci.code.MemoryBarriers.JMM_POST_VOLATILE_WRITE;
+import static jdk.vm.ci.code.MemoryBarriers.JMM_PRE_VOLATILE_READ;
+import static jdk.vm.ci.code.MemoryBarriers.JMM_PRE_VOLATILE_WRITE;
+import static jdk.vm.ci.code.MemoryBarriers.LOAD_LOAD;
+import static jdk.vm.ci.code.MemoryBarriers.LOAD_STORE;
+import static jdk.vm.ci.code.MemoryBarriers.STORE_STORE;
+
+/**
+ * The new memory order modes (JDK9+) are defined with cumulative effect, from weakest to strongest:
+ * Plain, Opaque, Release/Acquire, and Volatile. The existing Plain and Volatile modes are defined
+ * compatibly with their pre-JDK 9 forms. Any guaranteed property of a weaker mode, plus more, holds
+ * for a stronger mode. (Conversely, implementations are allowed to use a stronger mode than
+ * requested for any access.) In JDK 9, these are provided without a full formal specification.
+ */
+public enum MemoryOrderMode {
+    PLAIN(0, 0, 0, 0, false),
+    /**
+     * Opaque accesses are wrapped by dummy membars to avoid floating/hoisting, this is stronger
+     * than required since Opaque mode does not directly impose any ordering constraints with
+     * respect to other variables beyond Plain mode.
+     */
+    OPAQUE(0, 0, 0, 0, true),
+    ACQUIRE(0, LOAD_LOAD | LOAD_STORE, 0, 0, true),
+    RELEASE(0, 0, LOAD_STORE | STORE_STORE, 0, true),
+    RELEASE_ACQUIRE(0, LOAD_LOAD | LOAD_STORE, LOAD_STORE | STORE_STORE, 0, true),
+    VOLATILE(JMM_PRE_VOLATILE_READ, JMM_POST_VOLATILE_READ, JMM_PRE_VOLATILE_WRITE, JMM_POST_VOLATILE_WRITE, true);
+
+    public final boolean emitBarriers;
+    public final int preReadBarriers;
+    public final int postReadBarriers;
+    public final int preWriteBarriers;
+    public final int postWriteBarriers;
+
+    MemoryOrderMode(int preReadBarriers, int postReadBarriers, int preWriteBarriers, int postWriteBarriers, boolean emitBarriers) {
+        this.emitBarriers = emitBarriers;
+        this.preReadBarriers = preReadBarriers;
+        this.postReadBarriers = postReadBarriers;
+        this.preWriteBarriers = preWriteBarriers;
+        this.postWriteBarriers = postWriteBarriers;
+    }
+}

--- a/compiler/src/org.graalvm.compiler.core.sparc/src/org/graalvm/compiler/core/sparc/SPARCNodeMatchRules.java
+++ b/compiler/src/org.graalvm.compiler.core.sparc/src/org/graalvm/compiler/core/sparc/SPARCNodeMatchRules.java
@@ -175,7 +175,7 @@ public class SPARCNodeMatchRules extends NodeMatchRules {
                 SPARCAddressValue address = (SPARCAddressValue) operand(cas.getAddress());
                 Condition condition = successIsTrue ? Condition.EQ : Condition.NE;
 
-                Value result = getLIRGeneratorTool().emitValueCompareAndSwap(kind, address, expectedValue, newValue, cas.getMemoryBarrier());
+                Value result = getLIRGeneratorTool().emitValueCompareAndSwap(kind, address, expectedValue, newValue, cas.getMemoryOrder());
                 getLIRGeneratorTool().emitCompareBranch(kind.getPlatformKind(), result, expectedValue, condition, false, trueLabel, falseLabel, trueLabelProbability);
                 return null;
             };

--- a/compiler/src/org.graalvm.compiler.core.sparc/src/org/graalvm/compiler/core/sparc/SPARCNodeMatchRules.java
+++ b/compiler/src/org.graalvm.compiler.core.sparc/src/org/graalvm/compiler/core/sparc/SPARCNodeMatchRules.java
@@ -175,7 +175,7 @@ public class SPARCNodeMatchRules extends NodeMatchRules {
                 SPARCAddressValue address = (SPARCAddressValue) operand(cas.getAddress());
                 Condition condition = successIsTrue ? Condition.EQ : Condition.NE;
 
-                Value result = getLIRGeneratorTool().emitValueCompareAndSwap(kind, address, expectedValue, newValue);
+                Value result = getLIRGeneratorTool().emitValueCompareAndSwap(kind, address, expectedValue, newValue, cas.getMemoryBarrier());
                 getLIRGeneratorTool().emitCompareBranch(kind.getPlatformKind(), result, expectedValue, condition, false, trueLabel, falseLabel, trueLabelProbability);
                 return null;
             };

--- a/compiler/src/org.graalvm.compiler.core.sparc/src/org/graalvm/compiler/core/sparc/SPARCNodeMatchRules.java
+++ b/compiler/src/org.graalvm.compiler.core.sparc/src/org/graalvm/compiler/core/sparc/SPARCNodeMatchRules.java
@@ -175,7 +175,7 @@ public class SPARCNodeMatchRules extends NodeMatchRules {
                 SPARCAddressValue address = (SPARCAddressValue) operand(cas.getAddress());
                 Condition condition = successIsTrue ? Condition.EQ : Condition.NE;
 
-                Value result = getLIRGeneratorTool().emitValueCompareAndSwap(kind, address, expectedValue, newValue, false);
+                Value result = getLIRGeneratorTool().emitValueCompareAndSwap(kind, address, expectedValue, newValue);
                 getLIRGeneratorTool().emitCompareBranch(kind.getPlatformKind(), result, expectedValue, condition, false, trueLabel, falseLabel, trueLabelProbability);
                 return null;
             };

--- a/compiler/src/org.graalvm.compiler.hotspot.sparc/src/org/graalvm/compiler/hotspot/sparc/SPARCHotSpotLIRGenerator.java
+++ b/compiler/src/org.graalvm.compiler.hotspot.sparc/src/org/graalvm/compiler/hotspot/sparc/SPARCHotSpotLIRGenerator.java
@@ -34,6 +34,7 @@ import org.graalvm.compiler.asm.sparc.SPARCAssembler;
 import org.graalvm.compiler.core.common.CompressEncoding;
 import org.graalvm.compiler.core.common.LIRKind;
 import org.graalvm.compiler.core.common.calc.Condition;
+import org.graalvm.compiler.core.common.memory.MemoryOrderMode;
 import org.graalvm.compiler.core.common.spi.ForeignCallLinkage;
 import org.graalvm.compiler.core.common.spi.LIRKindTool;
 import org.graalvm.compiler.core.sparc.SPARCArithmeticLIRGenerator;
@@ -245,7 +246,7 @@ public class SPARCHotSpotLIRGenerator extends SPARCLIRGenerator implements HotSp
     }
 
     @Override
-    public Variable emitLogicCompareAndSwap(LIRKind accessKind, Value address, Value expectedValue, Value newValue, Value trueValue, Value falseValue, int memoryBarrier) {
+    public Variable emitLogicCompareAndSwap(LIRKind accessKind, Value address, Value expectedValue, Value newValue, Value trueValue, Value falseValue, MemoryOrderMode memoryOrder) {
         ValueKind<?> kind = newValue.getValueKind();
         assert kind.equals(expectedValue.getValueKind());
         SPARCKind memKind = (SPARCKind) kind.getPlatformKind();
@@ -255,7 +256,7 @@ public class SPARCHotSpotLIRGenerator extends SPARCLIRGenerator implements HotSp
     }
 
     @Override
-    public Variable emitValueCompareAndSwap(LIRKind accessKind, Value address, Value expectedValue, Value newValue, int memoryBarrier) {
+    public Variable emitValueCompareAndSwap(LIRKind accessKind, Value address, Value expectedValue, Value newValue, MemoryOrderMode memoryOrder) {
         ValueKind<?> kind = newValue.getValueKind();
         assert kind.equals(expectedValue.getValueKind());
         Variable result = newVariable(newValue.getValueKind());

--- a/compiler/src/org.graalvm.compiler.hotspot.sparc/src/org/graalvm/compiler/hotspot/sparc/SPARCHotSpotLIRGenerator.java
+++ b/compiler/src/org.graalvm.compiler.hotspot.sparc/src/org/graalvm/compiler/hotspot/sparc/SPARCHotSpotLIRGenerator.java
@@ -245,7 +245,7 @@ public class SPARCHotSpotLIRGenerator extends SPARCLIRGenerator implements HotSp
     }
 
     @Override
-    public Variable emitLogicCompareAndSwap(LIRKind accessKind, Value address, Value expectedValue, Value newValue, Value trueValue, Value falseValue) {
+    public Variable emitLogicCompareAndSwap(LIRKind accessKind, Value address, Value expectedValue, Value newValue, Value trueValue, Value falseValue, int memoryBarrier) {
         ValueKind<?> kind = newValue.getValueKind();
         assert kind.equals(expectedValue.getValueKind());
         SPARCKind memKind = (SPARCKind) kind.getPlatformKind();
@@ -255,7 +255,7 @@ public class SPARCHotSpotLIRGenerator extends SPARCLIRGenerator implements HotSp
     }
 
     @Override
-    public Variable emitValueCompareAndSwap(LIRKind accessKind, Value address, Value expectedValue, Value newValue) {
+    public Variable emitValueCompareAndSwap(LIRKind accessKind, Value address, Value expectedValue, Value newValue, int memoryBarrier) {
         ValueKind<?> kind = newValue.getValueKind();
         assert kind.equals(expectedValue.getValueKind());
         Variable result = newVariable(newValue.getValueKind());

--- a/compiler/src/org.graalvm.compiler.hotspot.sparc/src/org/graalvm/compiler/hotspot/sparc/SPARCHotSpotLIRGenerator.java
+++ b/compiler/src/org.graalvm.compiler.hotspot.sparc/src/org/graalvm/compiler/hotspot/sparc/SPARCHotSpotLIRGenerator.java
@@ -245,7 +245,7 @@ public class SPARCHotSpotLIRGenerator extends SPARCLIRGenerator implements HotSp
     }
 
     @Override
-    public Variable emitLogicCompareAndSwap(LIRKind accessKind, Value address, Value expectedValue, Value newValue, Value trueValue, Value falseValue, boolean useBarriers) {
+    public Variable emitLogicCompareAndSwap(LIRKind accessKind, Value address, Value expectedValue, Value newValue, Value trueValue, Value falseValue) {
         ValueKind<?> kind = newValue.getValueKind();
         assert kind.equals(expectedValue.getValueKind());
         SPARCKind memKind = (SPARCKind) kind.getPlatformKind();
@@ -255,7 +255,7 @@ public class SPARCHotSpotLIRGenerator extends SPARCLIRGenerator implements HotSp
     }
 
     @Override
-    public Variable emitValueCompareAndSwap(LIRKind accessKind, Value address, Value expectedValue, Value newValue, boolean useBarriers) {
+    public Variable emitValueCompareAndSwap(LIRKind accessKind, Value address, Value expectedValue, Value newValue) {
         ValueKind<?> kind = newValue.getValueKind();
         assert kind.equals(expectedValue.getValueKind());
         Variable result = newVariable(newValue.getValueKind());

--- a/compiler/src/org.graalvm.compiler.hotspot.test/src/org/graalvm/compiler/hotspot/test/CheckGraalIntrinsics.java
+++ b/compiler/src/org.graalvm.compiler.hotspot.test/src/org/graalvm/compiler/hotspot/test/CheckGraalIntrinsics.java
@@ -302,41 +302,42 @@ public class CheckGraalIntrinsics extends GraalTest {
              * explicitly as the more generic method might be more restrictive and therefore slower
              * than necessary.
              */
+            if (!(arch instanceof AArch64)) {
+                add(toBeInvestigated,
+                                // Mapped to compareAndExchange*
+                                "jdk/internal/misc/Unsafe.compareAndExchangeByteAcquire(Ljava/lang/Object;JBB)B",
+                                "jdk/internal/misc/Unsafe.compareAndExchangeByteRelease(Ljava/lang/Object;JBB)B",
+                                "jdk/internal/misc/Unsafe.compareAndExchangeIntAcquire(Ljava/lang/Object;JII)I",
+                                "jdk/internal/misc/Unsafe.compareAndExchangeIntRelease(Ljava/lang/Object;JII)I",
+                                "jdk/internal/misc/Unsafe.compareAndExchangeLongAcquire(Ljava/lang/Object;JJJ)J",
+                                "jdk/internal/misc/Unsafe.compareAndExchangeLongRelease(Ljava/lang/Object;JJJ)J",
+                                "jdk/internal/misc/Unsafe.compareAndExchange" + oopName + "Acquire(Ljava/lang/Object;JLjava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;",
+                                "jdk/internal/misc/Unsafe.compareAndExchange" + oopName + "Release(Ljava/lang/Object;JLjava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;",
+                                "jdk/internal/misc/Unsafe.compareAndExchangeShortAcquire(Ljava/lang/Object;JSS)S",
+                                "jdk/internal/misc/Unsafe.compareAndExchangeShortRelease(Ljava/lang/Object;JSS)S",
 
-            add(toBeInvestigated,
-                            // Mapped to compareAndExchange*
-                            "jdk/internal/misc/Unsafe.compareAndExchangeByteAcquire(Ljava/lang/Object;JBB)B",
-                            "jdk/internal/misc/Unsafe.compareAndExchangeByteRelease(Ljava/lang/Object;JBB)B",
-                            "jdk/internal/misc/Unsafe.compareAndExchangeIntAcquire(Ljava/lang/Object;JII)I",
-                            "jdk/internal/misc/Unsafe.compareAndExchangeIntRelease(Ljava/lang/Object;JII)I",
-                            "jdk/internal/misc/Unsafe.compareAndExchangeLongAcquire(Ljava/lang/Object;JJJ)J",
-                            "jdk/internal/misc/Unsafe.compareAndExchangeLongRelease(Ljava/lang/Object;JJJ)J",
-                            "jdk/internal/misc/Unsafe.compareAndExchange" + oopName + "Acquire(Ljava/lang/Object;JLjava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;",
-                            "jdk/internal/misc/Unsafe.compareAndExchange" + oopName + "Release(Ljava/lang/Object;JLjava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;",
-                            "jdk/internal/misc/Unsafe.compareAndExchangeShortAcquire(Ljava/lang/Object;JSS)S",
-                            "jdk/internal/misc/Unsafe.compareAndExchangeShortRelease(Ljava/lang/Object;JSS)S",
-
-                            // Mapped to compareAndSet*
-                            "jdk/internal/misc/Unsafe.weakCompareAndSetByte(Ljava/lang/Object;JBB)Z",
-                            "jdk/internal/misc/Unsafe.weakCompareAndSetByteAcquire(Ljava/lang/Object;JBB)Z",
-                            "jdk/internal/misc/Unsafe.weakCompareAndSetBytePlain(Ljava/lang/Object;JBB)Z",
-                            "jdk/internal/misc/Unsafe.weakCompareAndSetByteRelease(Ljava/lang/Object;JBB)Z",
-                            "jdk/internal/misc/Unsafe.weakCompareAndSetInt(Ljava/lang/Object;JII)Z",
-                            "jdk/internal/misc/Unsafe.weakCompareAndSetIntAcquire(Ljava/lang/Object;JII)Z",
-                            "jdk/internal/misc/Unsafe.weakCompareAndSetIntPlain(Ljava/lang/Object;JII)Z",
-                            "jdk/internal/misc/Unsafe.weakCompareAndSetIntRelease(Ljava/lang/Object;JII)Z",
-                            "jdk/internal/misc/Unsafe.weakCompareAndSetLong(Ljava/lang/Object;JJJ)Z",
-                            "jdk/internal/misc/Unsafe.weakCompareAndSetLongAcquire(Ljava/lang/Object;JJJ)Z",
-                            "jdk/internal/misc/Unsafe.weakCompareAndSetLongPlain(Ljava/lang/Object;JJJ)Z",
-                            "jdk/internal/misc/Unsafe.weakCompareAndSetLongRelease(Ljava/lang/Object;JJJ)Z",
-                            "jdk/internal/misc/Unsafe.weakCompareAndSet" + oopName + "(Ljava/lang/Object;JLjava/lang/Object;Ljava/lang/Object;)Z",
-                            "jdk/internal/misc/Unsafe.weakCompareAndSet" + oopName + "Acquire(Ljava/lang/Object;JLjava/lang/Object;Ljava/lang/Object;)Z",
-                            "jdk/internal/misc/Unsafe.weakCompareAndSet" + oopName + "Plain(Ljava/lang/Object;JLjava/lang/Object;Ljava/lang/Object;)Z",
-                            "jdk/internal/misc/Unsafe.weakCompareAndSet" + oopName + "Release(Ljava/lang/Object;JLjava/lang/Object;Ljava/lang/Object;)Z",
-                            "jdk/internal/misc/Unsafe.weakCompareAndSetShort(Ljava/lang/Object;JSS)Z",
-                            "jdk/internal/misc/Unsafe.weakCompareAndSetShortAcquire(Ljava/lang/Object;JSS)Z",
-                            "jdk/internal/misc/Unsafe.weakCompareAndSetShortPlain(Ljava/lang/Object;JSS)Z",
-                            "jdk/internal/misc/Unsafe.weakCompareAndSetShortRelease(Ljava/lang/Object;JSS)Z");
+                                // Mapped to compareAndSet*
+                                "jdk/internal/misc/Unsafe.weakCompareAndSetByte(Ljava/lang/Object;JBB)Z",
+                                "jdk/internal/misc/Unsafe.weakCompareAndSetByteAcquire(Ljava/lang/Object;JBB)Z",
+                                "jdk/internal/misc/Unsafe.weakCompareAndSetBytePlain(Ljava/lang/Object;JBB)Z",
+                                "jdk/internal/misc/Unsafe.weakCompareAndSetByteRelease(Ljava/lang/Object;JBB)Z",
+                                "jdk/internal/misc/Unsafe.weakCompareAndSetInt(Ljava/lang/Object;JII)Z",
+                                "jdk/internal/misc/Unsafe.weakCompareAndSetIntAcquire(Ljava/lang/Object;JII)Z",
+                                "jdk/internal/misc/Unsafe.weakCompareAndSetIntPlain(Ljava/lang/Object;JII)Z",
+                                "jdk/internal/misc/Unsafe.weakCompareAndSetIntRelease(Ljava/lang/Object;JII)Z",
+                                "jdk/internal/misc/Unsafe.weakCompareAndSetLong(Ljava/lang/Object;JJJ)Z",
+                                "jdk/internal/misc/Unsafe.weakCompareAndSetLongAcquire(Ljava/lang/Object;JJJ)Z",
+                                "jdk/internal/misc/Unsafe.weakCompareAndSetLongPlain(Ljava/lang/Object;JJJ)Z",
+                                "jdk/internal/misc/Unsafe.weakCompareAndSetLongRelease(Ljava/lang/Object;JJJ)Z",
+                                "jdk/internal/misc/Unsafe.weakCompareAndSet" + oopName + "(Ljava/lang/Object;JLjava/lang/Object;Ljava/lang/Object;)Z",
+                                "jdk/internal/misc/Unsafe.weakCompareAndSet" + oopName + "Acquire(Ljava/lang/Object;JLjava/lang/Object;Ljava/lang/Object;)Z",
+                                "jdk/internal/misc/Unsafe.weakCompareAndSet" + oopName + "Plain(Ljava/lang/Object;JLjava/lang/Object;Ljava/lang/Object;)Z",
+                                "jdk/internal/misc/Unsafe.weakCompareAndSet" + oopName + "Release(Ljava/lang/Object;JLjava/lang/Object;Ljava/lang/Object;)Z",
+                                "jdk/internal/misc/Unsafe.weakCompareAndSetShort(Ljava/lang/Object;JSS)Z",
+                                "jdk/internal/misc/Unsafe.weakCompareAndSetShortAcquire(Ljava/lang/Object;JSS)Z",
+                                "jdk/internal/misc/Unsafe.weakCompareAndSetShortPlain(Ljava/lang/Object;JSS)Z",
+                                "jdk/internal/misc/Unsafe.weakCompareAndSetShortRelease(Ljava/lang/Object;JSS)Z");
+            }
 
             // Compact string support - HotSpot MacroAssembler-based intrinsic or complex C2 logic.
             add(toBeInvestigated,

--- a/compiler/src/org.graalvm.compiler.hotspot.test/src/org/graalvm/compiler/hotspot/test/CheckGraalIntrinsics.java
+++ b/compiler/src/org.graalvm.compiler.hotspot.test/src/org/graalvm/compiler/hotspot/test/CheckGraalIntrinsics.java
@@ -451,6 +451,21 @@ public class CheckGraalIntrinsics extends GraalTest {
             add(ignore, "java/lang/Object.notifyAll()V");
         }
 
+        if (!(arch instanceof AMD64 || arch instanceof AArch64)) {
+            add(toBeInvestigated, "jdk/internal/misc/Unsafe.getAndAddByte(Ljava/lang/Object;JB)B",
+                            "jdk/internal/misc/Unsafe.getAndAddShort(Ljava/lang/Object;JS)S",
+                            "jdk/internal/misc/Unsafe.getAndSetByte(Ljava/lang/Object;JB)B",
+                            "jdk/internal/misc/Unsafe.getAndSetShort(Ljava/lang/Object;JS)S",
+                            "jdk/internal/misc/Unsafe.compareAndExchangeByte(Ljava/lang/Object;JBB)B",
+                            "jdk/internal/misc/Unsafe.compareAndExchangeShort(Ljava/lang/Object;JSS)S",
+                            "jdk/internal/misc/Unsafe.compareAndSetByte(Ljava/lang/Object;JBB)Z",
+                            "jdk/internal/misc/Unsafe.compareAndSetShort(Ljava/lang/Object;JSS)Z",
+                            "sun/misc/Unsafe.getAndAddInt(Ljava/lang/Object;JI)I",
+                            "sun/misc/Unsafe.getAndAddLong(Ljava/lang/Object;JJ)J",
+                            "sun/misc/Unsafe.getAndSetInt(Ljava/lang/Object;JI)I",
+                            "sun/misc/Unsafe.getAndSetLong(Ljava/lang/Object;JJ)J");
+        }
+
         if (!(arch instanceof AMD64)) {
             // Can we implement these on non-AMD64 platforms? C2 seems to.
             add(toBeInvestigated,
@@ -466,18 +481,6 @@ public class CheckGraalIntrinsics extends GraalTest {
                             "java/lang/StringUTF16.indexOfChar([BIII)I",
                             "java/lang/StringUTF16.indexOfLatin1([BI[BII)I",
                             "java/lang/StringUTF16.indexOfLatin1([B[B)I",
-                            "jdk/internal/misc/Unsafe.compareAndExchangeByte(Ljava/lang/Object;JBB)B",
-                            "jdk/internal/misc/Unsafe.compareAndExchangeShort(Ljava/lang/Object;JSS)S",
-                            "jdk/internal/misc/Unsafe.compareAndSetByte(Ljava/lang/Object;JBB)Z",
-                            "jdk/internal/misc/Unsafe.compareAndSetShort(Ljava/lang/Object;JSS)Z",
-                            "jdk/internal/misc/Unsafe.getAndAddByte(Ljava/lang/Object;JB)B",
-                            "jdk/internal/misc/Unsafe.getAndAddShort(Ljava/lang/Object;JS)S",
-                            "jdk/internal/misc/Unsafe.getAndSetByte(Ljava/lang/Object;JB)B",
-                            "jdk/internal/misc/Unsafe.getAndSetShort(Ljava/lang/Object;JS)S",
-                            "sun/misc/Unsafe.getAndAddInt(Ljava/lang/Object;JI)I",
-                            "sun/misc/Unsafe.getAndAddLong(Ljava/lang/Object;JJ)J",
-                            "sun/misc/Unsafe.getAndSetInt(Ljava/lang/Object;JI)I",
-                            "sun/misc/Unsafe.getAndSetLong(Ljava/lang/Object;JJ)J",
                             "sun/misc/Unsafe.getAndSet" + oopName + "(Ljava/lang/Object;JLjava/lang/Object;)Ljava/lang/Object;");
 
             if (isJDK9OrHigher()) {

--- a/compiler/src/org.graalvm.compiler.lir.aarch64/src/org/graalvm/compiler/lir/aarch64/AArch64AtomicMove.java
+++ b/compiler/src/org.graalvm.compiler.lir.aarch64/src/org/graalvm/compiler/lir/aarch64/AArch64AtomicMove.java
@@ -35,6 +35,7 @@ import org.graalvm.compiler.asm.Label;
 import org.graalvm.compiler.asm.aarch64.AArch64Assembler;
 import org.graalvm.compiler.asm.aarch64.AArch64MacroAssembler;
 import org.graalvm.compiler.asm.aarch64.AArch64MacroAssembler.ScratchRegister;
+import org.graalvm.compiler.core.common.memory.MemoryOrderMode;
 import org.graalvm.compiler.lir.LIRInstructionClass;
 import org.graalvm.compiler.lir.LIRValueUtil;
 import org.graalvm.compiler.lir.Opcode;
@@ -60,7 +61,7 @@ public class AArch64AtomicMove {
         public static final LIRInstructionClass<CompareAndSwapOp> TYPE = LIRInstructionClass.create(CompareAndSwapOp.class);
 
         private final AArch64Kind accessKind;
-        private final int memoryBarrier;
+        private final MemoryOrderMode memoryOrder;
 
         @Def protected AllocatableValue resultValue;
         @Alive protected Value expectedValue;
@@ -69,7 +70,7 @@ public class AArch64AtomicMove {
         @Temp protected AllocatableValue scratchValue;
 
         public CompareAndSwapOp(AArch64Kind accessKind, AllocatableValue result, Value expectedValue, AllocatableValue newValue, AllocatableValue addressValue, AllocatableValue scratch,
-                        int memoryBarrier) {
+                                MemoryOrderMode memoryOrder) {
             super(TYPE);
             this.accessKind = accessKind;
             this.resultValue = result;
@@ -77,7 +78,7 @@ public class AArch64AtomicMove {
             this.newValue = newValue;
             this.addressValue = addressValue;
             this.scratchValue = scratch;
-            this.memoryBarrier = memoryBarrier;
+            this.memoryOrder = memoryOrder;
         }
 
         @Override
@@ -90,17 +91,11 @@ public class AArch64AtomicMove {
             Register newVal = asRegister(newValue);
             Register expected = asRegister(expectedValue);
 
-            // For the atomics with "acquire/release" suffixes, the corresponding memory barrier has
-            // been inserted after/before the CAS respectively. Thus, the CAS operation here does
-            // not need the "acquire" semantics. Contrarily, the strong variants, i.e., atomics
-            // without "acquire/release" suffixes, are not surrounded by memory barriers. Thus, the
-            // CAS operation needs to use the variant of instruction that has the "acquire" effect.
-            boolean acquire = memoryBarrier >= (LOAD_LOAD | LOAD_STORE | STORE_STORE);
-
-            // The exclusive store is always using the "release" semantic. That is required to
-            // ensure visibility to other threads of the exclusive write (assuming it succeeds)
-            // before that of any subsequent writes.
-            boolean release = true;
+            /**
+             * Determining whether acquire and/or release semantics are needed.
+             */
+            boolean acquire = (memoryOrder.postReadBarriers & (LOAD_LOAD | LOAD_STORE)) != 0;
+            boolean release = (memoryOrder.preWriteBarriers & (LOAD_STORE | STORE_STORE)) != 0;
 
             if (AArch64LIRFlagsVersioned.useLSE(masm.target.arch)) {
                 masm.mov(Math.max(size, 32), result, expected);

--- a/compiler/src/org.graalvm.compiler.lir.aarch64/src/org/graalvm/compiler/lir/aarch64/AArch64AtomicMove.java
+++ b/compiler/src/org.graalvm.compiler.lir.aarch64/src/org/graalvm/compiler/lir/aarch64/AArch64AtomicMove.java
@@ -56,48 +56,36 @@ public class AArch64AtomicMove {
     public static class CompareAndSwapOp extends AArch64LIRInstruction {
         public static final LIRInstructionClass<CompareAndSwapOp> TYPE = LIRInstructionClass.create(CompareAndSwapOp.class);
 
+        private final AArch64Kind accessKind;
+
         @Def protected AllocatableValue resultValue;
         @Alive protected Value expectedValue;
         @Alive protected AllocatableValue newValue;
         @Alive protected AllocatableValue addressValue;
         @Temp protected AllocatableValue scratchValue;
 
-        private final boolean useBarriers;
-
-        public CompareAndSwapOp(AllocatableValue result, Value expectedValue, AllocatableValue newValue,
-                        AllocatableValue addressValue, AllocatableValue scratch, boolean useBarriers) {
+        public CompareAndSwapOp(AArch64Kind accessKind, AllocatableValue result, Value expectedValue, AllocatableValue newValue, AllocatableValue addressValue, AllocatableValue scratch) {
             super(TYPE);
+            this.accessKind = accessKind;
             this.resultValue = result;
             this.expectedValue = expectedValue;
             this.newValue = newValue;
             this.addressValue = addressValue;
             this.scratchValue = scratch;
-            this.useBarriers = useBarriers;
         }
 
         @Override
         public void emitCode(CompilationResultBuilder crb, AArch64MacroAssembler masm) {
-            AArch64Kind kind = (AArch64Kind) expectedValue.getPlatformKind();
-            assert kind.isInteger();
-            final int size = kind.getSizeInBytes() * Byte.SIZE;
+            assert accessKind.isInteger();
+            final int size = accessKind.getSizeInBytes() * Byte.SIZE;
 
             Register address = asRegister(addressValue);
             Register result = asRegister(resultValue);
             Register newVal = asRegister(newValue);
-            if (useBarriers) {
-                masm.dmb(AArch64Assembler.BarrierKind.ANY_ANY);
-                emitCompareAndSwap(masm, size, address, result, newVal, false, false);
-                masm.dmb(AArch64Assembler.BarrierKind.ANY_ANY);
-            } else {
-                emitCompareAndSwap(masm, size, address, result, newVal, true, true);
-            }
-        }
-
-        private void emitCompareAndSwap(AArch64MacroAssembler masm, int size, Register address, Register result, Register newVal, boolean acquire, boolean release) {
+            Register expected = asRegister(expectedValue);
             if (AArch64LIRFlagsVersioned.useLSE(masm.target.arch)) {
-                Register expected = asRegister(expectedValue);
-                masm.mov(size, result, expected);
-                masm.cas(size, result, newVal, address, acquire, release);
+                masm.mov(Math.max(size, 32), result, expected);
+                masm.cas(size, result, newVal, address, true /* acquire */, true /* release */);
                 AArch64Compare.gpCompare(masm, resultValue, expectedValue);
             } else {
                 // We could avoid using a scratch register here, by reusing resultValue for the
@@ -107,10 +95,10 @@ public class AArch64AtomicMove {
                 Label retry = new Label();
                 Label fail = new Label();
                 masm.bind(retry);
-                masm.loadExclusive(size, result, address, acquire);
+                masm.loadExclusive(size, result, address, true);
                 AArch64Compare.gpCompare(masm, resultValue, expectedValue);
                 masm.branchConditionally(AArch64Assembler.ConditionFlag.NE, fail);
-                masm.storeExclusive(size, scratch, newVal, address, release);
+                masm.storeExclusive(size, scratch, newVal, address, true);
                 // if scratch == 0 then write successful, else retry.
                 masm.cbnz(32, scratch, retry);
                 masm.bind(fail);
@@ -147,25 +135,26 @@ public class AArch64AtomicMove {
         @Override
         public void emitCode(CompilationResultBuilder crb, AArch64MacroAssembler masm) {
             assert accessKind.isInteger();
-            final int size = accessKind.getSizeInBytes() * Byte.SIZE;
+            final int srcSize = accessKind.getSizeInBytes() * Byte.SIZE;
+            final int dstSize = Math.max(srcSize, 32);
 
             Register address = asRegister(addressValue);
             Register result = asRegister(resultValue);
 
             Label retry = new Label();
             masm.bind(retry);
-            masm.ldaxr(size, result, address);
+            masm.ldaxr(srcSize, result, address);
             try (ScratchRegister scratchRegister1 = masm.getScratchRegister()) {
                 Register scratch1 = scratchRegister1.getRegister();
                 if (LIRValueUtil.isConstantValue(deltaValue)) {
                     long delta = LIRValueUtil.asConstantValue(deltaValue).getJavaConstant().asLong();
-                    masm.add(size, scratch1, result, delta);
+                    masm.add(dstSize, scratch1, result, delta);
                 } else { // must be a register then
-                    masm.add(size, scratch1, result, asRegister(deltaValue));
+                    masm.add(dstSize, scratch1, result, asRegister(deltaValue));
                 }
                 try (ScratchRegister scratchRegister2 = masm.getScratchRegister()) {
                     Register scratch2 = scratchRegister2.getRegister();
-                    masm.stlxr(size, scratch2, scratch1, address);
+                    masm.stlxr(srcSize, scratch2, scratch1, address);
                     // if scratch2 == 0 then write successful, else retry
                     masm.cbnz(32, scratch2, retry);
                 }
@@ -210,12 +199,12 @@ public class AArch64AtomicMove {
         @Override
         public void emitCode(CompilationResultBuilder crb, AArch64MacroAssembler masm) {
             assert accessKind.isInteger();
-            final int size = accessKind.getSizeInBytes() * Byte.SIZE;
+            final int srcSize = accessKind.getSizeInBytes() * Byte.SIZE;
 
             Register address = asRegister(addressValue);
             Register delta = asRegister(deltaValue);
             Register result = asRegister(resultValue);
-            masm.ldadd(size, delta, result, address, true, true);
+            masm.ldadd(srcSize, delta, result, address, true, true);
         }
     }
 

--- a/compiler/src/org.graalvm.compiler.lir.aarch64/src/org/graalvm/compiler/lir/aarch64/AArch64Move.java
+++ b/compiler/src/org.graalvm.compiler.lir.aarch64/src/org/graalvm/compiler/lir/aarch64/AArch64Move.java
@@ -514,7 +514,7 @@ public class AArch64Move {
             return;
         }
         AArch64Kind kind = (AArch64Kind) input.getPlatformKind();
-        int size = kind.getSizeInBytes() * Byte.SIZE;
+        final int size = Math.max(kind.getSizeInBytes() * Byte.SIZE, 32);
         if (kind.isInteger()) {
             masm.mov(size, dst, src);
         } else {

--- a/compiler/src/org.graalvm.compiler.lir/src/org/graalvm/compiler/lir/gen/LIRGeneratorTool.java
+++ b/compiler/src/org.graalvm.compiler.lir/src/org/graalvm/compiler/lir/gen/LIRGeneratorTool.java
@@ -28,6 +28,7 @@ import org.graalvm.compiler.core.common.CompressEncoding;
 import org.graalvm.compiler.core.common.LIRKind;
 import org.graalvm.compiler.core.common.calc.Condition;
 import org.graalvm.compiler.core.common.cfg.AbstractBlockBase;
+import org.graalvm.compiler.core.common.memory.MemoryOrderMode;
 import org.graalvm.compiler.core.common.spi.CodeGenProviders;
 import org.graalvm.compiler.core.common.spi.ForeignCallLinkage;
 import org.graalvm.compiler.core.common.spi.ForeignCallsProvider;
@@ -151,9 +152,9 @@ public interface LIRGeneratorTool extends DiagnosticLIRGeneratorTool, ValueKindF
 
     void emitNullCheck(Value address, LIRFrameState state);
 
-    Variable emitLogicCompareAndSwap(LIRKind accessKind, Value address, Value expectedValue, Value newValue, Value trueValue, Value falseValue, int memoryBarrier);
+    Variable emitLogicCompareAndSwap(LIRKind accessKind, Value address, Value expectedValue, Value newValue, Value trueValue, Value falseValue, MemoryOrderMode memoryOrder);
 
-    Value emitValueCompareAndSwap(LIRKind accessKind, Value address, Value expectedValue, Value newValue, int memoryBarrier);
+    Value emitValueCompareAndSwap(LIRKind accessKind, Value address, Value expectedValue, Value newValue, MemoryOrderMode memoryOrder);
 
     /**
      * Emit an atomic read-and-add instruction.

--- a/compiler/src/org.graalvm.compiler.lir/src/org/graalvm/compiler/lir/gen/LIRGeneratorTool.java
+++ b/compiler/src/org.graalvm.compiler.lir/src/org/graalvm/compiler/lir/gen/LIRGeneratorTool.java
@@ -151,9 +151,9 @@ public interface LIRGeneratorTool extends DiagnosticLIRGeneratorTool, ValueKindF
 
     void emitNullCheck(Value address, LIRFrameState state);
 
-    Variable emitLogicCompareAndSwap(LIRKind accessKind, Value address, Value expectedValue, Value newValue, Value trueValue, Value falseValues);
+    Variable emitLogicCompareAndSwap(LIRKind accessKind, Value address, Value expectedValue, Value newValue, Value trueValue, Value falseValue, int memoryBarrier);
 
-    Value emitValueCompareAndSwap(LIRKind accessKind, Value address, Value expectedValue, Value newValue);
+    Value emitValueCompareAndSwap(LIRKind accessKind, Value address, Value expectedValue, Value newValue, int memoryBarrier);
 
     /**
      * Emit an atomic read-and-add instruction.

--- a/compiler/src/org.graalvm.compiler.lir/src/org/graalvm/compiler/lir/gen/LIRGeneratorTool.java
+++ b/compiler/src/org.graalvm.compiler.lir/src/org/graalvm/compiler/lir/gen/LIRGeneratorTool.java
@@ -151,9 +151,9 @@ public interface LIRGeneratorTool extends DiagnosticLIRGeneratorTool, ValueKindF
 
     void emitNullCheck(Value address, LIRFrameState state);
 
-    Variable emitLogicCompareAndSwap(LIRKind accessKind, Value address, Value expectedValue, Value newValue, Value trueValue, Value falseValues, boolean useBarriers);
+    Variable emitLogicCompareAndSwap(LIRKind accessKind, Value address, Value expectedValue, Value newValue, Value trueValue, Value falseValues);
 
-    Value emitValueCompareAndSwap(LIRKind accessKind, Value address, Value expectedValue, Value newValue, boolean useBarriers);
+    Value emitValueCompareAndSwap(LIRKind accessKind, Value address, Value expectedValue, Value newValue);
 
     /**
      * Emit an atomic read-and-add instruction.

--- a/compiler/src/org.graalvm.compiler.nodes/src/org/graalvm/compiler/nodes/java/AbstractCompareAndSwapNode.java
+++ b/compiler/src/org.graalvm.compiler.nodes/src/org/graalvm/compiler/nodes/java/AbstractCompareAndSwapNode.java
@@ -27,6 +27,7 @@ package org.graalvm.compiler.nodes.java;
 import static org.graalvm.compiler.nodeinfo.InputType.Memory;
 import static org.graalvm.compiler.nodeinfo.InputType.State;
 
+import jdk.vm.ci.code.MemoryBarriers;
 import org.graalvm.compiler.core.common.type.Stamp;
 import org.graalvm.compiler.graph.NodeClass;
 import org.graalvm.compiler.nodeinfo.InputType;
@@ -47,9 +48,11 @@ import org.graalvm.word.LocationIdentity;
 @NodeInfo(allowedUsageTypes = {InputType.Value, Memory})
 public abstract class AbstractCompareAndSwapNode extends FixedAccessNode implements StateSplit, LIRLowerableAccess, SingleMemoryKill {
     public static final NodeClass<AbstractCompareAndSwapNode> TYPE = NodeClass.create(AbstractCompareAndSwapNode.class);
+    protected static final int DEFAULT_MEMORY_BARRIER = MemoryBarriers.LOAD_LOAD | MemoryBarriers.LOAD_STORE | MemoryBarriers.STORE_LOAD | MemoryBarriers.STORE_STORE;
     @Input ValueNode expectedValue;
     @Input ValueNode newValue;
     @OptionalInput(State) FrameState stateAfter;
+    protected final int memoryBarrier;
 
     @Override
     public FrameState stateAfter() {
@@ -76,12 +79,17 @@ public abstract class AbstractCompareAndSwapNode extends FixedAccessNode impleme
         return newValue;
     }
 
+    public final int getMemoryBarrier() {
+        return memoryBarrier;
+    }
+
     public AbstractCompareAndSwapNode(NodeClass<? extends AbstractCompareAndSwapNode> c, AddressNode address, LocationIdentity location, ValueNode expectedValue, ValueNode newValue,
-                    BarrierType barrierType, Stamp stamp) {
+                    BarrierType barrierType, Stamp stamp, int memoryBarrier) {
         super(c, address, location, stamp, barrierType);
         assert expectedValue.getStackKind() == newValue.getStackKind();
         this.expectedValue = expectedValue;
         this.newValue = newValue;
+        this.memoryBarrier = memoryBarrier;
     }
 
     @Override

--- a/compiler/src/org.graalvm.compiler.nodes/src/org/graalvm/compiler/nodes/java/AbstractCompareAndSwapNode.java
+++ b/compiler/src/org.graalvm.compiler.nodes/src/org/graalvm/compiler/nodes/java/AbstractCompareAndSwapNode.java
@@ -27,7 +27,7 @@ package org.graalvm.compiler.nodes.java;
 import static org.graalvm.compiler.nodeinfo.InputType.Memory;
 import static org.graalvm.compiler.nodeinfo.InputType.State;
 
-import jdk.vm.ci.code.MemoryBarriers;
+import org.graalvm.compiler.core.common.memory.MemoryOrderMode;
 import org.graalvm.compiler.core.common.type.Stamp;
 import org.graalvm.compiler.graph.NodeClass;
 import org.graalvm.compiler.nodeinfo.InputType;
@@ -38,6 +38,7 @@ import org.graalvm.compiler.nodes.StateSplit;
 import org.graalvm.compiler.nodes.ValueNode;
 import org.graalvm.compiler.nodes.memory.FixedAccessNode;
 import org.graalvm.compiler.nodes.memory.LIRLowerableAccess;
+import org.graalvm.compiler.nodes.memory.OrderedMemoryAccess;
 import org.graalvm.compiler.nodes.memory.SingleMemoryKill;
 import org.graalvm.compiler.nodes.memory.address.AddressNode;
 import org.graalvm.word.LocationIdentity;
@@ -46,13 +47,12 @@ import org.graalvm.word.LocationIdentity;
  * Low-level atomic compare-and-swap operation.
  */
 @NodeInfo(allowedUsageTypes = {InputType.Value, Memory})
-public abstract class AbstractCompareAndSwapNode extends FixedAccessNode implements StateSplit, LIRLowerableAccess, SingleMemoryKill {
+public abstract class AbstractCompareAndSwapNode extends FixedAccessNode implements OrderedMemoryAccess, StateSplit, LIRLowerableAccess, SingleMemoryKill {
     public static final NodeClass<AbstractCompareAndSwapNode> TYPE = NodeClass.create(AbstractCompareAndSwapNode.class);
-    protected static final int DEFAULT_MEMORY_BARRIER = MemoryBarriers.LOAD_LOAD | MemoryBarriers.LOAD_STORE | MemoryBarriers.STORE_LOAD | MemoryBarriers.STORE_STORE;
     @Input ValueNode expectedValue;
     @Input ValueNode newValue;
     @OptionalInput(State) FrameState stateAfter;
-    protected final int memoryBarrier;
+    protected final MemoryOrderMode memoryOrder;
 
     @Override
     public FrameState stateAfter() {
@@ -79,17 +79,17 @@ public abstract class AbstractCompareAndSwapNode extends FixedAccessNode impleme
         return newValue;
     }
 
-    public final int getMemoryBarrier() {
-        return memoryBarrier;
+    public final MemoryOrderMode getMemoryOrder() {
+        return memoryOrder;
     }
 
     public AbstractCompareAndSwapNode(NodeClass<? extends AbstractCompareAndSwapNode> c, AddressNode address, LocationIdentity location, ValueNode expectedValue, ValueNode newValue,
-                    BarrierType barrierType, Stamp stamp, int memoryBarrier) {
+                    BarrierType barrierType, Stamp stamp, MemoryOrderMode memoryOrder) {
         super(c, address, location, stamp, barrierType);
         assert expectedValue.getStackKind() == newValue.getStackKind();
         this.expectedValue = expectedValue;
         this.newValue = newValue;
-        this.memoryBarrier = memoryBarrier;
+        this.memoryOrder = memoryOrder;
     }
 
     @Override

--- a/compiler/src/org.graalvm.compiler.nodes/src/org/graalvm/compiler/nodes/java/AbstractCompareAndSwapNode.java
+++ b/compiler/src/org.graalvm.compiler.nodes/src/org/graalvm/compiler/nodes/java/AbstractCompareAndSwapNode.java
@@ -79,6 +79,7 @@ public abstract class AbstractCompareAndSwapNode extends FixedAccessNode impleme
         return newValue;
     }
 
+    @Override
     public final MemoryOrderMode getMemoryOrder() {
         return memoryOrder;
     }

--- a/compiler/src/org.graalvm.compiler.nodes/src/org/graalvm/compiler/nodes/java/AbstractUnsafeCompareAndSwapNode.java
+++ b/compiler/src/org.graalvm.compiler.nodes/src/org/graalvm/compiler/nodes/java/AbstractUnsafeCompareAndSwapNode.java
@@ -51,6 +51,7 @@ import org.graalvm.compiler.nodes.virtual.VirtualInstanceNode;
 import org.graalvm.compiler.nodes.virtual.VirtualObjectNode;
 import org.graalvm.word.LocationIdentity;
 
+import jdk.vm.ci.code.MemoryBarriers;
 import jdk.vm.ci.meta.JavaKind;
 import jdk.vm.ci.meta.ResolvedJavaField;
 
@@ -63,9 +64,15 @@ public abstract class AbstractUnsafeCompareAndSwapNode extends AbstractMemoryChe
     @Input ValueNode newValue;
     protected final JavaKind valueKind;
     protected final LocationIdentity locationIdentity;
+    protected final int memoryBarrier;
 
     public AbstractUnsafeCompareAndSwapNode(NodeClass<? extends AbstractMemoryCheckpoint> c, Stamp stamp, ValueNode object, ValueNode offset, ValueNode expected, ValueNode newValue,
                     JavaKind valueKind, LocationIdentity locationIdentity) {
+        this(c, stamp, object, offset, expected, newValue, valueKind, locationIdentity, MemoryBarriers.LOAD_LOAD | MemoryBarriers.LOAD_STORE | MemoryBarriers.STORE_LOAD | MemoryBarriers.STORE_STORE);
+    }
+
+    public AbstractUnsafeCompareAndSwapNode(NodeClass<? extends AbstractMemoryCheckpoint> c, Stamp stamp, ValueNode object, ValueNode offset, ValueNode expected, ValueNode newValue,
+                    JavaKind valueKind, LocationIdentity locationIdentity, int memoryBarrier) {
         super(c, stamp);
         this.object = object;
         this.offset = offset;
@@ -73,6 +80,7 @@ public abstract class AbstractUnsafeCompareAndSwapNode extends AbstractMemoryChe
         this.newValue = newValue;
         this.valueKind = valueKind;
         this.locationIdentity = locationIdentity;
+        this.memoryBarrier = memoryBarrier;
     }
 
     public ValueNode object() {
@@ -93,6 +101,10 @@ public abstract class AbstractUnsafeCompareAndSwapNode extends AbstractMemoryChe
 
     public JavaKind getValueKind() {
         return valueKind;
+    }
+
+    public final int getMemoryBarrier() {
+        return memoryBarrier;
     }
 
     @Override

--- a/compiler/src/org.graalvm.compiler.nodes/src/org/graalvm/compiler/nodes/java/AbstractUnsafeCompareAndSwapNode.java
+++ b/compiler/src/org.graalvm.compiler.nodes/src/org/graalvm/compiler/nodes/java/AbstractUnsafeCompareAndSwapNode.java
@@ -68,11 +68,6 @@ public abstract class AbstractUnsafeCompareAndSwapNode extends AbstractMemoryChe
     protected final MemoryOrderMode memoryOrder;
 
     public AbstractUnsafeCompareAndSwapNode(NodeClass<? extends AbstractMemoryCheckpoint> c, Stamp stamp, ValueNode object, ValueNode offset, ValueNode expected, ValueNode newValue,
-                    JavaKind valueKind, LocationIdentity locationIdentity) {
-        this(c, stamp, object, offset, expected, newValue, valueKind, locationIdentity, MemoryOrderMode.VOLATILE);
-    }
-
-    public AbstractUnsafeCompareAndSwapNode(NodeClass<? extends AbstractMemoryCheckpoint> c, Stamp stamp, ValueNode object, ValueNode offset, ValueNode expected, ValueNode newValue,
                     JavaKind valueKind, LocationIdentity locationIdentity, MemoryOrderMode memoryOrder) {
         super(c, stamp);
         this.object = object;

--- a/compiler/src/org.graalvm.compiler.nodes/src/org/graalvm/compiler/nodes/java/LogicCompareAndSwapNode.java
+++ b/compiler/src/org.graalvm.compiler.nodes/src/org/graalvm/compiler/nodes/java/LogicCompareAndSwapNode.java
@@ -68,7 +68,7 @@ public final class LogicCompareAndSwapNode extends AbstractCompareAndSwapNode {
         Value trueResult = tool.emitConstant(resultKind, JavaConstant.TRUE);
         Value falseResult = tool.emitConstant(resultKind, JavaConstant.FALSE);
         Value result = tool.emitLogicCompareAndSwap(tool.getLIRKind(getAccessStamp(NodeView.DEFAULT)), gen.operand(getAddress()),
-                        gen.operand(getExpectedValue()), gen.operand(getNewValue()), trueResult, falseResult, false);
+                        gen.operand(getExpectedValue()), gen.operand(getNewValue()), trueResult, falseResult);
         gen.setResult(this, result);
     }
 }

--- a/compiler/src/org.graalvm.compiler.nodes/src/org/graalvm/compiler/nodes/java/LogicCompareAndSwapNode.java
+++ b/compiler/src/org.graalvm.compiler.nodes/src/org/graalvm/compiler/nodes/java/LogicCompareAndSwapNode.java
@@ -52,11 +52,7 @@ import jdk.vm.ci.meta.Value;
 public final class LogicCompareAndSwapNode extends AbstractCompareAndSwapNode {
     public static final NodeClass<LogicCompareAndSwapNode> TYPE = NodeClass.create(LogicCompareAndSwapNode.class);
 
-    public LogicCompareAndSwapNode(ValueNode address, ValueNode expectedValue, ValueNode newValue, LocationIdentity location) {
-        this((AddressNode) address, location, expectedValue, newValue, BarrierType.NONE, MemoryOrderMode.VOLATILE);
-    }
-
-    public LogicCompareAndSwapNode(AddressNode address, LocationIdentity location, ValueNode expectedValue, ValueNode newValue, BarrierType barrierType, MemoryOrderMode memoryOrder) {
+    public LogicCompareAndSwapNode(AddressNode address, ValueNode expectedValue, ValueNode newValue, LocationIdentity location, BarrierType barrierType, MemoryOrderMode memoryOrder) {
         super(TYPE, address, location, expectedValue, newValue, barrierType, StampFactory.forInteger(JavaKind.Int, 0, 1), memoryOrder);
     }
 

--- a/compiler/src/org.graalvm.compiler.nodes/src/org/graalvm/compiler/nodes/java/LogicCompareAndSwapNode.java
+++ b/compiler/src/org.graalvm.compiler.nodes/src/org/graalvm/compiler/nodes/java/LogicCompareAndSwapNode.java
@@ -52,11 +52,11 @@ public final class LogicCompareAndSwapNode extends AbstractCompareAndSwapNode {
     public static final NodeClass<LogicCompareAndSwapNode> TYPE = NodeClass.create(LogicCompareAndSwapNode.class);
 
     public LogicCompareAndSwapNode(ValueNode address, ValueNode expectedValue, ValueNode newValue, LocationIdentity location) {
-        this((AddressNode) address, location, expectedValue, newValue, BarrierType.NONE);
+        this((AddressNode) address, location, expectedValue, newValue, BarrierType.NONE, DEFAULT_MEMORY_BARRIER);
     }
 
-    public LogicCompareAndSwapNode(AddressNode address, LocationIdentity location, ValueNode expectedValue, ValueNode newValue, BarrierType barrierType) {
-        super(TYPE, address, location, expectedValue, newValue, barrierType, StampFactory.forInteger(JavaKind.Int, 0, 1));
+    public LogicCompareAndSwapNode(AddressNode address, LocationIdentity location, ValueNode expectedValue, ValueNode newValue, BarrierType barrierType, int memoryBarrier) {
+        super(TYPE, address, location, expectedValue, newValue, barrierType, StampFactory.forInteger(JavaKind.Int, 0, 1), memoryBarrier);
     }
 
     @Override
@@ -67,8 +67,9 @@ public final class LogicCompareAndSwapNode extends AbstractCompareAndSwapNode {
         LIRKind resultKind = tool.getLIRKind(stamp(NodeView.DEFAULT));
         Value trueResult = tool.emitConstant(resultKind, JavaConstant.TRUE);
         Value falseResult = tool.emitConstant(resultKind, JavaConstant.FALSE);
-        Value result = tool.emitLogicCompareAndSwap(tool.getLIRKind(getAccessStamp(NodeView.DEFAULT)), gen.operand(getAddress()),
-                        gen.operand(getExpectedValue()), gen.operand(getNewValue()), trueResult, falseResult);
+        Value result = tool.emitLogicCompareAndSwap(tool.getLIRKind(getAccessStamp(NodeView.DEFAULT)), gen.operand(getAddress()), gen.operand(getExpectedValue()), gen.operand(getNewValue()),
+                        trueResult, falseResult, memoryBarrier);
+
         gen.setResult(this, result);
     }
 }

--- a/compiler/src/org.graalvm.compiler.nodes/src/org/graalvm/compiler/nodes/java/LogicCompareAndSwapNode.java
+++ b/compiler/src/org.graalvm.compiler.nodes/src/org/graalvm/compiler/nodes/java/LogicCompareAndSwapNode.java
@@ -28,6 +28,7 @@ import static org.graalvm.compiler.nodeinfo.NodeCycles.CYCLES_8;
 import static org.graalvm.compiler.nodeinfo.NodeSize.SIZE_8;
 
 import org.graalvm.compiler.core.common.LIRKind;
+import org.graalvm.compiler.core.common.memory.MemoryOrderMode;
 import org.graalvm.compiler.core.common.type.StampFactory;
 import org.graalvm.compiler.graph.NodeClass;
 import org.graalvm.compiler.lir.gen.LIRGeneratorTool;
@@ -52,11 +53,11 @@ public final class LogicCompareAndSwapNode extends AbstractCompareAndSwapNode {
     public static final NodeClass<LogicCompareAndSwapNode> TYPE = NodeClass.create(LogicCompareAndSwapNode.class);
 
     public LogicCompareAndSwapNode(ValueNode address, ValueNode expectedValue, ValueNode newValue, LocationIdentity location) {
-        this((AddressNode) address, location, expectedValue, newValue, BarrierType.NONE, DEFAULT_MEMORY_BARRIER);
+        this((AddressNode) address, location, expectedValue, newValue, BarrierType.NONE, MemoryOrderMode.VOLATILE);
     }
 
-    public LogicCompareAndSwapNode(AddressNode address, LocationIdentity location, ValueNode expectedValue, ValueNode newValue, BarrierType barrierType, int memoryBarrier) {
-        super(TYPE, address, location, expectedValue, newValue, barrierType, StampFactory.forInteger(JavaKind.Int, 0, 1), memoryBarrier);
+    public LogicCompareAndSwapNode(AddressNode address, LocationIdentity location, ValueNode expectedValue, ValueNode newValue, BarrierType barrierType, MemoryOrderMode memoryOrder) {
+        super(TYPE, address, location, expectedValue, newValue, barrierType, StampFactory.forInteger(JavaKind.Int, 0, 1), memoryOrder);
     }
 
     @Override
@@ -68,7 +69,7 @@ public final class LogicCompareAndSwapNode extends AbstractCompareAndSwapNode {
         Value trueResult = tool.emitConstant(resultKind, JavaConstant.TRUE);
         Value falseResult = tool.emitConstant(resultKind, JavaConstant.FALSE);
         Value result = tool.emitLogicCompareAndSwap(tool.getLIRKind(getAccessStamp(NodeView.DEFAULT)), gen.operand(getAddress()), gen.operand(getExpectedValue()), gen.operand(getNewValue()),
-                        trueResult, falseResult, memoryBarrier);
+                        trueResult, falseResult, memoryOrder);
 
         gen.setResult(this, result);
     }

--- a/compiler/src/org.graalvm.compiler.nodes/src/org/graalvm/compiler/nodes/java/UnsafeCompareAndExchangeNode.java
+++ b/compiler/src/org.graalvm.compiler.nodes/src/org/graalvm/compiler/nodes/java/UnsafeCompareAndExchangeNode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -44,8 +44,8 @@ public final class UnsafeCompareAndExchangeNode extends AbstractUnsafeCompareAnd
 
     public static final NodeClass<UnsafeCompareAndExchangeNode> TYPE = NodeClass.create(UnsafeCompareAndExchangeNode.class);
 
-    public UnsafeCompareAndExchangeNode(ValueNode object, ValueNode offset, ValueNode expected, ValueNode newValue, JavaKind valueKind, LocationIdentity locationIdentity) {
-        super(TYPE, meetInputs(expected.stamp(NodeView.DEFAULT), newValue.stamp(NodeView.DEFAULT)), object, offset, expected, newValue, valueKind, locationIdentity);
+    public UnsafeCompareAndExchangeNode(ValueNode object, ValueNode offset, ValueNode expected, ValueNode newValue, JavaKind valueKind, LocationIdentity locationIdentity, int memoryBarrier) {
+        super(TYPE, meetInputs(expected.stamp(NodeView.DEFAULT), newValue.stamp(NodeView.DEFAULT)), object, offset, expected, newValue, valueKind, locationIdentity, memoryBarrier);
     }
 
     private static Stamp meetInputs(Stamp expected, Stamp newValue) {

--- a/compiler/src/org.graalvm.compiler.nodes/src/org/graalvm/compiler/nodes/java/UnsafeCompareAndExchangeNode.java
+++ b/compiler/src/org.graalvm.compiler.nodes/src/org/graalvm/compiler/nodes/java/UnsafeCompareAndExchangeNode.java
@@ -24,6 +24,7 @@
  */
 package org.graalvm.compiler.nodes.java;
 
+import org.graalvm.compiler.core.common.memory.MemoryOrderMode;
 import org.graalvm.compiler.core.common.type.Stamp;
 import org.graalvm.compiler.graph.NodeClass;
 import org.graalvm.compiler.nodeinfo.NodeInfo;
@@ -44,8 +45,8 @@ public final class UnsafeCompareAndExchangeNode extends AbstractUnsafeCompareAnd
 
     public static final NodeClass<UnsafeCompareAndExchangeNode> TYPE = NodeClass.create(UnsafeCompareAndExchangeNode.class);
 
-    public UnsafeCompareAndExchangeNode(ValueNode object, ValueNode offset, ValueNode expected, ValueNode newValue, JavaKind valueKind, LocationIdentity locationIdentity, int memoryBarrier) {
-        super(TYPE, meetInputs(expected.stamp(NodeView.DEFAULT), newValue.stamp(NodeView.DEFAULT)), object, offset, expected, newValue, valueKind, locationIdentity, memoryBarrier);
+    public UnsafeCompareAndExchangeNode(ValueNode object, ValueNode offset, ValueNode expected, ValueNode newValue, JavaKind valueKind, LocationIdentity locationIdentity, MemoryOrderMode memoryOrder) {
+        super(TYPE, meetInputs(expected.stamp(NodeView.DEFAULT), newValue.stamp(NodeView.DEFAULT)), object, offset, expected, newValue, valueKind, locationIdentity, memoryOrder);
     }
 
     private static Stamp meetInputs(Stamp expected, Stamp newValue) {

--- a/compiler/src/org.graalvm.compiler.nodes/src/org/graalvm/compiler/nodes/java/UnsafeCompareAndExchangeNode.java
+++ b/compiler/src/org.graalvm.compiler.nodes/src/org/graalvm/compiler/nodes/java/UnsafeCompareAndExchangeNode.java
@@ -45,7 +45,8 @@ public final class UnsafeCompareAndExchangeNode extends AbstractUnsafeCompareAnd
 
     public static final NodeClass<UnsafeCompareAndExchangeNode> TYPE = NodeClass.create(UnsafeCompareAndExchangeNode.class);
 
-    public UnsafeCompareAndExchangeNode(ValueNode object, ValueNode offset, ValueNode expected, ValueNode newValue, JavaKind valueKind, LocationIdentity locationIdentity, MemoryOrderMode memoryOrder) {
+    public UnsafeCompareAndExchangeNode(ValueNode object, ValueNode offset, ValueNode expected, ValueNode newValue, JavaKind valueKind, LocationIdentity locationIdentity,
+                    MemoryOrderMode memoryOrder) {
         super(TYPE, meetInputs(expected.stamp(NodeView.DEFAULT), newValue.stamp(NodeView.DEFAULT)), object, offset, expected, newValue, valueKind, locationIdentity, memoryOrder);
     }
 

--- a/compiler/src/org.graalvm.compiler.nodes/src/org/graalvm/compiler/nodes/java/UnsafeCompareAndSwapNode.java
+++ b/compiler/src/org.graalvm.compiler.nodes/src/org/graalvm/compiler/nodes/java/UnsafeCompareAndSwapNode.java
@@ -24,6 +24,7 @@
  */
 package org.graalvm.compiler.nodes.java;
 
+import org.graalvm.compiler.core.common.memory.MemoryOrderMode;
 import org.graalvm.compiler.core.common.type.StampFactory;
 import org.graalvm.compiler.graph.NodeClass;
 import org.graalvm.compiler.nodeinfo.NodeInfo;
@@ -51,8 +52,8 @@ public final class UnsafeCompareAndSwapNode extends AbstractUnsafeCompareAndSwap
         assert expected.stamp(NodeView.DEFAULT).isCompatible(newValue.stamp(NodeView.DEFAULT));
     }
 
-    public UnsafeCompareAndSwapNode(ValueNode object, ValueNode offset, ValueNode expected, ValueNode newValue, JavaKind valueKind, LocationIdentity locationIdentity, int memoryBarrier) {
-        super(TYPE, StampFactory.forInteger(JavaKind.Int, 0, 1), object, offset, expected, newValue, valueKind, locationIdentity, memoryBarrier);
+    public UnsafeCompareAndSwapNode(ValueNode object, ValueNode offset, ValueNode expected, ValueNode newValue, JavaKind valueKind, LocationIdentity locationIdentity, MemoryOrderMode memoryOrder) {
+        super(TYPE, StampFactory.forInteger(JavaKind.Int, 0, 1), object, offset, expected, newValue, valueKind, locationIdentity, memoryOrder);
         assert expected.stamp(NodeView.DEFAULT).isCompatible(newValue.stamp(NodeView.DEFAULT));
     }
 

--- a/compiler/src/org.graalvm.compiler.nodes/src/org/graalvm/compiler/nodes/java/UnsafeCompareAndSwapNode.java
+++ b/compiler/src/org.graalvm.compiler.nodes/src/org/graalvm/compiler/nodes/java/UnsafeCompareAndSwapNode.java
@@ -51,6 +51,11 @@ public final class UnsafeCompareAndSwapNode extends AbstractUnsafeCompareAndSwap
         assert expected.stamp(NodeView.DEFAULT).isCompatible(newValue.stamp(NodeView.DEFAULT));
     }
 
+    public UnsafeCompareAndSwapNode(ValueNode object, ValueNode offset, ValueNode expected, ValueNode newValue, JavaKind valueKind, LocationIdentity locationIdentity, int memoryBarrier) {
+        super(TYPE, StampFactory.forInteger(JavaKind.Int, 0, 1), object, offset, expected, newValue, valueKind, locationIdentity, memoryBarrier);
+        assert expected.stamp(NodeView.DEFAULT).isCompatible(newValue.stamp(NodeView.DEFAULT));
+    }
+
     @Override
     protected void finishVirtualize(VirtualizerTool tool, LogicNode equalsNode, ValueNode currentValue) {
         ValueNode result = ConditionalNode.create(equalsNode, ConstantNode.forBoolean(true, graph()), ConstantNode.forBoolean(false, graph()), NodeView.DEFAULT);

--- a/compiler/src/org.graalvm.compiler.nodes/src/org/graalvm/compiler/nodes/java/UnsafeCompareAndSwapNode.java
+++ b/compiler/src/org.graalvm.compiler.nodes/src/org/graalvm/compiler/nodes/java/UnsafeCompareAndSwapNode.java
@@ -47,11 +47,6 @@ public final class UnsafeCompareAndSwapNode extends AbstractUnsafeCompareAndSwap
 
     public static final NodeClass<UnsafeCompareAndSwapNode> TYPE = NodeClass.create(UnsafeCompareAndSwapNode.class);
 
-    public UnsafeCompareAndSwapNode(ValueNode object, ValueNode offset, ValueNode expected, ValueNode newValue, JavaKind valueKind, LocationIdentity locationIdentity) {
-        super(TYPE, StampFactory.forInteger(JavaKind.Int, 0, 1), object, offset, expected, newValue, valueKind, locationIdentity);
-        assert expected.stamp(NodeView.DEFAULT).isCompatible(newValue.stamp(NodeView.DEFAULT));
-    }
-
     public UnsafeCompareAndSwapNode(ValueNode object, ValueNode offset, ValueNode expected, ValueNode newValue, JavaKind valueKind, LocationIdentity locationIdentity, MemoryOrderMode memoryOrder) {
         super(TYPE, StampFactory.forInteger(JavaKind.Int, 0, 1), object, offset, expected, newValue, valueKind, locationIdentity, memoryOrder);
         assert expected.stamp(NodeView.DEFAULT).isCompatible(newValue.stamp(NodeView.DEFAULT));

--- a/compiler/src/org.graalvm.compiler.nodes/src/org/graalvm/compiler/nodes/java/ValueCompareAndSwapNode.java
+++ b/compiler/src/org.graalvm.compiler.nodes/src/org/graalvm/compiler/nodes/java/ValueCompareAndSwapNode.java
@@ -45,12 +45,12 @@ import org.graalvm.word.LocationIdentity;
 public final class ValueCompareAndSwapNode extends AbstractCompareAndSwapNode {
     public static final NodeClass<ValueCompareAndSwapNode> TYPE = NodeClass.create(ValueCompareAndSwapNode.class);
 
-    public ValueCompareAndSwapNode(ValueNode address, ValueNode expectedValue, ValueNode newValue, LocationIdentity location) {
-        this((AddressNode) address, expectedValue, newValue, location, BarrierType.NONE);
+    public ValueCompareAndSwapNode(AddressNode address, ValueNode expectedValue, ValueNode newValue, LocationIdentity location) {
+        this(address, expectedValue, newValue, location, BarrierType.NONE, DEFAULT_MEMORY_BARRIER);
     }
 
-    public ValueCompareAndSwapNode(AddressNode address, ValueNode expectedValue, ValueNode newValue, LocationIdentity location, BarrierType barrierType) {
-        super(TYPE, address, location, expectedValue, newValue, barrierType, expectedValue.stamp(NodeView.DEFAULT).meet(newValue.stamp(NodeView.DEFAULT)).unrestricted());
+    public ValueCompareAndSwapNode(AddressNode address, ValueNode expectedValue, ValueNode newValue, LocationIdentity location, BarrierType barrierType, int memoryBarrier) {
+        super(TYPE, address, location, expectedValue, newValue, barrierType, expectedValue.stamp(NodeView.DEFAULT).meet(newValue.stamp(NodeView.DEFAULT)).unrestricted(), memoryBarrier);
     }
 
     @Override
@@ -59,7 +59,7 @@ public final class ValueCompareAndSwapNode extends AbstractCompareAndSwapNode {
         LIRGeneratorTool tool = gen.getLIRGeneratorTool();
         assert !this.canDeoptimize();
         Value result = tool.emitValueCompareAndSwap(tool.getLIRKind(getAccessStamp(NodeView.DEFAULT)),
-                        gen.operand(getAddress()), gen.operand(getExpectedValue()), gen.operand(getNewValue()));
+                        gen.operand(getAddress()), gen.operand(getExpectedValue()), gen.operand(getNewValue()), memoryBarrier);
         gen.setResult(this, result);
     }
 }

--- a/compiler/src/org.graalvm.compiler.nodes/src/org/graalvm/compiler/nodes/java/ValueCompareAndSwapNode.java
+++ b/compiler/src/org.graalvm.compiler.nodes/src/org/graalvm/compiler/nodes/java/ValueCompareAndSwapNode.java
@@ -27,7 +27,7 @@ package org.graalvm.compiler.nodes.java;
 import static org.graalvm.compiler.nodeinfo.NodeCycles.CYCLES_8;
 import static org.graalvm.compiler.nodeinfo.NodeSize.SIZE_8;
 
-import jdk.vm.ci.meta.Value;
+import org.graalvm.compiler.core.common.memory.MemoryOrderMode;
 import org.graalvm.compiler.graph.NodeClass;
 import org.graalvm.compiler.lir.gen.LIRGeneratorTool;
 import org.graalvm.compiler.nodeinfo.NodeInfo;
@@ -36,6 +36,8 @@ import org.graalvm.compiler.nodes.ValueNode;
 import org.graalvm.compiler.nodes.memory.address.AddressNode;
 import org.graalvm.compiler.nodes.spi.NodeLIRBuilderTool;
 import org.graalvm.word.LocationIdentity;
+
+import jdk.vm.ci.meta.Value;
 
 /**
  * A special purpose store node that differs from {@link LogicCompareAndSwapNode} in that it returns
@@ -46,11 +48,11 @@ public final class ValueCompareAndSwapNode extends AbstractCompareAndSwapNode {
     public static final NodeClass<ValueCompareAndSwapNode> TYPE = NodeClass.create(ValueCompareAndSwapNode.class);
 
     public ValueCompareAndSwapNode(AddressNode address, ValueNode expectedValue, ValueNode newValue, LocationIdentity location) {
-        this(address, expectedValue, newValue, location, BarrierType.NONE, DEFAULT_MEMORY_BARRIER);
+        this(address, expectedValue, newValue, location, BarrierType.NONE, MemoryOrderMode.VOLATILE);
     }
 
-    public ValueCompareAndSwapNode(AddressNode address, ValueNode expectedValue, ValueNode newValue, LocationIdentity location, BarrierType barrierType, int memoryBarrier) {
-        super(TYPE, address, location, expectedValue, newValue, barrierType, expectedValue.stamp(NodeView.DEFAULT).meet(newValue.stamp(NodeView.DEFAULT)).unrestricted(), memoryBarrier);
+    public ValueCompareAndSwapNode(AddressNode address, ValueNode expectedValue, ValueNode newValue, LocationIdentity location, BarrierType barrierType, MemoryOrderMode memoryOrder) {
+        super(TYPE, address, location, expectedValue, newValue, barrierType, expectedValue.stamp(NodeView.DEFAULT).meet(newValue.stamp(NodeView.DEFAULT)).unrestricted(), memoryOrder);
     }
 
     @Override
@@ -59,7 +61,7 @@ public final class ValueCompareAndSwapNode extends AbstractCompareAndSwapNode {
         LIRGeneratorTool tool = gen.getLIRGeneratorTool();
         assert !this.canDeoptimize();
         Value result = tool.emitValueCompareAndSwap(tool.getLIRKind(getAccessStamp(NodeView.DEFAULT)),
-                        gen.operand(getAddress()), gen.operand(getExpectedValue()), gen.operand(getNewValue()), memoryBarrier);
+                        gen.operand(getAddress()), gen.operand(getExpectedValue()), gen.operand(getNewValue()), memoryOrder);
         gen.setResult(this, result);
     }
 }

--- a/compiler/src/org.graalvm.compiler.nodes/src/org/graalvm/compiler/nodes/java/ValueCompareAndSwapNode.java
+++ b/compiler/src/org.graalvm.compiler.nodes/src/org/graalvm/compiler/nodes/java/ValueCompareAndSwapNode.java
@@ -59,7 +59,7 @@ public final class ValueCompareAndSwapNode extends AbstractCompareAndSwapNode {
         LIRGeneratorTool tool = gen.getLIRGeneratorTool();
         assert !this.canDeoptimize();
         Value result = tool.emitValueCompareAndSwap(tool.getLIRKind(getAccessStamp(NodeView.DEFAULT)),
-                        gen.operand(getAddress()), gen.operand(getExpectedValue()), gen.operand(getNewValue()), false);
+                        gen.operand(getAddress()), gen.operand(getExpectedValue()), gen.operand(getNewValue()));
         gen.setResult(this, result);
     }
 }

--- a/compiler/src/org.graalvm.compiler.nodes/src/org/graalvm/compiler/nodes/java/ValueCompareAndSwapNode.java
+++ b/compiler/src/org.graalvm.compiler.nodes/src/org/graalvm/compiler/nodes/java/ValueCompareAndSwapNode.java
@@ -47,10 +47,6 @@ import jdk.vm.ci.meta.Value;
 public final class ValueCompareAndSwapNode extends AbstractCompareAndSwapNode {
     public static final NodeClass<ValueCompareAndSwapNode> TYPE = NodeClass.create(ValueCompareAndSwapNode.class);
 
-    public ValueCompareAndSwapNode(AddressNode address, ValueNode expectedValue, ValueNode newValue, LocationIdentity location) {
-        this(address, expectedValue, newValue, location, BarrierType.NONE, MemoryOrderMode.VOLATILE);
-    }
-
     public ValueCompareAndSwapNode(AddressNode address, ValueNode expectedValue, ValueNode newValue, LocationIdentity location, BarrierType barrierType, MemoryOrderMode memoryOrder) {
         super(TYPE, address, location, expectedValue, newValue, barrierType, expectedValue.stamp(NodeView.DEFAULT).meet(newValue.stamp(NodeView.DEFAULT)).unrestricted(), memoryOrder);
     }

--- a/compiler/src/org.graalvm.compiler.nodes/src/org/graalvm/compiler/nodes/memory/OrderedMemoryAccess.java
+++ b/compiler/src/org.graalvm.compiler.nodes/src/org/graalvm/compiler/nodes/memory/OrderedMemoryAccess.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.graalvm.compiler.nodes.memory;
+
+import org.graalvm.compiler.core.common.memory.MemoryOrderMode;
+
+/**
+ * Nodes implementing this class have memory ordering requirements according to
+ * {@link MemoryOrderMode}.
+ */
+public interface OrderedMemoryAccess {
+
+    /**
+     * Retrieves the node's required memory ordering.
+     */
+    MemoryOrderMode getMemoryOrder();
+}

--- a/compiler/src/org.graalvm.compiler.replacements.aarch64/src/org/graalvm/compiler/replacements/aarch64/AArch64GraphBuilderPlugins.java
+++ b/compiler/src/org.graalvm.compiler.replacements.aarch64/src/org/graalvm/compiler/replacements/aarch64/AArch64GraphBuilderPlugins.java
@@ -89,7 +89,7 @@ public class AArch64GraphBuilderPlugins implements TargetGraphBuilderPlugins {
                 // This is temporarily disabled until we implement correct emitting of the CAS
                 // instructions of the proper width.
                 registerPlatformSpecificUnsafePlugins(invocationPlugins, replacements, explicitUnsafeNullChecks,
-                                new JavaKind[]{JavaKind.Int, JavaKind.Long, JavaKind.Object});
+                                new JavaKind[]{JavaKind.Boolean, JavaKind.Byte, JavaKind.Char, JavaKind.Short, JavaKind.Int, JavaKind.Long, JavaKind.Object});
             }
         });
     }
@@ -320,7 +320,8 @@ public class AArch64GraphBuilderPlugins implements TargetGraphBuilderPlugins {
                         new JavaKind[]{JavaKind.Int, JavaKind.Long, JavaKind.Object}, "Object");
         if (JavaVersionUtil.JAVA_SPEC > 8) {
             Registration r = new Registration(plugins, "jdk.internal.misc.Unsafe", replacements);
-            registerUnsafePlugins(r, explicitUnsafeNullChecks, new JavaKind[]{JavaKind.Int, JavaKind.Long, JavaKind.Object},
+            registerUnsafePlugins(r, explicitUnsafeNullChecks,
+                            new JavaKind[]{JavaKind.Boolean, JavaKind.Byte, JavaKind.Char, JavaKind.Short, JavaKind.Int, JavaKind.Long, JavaKind.Object},
                             JavaVersionUtil.JAVA_SPEC <= 11 ? "Object" : "Reference");
             registerUnsafeUnalignedPlugins(r, explicitUnsafeNullChecks);
         }

--- a/compiler/src/org.graalvm.compiler.replacements.jdk9.test/src/org/graalvm/compiler/replacements/jdk9/test/UnsafeReplacementsTest.java
+++ b/compiler/src/org.graalvm.compiler.replacements.jdk9.test/src/org/graalvm/compiler/replacements/jdk9/test/UnsafeReplacementsTest.java
@@ -44,9 +44,9 @@ public class UnsafeReplacementsTest extends MethodSubstitutionTest {
 
     static class Container {
         public volatile boolean booleanField;
-        public volatile byte byteField = 17;
+        public volatile byte byteField = -17;
         public volatile char charField = 1025;
-        public volatile short shortField = 2232;
+        public volatile short shortField = -2232;
         public volatile int intField = 0xcafebabe;
         public volatile long longField = 0xdedababafafaL;
         public volatile float floatField = 0.125f;
@@ -90,7 +90,7 @@ public class UnsafeReplacementsTest extends MethodSubstitutionTest {
 
     public static boolean unsafeCompareAndSetByte() {
         Container container = new Container();
-        return unsafe.compareAndSetByte(container, byteOffset, (byte) 17, (byte) 121);
+        return unsafe.compareAndSetByte(container, byteOffset, (byte) -17, (byte) 121);
     }
 
     public static boolean unsafeCompareAndSetChar() {
@@ -100,7 +100,7 @@ public class UnsafeReplacementsTest extends MethodSubstitutionTest {
 
     public static boolean unsafeCompareAndSetShort() {
         Container container = new Container();
-        return unsafe.compareAndSetShort(container, shortOffset, (short) 2232, (short) 12111);
+        return unsafe.compareAndSetShort(container, shortOffset, (short) -2232, (short) 12111);
     }
 
     public static boolean unsafeCompareAndSetInt() {
@@ -130,7 +130,7 @@ public class UnsafeReplacementsTest extends MethodSubstitutionTest {
 
     public static byte unsafeCompareAndExchangeByte() {
         Container container = new Container();
-        return unsafe.compareAndExchangeByte(container, byteOffset, (byte) 17, (byte) 31);
+        return unsafe.compareAndExchangeByte(container, byteOffset, (byte) -17, (byte) 31);
     }
 
     public static char unsafeCompareAndExchangeChar() {
@@ -140,7 +140,7 @@ public class UnsafeReplacementsTest extends MethodSubstitutionTest {
 
     public static short unsafeCompareAndExchangeShort() {
         Container container = new Container();
-        return unsafe.compareAndExchangeShort(container, shortOffset, (short) 2232, (short) 8121);
+        return unsafe.compareAndExchangeShort(container, shortOffset, (short) -2232, (short) 8121);
     }
 
     public static int unsafeCompareAndExchangeInt() {
@@ -166,22 +166,24 @@ public class UnsafeReplacementsTest extends MethodSubstitutionTest {
     @Test
     public void testCompareAndSet() {
         if (target.arch instanceof AMD64) {
+            testGraph("unsafeCompareAndSetFloat");
+            testGraph("unsafeCompareAndSetDouble");
+            testGraph("unsafeCompareAndExchangeFloat");
+            testGraph("unsafeCompareAndExchangeDouble");
+        }
+        if (target.arch instanceof AMD64 || target.arch instanceof AArch64) {
             testGraph("unsafeCompareAndSetBoolean");
             testGraph("unsafeCompareAndSetByte");
             testGraph("unsafeCompareAndSetChar");
             testGraph("unsafeCompareAndSetShort");
             testGraph("unsafeCompareAndSetInt");
             testGraph("unsafeCompareAndSetLong");
-            testGraph("unsafeCompareAndSetFloat");
-            testGraph("unsafeCompareAndSetDouble");
             testGraph("unsafeCompareAndExchangeBoolean");
             testGraph("unsafeCompareAndExchangeByte");
             testGraph("unsafeCompareAndExchangeChar");
             testGraph("unsafeCompareAndExchangeShort");
             testGraph("unsafeCompareAndExchangeInt");
             testGraph("unsafeCompareAndExchangeLong");
-            testGraph("unsafeCompareAndExchangeFloat");
-            testGraph("unsafeCompareAndExchangeDouble");
         }
         test("unsafeCompareAndSetBoolean");
         test("unsafeCompareAndSetByte");
@@ -234,12 +236,10 @@ public class UnsafeReplacementsTest extends MethodSubstitutionTest {
 
     @Test
     public void testGetAndAdd() {
-        if (target.arch instanceof AMD64) {
+        if (target.arch instanceof AMD64 || target.arch instanceof AArch64) {
             testGraph("unsafeGetAndAddByte");
             testGraph("unsafeGetAndAddChar");
             testGraph("unsafeGetAndAddShort");
-        }
-        if (target.arch instanceof AMD64 || target.arch instanceof AArch64) {
             testGraph("unsafeGetAndAddInt");
             testGraph("unsafeGetAndAddLong");
         }
@@ -289,13 +289,11 @@ public class UnsafeReplacementsTest extends MethodSubstitutionTest {
 
     @Test
     public void testGetAndSet() {
-        if (target.arch instanceof AMD64) {
+        if (target.arch instanceof AMD64 || target.arch instanceof AArch64) {
             testGraph("unsafeGetAndSetBoolean");
             testGraph("unsafeGetAndSetByte");
             testGraph("unsafeGetAndSetChar");
             testGraph("unsafeGetAndSetShort");
-        }
-        if (target.arch instanceof AMD64 || target.arch instanceof AArch64) {
             testGraph("unsafeGetAndSetInt");
             testGraph("unsafeGetAndSetLong");
         }

--- a/compiler/src/org.graalvm.compiler.replacements.jdk9.test/src/org/graalvm/compiler/replacements/jdk9/test/UnsafeReplacementsTest.java
+++ b/compiler/src/org.graalvm.compiler.replacements.jdk9.test/src/org/graalvm/compiler/replacements/jdk9/test/UnsafeReplacementsTest.java
@@ -28,14 +28,10 @@ import jdk.vm.ci.aarch64.AArch64;
 import jdk.vm.ci.amd64.AMD64;
 import jdk.vm.ci.code.TargetDescription;
 import org.graalvm.compiler.api.test.Graal;
-import org.graalvm.compiler.core.phases.HighTier;
-import org.graalvm.compiler.options.OptionValues;
 import org.graalvm.compiler.replacements.test.MethodSubstitutionTest;
 import org.graalvm.compiler.runtime.RuntimeProvider;
 import org.graalvm.compiler.test.AddExports;
 import org.junit.Test;
-
-import java.lang.reflect.Field;
 
 @AddExports("java.base/jdk.internal.misc")
 public class UnsafeReplacementsTest extends MethodSubstitutionTest {
@@ -66,6 +62,8 @@ public class UnsafeReplacementsTest extends MethodSubstitutionTest {
     static long floatOffset;
     static long doubleOffset;
     static long byteArrayBaseOffset;
+
+    static final int WEAK_ATTEMPTS = 10;
 
     static {
         try {
@@ -123,53 +121,11 @@ public class UnsafeReplacementsTest extends MethodSubstitutionTest {
         return unsafe.compareAndSetDouble(container, doubleOffset, 0.125, 0.25);
     }
 
-    public static boolean unsafeCompareAndExchangeBoolean() {
-        Container container = new Container();
-        return unsafe.compareAndExchangeBoolean(container, booleanOffset, false, true);
-    }
-
-    public static byte unsafeCompareAndExchangeByte() {
-        Container container = new Container();
-        return unsafe.compareAndExchangeByte(container, byteOffset, (byte) -17, (byte) 31);
-    }
-
-    public static char unsafeCompareAndExchangeChar() {
-        Container container = new Container();
-        return unsafe.compareAndExchangeChar(container, charOffset, (char) 1025, (char) 4502);
-    }
-
-    public static short unsafeCompareAndExchangeShort() {
-        Container container = new Container();
-        return unsafe.compareAndExchangeShort(container, shortOffset, (short) -2232, (short) 8121);
-    }
-
-    public static int unsafeCompareAndExchangeInt() {
-        Container container = new Container();
-        return unsafe.compareAndExchangeInt(container, intOffset, 0xcafebabe, 0xbabefafa);
-    }
-
-    public static long unsafeCompareAndExchangeLong() {
-        Container container = new Container();
-        return unsafe.compareAndExchangeLong(container, longOffset, 0xdedababafafaL, 0xfafacecafafadedaL);
-    }
-
-    public static float unsafeCompareAndExchangeFloat() {
-        Container container = new Container();
-        return unsafe.compareAndExchangeFloat(container, floatOffset, 0.125f, 0.25f);
-    }
-
-    public static double unsafeCompareAndExchangeDouble() {
-        Container container = new Container();
-        return unsafe.compareAndExchangeDouble(container, doubleOffset, 0.125, 0.25);
-    }
-
     @Test
     public void testCompareAndSet() {
         if (target.arch instanceof AMD64) {
             testGraph("unsafeCompareAndSetFloat");
             testGraph("unsafeCompareAndSetDouble");
-            testGraph("unsafeCompareAndExchangeFloat");
-            testGraph("unsafeCompareAndExchangeDouble");
         }
         if (target.arch instanceof AMD64 || target.arch instanceof AArch64) {
             testGraph("unsafeCompareAndSetBoolean");
@@ -178,12 +134,6 @@ public class UnsafeReplacementsTest extends MethodSubstitutionTest {
             testGraph("unsafeCompareAndSetShort");
             testGraph("unsafeCompareAndSetInt");
             testGraph("unsafeCompareAndSetLong");
-            testGraph("unsafeCompareAndExchangeBoolean");
-            testGraph("unsafeCompareAndExchangeByte");
-            testGraph("unsafeCompareAndExchangeChar");
-            testGraph("unsafeCompareAndExchangeShort");
-            testGraph("unsafeCompareAndExchangeInt");
-            testGraph("unsafeCompareAndExchangeLong");
         }
         test("unsafeCompareAndSetBoolean");
         test("unsafeCompareAndSetByte");
@@ -193,14 +143,543 @@ public class UnsafeReplacementsTest extends MethodSubstitutionTest {
         test("unsafeCompareAndSetLong");
         test("unsafeCompareAndSetFloat");
         test("unsafeCompareAndSetDouble");
+    }
+
+    public static boolean unsafeWeakCompareAndSetBoolean() {
+        Container container = new Container();
+        boolean success = false;
+        for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
+            success = unsafe.weakCompareAndSetBoolean(container, booleanOffset, false, true);
+        }
+        return success;
+    }
+
+    public static boolean unsafeWeakCompareAndSetBooleanAcquire() {
+        Container container = new Container();
+        boolean success = false;
+        for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
+            success = unsafe.weakCompareAndSetBooleanAcquire(container, booleanOffset, false, true);
+        }
+        return success;
+    }
+
+    public static boolean unsafeWeakCompareAndSetBooleanPlain() {
+        Container container = new Container();
+        boolean success = false;
+        for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
+            success = unsafe.weakCompareAndSetBooleanPlain(container, booleanOffset, false, true);
+        }
+        return success;
+    }
+
+    public static boolean unsafeWeakCompareAndSetBooleanRelease() {
+        Container container = new Container();
+        boolean success = false;
+        for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
+            unsafe.weakCompareAndSetBooleanRelease(container, booleanOffset, false, true);
+        }
+        return success;
+    }
+
+    public static boolean unsafeWeakCompareAndSetByte() {
+        Container container = new Container();
+        boolean success = false;
+        for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
+            success = unsafe.weakCompareAndSetByte(container, byteOffset, (byte) -17, (byte) 121);
+        }
+        return success;
+    }
+
+    public static boolean unsafeWeakCompareAndSetByteAcquire() {
+        Container container = new Container();
+        boolean success = false;
+        for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
+            success = unsafe.weakCompareAndSetByteAcquire(container, byteOffset, (byte) -17, (byte) 121);
+        }
+        return success;
+    }
+
+    public static boolean unsafeWeakCompareAndSetBytePlain() {
+        Container container = new Container();
+        boolean success = false;
+        for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
+            success = unsafe.weakCompareAndSetBytePlain(container, byteOffset, (byte) -17, (byte) 121);
+        }
+        return success;
+    }
+
+    public static boolean unsafeWeakCompareAndSetByteRelease() {
+        Container container = new Container();
+        boolean success = false;
+        for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
+            success = unsafe.weakCompareAndSetByteRelease(container, byteOffset, (byte) -17, (byte) 121);
+        }
+        return success;
+    }
+
+    public static boolean unsafeWeakCompareAndSetChar() {
+        Container container = new Container();
+        boolean success = false;
+        for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
+            success = unsafe.weakCompareAndSetChar(container, charOffset, (char) 1025, (char) 1777);
+        }
+        return success;
+    }
+
+    public static boolean unsafeWeakCompareAndSetCharAcquire() {
+        Container container = new Container();
+        boolean success = false;
+        for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
+            success = unsafe.weakCompareAndSetCharAcquire(container, charOffset, (char) 1025, (char) 1777);
+        }
+        return success;
+    }
+
+    public static boolean unsafeWeakCompareAndSetCharPlain() {
+        Container container = new Container();
+        boolean success = false;
+        for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
+            success = unsafe.weakCompareAndSetCharPlain(container, charOffset, (char) 1025, (char) 1777);
+        }
+        return success;
+    }
+
+    public static boolean unsafeWeakCompareAndSetCharRelease() {
+        Container container = new Container();
+        boolean success = false;
+        for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
+            success = unsafe.weakCompareAndSetCharRelease(container, charOffset, (char) 1025, (char) 1777);
+        }
+        return success;
+    }
+
+    public static boolean unsafeWeakCompareAndSetShort() {
+        Container container = new Container();
+        boolean success = false;
+        for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
+            success = unsafe.weakCompareAndSetShort(container, shortOffset, (short) -2232, (short) 12111);
+        }
+        return success;
+    }
+
+    public static boolean unsafeWeakCompareAndSetShortAcquire() {
+        Container container = new Container();
+        boolean success = false;
+        for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
+            success = unsafe.weakCompareAndSetShortAcquire(container, shortOffset, (short) -2232, (short) 12111);
+        }
+        return success;
+    }
+
+    public static boolean unsafeWeakCompareAndSetShortPlain() {
+        Container container = new Container();
+        boolean success = false;
+        for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
+            success = unsafe.weakCompareAndSetShortPlain(container, shortOffset, (short) -2232, (short) 12111);
+        }
+        return success;
+    }
+
+    public static boolean unsafeWeakCompareAndSetShortRelease() {
+        Container container = new Container();
+        boolean success = false;
+        for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
+            success = unsafe.weakCompareAndSetShortRelease(container, shortOffset, (short) -2232, (short) 12111);
+        }
+        return success;
+    }
+
+    public static boolean unsafeWeakCompareAndSetInt() {
+        Container container = new Container();
+        boolean success = false;
+        for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
+            success = unsafe.weakCompareAndSetInt(container, intOffset, 0xcafebabe, 0xbabefafa);
+        }
+        return success;
+    }
+
+    public static boolean unsafeWeakCompareAndSetIntAcquire() {
+        Container container = new Container();
+        boolean success = false;
+        for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
+            success = unsafe.weakCompareAndSetIntAcquire(container, intOffset, 0xcafebabe, 0xbabefafa);
+        }
+        return success;
+    }
+
+    public static boolean unsafeWeakCompareAndSetIntPlain() {
+        Container container = new Container();
+        boolean success = false;
+        for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
+            success = unsafe.weakCompareAndSetIntPlain(container, intOffset, 0xcafebabe, 0xbabefafa);
+        }
+        return success;
+    }
+
+    public static boolean unsafeWeakCompareAndSetIntRelease() {
+        Container container = new Container();
+        boolean success = false;
+        for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
+            success = unsafe.weakCompareAndSetIntRelease(container, intOffset, 0xcafebabe, 0xbabefafa);
+        }
+        return success;
+    }
+
+    public static boolean unsafeWeakCompareAndSetLong() {
+        Container container = new Container();
+        boolean success = false;
+        for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
+            success = unsafe.weakCompareAndSetLong(container, longOffset, 0xdedababafafaL, 0xfafacecafafadedaL);
+        }
+        return success;
+    }
+
+    public static boolean unsafeWeakCompareAndSetLongAcquire() {
+        Container container = new Container();
+        boolean success = false;
+        for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
+            success = unsafe.weakCompareAndSetLongAcquire(container, longOffset, 0xdedababafafaL, 0xfafacecafafadedaL);
+        }
+        return success;
+    }
+
+    public static boolean unsafeWeakCompareAndSetLongPlain() {
+        Container container = new Container();
+        boolean success = false;
+        for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
+            success = unsafe.weakCompareAndSetLongPlain(container, longOffset, 0xdedababafafaL, 0xfafacecafafadedaL);
+        }
+        return success;
+    }
+
+    public static boolean unsafeWeakCompareAndSetLongRelease() {
+        Container container = new Container();
+        boolean success = false;
+        for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
+            success = unsafe.weakCompareAndSetLongRelease(container, longOffset, 0xdedababafafaL, 0xfafacecafafadedaL);
+        }
+        return success;
+    }
+
+    public static boolean unsafeWeakCompareAndSetFloat() {
+        Container container = new Container();
+        boolean success = false;
+        for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
+            success = unsafe.weakCompareAndSetFloat(container, floatOffset, 0.125f, 0.25f);
+        }
+        return success;
+    }
+
+    public static boolean unsafeWeakCompareAndSetFloatAcquire() {
+        Container container = new Container();
+        boolean success = false;
+        for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
+            success = unsafe.weakCompareAndSetFloatAcquire(container, floatOffset, 0.125f, 0.25f);
+        }
+        return success;
+    }
+
+    public static boolean unsafeWeakCompareAndSetFloatPlain() {
+        Container container = new Container();
+        boolean success = false;
+        for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
+            success = unsafe.weakCompareAndSetFloatPlain(container, floatOffset, 0.125f, 0.25f);
+        }
+        return success;
+    }
+
+    public static boolean unsafeWeakCompareAndSetFloatRelease() {
+        Container container = new Container();
+        boolean success = false;
+        for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
+            success = unsafe.weakCompareAndSetFloatRelease(container, floatOffset, 0.125f, 0.25f);
+        }
+        return success;
+    }
+
+    public static boolean unsafeWeakCompareAndSetDouble() {
+        Container container = new Container();
+        boolean success = false;
+        for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
+            success = unsafe.weakCompareAndSetDouble(container, doubleOffset, 0.125, 0.25);
+        }
+        return success;
+    }
+
+    public static boolean unsafeWeakCompareAndSetDoubleAcquire() {
+        Container container = new Container();
+        boolean success = false;
+        for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
+            success = unsafe.weakCompareAndSetDoubleAcquire(container, doubleOffset, 0.125, 0.25);
+        }
+        return success;
+    }
+
+    public static boolean unsafeWeakCompareAndSetDoublePlain() {
+        Container container = new Container();
+        boolean success = false;
+        for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
+            success = unsafe.weakCompareAndSetDoublePlain(container, doubleOffset, 0.125, 0.25);
+        }
+        return success;
+    }
+
+    public static boolean unsafeWeakCompareAndSetDoubleRelease() {
+        Container container = new Container();
+        boolean success = false;
+        for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
+            success = unsafe.weakCompareAndSetDoubleRelease(container, doubleOffset, 0.125, 0.25);
+        }
+        return success;
+    }
+
+    @Test
+    public void testWeakCompareAndSet() {
+        if (target.arch instanceof AMD64) {
+            testGraph("unsafeWeakCompareAndSetFloat");
+            testGraph("unsafeWeakCompareAndSetFloatAcquire");
+            testGraph("unsafeWeakCompareAndSetFloatPlain");
+            testGraph("unsafeWeakCompareAndSetFloatRelease");
+            testGraph("unsafeWeakCompareAndSetDouble");
+            testGraph("unsafeWeakCompareAndSetDoubleAcquire");
+            testGraph("unsafeWeakCompareAndSetDoublePlain");
+            testGraph("unsafeWeakCompareAndSetDoubleRelease");
+        }
+        if (target.arch instanceof AMD64 || target.arch instanceof AArch64) {
+            testGraph("unsafeWeakCompareAndSetBoolean");
+            testGraph("unsafeWeakCompareAndSetBooleanAcquire");
+            testGraph("unsafeWeakCompareAndSetBooleanPlain");
+            testGraph("unsafeWeakCompareAndSetBooleanRelease");
+            testGraph("unsafeWeakCompareAndSetByte");
+            testGraph("unsafeWeakCompareAndSetByteAcquire");
+            testGraph("unsafeWeakCompareAndSetBytePlain");
+            testGraph("unsafeWeakCompareAndSetByteRelease");
+            testGraph("unsafeWeakCompareAndSetChar");
+            testGraph("unsafeWeakCompareAndSetCharAcquire");
+            testGraph("unsafeWeakCompareAndSetCharPlain");
+            testGraph("unsafeWeakCompareAndSetCharRelease");
+            testGraph("unsafeWeakCompareAndSetShort");
+            testGraph("unsafeWeakCompareAndSetShortAcquire");
+            testGraph("unsafeWeakCompareAndSetShortPlain");
+            testGraph("unsafeWeakCompareAndSetShortRelease");
+            testGraph("unsafeWeakCompareAndSetInt");
+            testGraph("unsafeWeakCompareAndSetIntAcquire");
+            testGraph("unsafeWeakCompareAndSetIntPlain");
+            testGraph("unsafeWeakCompareAndSetIntRelease");
+            testGraph("unsafeWeakCompareAndSetLong");
+            testGraph("unsafeWeakCompareAndSetLongAcquire");
+            testGraph("unsafeWeakCompareAndSetLongPlain");
+            testGraph("unsafeWeakCompareAndSetLongRelease");
+        }
+        test("unsafeWeakCompareAndSetFloat");
+        test("unsafeWeakCompareAndSetFloatAcquire");
+        test("unsafeWeakCompareAndSetFloatPlain");
+        test("unsafeWeakCompareAndSetFloatRelease");
+        test("unsafeWeakCompareAndSetDouble");
+        test("unsafeWeakCompareAndSetDoubleAcquire");
+        test("unsafeWeakCompareAndSetDoublePlain");
+        test("unsafeWeakCompareAndSetDoubleRelease");
+        test("unsafeWeakCompareAndSetBoolean");
+        test("unsafeWeakCompareAndSetBooleanAcquire");
+        test("unsafeWeakCompareAndSetBooleanPlain");
+        test("unsafeWeakCompareAndSetBooleanRelease");
+        test("unsafeWeakCompareAndSetByte");
+        test("unsafeWeakCompareAndSetByteAcquire");
+        test("unsafeWeakCompareAndSetBytePlain");
+        test("unsafeWeakCompareAndSetByteRelease");
+        test("unsafeWeakCompareAndSetChar");
+        test("unsafeWeakCompareAndSetCharAcquire");
+        test("unsafeWeakCompareAndSetCharPlain");
+        test("unsafeWeakCompareAndSetCharRelease");
+        test("unsafeWeakCompareAndSetShort");
+        test("unsafeWeakCompareAndSetShortAcquire");
+        test("unsafeWeakCompareAndSetShortPlain");
+        test("unsafeWeakCompareAndSetShortRelease");
+        test("unsafeWeakCompareAndSetInt");
+        test("unsafeWeakCompareAndSetIntAcquire");
+        test("unsafeWeakCompareAndSetIntPlain");
+        test("unsafeWeakCompareAndSetIntRelease");
+        test("unsafeWeakCompareAndSetLong");
+        test("unsafeWeakCompareAndSetLongAcquire");
+        test("unsafeWeakCompareAndSetLongPlain");
+        test("unsafeWeakCompareAndSetLongRelease");
+    }
+
+    public static boolean unsafeCompareAndExchangeBoolean() {
+        Container container = new Container();
+        return unsafe.compareAndExchangeBoolean(container, booleanOffset, false, true);
+    }
+
+    public static boolean unsafeCompareAndExchangeBooleanAcquire() {
+        Container container = new Container();
+        return unsafe.compareAndExchangeBooleanAcquire(container, booleanOffset, false, true);
+    }
+
+    public static boolean unsafeCompareAndExchangeBooleanRelease() {
+        Container container = new Container();
+        return unsafe.compareAndExchangeBooleanRelease(container, booleanOffset, false, true);
+    }
+
+    public static byte unsafeCompareAndExchangeByte() {
+        Container container = new Container();
+        return unsafe.compareAndExchangeByte(container, byteOffset, (byte) -17, (byte) 31);
+    }
+
+    public static int unsafeCompareAndExchangeByteAcquire() {
+        Container container = new Container();
+        return unsafe.compareAndExchangeByteAcquire(container, byteOffset, (byte) -17, (byte) 31);
+    }
+
+    public static int unsafeCompareAndExchangeByteRelease() {
+        Container container = new Container();
+        return unsafe.compareAndExchangeByteRelease(container, byteOffset, (byte) -17, (byte) 31);
+    }
+
+    public static char unsafeCompareAndExchangeChar() {
+        Container container = new Container();
+        return unsafe.compareAndExchangeChar(container, charOffset, (char) 1025, (char) 4502);
+    }
+
+    public static int unsafeCompareAndExchangeCharAcquire() {
+        Container container = new Container();
+        return unsafe.compareAndExchangeCharAcquire(container, charOffset, (char) 1025, (char) 4502);
+    }
+
+    public static int unsafeCompareAndExchangeCharRelease() {
+        Container container = new Container();
+        return unsafe.compareAndExchangeCharRelease(container, charOffset, (char) 1025, (char) 4502);
+    }
+
+    public static short unsafeCompareAndExchangeShort() {
+        Container container = new Container();
+        return unsafe.compareAndExchangeShort(container, shortOffset, (short) -2232, (short) 8121);
+    }
+
+    public static int unsafeCompareAndExchangeShortAcquire() {
+        Container container = new Container();
+        return unsafe.compareAndExchangeShortAcquire(container, shortOffset, (short) -2232, (short) 8121);
+    }
+
+    public static int unsafeCompareAndExchangeShortRelease() {
+        Container container = new Container();
+        return unsafe.compareAndExchangeShortRelease(container, shortOffset, (short) -2232, (short) 8121);
+    }
+
+    public static int unsafeCompareAndExchangeInt() {
+        Container container = new Container();
+        return unsafe.compareAndExchangeInt(container, intOffset, 0xcafebabe, 0xbabefafa);
+    }
+
+    public static int unsafeCompareAndExchangeIntAcquire() {
+        Container container = new Container();
+        return unsafe.compareAndExchangeIntAcquire(container, intOffset, 0xcafebabe, 0xbabefafa);
+    }
+
+    public static int unsafeCompareAndExchangeIntRelease() {
+        Container container = new Container();
+        return unsafe.compareAndExchangeIntRelease(container, intOffset, 0xcafebabe, 0xbabefafa);
+    }
+
+    public static long unsafeCompareAndExchangeLong() {
+        Container container = new Container();
+        return unsafe.compareAndExchangeLong(container, longOffset, 0xdedababafafaL, 0xfafacecafafadedaL);
+    }
+
+    public static long unsafeCompareAndExchangeLongAcquire() {
+        Container container = new Container();
+        return unsafe.compareAndExchangeLongAcquire(container, longOffset, 0xdedababafafaL, 0xfafacecafafadedaL);
+    }
+
+    public static long unsafeCompareAndExchangeLongRelease() {
+        Container container = new Container();
+        return unsafe.compareAndExchangeLongRelease(container, longOffset, 0xdedababafafaL, 0xfafacecafafadedaL);
+    }
+
+    public static float unsafeCompareAndExchangeFloat() {
+        Container container = new Container();
+        return unsafe.compareAndExchangeFloat(container, floatOffset, 0.125f, 0.25f);
+    }
+
+    public static float unsafeCompareAndExchangeFloatAcquire() {
+        Container container = new Container();
+        return unsafe.compareAndExchangeFloatAcquire(container, floatOffset, 0.125f, 0.25f);
+    }
+
+    public static float unsafeCompareAndExchangeFloatRelease() {
+        Container container = new Container();
+        return unsafe.compareAndExchangeFloatRelease(container, floatOffset, 0.125f, 0.25f);
+    }
+
+    public static double unsafeCompareAndExchangeDouble() {
+        Container container = new Container();
+        return unsafe.compareAndExchangeDouble(container, doubleOffset, 0.125, 0.25);
+    }
+
+    public static double unsafeCompareAndExchangeDoubleAcquire() {
+        Container container = new Container();
+        return unsafe.compareAndExchangeDoubleAcquire(container, doubleOffset, 0.125, 0.25);
+    }
+
+    public static double unsafeCompareAndExchangeDoubleRelease() {
+        Container container = new Container();
+        return unsafe.compareAndExchangeDoubleRelease(container, doubleOffset, 0.125, 0.25);
+    }
+
+    @Test
+    public void testCompareAndExchange() {
+        if (target.arch instanceof AMD64) {
+            testGraph("unsafeCompareAndExchangeFloat");
+            testGraph("unsafeCompareAndExchangeFloatAcquire");
+            testGraph("unsafeCompareAndExchangeFloatRelease");
+            testGraph("unsafeCompareAndExchangeDouble");
+            testGraph("unsafeCompareAndExchangeDoubleAcquire");
+            testGraph("unsafeCompareAndExchangeDoubleRelease");
+        }
+        if (target.arch instanceof AMD64 || target.arch instanceof AArch64) {
+            testGraph("unsafeCompareAndExchangeBoolean");
+            testGraph("unsafeCompareAndExchangeBooleanAcquire");
+            testGraph("unsafeCompareAndExchangeBooleanRelease");
+            testGraph("unsafeCompareAndExchangeByte");
+            testGraph("unsafeCompareAndExchangeByteAcquire");
+            testGraph("unsafeCompareAndExchangeByteRelease");
+            testGraph("unsafeCompareAndExchangeChar");
+            testGraph("unsafeCompareAndExchangeCharAcquire");
+            testGraph("unsafeCompareAndExchangeCharRelease");
+            testGraph("unsafeCompareAndExchangeShort");
+            testGraph("unsafeCompareAndExchangeShortAcquire");
+            testGraph("unsafeCompareAndExchangeShortRelease");
+            testGraph("unsafeCompareAndExchangeInt");
+            testGraph("unsafeCompareAndExchangeIntAcquire");
+            testGraph("unsafeCompareAndExchangeIntRelease");
+            testGraph("unsafeCompareAndExchangeLong");
+            testGraph("unsafeCompareAndExchangeLongAcquire");
+            testGraph("unsafeCompareAndExchangeLongRelease");
+        }
+
         test("unsafeCompareAndExchangeBoolean");
+        test("unsafeCompareAndExchangeBooleanAcquire");
+        test("unsafeCompareAndExchangeBooleanRelease");
         test("unsafeCompareAndExchangeByte");
+        test("unsafeCompareAndExchangeByteAcquire");
+        test("unsafeCompareAndExchangeByteRelease");
         test("unsafeCompareAndExchangeChar");
+        test("unsafeCompareAndExchangeCharAcquire");
+        test("unsafeCompareAndExchangeCharRelease");
         test("unsafeCompareAndExchangeShort");
+        test("unsafeCompareAndExchangeShortAcquire");
+        test("unsafeCompareAndExchangeShortRelease");
         test("unsafeCompareAndExchangeInt");
+        test("unsafeCompareAndExchangeIntAcquire");
+        test("unsafeCompareAndExchangeIntRelease");
         test("unsafeCompareAndExchangeLong");
+        test("unsafeCompareAndExchangeLongAcquire");
+        test("unsafeCompareAndExchangeLongRelease");
         test("unsafeCompareAndExchangeFloat");
+        test("unsafeCompareAndExchangeFloatAcquire");
+        test("unsafeCompareAndExchangeFloatRelease");
         test("unsafeCompareAndExchangeDouble");
+        test("unsafeCompareAndExchangeDoubleAcquire");
+        test("unsafeCompareAndExchangeDoubleRelease");
     }
 
     public static int unsafeGetAndAddByte() {
@@ -306,200 +785,10 @@ public class UnsafeReplacementsTest extends MethodSubstitutionTest {
         test("unsafeGetAndSetLong");
     }
 
-    public static void fieldInstance() {
-        JdkInternalMiscUnsafeAccessTestBoolean.testFieldInstance();
-    }
-
-    @Test
-    public void testFieldInstance() {
-        test(new OptionValues(getInitialOptions(), HighTier.Options.Inline, false), "fieldInstance");
-    }
-
-    public static void array() {
-        JdkInternalMiscUnsafeAccessTestBoolean.testArray();
-    }
-
-    @Test
-    public void testArray() {
-        test(new OptionValues(getInitialOptions(), HighTier.Options.Inline, false), "array");
-    }
-
-    public static void fieldStatic() {
-        JdkInternalMiscUnsafeAccessTestBoolean.testFieldStatic();
-    }
-
-    @Test
-    public void testFieldStatic() {
-        test(new OptionValues(getInitialOptions(), HighTier.Options.Inline, false), "fieldStatic");
-    }
-
     public static void assertEquals(Object seen, Object expected, String message) {
         if (seen != expected) {
             throw new AssertionError(message + " - seen: " + seen + ", expected: " + expected);
         }
-    }
-
-    public static class JdkInternalMiscUnsafeAccessTestBoolean {
-        static final int ITERATIONS = 100000;
-
-        static final int WEAK_ATTEMPTS = 10;
-
-        static final long V_OFFSET;
-
-        static final Object STATIC_V_BASE;
-
-        static final long STATIC_V_OFFSET;
-
-        static final int ARRAY_OFFSET;
-
-        static final int ARRAY_SHIFT;
-
-        static {
-            try {
-                Field staticVField = UnsafeReplacementsTest.JdkInternalMiscUnsafeAccessTestBoolean.class.getDeclaredField("staticV");
-                STATIC_V_BASE = unsafe.staticFieldBase(staticVField);
-                STATIC_V_OFFSET = unsafe.staticFieldOffset(staticVField);
-            } catch (Exception e) {
-                throw new RuntimeException(e);
-            }
-
-            try {
-                Field vField = UnsafeReplacementsTest.JdkInternalMiscUnsafeAccessTestBoolean.class.getDeclaredField("v");
-                V_OFFSET = unsafe.objectFieldOffset(vField);
-            } catch (Exception e) {
-                throw new RuntimeException(e);
-            }
-
-            ARRAY_OFFSET = unsafe.arrayBaseOffset(boolean[].class);
-            int ascale = unsafe.arrayIndexScale(boolean[].class);
-            ARRAY_SHIFT = 31 - Integer.numberOfLeadingZeros(ascale);
-        }
-
-        static boolean staticV;
-
-        boolean v;
-
-        @BytecodeParserForceInline
-        public static void testFieldInstance() {
-            JdkInternalMiscUnsafeAccessTestBoolean t = new JdkInternalMiscUnsafeAccessTestBoolean();
-            for (int c = 0; c < ITERATIONS; c++) {
-                testAccess(t, V_OFFSET);
-            }
-        }
-
-        public static void testFieldStatic() {
-            for (int c = 0; c < ITERATIONS; c++) {
-                testAccess(STATIC_V_BASE, STATIC_V_OFFSET);
-            }
-        }
-
-        public static void testArray() {
-            boolean[] array = new boolean[10];
-            for (int c = 0; c < ITERATIONS; c++) {
-                for (int i = 0; i < array.length; i++) {
-                    testAccess(array, (((long) i) << ARRAY_SHIFT) + ARRAY_OFFSET);
-                }
-            }
-        }
-
-        // Checkstyle: stop
-        @BytecodeParserForceInline
-        public static void testAccess(Object base, long offset) {
-            // Advanced compare
-            {
-                boolean r = unsafe.compareAndExchangeBoolean(base, offset, false, true);
-                assertEquals(r, false, "success compareAndExchange boolean");
-                boolean x = unsafe.getBoolean(base, offset);
-                assertEquals(x, true, "success compareAndExchange boolean value");
-            }
-
-            {
-                boolean r = unsafe.compareAndExchangeBoolean(base, offset, false, false);
-                assertEquals(r, true, "failing compareAndExchange boolean");
-                boolean x = unsafe.getBoolean(base, offset);
-                assertEquals(x, true, "failing compareAndExchange boolean value");
-            }
-
-            {
-                boolean r = unsafe.compareAndExchangeBooleanAcquire(base, offset, true, false);
-                assertEquals(r, true, "success compareAndExchangeAcquire boolean");
-                boolean x = unsafe.getBoolean(base, offset);
-                assertEquals(x, false, "success compareAndExchangeAcquire boolean value");
-            }
-
-            {
-                boolean r = unsafe.compareAndExchangeBooleanAcquire(base, offset, true, false);
-                assertEquals(r, false, "failing compareAndExchangeAcquire boolean");
-                boolean x = unsafe.getBoolean(base, offset);
-                assertEquals(x, false, "failing compareAndExchangeAcquire boolean value");
-            }
-
-            {
-                boolean r = unsafe.compareAndExchangeBooleanRelease(base, offset, false, true);
-                assertEquals(r, false, "success compareAndExchangeRelease boolean");
-                boolean x = unsafe.getBoolean(base, offset);
-                assertEquals(x, true, "success compareAndExchangeRelease boolean value");
-            }
-
-            {
-                boolean r = unsafe.compareAndExchangeBooleanRelease(base, offset, false, false);
-                assertEquals(r, true, "failing compareAndExchangeRelease boolean");
-                boolean x = unsafe.getBoolean(base, offset);
-                assertEquals(x, true, "failing compareAndExchangeRelease boolean value");
-            }
-
-            {
-                boolean success = false;
-                for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
-                    success = unsafe.weakCompareAndSetBooleanPlain(base, offset, true, false);
-                }
-                assertEquals(success, true, "weakCompareAndSetPlain boolean");
-                boolean x = unsafe.getBoolean(base, offset);
-                assertEquals(x, false, "weakCompareAndSetPlain boolean value");
-            }
-
-            {
-                boolean success = false;
-                for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
-                    success = unsafe.weakCompareAndSetBooleanAcquire(base, offset, false, true);
-                }
-                assertEquals(success, true, "weakCompareAndSetAcquire boolean");
-                boolean x = unsafe.getBoolean(base, offset);
-                assertEquals(x, true, "weakCompareAndSetAcquire boolean");
-            }
-
-            {
-                boolean success = false;
-                for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
-                    success = unsafe.weakCompareAndSetBooleanRelease(base, offset, true, false);
-                }
-                assertEquals(success, true, "weakCompareAndSetRelease boolean");
-                boolean x = unsafe.getBoolean(base, offset);
-                assertEquals(x, false, "weakCompareAndSetRelease boolean");
-            }
-
-            {
-                boolean success = false;
-                for (int c = 0; c < WEAK_ATTEMPTS && !success; c++) {
-                    success = unsafe.weakCompareAndSetBoolean(base, offset, false, true);
-                }
-                assertEquals(success, true, "weakCompareAndSet boolean");
-                boolean x = unsafe.getBoolean(base, offset);
-                assertEquals(x, true, "weakCompareAndSet boolean");
-            }
-
-            unsafe.putBoolean(base, offset, false);
-
-            // Compare set and get
-            {
-                boolean o = unsafe.getAndSetBoolean(base, offset, true);
-                assertEquals(o, false, "getAndSet boolean");
-                boolean x = unsafe.getBoolean(base, offset);
-                assertEquals(x, true, "getAndSet boolean value");
-            }
-
-        }
-        // Checkstyle: resume
     }
 
     public static boolean unsafeGetPutBoolean() {

--- a/compiler/src/org.graalvm.compiler.replacements/src/org/graalvm/compiler/replacements/DefaultJavaLoweringProvider.java
+++ b/compiler/src/org.graalvm.compiler.replacements/src/org/graalvm/compiler/replacements/DefaultJavaLoweringProvider.java
@@ -665,7 +665,7 @@ public abstract class DefaultJavaLoweringProvider implements LoweringProvider {
         AddressNode address = graph.unique(new OffsetAddressNode(cas.object(), cas.offset()));
         BarrierType barrierType = barrierSet.guessStoreBarrierType(cas.object(), newValue);
         LogicCompareAndSwapNode atomicNode = graph.add(
-                        new LogicCompareAndSwapNode(address, cas.getKilledLocationIdentity(), expectedValue, newValue, barrierType, cas.getMemoryOrder()));
+                        new LogicCompareAndSwapNode(address, expectedValue, newValue, cas.getKilledLocationIdentity(), barrierType, cas.getMemoryOrder()));
         atomicNode.setStateAfter(cas.stateAfter());
         graph.replaceFixedWithFixed(cas, atomicNode);
     }

--- a/compiler/src/org.graalvm.compiler.replacements/src/org/graalvm/compiler/replacements/DefaultJavaLoweringProvider.java
+++ b/compiler/src/org.graalvm.compiler.replacements/src/org/graalvm/compiler/replacements/DefaultJavaLoweringProvider.java
@@ -664,7 +664,8 @@ public abstract class DefaultJavaLoweringProvider implements LoweringProvider {
 
         AddressNode address = graph.unique(new OffsetAddressNode(cas.object(), cas.offset()));
         BarrierType barrierType = barrierSet.guessStoreBarrierType(cas.object(), newValue);
-        LogicCompareAndSwapNode atomicNode = graph.add(new LogicCompareAndSwapNode(address, cas.getKilledLocationIdentity(), expectedValue, newValue, barrierType));
+        LogicCompareAndSwapNode atomicNode = graph.add(
+                        new LogicCompareAndSwapNode(address, cas.getKilledLocationIdentity(), expectedValue, newValue, barrierType, cas.getMemoryBarrier()));
         atomicNode.setStateAfter(cas.stateAfter());
         graph.replaceFixedWithFixed(cas, atomicNode);
     }
@@ -678,7 +679,8 @@ public abstract class DefaultJavaLoweringProvider implements LoweringProvider {
 
         AddressNode address = graph.unique(new OffsetAddressNode(cas.object(), cas.offset()));
         BarrierType barrierType = barrierSet.guessStoreBarrierType(cas.object(), newValue);
-        ValueCompareAndSwapNode atomicNode = graph.add(new ValueCompareAndSwapNode(address, expectedValue, newValue, cas.getKilledLocationIdentity(), barrierType));
+        ValueCompareAndSwapNode atomicNode = graph.add(
+                        new ValueCompareAndSwapNode(address, expectedValue, newValue, cas.getKilledLocationIdentity(), barrierType, cas.getMemoryBarrier()));
         ValueNode coercedNode = implicitLoadConvert(graph, valueKind, atomicNode, true);
         atomicNode.setStateAfter(cas.stateAfter());
         cas.replaceAtUsages(coercedNode);

--- a/compiler/src/org.graalvm.compiler.replacements/src/org/graalvm/compiler/replacements/DefaultJavaLoweringProvider.java
+++ b/compiler/src/org.graalvm.compiler.replacements/src/org/graalvm/compiler/replacements/DefaultJavaLoweringProvider.java
@@ -665,7 +665,7 @@ public abstract class DefaultJavaLoweringProvider implements LoweringProvider {
         AddressNode address = graph.unique(new OffsetAddressNode(cas.object(), cas.offset()));
         BarrierType barrierType = barrierSet.guessStoreBarrierType(cas.object(), newValue);
         LogicCompareAndSwapNode atomicNode = graph.add(
-                        new LogicCompareAndSwapNode(address, cas.getKilledLocationIdentity(), expectedValue, newValue, barrierType, cas.getMemoryBarrier()));
+                        new LogicCompareAndSwapNode(address, cas.getKilledLocationIdentity(), expectedValue, newValue, barrierType, cas.getMemoryOrder()));
         atomicNode.setStateAfter(cas.stateAfter());
         graph.replaceFixedWithFixed(cas, atomicNode);
     }
@@ -680,7 +680,7 @@ public abstract class DefaultJavaLoweringProvider implements LoweringProvider {
         AddressNode address = graph.unique(new OffsetAddressNode(cas.object(), cas.offset()));
         BarrierType barrierType = barrierSet.guessStoreBarrierType(cas.object(), newValue);
         ValueCompareAndSwapNode atomicNode = graph.add(
-                        new ValueCompareAndSwapNode(address, expectedValue, newValue, cas.getKilledLocationIdentity(), barrierType, cas.getMemoryBarrier()));
+                        new ValueCompareAndSwapNode(address, expectedValue, newValue, cas.getKilledLocationIdentity(), barrierType, cas.getMemoryOrder()));
         ValueNode coercedNode = implicitLoadConvert(graph, valueKind, atomicNode, true);
         atomicNode.setStateAfter(cas.stateAfter());
         cas.replaceAtUsages(coercedNode);

--- a/compiler/src/org.graalvm.compiler.replacements/src/org/graalvm/compiler/replacements/StandardGraphBuilderPlugins.java
+++ b/compiler/src/org.graalvm.compiler.replacements/src/org/graalvm/compiler/replacements/StandardGraphBuilderPlugins.java
@@ -369,74 +369,39 @@ public class StandardGraphBuilderPlugins {
         }
     }
 
-    private abstract static class UnsafeCompareAndUpdatePluginsRegistrar {
-        public void register(Registration r, String casPrefix, boolean explicitUnsafeNullChecks, JavaKind[] compareAndSwapTypes, boolean java11OrEarlier) {
-            for (JavaKind kind : compareAndSwapTypes) {
-                Class<?> javaClass = kind == JavaKind.Object ? Object.class : kind.toJavaClass();
-                String kindName = (kind == JavaKind.Object && !java11OrEarlier) ? "Reference" : kind.name();
-                r.register5(casPrefix + kindName, Receiver.class, Object.class, long.class, javaClass, javaClass, new UnsafeAccessPlugin(returnKind(kind), explicitUnsafeNullChecks) {
-                    @Override
-                    public boolean apply(GraphBuilderContext b, ResolvedJavaMethod targetMethod, Receiver unsafe, ValueNode object, ValueNode offset, ValueNode expected, ValueNode x) {
-                        // Emits a null-check for the otherwise unused receiver
-                        unsafe.get();
-                        createUnsafeAccess(object, b, (obj, loc) -> UnsafeCompareAndUpdatePluginsRegistrar.this.createNode(obj, offset, expected, x, kind, loc));
-                        return true;
-                    }
-                });
-            }
-        }
-
-        public abstract FixedWithNextNode createNode(ValueNode object, ValueNode offset, ValueNode expected, ValueNode newValue, JavaKind kind, LocationIdentity identity);
-
-        public abstract JavaKind returnKind(JavaKind accessKind);
+    private static Class<?> getJavaClass(JavaKind kind) {
+        return kind == JavaKind.Object ? Object.class : kind.toJavaClass();
     }
 
-    private static class UnsafeCompareAndSwapPluginsRegistrar extends UnsafeCompareAndUpdatePluginsRegistrar {
-        @Override
-        public FixedWithNextNode createNode(ValueNode object, ValueNode offset, ValueNode expected, ValueNode newValue, JavaKind kind, LocationIdentity identity) {
-            return new UnsafeCompareAndSwapNode(object, offset, expected, newValue, kind, identity);
-        }
-
-        @Override
-        public JavaKind returnKind(JavaKind accessKind) {
-            return JavaKind.Boolean.getStackKind();
-        }
+    private static String getKindName(boolean isSunMiscUnsafe, JavaKind kind) {
+        return (kind == JavaKind.Object && !isSunMiscUnsafe && !(JavaVersionUtil.JAVA_SPEC <= 11)) ? "Reference" : kind.name();
     }
 
-    private static final UnsafeCompareAndSwapPluginsRegistrar unsafeCompareAndSwapPluginsRegistrar = new UnsafeCompareAndSwapPluginsRegistrar();
-
-    private static class UnsafeCompareAndExchangePluginsRegistrar extends UnsafeCompareAndUpdatePluginsRegistrar {
-        @Override
-        public FixedWithNextNode createNode(ValueNode object, ValueNode offset, ValueNode expected, ValueNode newValue, JavaKind kind, LocationIdentity identity) {
-            return new UnsafeCompareAndExchangeNode(object, offset, expected, newValue, kind, identity);
-        }
-
-        @Override
-        public JavaKind returnKind(JavaKind accessKind) {
-            if (accessKind.isNumericInteger()) {
-                return accessKind.getStackKind();
-            } else {
-                return accessKind;
-            }
-        }
-    }
-
-    private static final UnsafeCompareAndExchangePluginsRegistrar unsafeCompareAndExchangePluginsRegistrar = new UnsafeCompareAndExchangePluginsRegistrar();
-
-    public static void registerPlatformSpecificUnsafePlugins(InvocationPlugins plugins, Replacements replacements, boolean explicitUnsafeNullChecks, JavaKind[] supportedCasKinds) {
-        registerPlatformSpecificUnsafePlugins(supportedCasKinds, new Registration(plugins, Unsafe.class), true, explicitUnsafeNullChecks);
+    public static void registerPlatformSpecificUnsafePlugins(InvocationPlugins plugins, Replacements replacements, boolean explicitUnsafeNullChecks, JavaKind[] supportedJavaKinds) {
+        registerUnsafeAtomicsPlugins(new Registration(plugins, Unsafe.class), true, explicitUnsafeNullChecks, "compareAndSwap", new String[]{""},
+                        new JavaKind[]{JavaKind.Int, JavaKind.Long, JavaKind.Object});
         if (JavaVersionUtil.JAVA_SPEC > 8) {
-            registerPlatformSpecificUnsafePlugins(supportedCasKinds, new Registration(plugins, "jdk.internal.misc.Unsafe", replacements), false, explicitUnsafeNullChecks);
+            Registration r = new Registration(plugins, "jdk.internal.misc.Unsafe", replacements);
+            registerUnsafeAtomicsPlugins(r, false, explicitUnsafeNullChecks, "compareAndSet", new String[]{""}, supportedJavaKinds);
+            registerUnsafeAtomicsPlugins(r, false, explicitUnsafeNullChecks, "compareAndExchange", new String[]{""}, supportedJavaKinds);
         }
-
     }
 
-    private static void registerPlatformSpecificUnsafePlugins(JavaKind[] supportedCasKinds, Registration r, boolean java8OrEarlier, boolean explicitUnsafeNullChecks) {
-        if (java8OrEarlier) {
-            unsafeCompareAndSwapPluginsRegistrar.register(r, "compareAndSwap", explicitUnsafeNullChecks, new JavaKind[]{JavaKind.Int, JavaKind.Long, JavaKind.Object}, true);
-        } else {
-            unsafeCompareAndSwapPluginsRegistrar.register(r, "compareAndSet", explicitUnsafeNullChecks, supportedCasKinds, JavaVersionUtil.JAVA_SPEC <= 11);
-            unsafeCompareAndExchangePluginsRegistrar.register(r, "compareAndExchange", explicitUnsafeNullChecks, supportedCasKinds, JavaVersionUtil.JAVA_SPEC <= 11);
+    public static void registerUnsafeAtomicsPlugins(Registration r, boolean isSunMiscUnsafe, boolean explicitUnsafeNullChecks, String casPrefix, String[] barrierTypes, JavaKind[] supportedJavaKinds) {
+        for (JavaKind kind : supportedJavaKinds) {
+            Class<?> javaClass = getJavaClass(kind);
+            String kindName = getKindName(isSunMiscUnsafe, kind);
+            boolean isLogic = true;
+            JavaKind returnKind = JavaKind.Boolean.getStackKind();
+            if (casPrefix.startsWith("compareAndExchange")) {
+                isLogic = false;
+                returnKind = kind.isNumericInteger() ? kind.getStackKind() : kind;
+            }
+            for (String barrierType : barrierTypes) {
+                MemoryBarriersKind barrierKind = barrierType.equals("") ? MemoryBarriersKind.RELEASE_ACQUIRE : MemoryBarriersKind.valueOf(barrierType.toUpperCase());
+                r.register5(casPrefix + kindName + barrierType, Receiver.class, Object.class, long.class, javaClass, javaClass,
+                                new UnsafeCompareAndSwapPlugin(returnKind, kind, barrierKind, isLogic, explicitUnsafeNullChecks));
+            }
         }
     }
 
@@ -451,25 +416,27 @@ public class StandardGraphBuilderPlugins {
         for (JavaKind kind : JavaKind.values()) {
             if ((kind.isPrimitive() && kind != JavaKind.Void) || kind == JavaKind.Object) {
                 Class<?> javaClass = kind == JavaKind.Object ? Object.class : kind.toJavaClass();
-                String kindName = (kind == JavaKind.Object && !sunMiscUnsafe && !(JavaVersionUtil.JAVA_SPEC <= 11)) ? "Reference" : kind.name();
+                String kindName = getKindName(sunMiscUnsafe, kind);
                 String getName = "get" + kindName;
                 String putName = "put" + kindName;
                 // Object-based accesses
                 r.register3(getName, Receiver.class, Object.class, long.class, new UnsafeGetPlugin(kind, explicitUnsafeNullChecks));
                 r.register4(putName, Receiver.class, Object.class, long.class, javaClass, new UnsafePutPlugin(kind, explicitUnsafeNullChecks));
                 // Volatile object-based accesses
-                r.register3(getName + "Volatile", Receiver.class, Object.class, long.class, new UnsafeGetPlugin(kind, AccessKind.VOLATILE, explicitUnsafeNullChecks));
-                r.register4(putName + "Volatile", Receiver.class, Object.class, long.class, javaClass, new UnsafePutPlugin(kind, AccessKind.VOLATILE, explicitUnsafeNullChecks));
+                r.register3(getName + "Volatile", Receiver.class, Object.class, long.class, new UnsafeGetPlugin(kind, MemoryBarriersKind.VOLATILE, explicitUnsafeNullChecks));
+                r.register4(putName + "Volatile", Receiver.class, Object.class, long.class, javaClass, new UnsafePutPlugin(kind, MemoryBarriersKind.VOLATILE, explicitUnsafeNullChecks));
                 // Ordered object-based accesses
                 if (sunMiscUnsafe) {
                     if (kind == JavaKind.Int || kind == JavaKind.Long || kind == JavaKind.Object) {
-                        r.register4("putOrdered" + kindName, Receiver.class, Object.class, long.class, javaClass, new UnsafePutPlugin(kind, AccessKind.RELEASE_ACQUIRE, explicitUnsafeNullChecks));
+                        r.register4("putOrdered" + kindName, Receiver.class, Object.class, long.class, javaClass,
+                                        new UnsafePutPlugin(kind, MemoryBarriersKind.RELEASE_ACQUIRE, explicitUnsafeNullChecks));
                     }
                 } else {
-                    r.register4("put" + kindName + "Release", Receiver.class, Object.class, long.class, javaClass, new UnsafePutPlugin(kind, AccessKind.RELEASE_ACQUIRE, explicitUnsafeNullChecks));
-                    r.register3("get" + kindName + "Acquire", Receiver.class, Object.class, long.class, new UnsafeGetPlugin(kind, AccessKind.RELEASE_ACQUIRE, explicitUnsafeNullChecks));
-                    r.register4("put" + kindName + "Opaque", Receiver.class, Object.class, long.class, javaClass, new UnsafePutPlugin(kind, AccessKind.OPAQUE, explicitUnsafeNullChecks));
-                    r.register3("get" + kindName + "Opaque", Receiver.class, Object.class, long.class, new UnsafeGetPlugin(kind, AccessKind.OPAQUE, explicitUnsafeNullChecks));
+                    r.register4("put" + kindName + "Release", Receiver.class, Object.class, long.class, javaClass,
+                                    new UnsafePutPlugin(kind, MemoryBarriersKind.RELEASE_ACQUIRE, explicitUnsafeNullChecks));
+                    r.register3("get" + kindName + "Acquire", Receiver.class, Object.class, long.class, new UnsafeGetPlugin(kind, MemoryBarriersKind.RELEASE_ACQUIRE, explicitUnsafeNullChecks));
+                    r.register4("put" + kindName + "Opaque", Receiver.class, Object.class, long.class, javaClass, new UnsafePutPlugin(kind, MemoryBarriersKind.OPAQUE, explicitUnsafeNullChecks));
+                    r.register3("get" + kindName + "Opaque", Receiver.class, Object.class, long.class, new UnsafeGetPlugin(kind, MemoryBarriersKind.OPAQUE, explicitUnsafeNullChecks));
                 }
                 if (kind != JavaKind.Boolean && kind != JavaKind.Object) {
                     // Raw accesses to memory addresses
@@ -1014,7 +981,7 @@ public class StandardGraphBuilderPlugins {
      * stronger mode than requested for any access.) In JDK 9, these are provided without a full
      * formal specification.
      */
-    enum AccessKind {
+    enum MemoryBarriersKind {
         PLAIN(0, 0, 0, 0, false),
         /**
          * Opaque accesses are wrapped by dummy membars to avoid floating/hoisting, this is stronger
@@ -1022,6 +989,8 @@ public class StandardGraphBuilderPlugins {
          * respect to other variables beyond Plain mode.
          */
         OPAQUE(0, 0, 0, 0, true),
+        ACQUIRE(0, LOAD_LOAD | LOAD_STORE, 0, 0, true),
+        RELEASE(0, 0, LOAD_STORE | STORE_STORE, 0, true),
         RELEASE_ACQUIRE(0, LOAD_LOAD | LOAD_STORE, LOAD_STORE | STORE_STORE, 0, true),
         VOLATILE(JMM_PRE_VOLATILE_READ, JMM_POST_VOLATILE_READ, JMM_PRE_VOLATILE_WRITE, JMM_POST_VOLATILE_WRITE, true);
 
@@ -1031,7 +1000,7 @@ public class StandardGraphBuilderPlugins {
         public final int preWriteBarriers;
         public final int postWriteBarriers;
 
-        AccessKind(int preReadBarriers, int postReadBarriers, int preWriteBarriers, int postWriteBarriers, boolean emitBarriers) {
+        MemoryBarriersKind(int preReadBarriers, int postReadBarriers, int preWriteBarriers, int postWriteBarriers, boolean emitBarriers) {
             this.emitBarriers = emitBarriers;
             this.preReadBarriers = preReadBarriers;
             this.postReadBarriers = postReadBarriers;
@@ -1127,15 +1096,15 @@ public class StandardGraphBuilderPlugins {
     }
 
     public static class UnsafeGetPlugin extends UnsafeAccessPlugin {
-        private final AccessKind accessKind;
+        private final MemoryBarriersKind memoryBarriersKind;
 
         public UnsafeGetPlugin(JavaKind returnKind, boolean explicitUnsafeNullChecks) {
-            this(returnKind, AccessKind.PLAIN, explicitUnsafeNullChecks);
+            this(returnKind, MemoryBarriersKind.PLAIN, explicitUnsafeNullChecks);
         }
 
-        public UnsafeGetPlugin(JavaKind kind, AccessKind accessKind, boolean explicitUnsafeNullChecks) {
+        public UnsafeGetPlugin(JavaKind kind, MemoryBarriersKind memoryBarriersKind, boolean explicitUnsafeNullChecks) {
             super(kind, explicitUnsafeNullChecks);
-            this.accessKind = accessKind;
+            this.memoryBarriersKind = memoryBarriersKind;
         }
 
         @Override
@@ -1151,16 +1120,16 @@ public class StandardGraphBuilderPlugins {
         public boolean apply(GraphBuilderContext b, ResolvedJavaMethod targetMethod, Receiver unsafe, ValueNode object, ValueNode offset) {
             // Opaque mode does not directly impose any ordering constraints with respect to other
             // variables beyond Plain mode.
-            if (accessKind == AccessKind.OPAQUE && StampTool.isPointerAlwaysNull(object)) {
+            if (memoryBarriersKind == MemoryBarriersKind.OPAQUE && StampTool.isPointerAlwaysNull(object)) {
                 // OFF_HEAP_LOCATION accesses are not floatable => no membars needed for opaque.
                 return apply(b, targetMethod, unsafe, offset);
             }
             // Emits a null-check for the otherwise unused receiver
             unsafe.get();
-            boolean isVolatile = accessKind == AccessKind.VOLATILE;
-            boolean emitBarriers = accessKind.emitBarriers && !isVolatile;
+            boolean isVolatile = memoryBarriersKind == MemoryBarriersKind.VOLATILE;
+            boolean emitBarriers = memoryBarriersKind.emitBarriers && !isVolatile;
             if (emitBarriers) {
-                b.add(new MembarNode(accessKind.preReadBarriers));
+                b.add(new MembarNode(memoryBarriersKind.preReadBarriers));
             }
             // Raw accesses can be turned into floatable field accesses, the membars preserve the
             // access mode. In the case of opaque access, and only for opaque, the location of the
@@ -1173,27 +1142,27 @@ public class StandardGraphBuilderPlugins {
             }
             createUnsafeAccess(object, b, unsafeNodeConstructor);
             if (emitBarriers) {
-                b.add(new MembarNode(accessKind.postReadBarriers));
+                b.add(new MembarNode(memoryBarriersKind.postReadBarriers));
             }
             return true;
         }
     }
 
     public static class UnsafePutPlugin extends UnsafeAccessPlugin {
-        private final AccessKind accessKind;
+        private final MemoryBarriersKind memoryBarriersKind;
 
         public UnsafePutPlugin(JavaKind kind, boolean explicitUnsafeNullChecks) {
-            this(kind, AccessKind.PLAIN, explicitUnsafeNullChecks);
+            this(kind, MemoryBarriersKind.PLAIN, explicitUnsafeNullChecks);
         }
 
-        private UnsafePutPlugin(JavaKind kind, AccessKind accessKind, boolean explicitUnsafeNullChecks) {
+        private UnsafePutPlugin(JavaKind kind, MemoryBarriersKind memoryBarriersKind, boolean explicitUnsafeNullChecks) {
             super(kind, explicitUnsafeNullChecks);
-            this.accessKind = accessKind;
+            this.memoryBarriersKind = memoryBarriersKind;
         }
 
         @Override
         public boolean apply(GraphBuilderContext b, ResolvedJavaMethod targetMethod, Receiver unsafe, ValueNode address, ValueNode value) {
-            assert !accessKind.emitBarriers : "Barriers for address based Unsafe put is not supported.";
+            assert !memoryBarriersKind.emitBarriers : "Barriers for address based Unsafe put is not supported.";
             // Emits a null-check for the otherwise unused receiver
             unsafe.get();
             b.add(new UnsafeMemoryStoreNode(address, value, unsafeAccessKind, OFF_HEAP_LOCATION));
@@ -1205,16 +1174,16 @@ public class StandardGraphBuilderPlugins {
         public boolean apply(GraphBuilderContext b, ResolvedJavaMethod targetMethod, Receiver unsafe, ValueNode object, ValueNode offset, ValueNode value) {
             // Opaque mode does not directly impose any ordering constraints with respect to other
             // variables beyond Plain mode.
-            if (accessKind == AccessKind.OPAQUE && StampTool.isPointerAlwaysNull(object)) {
+            if (memoryBarriersKind == MemoryBarriersKind.OPAQUE && StampTool.isPointerAlwaysNull(object)) {
                 // OFF_HEAP_LOCATION accesses are not floatable => no membars needed for opaque.
                 return apply(b, targetMethod, unsafe, offset, value);
             }
             // Emits a null-check for the otherwise unused receiver
             unsafe.get();
-            boolean isVolatile = accessKind == AccessKind.VOLATILE;
-            boolean emitBarriers = accessKind.emitBarriers && !isVolatile;
+            boolean isVolatile = memoryBarriersKind == MemoryBarriersKind.VOLATILE;
+            boolean emitBarriers = memoryBarriersKind.emitBarriers && !isVolatile;
             if (emitBarriers) {
-                b.add(new MembarNode(accessKind.preWriteBarriers));
+                b.add(new MembarNode(memoryBarriersKind.preWriteBarriers));
             }
             ValueNode maskedValue = b.maskSubWordValue(value, unsafeAccessKind);
             // Raw accesses can be turned into floatable field accesses, the membars preserve the
@@ -1222,7 +1191,39 @@ public class StandardGraphBuilderPlugins {
             // wrapping membars can be refined to the field location.
             createUnsafeAccess(object, b, (obj, loc) -> new RawStoreNode(obj, offset, maskedValue, unsafeAccessKind, loc, true, isVolatile));
             if (emitBarriers) {
-                b.add(new MembarNode(accessKind.postWriteBarriers));
+                b.add(new MembarNode(memoryBarriersKind.postWriteBarriers));
+            }
+            return true;
+        }
+    }
+
+    public static class UnsafeCompareAndSwapPlugin extends UnsafeAccessPlugin {
+        private final MemoryBarriersKind memoryBarriersKind;
+        private final JavaKind accessKind;
+        private final boolean isLogic;
+
+        public UnsafeCompareAndSwapPlugin(JavaKind returnKind, JavaKind accessKind, MemoryBarriersKind memoryBarriersKind, boolean isLogic, boolean explicitUnsafeNullChecks) {
+            super(returnKind, explicitUnsafeNullChecks);
+            this.memoryBarriersKind = memoryBarriersKind;
+            this.accessKind = accessKind;
+            this.isLogic = isLogic;
+        }
+
+        @Override
+        public boolean apply(GraphBuilderContext b, ResolvedJavaMethod targetMethod, Receiver unsafe, ValueNode object, ValueNode offset, ValueNode expected, ValueNode newValue) {
+            // Emits a null-check for the otherwise unused receiver
+            unsafe.get();
+            if (memoryBarriersKind == MemoryBarriersKind.RELEASE) {
+                b.add(new MembarNode(memoryBarriersKind.preWriteBarriers));
+            }
+            int memoryBarrier = memoryBarriersKind.preWriteBarriers | memoryBarriersKind.postReadBarriers;
+            if (isLogic) {
+                createUnsafeAccess(object, b, (obj, loc) -> new UnsafeCompareAndSwapNode(obj, offset, expected, newValue, accessKind, loc, memoryBarrier));
+            } else {
+                createUnsafeAccess(object, b, (obj, loc) -> new UnsafeCompareAndExchangeNode(obj, offset, expected, newValue, accessKind, loc, memoryBarrier));
+            }
+            if (memoryBarriersKind == MemoryBarriersKind.ACQUIRE) {
+                b.add(new MembarNode(memoryBarriersKind.postReadBarriers));
             }
             return true;
         }
@@ -1422,7 +1423,7 @@ public class StandardGraphBuilderPlugins {
         };
         for (JavaKind kind : JavaKind.values()) {
             if ((kind.isPrimitive() && kind != JavaKind.Void) || kind == JavaKind.Object) {
-                Class<?> javaClass = kind == JavaKind.Object ? Object.class : kind.toJavaClass();
+                Class<?> javaClass = getJavaClass(kind);
                 r.register1("blackhole", javaClass, blackholePlugin);
                 r.register1("bindToRegister", javaClass, bindToRegisterPlugin);
 
@@ -1508,7 +1509,7 @@ public class StandardGraphBuilderPlugins {
             Registration r = new Registration(plugins, name, replacements);
             for (JavaKind kind : JavaKind.values()) {
                 if ((kind.isPrimitive() && kind != JavaKind.Void) || kind == JavaKind.Object) {
-                    Class<?> javaClass = kind == JavaKind.Object ? Object.class : kind.toJavaClass();
+                    Class<?> javaClass = getJavaClass(kind);
                     r.registerOptional2("consume", Receiver.class, javaClass, blackholePlugin);
                 }
             }

--- a/compiler/src/org.graalvm.compiler.replacements/src/org/graalvm/compiler/replacements/StandardGraphBuilderPlugins.java
+++ b/compiler/src/org.graalvm.compiler.replacements/src/org/graalvm/compiler/replacements/StandardGraphBuilderPlugins.java
@@ -24,10 +24,6 @@
  */
 package org.graalvm.compiler.replacements;
 
-import static jdk.vm.ci.code.MemoryBarriers.JMM_POST_VOLATILE_READ;
-import static jdk.vm.ci.code.MemoryBarriers.JMM_POST_VOLATILE_WRITE;
-import static jdk.vm.ci.code.MemoryBarriers.JMM_PRE_VOLATILE_READ;
-import static jdk.vm.ci.code.MemoryBarriers.JMM_PRE_VOLATILE_WRITE;
 import static jdk.vm.ci.code.MemoryBarriers.LOAD_LOAD;
 import static jdk.vm.ci.code.MemoryBarriers.LOAD_STORE;
 import static jdk.vm.ci.code.MemoryBarriers.STORE_LOAD;
@@ -45,6 +41,7 @@ import org.graalvm.compiler.core.common.calc.Condition;
 import org.graalvm.compiler.core.common.calc.Condition.CanonicalizedCondition;
 import org.graalvm.compiler.core.common.calc.UnsignedMath;
 import org.graalvm.compiler.core.common.type.AbstractObjectStamp;
+import org.graalvm.compiler.core.common.memory.MemoryOrderMode;
 import org.graalvm.compiler.core.common.type.IntegerStamp;
 import org.graalvm.compiler.core.common.type.ObjectStamp;
 import org.graalvm.compiler.core.common.type.Stamp;
@@ -387,7 +384,7 @@ public class StandardGraphBuilderPlugins {
         }
     }
 
-    public static void registerUnsafeAtomicsPlugins(Registration r, boolean isSunMiscUnsafe, boolean explicitUnsafeNullChecks, String casPrefix, String[] barrierTypes, JavaKind[] supportedJavaKinds) {
+    public static void registerUnsafeAtomicsPlugins(Registration r, boolean isSunMiscUnsafe, boolean explicitUnsafeNullChecks, String casPrefix, String[] memoryOrders, JavaKind[] supportedJavaKinds) {
         for (JavaKind kind : supportedJavaKinds) {
             Class<?> javaClass = getJavaClass(kind);
             String kindName = getKindName(isSunMiscUnsafe, kind);
@@ -397,10 +394,10 @@ public class StandardGraphBuilderPlugins {
                 isLogic = false;
                 returnKind = kind.isNumericInteger() ? kind.getStackKind() : kind;
             }
-            for (String barrierType : barrierTypes) {
-                MemoryBarriersKind barrierKind = barrierType.equals("") ? MemoryBarriersKind.RELEASE_ACQUIRE : MemoryBarriersKind.valueOf(barrierType.toUpperCase());
-                r.register5(casPrefix + kindName + barrierType, Receiver.class, Object.class, long.class, javaClass, javaClass,
-                                new UnsafeCompareAndSwapPlugin(returnKind, kind, barrierKind, isLogic, explicitUnsafeNullChecks));
+            for (String memoryOrderString : memoryOrders) {
+                MemoryOrderMode memoryOrder = memoryOrderString.equals("") ? MemoryOrderMode.RELEASE_ACQUIRE : MemoryOrderMode.valueOf(memoryOrderString.toUpperCase());
+                r.register5(casPrefix + kindName + memoryOrderString, Receiver.class, Object.class, long.class, javaClass, javaClass,
+                                new UnsafeCompareAndSwapPlugin(returnKind, kind, memoryOrder, isLogic, explicitUnsafeNullChecks));
             }
         }
     }
@@ -423,20 +420,20 @@ public class StandardGraphBuilderPlugins {
                 r.register3(getName, Receiver.class, Object.class, long.class, new UnsafeGetPlugin(kind, explicitUnsafeNullChecks));
                 r.register4(putName, Receiver.class, Object.class, long.class, javaClass, new UnsafePutPlugin(kind, explicitUnsafeNullChecks));
                 // Volatile object-based accesses
-                r.register3(getName + "Volatile", Receiver.class, Object.class, long.class, new UnsafeGetPlugin(kind, MemoryBarriersKind.VOLATILE, explicitUnsafeNullChecks));
-                r.register4(putName + "Volatile", Receiver.class, Object.class, long.class, javaClass, new UnsafePutPlugin(kind, MemoryBarriersKind.VOLATILE, explicitUnsafeNullChecks));
+                r.register3(getName + "Volatile", Receiver.class, Object.class, long.class, new UnsafeGetPlugin(kind, MemoryOrderMode.VOLATILE, explicitUnsafeNullChecks));
+                r.register4(putName + "Volatile", Receiver.class, Object.class, long.class, javaClass, new UnsafePutPlugin(kind, MemoryOrderMode.VOLATILE, explicitUnsafeNullChecks));
                 // Ordered object-based accesses
                 if (sunMiscUnsafe) {
                     if (kind == JavaKind.Int || kind == JavaKind.Long || kind == JavaKind.Object) {
                         r.register4("putOrdered" + kindName, Receiver.class, Object.class, long.class, javaClass,
-                                        new UnsafePutPlugin(kind, MemoryBarriersKind.RELEASE_ACQUIRE, explicitUnsafeNullChecks));
+                                        new UnsafePutPlugin(kind, MemoryOrderMode.RELEASE_ACQUIRE, explicitUnsafeNullChecks));
                     }
                 } else {
                     r.register4("put" + kindName + "Release", Receiver.class, Object.class, long.class, javaClass,
-                                    new UnsafePutPlugin(kind, MemoryBarriersKind.RELEASE_ACQUIRE, explicitUnsafeNullChecks));
-                    r.register3("get" + kindName + "Acquire", Receiver.class, Object.class, long.class, new UnsafeGetPlugin(kind, MemoryBarriersKind.RELEASE_ACQUIRE, explicitUnsafeNullChecks));
-                    r.register4("put" + kindName + "Opaque", Receiver.class, Object.class, long.class, javaClass, new UnsafePutPlugin(kind, MemoryBarriersKind.OPAQUE, explicitUnsafeNullChecks));
-                    r.register3("get" + kindName + "Opaque", Receiver.class, Object.class, long.class, new UnsafeGetPlugin(kind, MemoryBarriersKind.OPAQUE, explicitUnsafeNullChecks));
+                                    new UnsafePutPlugin(kind, MemoryOrderMode.RELEASE_ACQUIRE, explicitUnsafeNullChecks));
+                    r.register3("get" + kindName + "Acquire", Receiver.class, Object.class, long.class, new UnsafeGetPlugin(kind, MemoryOrderMode.RELEASE_ACQUIRE, explicitUnsafeNullChecks));
+                    r.register4("put" + kindName + "Opaque", Receiver.class, Object.class, long.class, javaClass, new UnsafePutPlugin(kind, MemoryOrderMode.OPAQUE, explicitUnsafeNullChecks));
+                    r.register3("get" + kindName + "Opaque", Receiver.class, Object.class, long.class, new UnsafeGetPlugin(kind, MemoryOrderMode.OPAQUE, explicitUnsafeNullChecks));
                 }
                 if (kind != JavaKind.Boolean && kind != JavaKind.Object) {
                     // Raw accesses to memory addresses
@@ -974,42 +971,6 @@ public class StandardGraphBuilderPlugins {
     }
 
     /**
-     * The new memory order modes (JDK9+) are defined with cumulative effect, from weakest to
-     * strongest: Plain, Opaque, Release/Acquire, and Volatile. The existing Plain and Volatile
-     * modes are defined compatibly with their pre-JDK 9 forms. Any guaranteed property of a weaker
-     * mode, plus more, holds for a stronger mode. (Conversely, implementations are allowed to use a
-     * stronger mode than requested for any access.) In JDK 9, these are provided without a full
-     * formal specification.
-     */
-    enum MemoryBarriersKind {
-        PLAIN(0, 0, 0, 0, false),
-        /**
-         * Opaque accesses are wrapped by dummy membars to avoid floating/hoisting, this is stronger
-         * than required since Opaque mode does not directly impose any ordering constraints with
-         * respect to other variables beyond Plain mode.
-         */
-        OPAQUE(0, 0, 0, 0, true),
-        ACQUIRE(0, LOAD_LOAD | LOAD_STORE, 0, 0, true),
-        RELEASE(0, 0, LOAD_STORE | STORE_STORE, 0, true),
-        RELEASE_ACQUIRE(0, LOAD_LOAD | LOAD_STORE, LOAD_STORE | STORE_STORE, 0, true),
-        VOLATILE(JMM_PRE_VOLATILE_READ, JMM_POST_VOLATILE_READ, JMM_PRE_VOLATILE_WRITE, JMM_POST_VOLATILE_WRITE, true);
-
-        public final boolean emitBarriers;
-        public final int preReadBarriers;
-        public final int postReadBarriers;
-        public final int preWriteBarriers;
-        public final int postWriteBarriers;
-
-        MemoryBarriersKind(int preReadBarriers, int postReadBarriers, int preWriteBarriers, int postWriteBarriers, boolean emitBarriers) {
-            this.emitBarriers = emitBarriers;
-            this.preReadBarriers = preReadBarriers;
-            this.postReadBarriers = postReadBarriers;
-            this.preWriteBarriers = preWriteBarriers;
-            this.postWriteBarriers = postWriteBarriers;
-        }
-    }
-
-    /**
      * Unsafe access relative to null object is an access to off-heap memory. As linear pointer
      * compression uses non-zero null, here null object must be replaced with zero constant.
      */
@@ -1096,15 +1057,15 @@ public class StandardGraphBuilderPlugins {
     }
 
     public static class UnsafeGetPlugin extends UnsafeAccessPlugin {
-        private final MemoryBarriersKind memoryBarriersKind;
+        private final MemoryOrderMode memoryOrder;
 
         public UnsafeGetPlugin(JavaKind returnKind, boolean explicitUnsafeNullChecks) {
-            this(returnKind, MemoryBarriersKind.PLAIN, explicitUnsafeNullChecks);
+            this(returnKind, MemoryOrderMode.PLAIN, explicitUnsafeNullChecks);
         }
 
-        public UnsafeGetPlugin(JavaKind kind, MemoryBarriersKind memoryBarriersKind, boolean explicitUnsafeNullChecks) {
+        public UnsafeGetPlugin(JavaKind kind, MemoryOrderMode memoryOrder, boolean explicitUnsafeNullChecks) {
             super(kind, explicitUnsafeNullChecks);
-            this.memoryBarriersKind = memoryBarriersKind;
+            this.memoryOrder = memoryOrder;
         }
 
         @Override
@@ -1120,16 +1081,16 @@ public class StandardGraphBuilderPlugins {
         public boolean apply(GraphBuilderContext b, ResolvedJavaMethod targetMethod, Receiver unsafe, ValueNode object, ValueNode offset) {
             // Opaque mode does not directly impose any ordering constraints with respect to other
             // variables beyond Plain mode.
-            if (memoryBarriersKind == MemoryBarriersKind.OPAQUE && StampTool.isPointerAlwaysNull(object)) {
+            if (memoryOrder == MemoryOrderMode.OPAQUE && StampTool.isPointerAlwaysNull(object)) {
                 // OFF_HEAP_LOCATION accesses are not floatable => no membars needed for opaque.
                 return apply(b, targetMethod, unsafe, offset);
             }
             // Emits a null-check for the otherwise unused receiver
             unsafe.get();
-            boolean isVolatile = memoryBarriersKind == MemoryBarriersKind.VOLATILE;
-            boolean emitBarriers = memoryBarriersKind.emitBarriers && !isVolatile;
+            boolean isVolatile = memoryOrder == MemoryOrderMode.VOLATILE;
+            boolean emitBarriers = memoryOrder.emitBarriers && !isVolatile;
             if (emitBarriers) {
-                b.add(new MembarNode(memoryBarriersKind.preReadBarriers));
+                b.add(new MembarNode(memoryOrder.preReadBarriers));
             }
             // Raw accesses can be turned into floatable field accesses, the membars preserve the
             // access mode. In the case of opaque access, and only for opaque, the location of the
@@ -1142,27 +1103,27 @@ public class StandardGraphBuilderPlugins {
             }
             createUnsafeAccess(object, b, unsafeNodeConstructor);
             if (emitBarriers) {
-                b.add(new MembarNode(memoryBarriersKind.postReadBarriers));
+                b.add(new MembarNode(memoryOrder.postReadBarriers));
             }
             return true;
         }
     }
 
     public static class UnsafePutPlugin extends UnsafeAccessPlugin {
-        private final MemoryBarriersKind memoryBarriersKind;
+        private final MemoryOrderMode memoryOrder;
 
         public UnsafePutPlugin(JavaKind kind, boolean explicitUnsafeNullChecks) {
-            this(kind, MemoryBarriersKind.PLAIN, explicitUnsafeNullChecks);
+            this(kind, MemoryOrderMode.PLAIN, explicitUnsafeNullChecks);
         }
 
-        private UnsafePutPlugin(JavaKind kind, MemoryBarriersKind memoryBarriersKind, boolean explicitUnsafeNullChecks) {
+        private UnsafePutPlugin(JavaKind kind, MemoryOrderMode memoryOrder, boolean explicitUnsafeNullChecks) {
             super(kind, explicitUnsafeNullChecks);
-            this.memoryBarriersKind = memoryBarriersKind;
+            this.memoryOrder = memoryOrder;
         }
 
         @Override
         public boolean apply(GraphBuilderContext b, ResolvedJavaMethod targetMethod, Receiver unsafe, ValueNode address, ValueNode value) {
-            assert !memoryBarriersKind.emitBarriers : "Barriers for address based Unsafe put is not supported.";
+            assert !memoryOrder.emitBarriers : "Barriers for address based Unsafe put is not supported.";
             // Emits a null-check for the otherwise unused receiver
             unsafe.get();
             b.add(new UnsafeMemoryStoreNode(address, value, unsafeAccessKind, OFF_HEAP_LOCATION));
@@ -1174,16 +1135,16 @@ public class StandardGraphBuilderPlugins {
         public boolean apply(GraphBuilderContext b, ResolvedJavaMethod targetMethod, Receiver unsafe, ValueNode object, ValueNode offset, ValueNode value) {
             // Opaque mode does not directly impose any ordering constraints with respect to other
             // variables beyond Plain mode.
-            if (memoryBarriersKind == MemoryBarriersKind.OPAQUE && StampTool.isPointerAlwaysNull(object)) {
+            if (memoryOrder == MemoryOrderMode.OPAQUE && StampTool.isPointerAlwaysNull(object)) {
                 // OFF_HEAP_LOCATION accesses are not floatable => no membars needed for opaque.
                 return apply(b, targetMethod, unsafe, offset, value);
             }
             // Emits a null-check for the otherwise unused receiver
             unsafe.get();
-            boolean isVolatile = memoryBarriersKind == MemoryBarriersKind.VOLATILE;
-            boolean emitBarriers = memoryBarriersKind.emitBarriers && !isVolatile;
+            boolean isVolatile = memoryOrder == MemoryOrderMode.VOLATILE;
+            boolean emitBarriers = memoryOrder.emitBarriers && !isVolatile;
             if (emitBarriers) {
-                b.add(new MembarNode(memoryBarriersKind.preWriteBarriers));
+                b.add(new MembarNode(memoryOrder.preWriteBarriers));
             }
             ValueNode maskedValue = b.maskSubWordValue(value, unsafeAccessKind);
             // Raw accesses can be turned into floatable field accesses, the membars preserve the
@@ -1191,20 +1152,20 @@ public class StandardGraphBuilderPlugins {
             // wrapping membars can be refined to the field location.
             createUnsafeAccess(object, b, (obj, loc) -> new RawStoreNode(obj, offset, maskedValue, unsafeAccessKind, loc, true, isVolatile));
             if (emitBarriers) {
-                b.add(new MembarNode(memoryBarriersKind.postWriteBarriers));
+                b.add(new MembarNode(memoryOrder.postWriteBarriers));
             }
             return true;
         }
     }
 
     public static class UnsafeCompareAndSwapPlugin extends UnsafeAccessPlugin {
-        private final MemoryBarriersKind memoryBarriersKind;
+        private final MemoryOrderMode memoryOrder;
         private final JavaKind accessKind;
         private final boolean isLogic;
 
-        public UnsafeCompareAndSwapPlugin(JavaKind returnKind, JavaKind accessKind, MemoryBarriersKind memoryBarriersKind, boolean isLogic, boolean explicitUnsafeNullChecks) {
+        public UnsafeCompareAndSwapPlugin(JavaKind returnKind, JavaKind accessKind, MemoryOrderMode memoryOrder, boolean isLogic, boolean explicitUnsafeNullChecks) {
             super(returnKind, explicitUnsafeNullChecks);
-            this.memoryBarriersKind = memoryBarriersKind;
+            this.memoryOrder = memoryOrder;
             this.accessKind = accessKind;
             this.isLogic = isLogic;
         }
@@ -1213,17 +1174,10 @@ public class StandardGraphBuilderPlugins {
         public boolean apply(GraphBuilderContext b, ResolvedJavaMethod targetMethod, Receiver unsafe, ValueNode object, ValueNode offset, ValueNode expected, ValueNode newValue) {
             // Emits a null-check for the otherwise unused receiver
             unsafe.get();
-            if (memoryBarriersKind == MemoryBarriersKind.RELEASE) {
-                b.add(new MembarNode(memoryBarriersKind.preWriteBarriers));
-            }
-            int memoryBarrier = memoryBarriersKind.preWriteBarriers | memoryBarriersKind.postReadBarriers;
             if (isLogic) {
-                createUnsafeAccess(object, b, (obj, loc) -> new UnsafeCompareAndSwapNode(obj, offset, expected, newValue, accessKind, loc, memoryBarrier));
+                createUnsafeAccess(object, b, (obj, loc) -> new UnsafeCompareAndSwapNode(obj, offset, expected, newValue, accessKind, loc, memoryOrder));
             } else {
-                createUnsafeAccess(object, b, (obj, loc) -> new UnsafeCompareAndExchangeNode(obj, offset, expected, newValue, accessKind, loc, memoryBarrier));
-            }
-            if (memoryBarriersKind == MemoryBarriersKind.ACQUIRE) {
-                b.add(new MembarNode(memoryBarriersKind.postReadBarriers));
+                createUnsafeAccess(object, b, (obj, loc) -> new UnsafeCompareAndExchangeNode(obj, offset, expected, newValue, accessKind, loc, memoryOrder));
             }
             return true;
         }

--- a/compiler/src/org.graalvm.compiler.word/src/org/graalvm/compiler/word/WordOperationPlugin.java
+++ b/compiler/src/org.graalvm.compiler.word/src/org/graalvm/compiler/word/WordOperationPlugin.java
@@ -36,6 +36,7 @@ import org.graalvm.compiler.bytecode.BridgeMethodUtils;
 import org.graalvm.compiler.core.common.calc.CanonicalCondition;
 import org.graalvm.compiler.core.common.calc.Condition;
 import org.graalvm.compiler.core.common.calc.Condition.CanonicalizedCondition;
+import org.graalvm.compiler.core.common.memory.MemoryOrderMode;
 import org.graalvm.compiler.core.common.type.Stamp;
 import org.graalvm.compiler.core.common.type.StampFactory;
 import org.graalvm.compiler.core.common.type.StampPair;
@@ -485,9 +486,9 @@ public class WordOperationPlugin implements NodePlugin, TypePlugin, InlineInvoke
         assert isLogic || writeKind == returnKind : writeKind + " != " + returnKind;
         AbstractCompareAndSwapNode cas;
         if (isLogic) {
-            cas = new LogicCompareAndSwapNode(address, expectedValue, newValue, location);
+            cas = new LogicCompareAndSwapNode(address, expectedValue, newValue, location, BarrierType.NONE, MemoryOrderMode.PLAIN);
         } else {
-            cas = new ValueCompareAndSwapNode(address, expectedValue, newValue, location);
+            cas = new ValueCompareAndSwapNode(address, expectedValue, newValue, location, BarrierType.NONE, MemoryOrderMode.PLAIN);
         }
         return cas;
     }

--- a/substratevm/src/com.oracle.svm.core.graal.llvm/src/com/oracle/svm/core/graal/llvm/LLVMGenerator.java
+++ b/substratevm/src/com.oracle.svm.core.graal.llvm/src/com/oracle/svm/core/graal/llvm/LLVMGenerator.java
@@ -47,6 +47,7 @@ import org.graalvm.compiler.core.common.NumUtil;
 import org.graalvm.compiler.core.common.calc.Condition;
 import org.graalvm.compiler.core.common.calc.FloatConvert;
 import org.graalvm.compiler.core.common.cfg.AbstractBlockBase;
+import org.graalvm.compiler.core.common.memory.MemoryOrderMode;
 import org.graalvm.compiler.core.common.spi.CodeGenProviders;
 import org.graalvm.compiler.core.common.spi.ForeignCallLinkage;
 import org.graalvm.compiler.core.common.spi.ForeignCallsProvider;
@@ -713,14 +714,14 @@ public class LLVMGenerator implements LIRGeneratorTool, SubstrateLIRGenerator {
     }
 
     @Override
-    public Variable emitLogicCompareAndSwap(LIRKind accessKind, Value address, Value expectedValue, Value newValue, Value trueValue, Value falseValue, int memoryBarrier) {
+    public Variable emitLogicCompareAndSwap(LIRKind accessKind, Value address, Value expectedValue, Value newValue, Value trueValue, Value falseValue, MemoryOrderMode memoryOrder) {
         LLVMValueRef success = buildCmpxchg(getVal(address), getVal(expectedValue), getVal(newValue), false);
         LLVMValueRef result = builder.buildSelect(success, getVal(trueValue), getVal(falseValue));
         return new LLVMVariable(result);
     }
 
     @Override
-    public Value emitValueCompareAndSwap(LIRKind accessKind, Value address, Value expectedValue, Value newValue, int memoryBarrier) {
+    public Value emitValueCompareAndSwap(LIRKind accessKind, Value address, Value expectedValue, Value newValue, MemoryOrderMode memoryOrder) {
         LLVMValueRef result = buildCmpxchg(getVal(address), getVal(expectedValue), getVal(newValue), true);
         return new LLVMVariable(result);
     }

--- a/substratevm/src/com.oracle.svm.core.graal.llvm/src/com/oracle/svm/core/graal/llvm/LLVMGenerator.java
+++ b/substratevm/src/com.oracle.svm.core.graal.llvm/src/com/oracle/svm/core/graal/llvm/LLVMGenerator.java
@@ -713,14 +713,14 @@ public class LLVMGenerator implements LIRGeneratorTool, SubstrateLIRGenerator {
     }
 
     @Override
-    public Variable emitLogicCompareAndSwap(LIRKind accessKind, Value address, Value expectedValue, Value newValue, Value trueValue, Value falseValue, boolean useBarriers) {
+    public Variable emitLogicCompareAndSwap(LIRKind accessKind, Value address, Value expectedValue, Value newValue, Value trueValue, Value falseValue) {
         LLVMValueRef success = buildCmpxchg(getVal(address), getVal(expectedValue), getVal(newValue), false);
         LLVMValueRef result = builder.buildSelect(success, getVal(trueValue), getVal(falseValue));
         return new LLVMVariable(result);
     }
 
     @Override
-    public Value emitValueCompareAndSwap(LIRKind accessKind, Value address, Value expectedValue, Value newValue, boolean useBarriers) {
+    public Value emitValueCompareAndSwap(LIRKind accessKind, Value address, Value expectedValue, Value newValue) {
         LLVMValueRef result = buildCmpxchg(getVal(address), getVal(expectedValue), getVal(newValue), true);
         return new LLVMVariable(result);
     }

--- a/substratevm/src/com.oracle.svm.core.graal.llvm/src/com/oracle/svm/core/graal/llvm/LLVMGenerator.java
+++ b/substratevm/src/com.oracle.svm.core.graal.llvm/src/com/oracle/svm/core/graal/llvm/LLVMGenerator.java
@@ -713,14 +713,14 @@ public class LLVMGenerator implements LIRGeneratorTool, SubstrateLIRGenerator {
     }
 
     @Override
-    public Variable emitLogicCompareAndSwap(LIRKind accessKind, Value address, Value expectedValue, Value newValue, Value trueValue, Value falseValue) {
+    public Variable emitLogicCompareAndSwap(LIRKind accessKind, Value address, Value expectedValue, Value newValue, Value trueValue, Value falseValue, int memoryBarrier) {
         LLVMValueRef success = buildCmpxchg(getVal(address), getVal(expectedValue), getVal(newValue), false);
         LLVMValueRef result = builder.buildSelect(success, getVal(trueValue), getVal(falseValue));
         return new LLVMVariable(result);
     }
 
     @Override
-    public Value emitValueCompareAndSwap(LIRKind accessKind, Value address, Value expectedValue, Value newValue) {
+    public Value emitValueCompareAndSwap(LIRKind accessKind, Value address, Value expectedValue, Value newValue, int memoryBarrier) {
         LLVMValueRef result = buildCmpxchg(getVal(address), getVal(expectedValue), getVal(newValue), true);
         return new LLVMVariable(result);
     }

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/graal/thread/CompareAndSetVMThreadLocalNode.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/graal/thread/CompareAndSetVMThreadLocalNode.java
@@ -26,6 +26,7 @@ package com.oracle.svm.core.graal.thread;
 
 import static org.graalvm.compiler.nodeinfo.NodeCycles.CYCLES_8;
 
+import org.graalvm.compiler.core.common.memory.MemoryOrderMode;
 import org.graalvm.compiler.core.common.type.StampFactory;
 import org.graalvm.compiler.graph.NodeClass;
 import org.graalvm.compiler.nodeinfo.NodeInfo;
@@ -63,7 +64,8 @@ public class CompareAndSetVMThreadLocalNode extends AbstractStateSplit implement
         assert threadLocalInfo.offset >= 0;
 
         ConstantNode offset = ConstantNode.forLong(threadLocalInfo.offset, holder.graph());
-        UnsafeCompareAndSwapNode atomic = graph().add(new UnsafeCompareAndSwapNode(holder, offset, expect, update, threadLocalInfo.storageKind, threadLocalInfo.locationIdentity));
+        UnsafeCompareAndSwapNode atomic = graph()
+                        .add(new UnsafeCompareAndSwapNode(holder, offset, expect, update, threadLocalInfo.storageKind, threadLocalInfo.locationIdentity, MemoryOrderMode.PLAIN));
         atomic.setStateAfter(stateAfter());
         graph().replaceFixedWithFixed(this, atomic);
         tool.getLowerer().lower(atomic, tool);


### PR DESCRIPTION
This PR contains two commits implementing intrinsics for different weak atomics that :

1) add intrinsic support for byte/short methods in unsafe API.
Update the tests for Int/Long atomic intrinsics to reflect their
existing support. Also, update the AtomicReadAndAddOp for AMD64 to
preserve the sign while operating on byte/word size operands.

This patch improves performance of Unsafe.getAndSet/Add on byte/short by
about 27.6% on A72 machine.

2) add intrinsic support for the following Unsafe API methods.
i) compareAndExchange: acquire, release
ii) compareAndSet: plain, acquire, release
for byte, boolean, char short, int, long types.