### PR TITLE
[vscode] Fix a ClassCastException in TruffleLSP's shutdown routine

### DIFF
--- a/tools/src/org.graalvm.tools.lsp/src/org/graalvm/tools/lsp/server/types/NotificationMessage.java
+++ b/tools/src/org.graalvm.tools.lsp/src/org/graalvm/tools/lsp/server/types/NotificationMessage.java
@@ -52,7 +52,8 @@ public class NotificationMessage extends Message {
      * The notification's params.
      */
     public Object getParams() {
-        return jsonData.opt("params");
+        Object params = jsonData.opt("params");
+        return params.equals(null) ? null : params;
     }
 
     public NotificationMessage setParams(Object params) {


### PR DESCRIPTION
`NotificationMessage#getParams()` should not return `JSONObject$Null`. Return `null` instead. This fixes the TruffleLSP shutdown routine.

Please assign to @dbalek.

##### Before
```
[Graal LSP] Starting server and listening on localhost/127.0.0.1:8123
GraalVM MultiLanguage Shell 20.3.0-dev
Copyright (c) 2013-2019, Oracle and/or its affiliates
  JavaScript version 20.3.0-dev
  Ruby version 2.6.6
Usage: 
  Use Ctrl+L to switch language and Ctrl+D to exit.
  Enter -usage to get a list of available commands.
js> [Graal LSP] Client connected on /127.0.0.1:62710
[Graal LSP] Shutting down server...
[To redirect Truffle log output to a file use one of the following options:
* '--log.file=<path>' if the option is passed using a guest language launcher.
* '-Dpolyglot.log.file=<path>' if the option is passed using the host Java launcher.
* Configure logging using the polyglot embedding API.]
[lsp] SEVERE: class com.oracle.truffle.tools.utils.json.JSONObject$Null cannot be cast to class com.oracle.truffle.tools.utils.json.JSONObject (com.oracle.truffle.tools.utils.json.JSONObject$Null and com.oracle.truffle.tools.utils.json.JSONObject are in unnamed module of loader com.oracle.graalvm.locator.GraalVMLocator$GuestLangToolsLoader @61e4705b)
java.lang.ClassCastException: class com.oracle.truffle.tools.utils.json.JSONObject$Null cannot be cast to class com.oracle.truffle.tools.utils.json.JSONObject (com.oracle.truffle.tools.utils.json.JSONObject$Null and com.oracle.truffle.tools.utils.json.JSONObject are in unnamed module of loader com.oracle.graalvm.locator.GraalVMLocator$GuestLangToolsLoader @61e4705b)
        at org.graalvm.tools.lsp.server.types.LanguageServer$Session.processNotification(LanguageServer.java:705)
        at org.graalvm.tools.lsp.server.types.LanguageServer$Session.processMessage(LanguageServer.java:510)
        at org.graalvm.tools.lsp.server.types.LanguageServer$Session.run(LanguageServer.java:440)
        at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)
        at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
        at java.base/java.lang.Thread.run(Thread.java:834)
```

##### After
```
[Graal LSP] Starting server and listening on localhost/127.0.0.1:8123
GraalVM MultiLanguage Shell 20.3.0-dev
Copyright (c) 2013-2019, Oracle and/or its affiliates
  JavaScript version 20.3.0-dev
  Ruby version 2.6.6
Usage: 
  Use Ctrl+L to switch language and Ctrl+D to exit.
  Enter -usage to get a list of available commands.
js> [Graal LSP] Client connected on /127.0.0.1:63154
[Graal LSP] Shutting down server...
[Graal LSP] Server shutdown done.
```