### PR TITLE
Fix missing localization info issue for timezones

### DIFF
--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/LocalizationFeature.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/LocalizationFeature.java
@@ -237,7 +237,8 @@ public abstract class LocalizationFeature implements Feature {
         /* Note that JDK 11 support overrides this method to register more bundles. */
 
         final String[] alwaysRegisteredResourceBundles = new String[]{
-                        "sun.util.logging.resources.logging"
+                        "sun.util.logging.resources.logging",
+                        "sun.util.resources.TimeZoneNames"
         };
         for (String bundleName : alwaysRegisteredResourceBundles) {
             addBundleToCache(bundleName);


### PR DESCRIPTION
With JDK-8236548 in OpenJDK 11 an issue running
a generated native image may arise on programs using
TimeZone.getDisplayName(). With JDK-8236548 this might
become more noticeable since it now occurs on the
English locale too (no caching of English locales
happens any more).

Since all time zone data is included by default now,
also include the TimeZoneNames resource bundle by
default.

Closes: #2776 