### PR TITLE
Fix activation code of VSCode extension

### DIFF
--- a/vscode/graalvm/src/extension.ts
+++ b/vscode/graalvm/src/extension.ts
@@ -102,9 +102,14 @@ function config() {
 		if (process.platform === 'linux') {
 			section = 'env.linux';
 		} else if (process.platform === 'darwin') {
-			section = 'env.mac';
+			section = 'env.osx';
+		} else if (process.platform === 'win32') {
+			section = 'env.windows';
 		}
 		let env: any = termConfig.get(section);
+		if (env === undefined) {
+			throw new Error(`Unable to find platform-specific env for platform "${process.platform}"`);
+		}
 		env.GRAALVM_HOME = graalVMHome;
 		env.JAVA_HOME = graalVMHome;
 		let envPath = process.env.PATH;


### PR DESCRIPTION
The section is called ‘env.osx’, not ‘env.mac’ on macOS. Add a case for Windows. Also, throw a better error when `env` is not found.

Please assign to @dbalek.