### PR TITLE
Mark RandomNumbersFeature as an @AutomaticFeature

### DIFF
--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/RandomNumbersFeature.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/RandomNumbersFeature.java
@@ -26,10 +26,12 @@ package com.oracle.svm.core.jdk;
 
 import java.util.concurrent.ThreadLocalRandom;
 
+import com.oracle.svm.core.annotate.AutomaticFeature;
 import org.graalvm.nativeimage.ImageSingletons;
 import org.graalvm.nativeimage.hosted.Feature;
 import org.graalvm.nativeimage.impl.RuntimeClassInitializationSupport;
 
+@AutomaticFeature
 public class RandomNumbersFeature implements Feature {
 
     @Override


### PR DESCRIPTION
As a fix for https://github.com/oracle/graal/issues/1610 the `RandomNumbersFeature` was introduced https://github.com/oracle/graal/commit/294c0b1ad97e5ef196165719f27e11a2087900f0. This feature however, right now, isn't automatically enabled. This means that users have to enable it themselves or frameworks have to enable it for them. Here's a recent issue reported in Quarkus https://github.com/quarkusio/quarkus/issues/11573.

Given that this is such a core feature/necessity of the Java random APIs, enabling this automatically, IMO, would be better.

The commit here adds the `@AutomaticFeature` to enable this.