### PR TITLE
Fixing AArch64 emitCompare and zr/sp issues

### DIFF
--- a/compiler/src/org.graalvm.compiler.asm.aarch64/src/org/graalvm/compiler/asm/aarch64/AArch64Assembler.java
+++ b/compiler/src/org.graalvm.compiler.asm.aarch64/src/org/graalvm/compiler/asm/aarch64/AArch64Assembler.java
@@ -1936,6 +1936,9 @@ public abstract class AArch64Assembler extends Assembler {
     }
 
     private void addSubShiftedInstruction(Instruction instr, Register dst, Register src1, Register src2, ShiftType shiftType, int imm, InstructionType type) {
+        assert !dst.equals(sp);
+        assert !src1.equals(sp);
+        assert !src2.equals(sp);
         assert shiftType != ShiftType.ROR;
         assert imm >= 0 && imm < type.width;
         emitInt(type.encoding | instr.encoding | AddSubShiftedOp | imm << ImmediateOffset | shiftType.encoding << ShiftTypeOffset | rd(dst) | rs1(src1) | rs2(src2));


### PR DESCRIPTION
Previously the AArch64 emitCompare was issuing many unnecessary loads.
In addition, some of the logic for using zr/sp within cmp, sub(s), and
add(s) needed to be fixed.