### PR TITLE
Add `--target` API option

### DIFF
--- a/sdk/src/org.graalvm.nativeimage/snapshot.sigtest
+++ b/sdk/src/org.graalvm.nativeimage/snapshot.sigtest
@@ -228,7 +228,7 @@ CLSS public abstract interface static org.graalvm.nativeimage.Platform$AMD64
  outer org.graalvm.nativeimage.Platform
 intf org.graalvm.nativeimage.Platform
 
-CLSS public abstract interface static org.graalvm.nativeimage.Platform$DARWIN
+CLSS public abstract interface static org.graalvm.nativeimage.Platform$DARWIN_BASE
  outer org.graalvm.nativeimage.Platform
 intf org.graalvm.nativeimage.impl.InternalPlatform$PLATFORM_JNI
 
@@ -236,14 +236,14 @@ CLSS public final static org.graalvm.nativeimage.Platform$DARWIN_AARCH64
  outer org.graalvm.nativeimage.Platform
 cons public init()
 intf org.graalvm.nativeimage.Platform$AARCH64
-intf org.graalvm.nativeimage.Platform$DARWIN
+intf org.graalvm.nativeimage.Platform$DARWIN_BASE
 supr java.lang.Object
 
 CLSS public static org.graalvm.nativeimage.Platform$DARWIN_AMD64
  outer org.graalvm.nativeimage.Platform
 cons public init()
 intf org.graalvm.nativeimage.Platform$AMD64
-intf org.graalvm.nativeimage.Platform$DARWIN
+intf org.graalvm.nativeimage.Platform$DARWIN_BASE
 supr java.lang.Object
 
 CLSS public final static org.graalvm.nativeimage.Platform$HOSTED_ONLY
@@ -251,7 +251,7 @@ CLSS public final static org.graalvm.nativeimage.Platform$HOSTED_ONLY
 intf org.graalvm.nativeimage.Platform
 supr java.lang.Object
 
-CLSS public abstract interface static org.graalvm.nativeimage.Platform$LINUX
+CLSS public abstract interface static org.graalvm.nativeimage.Platform$LINUX_BASE
  outer org.graalvm.nativeimage.Platform
 intf org.graalvm.nativeimage.impl.InternalPlatform$PLATFORM_JNI
 
@@ -259,17 +259,17 @@ CLSS public final static org.graalvm.nativeimage.Platform$LINUX_AARCH64
  outer org.graalvm.nativeimage.Platform
 cons public init()
 intf org.graalvm.nativeimage.Platform$AARCH64
-intf org.graalvm.nativeimage.Platform$LINUX
+intf org.graalvm.nativeimage.Platform$LINUX_BASE
 supr java.lang.Object
 
 CLSS public static org.graalvm.nativeimage.Platform$LINUX_AMD64
  outer org.graalvm.nativeimage.Platform
 cons public init()
 intf org.graalvm.nativeimage.Platform$AMD64
-intf org.graalvm.nativeimage.Platform$LINUX
+intf org.graalvm.nativeimage.Platform$LINUX_BASE
 supr java.lang.Object
 
-CLSS public abstract interface static org.graalvm.nativeimage.Platform$WINDOWS
+CLSS public abstract interface static org.graalvm.nativeimage.Platform$WINDOWS_BASE
  outer org.graalvm.nativeimage.Platform
 intf org.graalvm.nativeimage.impl.InternalPlatform$PLATFORM_JNI
 
@@ -277,7 +277,7 @@ CLSS public static org.graalvm.nativeimage.Platform$WINDOWS_AMD64
  outer org.graalvm.nativeimage.Platform
 cons public init()
 intf org.graalvm.nativeimage.Platform$AMD64
-intf org.graalvm.nativeimage.Platform$WINDOWS
+intf org.graalvm.nativeimage.Platform$WINDOWS_BASE
 supr java.lang.Object
 
 CLSS public abstract interface !annotation org.graalvm.nativeimage.Platforms

--- a/sdk/src/org.graalvm.nativeimage/src/META-INF/services/org.graalvm.nativeimage.Platform
+++ b/sdk/src/org.graalvm.nativeimage/src/META-INF/services/org.graalvm.nativeimage.Platform
@@ -1,0 +1,7 @@
+org.graalvm.nativeimage.Platform$LINUX_AMD64
+org.graalvm.nativeimage.Platform$LINUX_AARCH64
+org.graalvm.nativeimage.Platform$ANDROID_AARCH64
+org.graalvm.nativeimage.Platform$DARWIN_AMD64
+org.graalvm.nativeimage.Platform$DARWIN_AARCH64
+org.graalvm.nativeimage.Platform$IOS_AARCH64
+org.graalvm.nativeimage.Platform$WINDOWS_AMD64

--- a/sdk/src/org.graalvm.nativeimage/src/org/graalvm/nativeimage/Platform.java
+++ b/sdk/src/org.graalvm.nativeimage/src/org/graalvm/nativeimage/Platform.java
@@ -40,6 +40,8 @@
  */
 package org.graalvm.nativeimage;
 
+import java.lang.UnsupportedOperationException;
+
 import org.graalvm.nativeimage.impl.InternalPlatform;
 
 /**
@@ -84,6 +86,31 @@ public interface Platform {
         return platformGroup.isInstance(ImageSingletons.lookup(Platform.class));
     }
 
+    /**
+     * Returns string representing Platform's OS name
+     * <p>
+     * This method should be implemented either in final class or as default in respective OS
+     * interface.
+     *
+     * @since 20.3
+     */
+    default String getOS() {
+        throw new UnsupportedOperationException("Platform doesn't implement getOS");
+    }
+
+    /**
+     * Returns string representing Platform's architecture name. This value should be the same as
+     * desired os.arch system property
+     * <p>
+     * This method should be implemented either in final class or as default in respective
+     * architecture interface.
+     *
+     * @since 20.3
+     */
+    default String getArchitecture() {
+        throw new UnsupportedOperationException("Platform doesn't implement getArchitecture");
+    }
+
     /*
      * The standard architectures that are supported.
      */
@@ -93,7 +120,9 @@ public interface Platform {
      * @since 19.0
      */
     interface AMD64 extends Platform {
-
+        default String getArchitecture() {
+            return "amd64";
+        }
     }
 
     /**
@@ -102,7 +131,9 @@ public interface Platform {
      * @since 19.0
      */
     interface AARCH64 extends Platform {
-
+        default String getArchitecture() {
+            return "aarch64";
+        }
     }
 
     /*
@@ -114,7 +145,20 @@ public interface Platform {
      * @since 19.0
      */
     interface LINUX extends InternalPlatform.PLATFORM_JNI {
+        default String getOS() {
+            return "linux";
+        }
+    }
 
+    /**
+     * Supported operating system: Android.
+     *
+     * @since 20.3
+     */
+    interface ANDROID extends LINUX {
+        default String getOS() {
+            return "android";
+        }
     }
 
     /**
@@ -123,7 +167,20 @@ public interface Platform {
      * @since 19.0
      */
     interface DARWIN extends InternalPlatform.PLATFORM_JNI {
+        default String getOS() {
+            return "darwin";
+        }
+    }
 
+    /**
+     * Supported operating system: iOS.
+     *
+     * @since 20.3
+     */
+    interface IOS extends DARWIN {
+        default String getOS() {
+            return "ios";
+        }
     }
 
     /**
@@ -132,7 +189,9 @@ public interface Platform {
      * @since 19.0
      */
     interface WINDOWS extends InternalPlatform.PLATFORM_JNI {
-
+        default String getOS() {
+            return "windows";
+        }
     }
 
     /*
@@ -173,11 +232,28 @@ public interface Platform {
     }
 
     /**
+     * Supported leaf platform: Android on AArch64 64-bit.
+     *
+     * @since 20.3
+     */
+    final class ANDROID_AARCH64 implements ANDROID, AARCH64 {
+
+        /**
+         * Instantiates a marker instance of this platform.
+         *
+         * @since 20.3
+         */
+        public ANDROID_AARCH64() {
+        }
+
+    }
+
+    /**
      * Supported leaf platform: Darwin (MacOS) on x86 64-bit.
      *
      * @since 19.0
      */
-    class DARWIN_AMD64 implements DARWIN, AMD64 {
+    final class DARWIN_AMD64 implements DARWIN, AMD64 {
 
         /**
          * Instantiates a marker instance of this platform.
@@ -205,11 +281,27 @@ public interface Platform {
     }
 
     /**
+     * Supported leaf platform: iOS on AArch 64-bit.
+     *
+     * @since 20.3
+     */
+    final class IOS_AARCH64 implements IOS, AARCH64 {
+
+        /**
+         * Instantiates a marker instance of this platform.
+         *
+         * @since 20.3
+         */
+        public IOS_AARCH64() {
+        }
+    }
+
+    /**
      * Supported leaf platform: Windows on x86 64-bit.
      *
      * @since 19.0
      */
-    class WINDOWS_AMD64 implements WINDOWS, AMD64 {
+    final class WINDOWS_AMD64 implements WINDOWS, AMD64 {
 
         /**
          * Instantiates a marker instance of this platform.

--- a/sdk/src/org.graalvm.nativeimage/src/org/graalvm/nativeimage/Platform.java
+++ b/sdk/src/org.graalvm.nativeimage/src/org/graalvm/nativeimage/Platform.java
@@ -137,6 +137,33 @@ public interface Platform {
     }
 
     /*
+     * Operating system bases.
+     */
+    /**
+     * Interface encapsulating all linux-derived operating systems.
+     *
+     * @since 20.3
+     */
+    interface LINUX_BASE extends InternalPlatform.PLATFORM_JNI {
+    }
+
+    /**
+     * Interface encapsulating all darwin-derived operating systems.
+     *
+     * @since 20.3
+     */
+    interface DARWIN_BASE extends InternalPlatform.PLATFORM_JNI {
+    }
+
+    /**
+     * Interface encapsulating all windows-derived operating systems.
+     *
+     * @since 20.3
+     */
+    interface WINDOWS_BASE extends InternalPlatform.PLATFORM_JNI {
+    }
+
+    /*
      * The standard operating systems that are supported.
      */
     /**
@@ -144,7 +171,7 @@ public interface Platform {
      *
      * @since 19.0
      */
-    interface LINUX extends InternalPlatform.PLATFORM_JNI {
+    interface LINUX extends LINUX_BASE {
         default String getOS() {
             return "linux";
         }
@@ -155,7 +182,7 @@ public interface Platform {
      *
      * @since 20.3
      */
-    interface ANDROID extends LINUX {
+    interface ANDROID extends LINUX_BASE {
         default String getOS() {
             return "android";
         }
@@ -166,7 +193,7 @@ public interface Platform {
      *
      * @since 19.0
      */
-    interface DARWIN extends InternalPlatform.PLATFORM_JNI {
+    interface DARWIN extends DARWIN_BASE {
         default String getOS() {
             return "darwin";
         }
@@ -177,7 +204,7 @@ public interface Platform {
      *
      * @since 20.3
      */
-    interface IOS extends DARWIN {
+    interface IOS extends DARWIN_BASE {
         default String getOS() {
             return "ios";
         }
@@ -188,7 +215,7 @@ public interface Platform {
      *
      * @since 19.0
      */
-    interface WINDOWS extends InternalPlatform.PLATFORM_JNI {
+    interface WINDOWS extends WINDOWS_BASE {
         default String getOS() {
             return "windows";
         }
@@ -202,7 +229,7 @@ public interface Platform {
      *
      * @since 19.0
      */
-    class LINUX_AMD64 implements LINUX, AMD64 {
+    class LINUX_AMD64 implements LINUX_BASE, AMD64 {
 
         /**
          * Instantiates a marker instance of this platform.
@@ -219,7 +246,7 @@ public interface Platform {
      *
      * @since 19.0
      */
-    final class LINUX_AARCH64 implements LINUX, AARCH64 {
+    final class LINUX_AARCH64 implements LINUX_BASE, AARCH64 {
 
         /**
          * Instantiates a marker instance of this platform.
@@ -253,7 +280,7 @@ public interface Platform {
      *
      * @since 19.0
      */
-    final class DARWIN_AMD64 implements DARWIN, AMD64 {
+    final class DARWIN_AMD64 implements DARWIN_BASE, AMD64 {
 
         /**
          * Instantiates a marker instance of this platform.
@@ -269,7 +296,7 @@ public interface Platform {
      *
      * @since 2.0
      */
-    final class DARWIN_AARCH64 implements DARWIN, AARCH64 {
+    final class DARWIN_AARCH64 implements DARWIN_BASE, AARCH64 {
 
         /**
          * Instantiates a marker instance of this platform.

--- a/sdk/src/org.graalvm.nativeimage/src/org/graalvm/nativeimage/Platform.java
+++ b/sdk/src/org.graalvm.nativeimage/src/org/graalvm/nativeimage/Platform.java
@@ -95,7 +95,7 @@ public interface Platform {
      * @since 20.3
      */
     default String getOS() {
-        throw new UnsupportedOperationException("Platform doesn't implement getOS");
+        throw new UnsupportedOperationException("Platform `" + this.getClass().getCanonicalName() + "`, doesn't implement getOS");
     }
 
     /**
@@ -108,7 +108,7 @@ public interface Platform {
      * @since 20.3
      */
     default String getArchitecture() {
-        throw new UnsupportedOperationException("Platform doesn't implement getArchitecture");
+        throw new UnsupportedOperationException("Platform `" + this.getClass().getCanonicalName() + "`, doesn't implement getArchitecture");
     }
 
     /*

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/ELFObjectFile.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/ELFObjectFile.java
@@ -52,6 +52,8 @@ import com.oracle.objectfile.elf.dwarf.DwarfDebugInfo;
 import com.oracle.objectfile.elf.dwarf.DwarfStrSectionImpl;
 import com.oracle.objectfile.io.AssemblyBuffer;
 import com.oracle.objectfile.io.OutputAssembler;
+import org.graalvm.nativeimage.ImageSingletons;
+import org.graalvm.nativeimage.Platform;
 
 /**
  * Represents an ELF object file (of any kind: relocatable, shared library, executable, core, ...).
@@ -102,7 +104,8 @@ public class ELFObjectFile extends ObjectFile {
     }
 
     public ELFObjectFile(int pageSize, boolean runtimeDebugInfoGeneration) {
-        this(pageSize, System.getProperty("svm.targetArch") == null ? ELFMachine.getSystemNativeValue() : ELFMachine.from(System.getProperty("svm.targetArch")), runtimeDebugInfoGeneration);
+        this(pageSize, System.getProperty("svm.targetArch") == null ? ELFMachine.from(ImageSingletons.lookup(Platform.class).getArchitecture()) : ELFMachine.from(System.getProperty("svm.targetArch")),
+                        runtimeDebugInfoGeneration);
     }
 
     @Override

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/macho/MachOObjectFile.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/macho/MachOObjectFile.java
@@ -52,6 +52,8 @@ import com.oracle.objectfile.ObjectFile;
 import com.oracle.objectfile.SymbolTable;
 import com.oracle.objectfile.io.AssemblyBuffer;
 import com.oracle.objectfile.io.OutputAssembler;
+import org.graalvm.nativeimage.ImageSingletons;
+import org.graalvm.nativeimage.Platform;
 
 /**
  * Models a Mach-O relocatable object file.
@@ -80,7 +82,7 @@ public final class MachOObjectFile extends ObjectFile {
      * Create an empty Mach-O object file.
      */
     public MachOObjectFile(int pageSize) {
-        this(pageSize, MachOCpuType.from(System.getProperty("svm.targetArch") == null ? System.getProperty("os.arch") : System.getProperty("svm.targetArch")));
+        this(pageSize, MachOCpuType.from(System.getProperty("svm.targetArch") == null ? ImageSingletons.lookup(Platform.class).getArchitecture() : System.getProperty("svm.targetArch")));
     }
 
     public MachOObjectFile(int pageSize, MachOCpuType cpuType) {

--- a/substratevm/src/com.oracle.svm.core.graal.llvm/src/com/oracle/svm/core/graal/llvm/LLVMFeature.java
+++ b/substratevm/src/com.oracle.svm.core.graal.llvm/src/com/oracle/svm/core/graal/llvm/LLVMFeature.java
@@ -72,7 +72,7 @@ import com.oracle.svm.hosted.image.NativeImageHeap;
  * from Graal graphs, and compile this bitcode into machine code.
  */
 @AutomaticFeature
-@Platforms({Platform.LINUX.class, Platform.DARWIN.class})
+@Platforms({Platform.LINUX_BASE.class, Platform.DARWIN_BASE.class})
 public class LLVMFeature implements Feature, GraalFeature {
 
     @Override

--- a/substratevm/src/com.oracle.svm.core.graal.llvm/src/com/oracle/svm/core/graal/llvm/util/LLVMDirectives.java
+++ b/substratevm/src/com.oracle.svm.core.graal.llvm/src/com/oracle/svm/core/graal/llvm/util/LLVMDirectives.java
@@ -48,7 +48,7 @@ public class LLVMDirectives implements CContext.Directives {
     public List<String> getLibraries() {
         List<String> libraries = new ArrayList<>();
         libraries.add("m");
-        if (Platform.includedIn(Platform.LINUX.class) && LLVMOptions.BitcodeOptimizations.getValue()) {
+        if (Platform.includedIn(Platform.LINUX_BASE.class) && LLVMOptions.BitcodeOptimizations.getValue()) {
             libraries.add("atomic");
         }
         return libraries;

--- a/substratevm/src/com.oracle.svm.core.graal.llvm/src/com/oracle/svm/core/graal/llvm/util/LLVMTargetSpecific.java
+++ b/substratevm/src/com.oracle.svm.core.graal.llvm/src/com/oracle/svm/core/graal/llvm/util/LLVMTargetSpecific.java
@@ -24,6 +24,7 @@
  */
 package com.oracle.svm.core.graal.llvm.util;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
@@ -222,7 +223,13 @@ class LLVMAArch64TargetSpecificFeature implements Feature {
 
             @Override
             public List<String> getLLCAdditionalOptions() {
-                return Arrays.asList("--frame-pointer=all", "--aarch64-frame-record-on-top");
+                List<String> list = new ArrayList<>();
+                list.add("--frame-pointer=all");
+                list.add("--aarch64-frame-record-on-top");
+                if (Platform.includedIn(Platform.IOS.class)) {
+                    list.add("-mtriple=arm64-ios");
+                }
+                return list;
             }
 
             @Override

--- a/substratevm/src/com.oracle.svm.core.posix/src/META-INF/services/com.oracle.svm.core.c.libc.LibCBase
+++ b/substratevm/src/com.oracle.svm.core.posix/src/META-INF/services/com.oracle.svm.core.c.libc.LibCBase
@@ -1,0 +1,3 @@
+com.oracle.svm.core.posix.linux.libc.BionicLibC
+com.oracle.svm.core.posix.linux.libc.GLibC
+com.oracle.svm.core.posix.linux.libc.MuslLibC

--- a/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/PosixNativeLibraryFeature.java
+++ b/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/PosixNativeLibraryFeature.java
@@ -81,7 +81,7 @@ final class PosixNativeLibrarySupport extends JNIPlatformNativeLibrarySupport {
             Resource.rlimit rlp = StackValue.get(Resource.rlimit.class);
             if (Resource.getrlimit(Resource.RLIMIT_NOFILE(), rlp) == 0) {
                 UnsignedWord newValue = rlp.rlim_max();
-                if (Platform.includedIn(Platform.DARWIN.class)) {
+                if (Platform.includedIn(Platform.DARWIN_BASE.class)) {
                     // On Darwin, getrlimit may return RLIM_INFINITY for rlim_max, but then OPEN_MAX
                     // must be used for setrlimit or it will fail with errno EINVAL.
                     newValue = WordFactory.unsigned(DarwinSyslimits.OPEN_MAX());
@@ -178,8 +178,8 @@ final class PosixNativeLibrarySupport extends JNIPlatformNativeLibrarySupport {
         private boolean doLoad() {
             // Make sure the jvm.lib is available for linking
             // Need a better place to put this.
-            if (Platform.includedIn(Platform.LINUX.class) ||
-                            Platform.includedIn(Platform.DARWIN.class)) {
+            if (Platform.includedIn(Platform.LINUX_BASE.class) ||
+                            Platform.includedIn(Platform.DARWIN_BASE.class)) {
                 Jvm.initialize();
             }
 

--- a/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/PosixSubstrateOperatingSystemMXBean.java
+++ b/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/PosixSubstrateOperatingSystemMXBean.java
@@ -91,10 +91,10 @@ class PosixSubstrateOperatingSystemMXBean extends SubstrateOperatingSystemMXBean
     }
 
     private static int fstat(int fd) {
-        if (Platform.includedIn(Platform.LINUX.class)) {
+        if (Platform.includedIn(Platform.LINUX_BASE.class)) {
             LinuxStat.stat64 stat = StackValue.get(LinuxStat.stat64.class);
             return LinuxStat.fstat64(fd, stat);
-        } else if (Platform.includedIn(Platform.DARWIN.class)) {
+        } else if (Platform.includedIn(Platform.DARWIN_BASE.class)) {
             DarwinStat.stat64 stat = StackValue.get(DarwinStat.stat64.class);
             return DarwinStat.fstat64(fd, stat);
         } else {

--- a/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/PosixSunSecuritySubstitutions.java
+++ b/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/PosixSunSecuritySubstitutions.java
@@ -50,7 +50,7 @@ import com.oracle.svm.core.jdk.RuntimeSupport;
  * not open file descriptors that would need to be closed.
  */
 @AutomaticFeature
-@Platforms({Platform.LINUX.class, Platform.DARWIN.class})
+@Platforms({Platform.LINUX_BASE.class, Platform.DARWIN_BASE.class})
 class NativeSecureRandomFilesCloser implements Feature {
     @Override
     public void beforeAnalysis(BeforeAnalysisAccess access) {
@@ -89,13 +89,13 @@ class NativeSecureRandomFilesCloser implements Feature {
 }
 
 @TargetClass(className = "sun.security.provider.NativePRNG")
-@Platforms({Platform.LINUX.class, Platform.DARWIN.class})
+@Platforms({Platform.LINUX_BASE.class, Platform.DARWIN_BASE.class})
 final class Target_sun_security_provider_NativePRNG {
     @Alias static Target_sun_security_provider_NativePRNG_RandomIO INSTANCE;
 }
 
 @TargetClass(className = "sun.security.provider.NativePRNG", innerClass = "RandomIO")
-@Platforms({Platform.LINUX.class, Platform.DARWIN.class})
+@Platforms({Platform.LINUX_BASE.class, Platform.DARWIN_BASE.class})
 final class Target_sun_security_provider_NativePRNG_RandomIO {
     @Alias InputStream seedIn;
     @Alias InputStream nextIn;

--- a/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/PosixUtils.java
+++ b/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/PosixUtils.java
@@ -94,7 +94,7 @@ public class PosixUtils {
                 return Locale.LC_MESSAGES();
         }
 
-        if (Platform.includedIn(Platform.LINUX.class) && ImageSingletons.lookup(LibCBase.class).getClass().equals(GLibC.class)) {
+        if (Platform.includedIn(Platform.LINUX_BASE.class) && ImageSingletons.lookup(LibCBase.class).getClass().equals(GLibC.class)) {
             switch (category) {
                 case "LC_PAPER":
                     return Locale.LC_PAPER();

--- a/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/aarch64/AArch64UContextRegisterDumper.java
+++ b/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/aarch64/AArch64UContextRegisterDumper.java
@@ -46,7 +46,7 @@ import com.oracle.svm.core.util.VMError;
 
 import jdk.vm.ci.aarch64.AArch64;
 
-@Platforms(Platform.LINUX_AARCH64.class)
+@Platforms({Platform.LINUX_AARCH64.class, Platform.ANDROID_AARCH64.class})
 @AutomaticFeature
 class AArch64UContextRegisterDumperFeature implements Feature {
     @Override

--- a/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/aarch64/package-info.java
+++ b/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/aarch64/package-info.java
@@ -23,7 +23,7 @@
  * questions.
  */
 
-@Platforms({Platform.LINUX.class, Platform.DARWIN.class})
+@Platforms({Platform.LINUX_BASE.class, Platform.DARWIN_BASE.class})
 package com.oracle.svm.core.posix.aarch64;
 
 import org.graalvm.nativeimage.Platform;

--- a/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/amd64/package-info.java
+++ b/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/amd64/package-info.java
@@ -23,7 +23,7 @@
  * questions.
  */
 
-@Platforms({Platform.LINUX.class, Platform.DARWIN.class})
+@Platforms({Platform.LINUX_BASE.class, Platform.DARWIN_BASE.class})
 package com.oracle.svm.core.posix.amd64;
 
 import org.graalvm.nativeimage.Platform;

--- a/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/darwin/DarwinSystemPropertiesSupport.java
+++ b/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/darwin/DarwinSystemPropertiesSupport.java
@@ -25,6 +25,7 @@
 package com.oracle.svm.core.posix.darwin;
 
 import org.graalvm.nativeimage.ImageSingletons;
+import org.graalvm.nativeimage.Platform;
 import org.graalvm.nativeimage.StackValue;
 import org.graalvm.nativeimage.c.function.CLibrary;
 import org.graalvm.nativeimage.c.type.CCharPointer;
@@ -58,6 +59,11 @@ public class DarwinSystemPropertiesSupport extends PosixSystemPropertiesSupport 
              */
             return "/var/tmp";
         }
+    }
+
+    @Override
+    protected String osNameValue() {
+        return Platform.includedIn(Platform.IOS.class) ? "iOS" : "Mac OS X";
     }
 
     private static volatile String osVersionValue = null;

--- a/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/darwin/DarwinUContextRegisterDumper.java
+++ b/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/darwin/DarwinUContextRegisterDumper.java
@@ -45,7 +45,7 @@ import com.oracle.svm.core.util.VMError;
 
 import jdk.vm.ci.amd64.AMD64;
 
-@Platforms({Platform.DARWIN.class})
+@Platforms({Platform.DARWIN_BASE.class})
 @AutomaticFeature
 class DarwinUContextRegisterDumperFeature implements Feature {
     @Override

--- a/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/darwin/DarwinUContextRegisterDumper.java
+++ b/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/darwin/DarwinUContextRegisterDumper.java
@@ -45,7 +45,7 @@ import com.oracle.svm.core.util.VMError;
 
 import jdk.vm.ci.amd64.AMD64;
 
-@Platforms({Platform.DARWIN_AMD64.class, Platform.DARWIN_AARCH64.class})
+@Platforms({Platform.DARWIN.class})
 @AutomaticFeature
 class DarwinUContextRegisterDumperFeature implements Feature {
     @Override

--- a/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/darwin/package-info.java
+++ b/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/darwin/package-info.java
@@ -23,7 +23,7 @@
  * questions.
  */
 
-@Platforms({Platform.DARWIN.class})
+@Platforms({Platform.DARWIN_BASE.class})
 package com.oracle.svm.core.posix.darwin;
 
 import org.graalvm.nativeimage.Platform;

--- a/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/headers/Dlfcn.java
+++ b/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/headers/Dlfcn.java
@@ -96,7 +96,7 @@ public class Dlfcn {
     @CFunction
     public static native int dladdr(WordBase address, Dl_info info);
 
-    @Platforms(Platform.LINUX.class)
+    @Platforms(Platform.LINUX_BASE.class)
     @CContext(PosixDirectives.class)
     @CLibrary("dl")
     @LibC(GLibC.class)

--- a/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/headers/Locale.java
+++ b/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/headers/Locale.java
@@ -63,32 +63,32 @@ public class Locale {
     public static native int LC_MESSAGES();
 
     @LibC(value = GLibC.class)
-    @Platforms(Platform.LINUX.class)
+    @Platforms(Platform.LINUX_BASE.class)
     @CConstant
     public static native int LC_PAPER();
 
     @LibC(value = GLibC.class)
-    @Platforms(Platform.LINUX.class)
+    @Platforms(Platform.LINUX_BASE.class)
     @CConstant
     public static native int LC_NAME();
 
     @LibC(value = GLibC.class)
-    @Platforms(Platform.LINUX.class)
+    @Platforms(Platform.LINUX_BASE.class)
     @CConstant
     public static native int LC_ADDRESS();
 
     @LibC(value = GLibC.class)
-    @Platforms(Platform.LINUX.class)
+    @Platforms(Platform.LINUX_BASE.class)
     @CConstant
     public static native int LC_TELEPHONE();
 
     @LibC(value = GLibC.class)
-    @Platforms(Platform.LINUX.class)
+    @Platforms(Platform.LINUX_BASE.class)
     @CConstant
     public static native int LC_MEASUREMENT();
 
     @LibC(value = GLibC.class)
-    @Platforms(Platform.LINUX.class)
+    @Platforms(Platform.LINUX_BASE.class)
     @CConstant
     public static native int LC_IDENTIFICATION();
 

--- a/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/headers/PosixDirectives.java
+++ b/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/headers/PosixDirectives.java
@@ -69,15 +69,15 @@ public class PosixDirectives implements CContext.Directives {
 
     @Override
     public boolean isInConfiguration() {
-        return Platform.includedIn(Platform.LINUX.class) || Platform.includedIn(Platform.DARWIN.class);
+        return Platform.includedIn(Platform.LINUX_BASE.class) || Platform.includedIn(Platform.DARWIN_BASE.class);
     }
 
     @Override
     public List<String> getHeaderFiles() {
         List<String> result = new ArrayList<>(Arrays.asList(commonLibs));
-        if (Platform.includedIn(Platform.LINUX.class)) {
+        if (Platform.includedIn(Platform.LINUX_BASE.class)) {
             result.addAll(Arrays.asList(linuxLibs));
-        } else if (Platform.includedIn(Platform.DARWIN.class)) {
+        } else if (Platform.includedIn(Platform.DARWIN_BASE.class)) {
             result.addAll(Arrays.asList(darwinLibs));
         } else {
             throw VMError.shouldNotReachHere("Unsupported OS");
@@ -87,7 +87,7 @@ public class PosixDirectives implements CContext.Directives {
 
     @Override
     public List<String> getOptions() {
-        if (Platform.includedIn(Platform.DARWIN.class)) {
+        if (Platform.includedIn(Platform.DARWIN_BASE.class)) {
             return Collections.singletonList("-ObjC");
         }
         return Collections.emptyList();

--- a/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/headers/Signal.java
+++ b/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/headers/Signal.java
@@ -139,15 +139,15 @@ public class Signal {
         GregsPointer uc_mcontext_gregs();
 
         @CFieldAddress("uc_mcontext")
-        @Platforms({Platform.LINUX_AARCH64.class})
+        @Platforms({Platform.LINUX_AARCH64.class, Platform.ANDROID_AARCH64.class})
         mcontext_t uc_mcontext();
 
         @CField("uc_mcontext")
-        @Platforms({Platform.DARWIN_AMD64.class, Platform.DARWIN_AARCH64.class})
+        @Platforms({Platform.DARWIN.class})
         MContext64 uc_mcontext64();
     }
 
-    @Platforms({Platform.DARWIN_AMD64.class, Platform.DARWIN_AARCH64.class})
+    @Platforms({Platform.DARWIN.class})
     @CStruct(value = "__darwin_mcontext64", addStructKeyword = true)
     public interface MContext64 extends PointerBase {
 
@@ -207,7 +207,7 @@ public class Signal {
     }
 
     @CStruct
-    @Platforms({Platform.LINUX_AARCH64.class})
+    @Platforms({Platform.LINUX_AARCH64.class, Platform.ANDROID_AARCH64.class})
     public interface mcontext_t extends PointerBase {
         @CField
         long fault_address();

--- a/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/headers/Signal.java
+++ b/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/headers/Signal.java
@@ -94,7 +94,7 @@ public class Signal {
     public interface siginfo_t extends PointerBase {
     }
 
-    @Platforms(Platform.LINUX.class)
+    @Platforms(Platform.LINUX_BASE.class)
     @CPointerTo(nameOfCType = "long long int")
     public interface GregsPointer extends PointerBase {
         long read(int index);
@@ -143,11 +143,11 @@ public class Signal {
         mcontext_t uc_mcontext();
 
         @CField("uc_mcontext")
-        @Platforms({Platform.DARWIN.class})
+        @Platforms({Platform.DARWIN_BASE.class})
         MContext64 uc_mcontext64();
     }
 
-    @Platforms({Platform.DARWIN.class})
+    @Platforms({Platform.DARWIN_BASE.class})
     @CStruct(value = "__darwin_mcontext64", addStructKeyword = true)
     public interface MContext64 extends PointerBase {
 
@@ -298,7 +298,7 @@ public class Signal {
         public native int getCValue();
     }
 
-    @Platforms(Platform.LINUX.class)
+    @Platforms(Platform.LINUX_BASE.class)
     @CEnum
     @CContext(PosixDirectives.class)
     public enum LinuxSignalEnum {
@@ -309,7 +309,7 @@ public class Signal {
         public native int getCValue();
     }
 
-    @Platforms(Platform.DARWIN.class)
+    @Platforms(Platform.DARWIN_BASE.class)
     @CEnum
     @CContext(PosixDirectives.class)
     public enum DarwinSignalEnum {

--- a/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/headers/Unistd.java
+++ b/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/headers/Unistd.java
@@ -75,11 +75,11 @@ public class Unistd {
     public static native int _SC_PAGE_SIZE();
 
     @CConstant
-    @Platforms(Platform.LINUX.class)
+    @Platforms(Platform.LINUX_BASE.class)
     public static native int _SC_PHYS_PAGES();
 
     @CConstant
-    @Platforms(Platform.DARWIN.class)
+    @Platforms(Platform.DARWIN_BASE.class)
     public static native int _CS_DARWIN_USER_TEMP_DIR();
 
     @CFunction

--- a/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/headers/darwin/package-info.java
+++ b/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/headers/darwin/package-info.java
@@ -23,7 +23,7 @@
  * questions.
  */
 
-@Platforms({Platform.DARWIN.class})
+@Platforms({Platform.DARWIN_BASE.class})
 package com.oracle.svm.core.posix.headers.darwin;
 
 import org.graalvm.nativeimage.Platform;

--- a/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/headers/linux/LinuxErrno.java
+++ b/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/headers/linux/LinuxErrno.java
@@ -24,6 +24,10 @@
  */
 package com.oracle.svm.core.posix.headers.linux;
 
+import com.oracle.svm.core.c.libc.LibC;
+import com.oracle.svm.core.posix.linux.libc.BionicLibC;
+import com.oracle.svm.core.posix.linux.libc.GLibC;
+import com.oracle.svm.core.posix.linux.libc.MuslLibC;
 import org.graalvm.nativeimage.c.function.CFunction;
 import org.graalvm.nativeimage.c.type.CIntPointer;
 
@@ -31,6 +35,11 @@ import org.graalvm.nativeimage.c.type.CIntPointer;
 
 public class LinuxErrno {
 
+    @LibC({GLibC.class, MuslLibC.class})
     @CFunction(transition = CFunction.Transition.NO_TRANSITION)
     public static native CIntPointer __errno_location();
+
+    @LibC(BionicLibC.class)
+    @CFunction(transition = CFunction.Transition.NO_TRANSITION)
+    public static native CIntPointer __errno();
 }

--- a/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/headers/linux/package-info.java
+++ b/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/headers/linux/package-info.java
@@ -23,7 +23,7 @@
  * questions.
  */
 
-@Platforms({Platform.LINUX.class})
+@Platforms({Platform.LINUX_BASE.class})
 package com.oracle.svm.core.posix.headers.linux;
 
 import org.graalvm.nativeimage.Platform;

--- a/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/headers/package-info.java
+++ b/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/headers/package-info.java
@@ -23,7 +23,7 @@
  * questions.
  */
 
-@Platforms({Platform.LINUX.class, Platform.DARWIN.class})
+@Platforms({Platform.LINUX_BASE.class, Platform.DARWIN_BASE.class})
 package com.oracle.svm.core.posix.headers;
 
 import org.graalvm.nativeimage.Platform;

--- a/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/linux/LinuxCErrorNumberSupport.java
+++ b/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/linux/LinuxCErrorNumberSupport.java
@@ -26,7 +26,9 @@ package com.oracle.svm.core.posix.linux;
 
 import com.oracle.svm.core.CErrorNumber.CErrorNumberSupport;
 import com.oracle.svm.core.annotate.Uninterruptible;
+import com.oracle.svm.core.c.libc.LibC;
 import com.oracle.svm.core.posix.headers.linux.LinuxErrno;
+import com.oracle.svm.core.posix.linux.libc.BionicLibC;
 
 class LinuxCErrorNumberSupport implements CErrorNumberSupport {
 
@@ -40,5 +42,21 @@ class LinuxCErrorNumberSupport implements CErrorNumberSupport {
     @Override
     public void setCErrorNumber(int value) {
         LinuxErrno.__errno_location().write(value);
+    }
+}
+
+@LibC(BionicLibC.class)
+class BionicCErrorNumberSupport extends LinuxCErrorNumberSupport {
+
+    @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
+    @Override
+    public int getCErrorNumber() {
+        return LinuxErrno.__errno().read();
+    }
+
+    @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
+    @Override
+    public void setCErrorNumber(int value) {
+        LinuxErrno.__errno().write(value);
     }
 }

--- a/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/linux/LinuxImageSingletonsFeature.java
+++ b/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/linux/LinuxImageSingletonsFeature.java
@@ -24,17 +24,32 @@
  */
 package com.oracle.svm.core.posix.linux;
 
+import com.oracle.svm.core.c.libc.LibCBase;
+import com.oracle.svm.core.posix.linux.libc.BionicLibC;
+import com.oracle.svm.core.posix.linux.libc.LibCFeature;
 import org.graalvm.nativeimage.ImageSingletons;
 import org.graalvm.nativeimage.hosted.Feature;
 
 import com.oracle.svm.core.CErrorNumber.CErrorNumberSupport;
 import com.oracle.svm.core.annotate.AutomaticFeature;
 
+import java.util.Collections;
+import java.util.List;
+
 @AutomaticFeature
 class LinuxImageSingletonsFeature implements Feature {
 
     @Override
+    public List<Class<? extends Feature>> getRequiredFeatures() {
+        return Collections.singletonList(LibCFeature.class);
+    }
+
+    @Override
     public void afterRegistration(AfterRegistrationAccess access) {
-        ImageSingletons.add(CErrorNumberSupport.class, new LinuxCErrorNumberSupport());
+        if (LibCBase.singleton() instanceof BionicLibC) {
+            ImageSingletons.add(CErrorNumberSupport.class, new BionicCErrorNumberSupport());
+        } else {
+            ImageSingletons.add(CErrorNumberSupport.class, new LinuxCErrorNumberSupport());
+        }
     }
 }

--- a/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/linux/LinuxSystemPropertiesSupport.java
+++ b/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/linux/LinuxSystemPropertiesSupport.java
@@ -47,6 +47,15 @@ public class LinuxSystemPropertiesSupport extends PosixSystemPropertiesSupport {
     }
 
     @Override
+    protected String osNameValue() {
+        Utsname.utsname name = StackValue.get(Utsname.utsname.class);
+        if (Utsname.uname(name) >= 0) {
+            return CTypeConversion.toJavaString(name.sysname());
+        }
+        return "Unknown";
+    }
+
+    @Override
     protected String osVersionValue() {
         Utsname.utsname name = StackValue.get(Utsname.utsname.class);
         if (Utsname.uname(name) >= 0) {

--- a/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/linux/libc/BionicLibC.java
+++ b/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/linux/libc/BionicLibC.java
@@ -45,7 +45,7 @@ public class BionicLibC implements LibCBase {
 
     @Override
     public String getTargetCompiler() {
-        return "gcc";
+        return "clang";
     }
 
     @Override
@@ -55,6 +55,6 @@ public class BionicLibC implements LibCBase {
 
     @Override
     public boolean requiresLibCSpecificStaticJDKLibraries() {
-        return false;
+        return true;
     }
 }

--- a/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/linux/libc/LibCFeature.java
+++ b/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/linux/libc/LibCFeature.java
@@ -46,7 +46,7 @@ public class LibCFeature implements Feature {
 
     @Override
     public boolean isInConfiguration(IsInConfigurationAccess access) {
-        return Platform.includedIn(Platform.LINUX.class);
+        return Platform.includedIn(Platform.LINUX_BASE.class);
     }
 
     public static class LibCOptions {

--- a/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/linux/libc/MuslLibC.java
+++ b/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/linux/libc/MuslLibC.java
@@ -34,15 +34,6 @@ import org.graalvm.compiler.serviceprovider.JavaVersionUtil;
 
 public class MuslLibC implements LibCBase {
 
-    public MuslLibC() {
-        if (!SubstrateOptions.StaticExecutable.getValue()) {
-            throw UserError.abort("Musl can only be used for statically linked executables.");
-        }
-        if (JavaVersionUtil.JAVA_SPEC != 11) {
-            throw UserError.abort("Musl can only be used with labsjdk 11.");
-        }
-    }
-
     public static final String NAME = "musl";
 
     @Override
@@ -69,5 +60,15 @@ public class MuslLibC implements LibCBase {
     @Override
     public boolean requiresLibCSpecificStaticJDKLibraries() {
         return true;
+    }
+
+    @Override
+    public void checkIfLibCSupported() {
+        if (!SubstrateOptions.StaticExecutable.getValue()) {
+            throw UserError.abort("Musl can only be used for statically linked executables.");
+        }
+        if (JavaVersionUtil.JAVA_SPEC != 11) {
+            throw UserError.abort("Musl can only be used with labsjdk 11.");
+        }
     }
 }

--- a/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/linux/package-info.java
+++ b/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/linux/package-info.java
@@ -23,7 +23,7 @@
  * questions.
  */
 
-@Platforms({Platform.LINUX.class})
+@Platforms({Platform.LINUX_BASE.class})
 package com.oracle.svm.core.posix.linux;
 
 import org.graalvm.nativeimage.Platform;

--- a/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/package-info.java
+++ b/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/package-info.java
@@ -23,7 +23,7 @@
  * questions.
  */
 
-@Platforms({Platform.LINUX.class, Platform.DARWIN.class})
+@Platforms({Platform.LINUX_BASE.class, Platform.DARWIN_BASE.class})
 package com.oracle.svm.core.posix;
 
 import org.graalvm.nativeimage.Platform;

--- a/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/pthread/PthreadConditionUtils.java
+++ b/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/pthread/PthreadConditionUtils.java
@@ -49,7 +49,7 @@ public class PthreadConditionUtils {
             return status;
         }
 
-        if (Platform.includedIn(Platform.LINUX.class)) {
+        if (Platform.includedIn(Platform.LINUX_BASE.class)) {
             /*
              * On Linux, CLOCK_MONOTONIC is also used in the implementation of System.nanoTime, so
              * we can safely assume that it is present.
@@ -69,7 +69,7 @@ public class PthreadConditionUtils {
          * We need the real-time clock to compute absolute deadlines when a conditional wait should
          * return, but calling System.currentTimeMillis reduces the resolution too much.
          */
-        if (Platform.includedIn(Platform.LINUX.class)) {
+        if (Platform.includedIn(Platform.LINUX_BASE.class)) {
             /*
              * Linux is easy, we can just access the clock that we registered as the attribute when
              * the condition was created.

--- a/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/pthread/package-info.java
+++ b/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/pthread/package-info.java
@@ -23,7 +23,7 @@
  * questions.
  */
 
-@Platforms({Platform.LINUX.class, Platform.DARWIN.class})
+@Platforms({Platform.LINUX_BASE.class, Platform.DARWIN_BASE.class})
 package com.oracle.svm.core.posix.pthread;
 
 import org.graalvm.nativeimage.Platform;

--- a/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/thread/package-info.java
+++ b/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/thread/package-info.java
@@ -23,7 +23,7 @@
  * questions.
  */
 
-@Platforms({Platform.LINUX.class, Platform.DARWIN.class})
+@Platforms({Platform.LINUX_BASE.class, Platform.DARWIN_BASE.class})
 package com.oracle.svm.core.posix.thread;
 
 import org.graalvm.nativeimage.Platform;

--- a/substratevm/src/com.oracle.svm.core.windows/src/com/oracle/svm/core/windows/WindowsJavaLangSubstitutions.java
+++ b/substratevm/src/com.oracle.svm.core.windows/src/com/oracle/svm/core/windows/WindowsJavaLangSubstitutions.java
@@ -34,7 +34,7 @@ import com.oracle.svm.core.annotate.TargetClass;
 import com.oracle.svm.core.annotate.Uninterruptible;
 
 @TargetClass(java.lang.System.class)
-@Platforms(Platform.WINDOWS.class)
+@Platforms(Platform.WINDOWS_BASE.class)
 final class Target_java_lang_System {
 
     @Alias @RecomputeFieldValue(kind = RecomputeFieldValue.Kind.Reset) static volatile Console cons;
@@ -52,7 +52,7 @@ final class Target_java_lang_System {
 }
 
 /** Dummy class to have a class with the file's name. */
-@Platforms(Platform.WINDOWS.class)
+@Platforms(Platform.WINDOWS_BASE.class)
 public final class WindowsJavaLangSubstitutions {
 
     /** Private constructor: No instances. */

--- a/substratevm/src/com.oracle.svm.core.windows/src/com/oracle/svm/core/windows/WindowsJavaNIOSubstitutions.java
+++ b/substratevm/src/com.oracle.svm.core.windows/src/com/oracle/svm/core/windows/WindowsJavaNIOSubstitutions.java
@@ -31,11 +31,11 @@ import com.oracle.svm.core.annotate.Alias;
 import com.oracle.svm.core.annotate.RecomputeFieldValue;
 import com.oracle.svm.core.annotate.TargetClass;
 
-@Platforms(Platform.WINDOWS.class)
+@Platforms(Platform.WINDOWS_BASE.class)
 public final class WindowsJavaNIOSubstitutions {
 
     @TargetClass(className = "sun.nio.fs.Cancellable")
-    @Platforms({Platform.WINDOWS.class})
+    @Platforms({Platform.WINDOWS_BASE.class})
     static final class Target_sun_nio_fs_Cancellable {
         @Alias @RecomputeFieldValue(kind = RecomputeFieldValue.Kind.Manual)//
         private long pollingAddress;

--- a/substratevm/src/com.oracle.svm.core.windows/src/com/oracle/svm/core/windows/WindowsJavaThreads.java
+++ b/substratevm/src/com.oracle.svm.core.windows/src/com/oracle/svm/core/windows/WindowsJavaThreads.java
@@ -61,7 +61,7 @@ import com.oracle.svm.core.windows.headers.Process;
 import com.oracle.svm.core.windows.headers.SynchAPI;
 import com.oracle.svm.core.windows.headers.WinBase;
 
-@Platforms(Platform.WINDOWS.class)
+@Platforms(Platform.WINDOWS_BASE.class)
 public final class WindowsJavaThreads extends JavaThreads {
     @Platforms(HOSTED_ONLY.class)
     WindowsJavaThreads() {
@@ -148,7 +148,7 @@ public final class WindowsJavaThreads extends JavaThreads {
     }
 }
 
-@Platforms(Platform.WINDOWS.class)
+@Platforms(Platform.WINDOWS_BASE.class)
 class WindowsParkEvent extends ParkEvent {
 
     /**
@@ -203,7 +203,7 @@ class WindowsParkEvent extends ParkEvent {
     }
 }
 
-@Platforms(Platform.WINDOWS.class)
+@Platforms(Platform.WINDOWS_BASE.class)
 class WindowsParkEventFactory implements ParkEventFactory {
     @Override
     public ParkEvent create() {
@@ -212,7 +212,7 @@ class WindowsParkEventFactory implements ParkEventFactory {
 }
 
 @AutomaticFeature
-@Platforms(Platform.WINDOWS.class)
+@Platforms(Platform.WINDOWS_BASE.class)
 class WindowsThreadsFeature implements Feature {
     @Override
     public void afterRegistration(AfterRegistrationAccess access) {

--- a/substratevm/src/com.oracle.svm.core.windows/src/com/oracle/svm/core/windows/WindowsLogHandler.java
+++ b/substratevm/src/com.oracle.svm.core.windows/src/com/oracle/svm/core/windows/WindowsLogHandler.java
@@ -39,7 +39,7 @@ import com.oracle.svm.core.windows.headers.LibC;
 import com.oracle.svm.core.windows.headers.SynchAPI;
 
 @AutomaticFeature
-@Platforms(Platform.WINDOWS.class)
+@Platforms(Platform.WINDOWS_BASE.class)
 class WindowsLogHandlerFeature implements Feature {
     @Override
     public void beforeAnalysis(BeforeAnalysisAccess access) {

--- a/substratevm/src/com.oracle.svm.core.windows/src/com/oracle/svm/core/windows/WindowsNativeLibraryFeature.java
+++ b/substratevm/src/com.oracle.svm.core.windows/src/com/oracle/svm/core/windows/WindowsNativeLibraryFeature.java
@@ -50,7 +50,7 @@ import com.oracle.svm.core.windows.headers.WinBase.HMODULE;
 import com.oracle.svm.core.windows.headers.WinSock;
 
 @AutomaticFeature
-@Platforms(Platform.WINDOWS.class)
+@Platforms(Platform.WINDOWS_BASE.class)
 class WindowsNativeLibraryFeature implements Feature {
     @Override
     public void afterRegistration(AfterRegistrationAccess access) {
@@ -183,7 +183,7 @@ class WindowsNativeLibrarySupport extends JNIPlatformNativeLibrarySupport {
 }
 
 @TargetClass(className = "java.io.WinNTFileSystem")
-@Platforms(Platform.WINDOWS.class)
+@Platforms(Platform.WINDOWS_BASE.class)
 final class Target_java_io_WinNTFileSystem {
     @Alias
     static native void initIDs();

--- a/substratevm/src/com.oracle.svm.core.windows/src/com/oracle/svm/core/windows/WindowsStackOverflowSupport.java
+++ b/substratevm/src/com.oracle.svm.core.windows/src/com/oracle/svm/core/windows/WindowsStackOverflowSupport.java
@@ -38,7 +38,7 @@ import com.oracle.svm.core.annotate.Uninterruptible;
 import com.oracle.svm.core.stack.StackOverflowCheck;
 import com.oracle.svm.core.windows.headers.MemoryAPI;
 
-@Platforms({Platform.WINDOWS.class})
+@Platforms({Platform.WINDOWS_BASE.class})
 class WindowsStackOverflowSupport implements StackOverflowCheck.OSSupport {
 
     @Uninterruptible(reason = "Called while thread is being attached to the VM, i.e., when the thread state is not yet set up.")
@@ -57,7 +57,7 @@ class WindowsStackOverflowSupport implements StackOverflowCheck.OSSupport {
     }
 }
 
-@Platforms({Platform.WINDOWS.class})
+@Platforms({Platform.WINDOWS_BASE.class})
 @AutomaticFeature
 class WindowsStackOverflowSupportFeature implements Feature {
     @Override

--- a/substratevm/src/com.oracle.svm.core.windows/src/com/oracle/svm/core/windows/WindowsSubstrateOperatingSystemMXBean.java
+++ b/substratevm/src/com.oracle.svm.core.windows/src/com/oracle/svm/core/windows/WindowsSubstrateOperatingSystemMXBean.java
@@ -40,7 +40,7 @@ class WindowsSubstrateOperatingSystemMXBean extends SubstrateOperatingSystemMXBe
 
 }
 
-@Platforms(Platform.WINDOWS.class)
+@Platforms(Platform.WINDOWS_BASE.class)
 @AutomaticFeature
 class WindowsSubstrateOperatingSystemMXBeanFeature implements Feature {
     @Override

--- a/substratevm/src/com.oracle.svm.core.windows/src/com/oracle/svm/core/windows/WindowsSystemPropertiesSupport.java
+++ b/substratevm/src/com.oracle.svm.core.windows/src/com/oracle/svm/core/windows/WindowsSystemPropertiesSupport.java
@@ -24,21 +24,6 @@
  */
 package com.oracle.svm.core.windows;
 
-import java.nio.ByteBuffer;
-import java.nio.charset.StandardCharsets;
-
-import org.graalvm.nativeimage.ImageSingletons;
-import org.graalvm.nativeimage.Platform;
-import org.graalvm.nativeimage.Platforms;
-import org.graalvm.nativeimage.StackValue;
-import org.graalvm.nativeimage.c.struct.SizeOf;
-import org.graalvm.nativeimage.c.type.CCharPointer;
-import org.graalvm.nativeimage.c.type.CIntPointer;
-import org.graalvm.nativeimage.c.type.CTypeConversion;
-import org.graalvm.nativeimage.hosted.Feature;
-import org.graalvm.word.UnsignedWord;
-import org.graalvm.word.WordFactory;
-
 import com.oracle.svm.core.annotate.AutomaticFeature;
 import com.oracle.svm.core.c.NonmovableArrays;
 import com.oracle.svm.core.jdk.SystemPropertiesSupport;
@@ -48,13 +33,37 @@ import com.oracle.svm.core.windows.headers.LibC;
 import com.oracle.svm.core.windows.headers.LibC.WCharPointer;
 import com.oracle.svm.core.windows.headers.Process;
 import com.oracle.svm.core.windows.headers.SysinfoAPI;
+import com.oracle.svm.core.windows.headers.VerRsrc;
 import com.oracle.svm.core.windows.headers.WinBase;
+import com.oracle.svm.core.windows.headers.WinVer;
+import org.graalvm.collections.Pair;
+import org.graalvm.nativeimage.ImageSingletons;
+import org.graalvm.nativeimage.Platform;
+import org.graalvm.nativeimage.Platforms;
+import org.graalvm.nativeimage.StackValue;
+import org.graalvm.nativeimage.c.struct.SizeOf;
+import org.graalvm.nativeimage.c.type.CCharPointer;
+import org.graalvm.nativeimage.c.type.CIntPointer;
+import org.graalvm.nativeimage.c.type.CTypeConversion;
+import org.graalvm.nativeimage.c.type.VoidPointer;
+import org.graalvm.nativeimage.c.type.WordPointer;
+import org.graalvm.nativeimage.hosted.Feature;
+import org.graalvm.word.UnsignedWord;
+import org.graalvm.word.WordFactory;
+
+import java.nio.charset.StandardCharsets;
 
 @Platforms(Platform.WINDOWS.class)
 public class WindowsSystemPropertiesSupport extends SystemPropertiesSupport {
 
     /* Null-terminated wide-character string. */
     private static final byte[] USERNAME = "USERNAME\0".getBytes(StandardCharsets.UTF_16LE);
+    private static final byte[] KERNEL_DLL = "\\kernel32.dll\0".getBytes(StandardCharsets.UTF_16LE);
+    private static final byte[] ROOT_PATH = "\\\0".getBytes(StandardCharsets.UTF_16LE);
+
+    private static final int VER_NT_WORKSTATION = 0x0000001;
+    private static final int VER_PLATFORM_WIN32_WINDOWS = 1;
+    private static final int VER_PLATFORM_WIN32_NT = 2;
 
     @Override
     protected String userNameValue() {
@@ -122,13 +131,205 @@ public class WindowsSystemPropertiesSupport extends SystemPropertiesSupport {
         return CTypeConversion.toJavaString((CCharPointer) wcString, SizeOf.unsigned(WCharPointer.class).multiply(length), StandardCharsets.UTF_16LE);
     }
 
+    private Pair<String, String> cachedOsNameAndVersion;
+
+    public Pair<String, String> getOsNameAndVersion() {
+        int majorVersion;
+        int minorVersion;
+        int buildNumber;
+        boolean isWorkstation;
+        boolean is64bit;
+        int platformId;
+
+        /*
+         * Reimplementation of code from java_props_md.c
+         */
+        SysinfoAPI.OSVERSIONINFOEX ver = StackValue.get(SysinfoAPI.OSVERSIONINFOEX.class);
+        ver.dwOSVersionInfoSize(SizeOf.get(SysinfoAPI.OSVERSIONINFOEX.class));
+        SysinfoAPI.GetVersionEx(ver);
+
+        // Since Windows 8.1 we cannot trust this interface to return correct version
+
+        majorVersion = ver.dwMajorVersion();
+        minorVersion = ver.dwMinorVersion();
+        buildNumber = ver.dwBuildNumber();
+
+        isWorkstation = (ver.wProductType() == VER_NT_WORKSTATION);
+        is64bit = true; // ATM we only support 64-bit Windows OS's
+        platformId = ver.dwPlatformId();
+
+        do {
+            LibC.WCharPointer kernel32Path = StackValue.get(WinBase.MAX_PATH, LibC.WCharPointer.class);
+            LibC.WCharPointer kernel32Dll = NonmovableArrays.addressOf(NonmovableArrays.fromImageHeap(KERNEL_DLL), 0);
+            int len = WinBase.MAX_PATH - (int) LibC.wcslen(kernel32Dll).rawValue() - 1;
+            int ret = SysinfoAPI.GetSystemDirectoryW(kernel32Path, len);
+            if (ret == 0 || ret > len) {
+                break;
+            }
+
+            LibC.wcsncat(kernel32Path, kernel32Dll, WordFactory.unsigned(WinBase.MAX_PATH - ret));
+
+            int versionSize = WinVer.GetFileVersionInfoSizeW(kernel32Path, WordFactory.nullPointer());
+            if (versionSize == 0) {
+                break;
+            }
+
+            VoidPointer versionInfo = LibC.malloc(WordFactory.unsigned(versionSize));
+            if (versionInfo.isNull()) {
+                break;
+            }
+
+            ret = WinVer.GetFileVersionInfoW(kernel32Path, 0, versionSize, versionInfo);
+            if (ret == 0) {
+                LibC.free(versionInfo);
+                break;
+            }
+
+            CIntPointer lengthPointer = StackValue.get(CIntPointer.class);
+            WordPointer fileInfoPointer = StackValue.get(WordPointer.class);
+
+            LibC.WCharPointer rootPath = NonmovableArrays.addressOf(NonmovableArrays.fromImageHeap(ROOT_PATH), 0);
+            ret = WinVer.VerQueryValueW(versionInfo, rootPath, fileInfoPointer, lengthPointer);
+            if (ret == 0) {
+                LibC.free(versionInfo);
+                break;
+            }
+            VerRsrc.VS_FIXEDFILEINFO fileInfo = fileInfoPointer.read();
+            majorVersion = (short) (fileInfo.dwProductVersionMS() >> 16); // HIWORD
+            minorVersion = (short) fileInfo.dwProductVersionMS(); // LOWORD
+            buildNumber = (short) (fileInfo.dwProductVersionLS() >> 16); // HIWORD
+            LibC.free(versionInfo);
+        } while (false);
+
+        String osVersion = majorVersion + "." + minorVersion;
+        String osName;
+
+        switch (platformId) {
+            case VER_PLATFORM_WIN32_WINDOWS:
+                if (majorVersion == 4) {
+                    switch (minorVersion) {
+                        case 0:
+                            osName = "Windows 95";
+                            break;
+                        case 10:
+                            osName = "Windows 98";
+                            break;
+                        case 90:
+                            osName = "Windows Me";
+                            break;
+                        default:
+                            osName = "Windows 9X (unknown)";
+                            break;
+                    }
+                } else {
+                    osName = "Windows 9X (unknown)";
+                }
+                break;
+            case VER_PLATFORM_WIN32_NT:
+                if (majorVersion <= 4) {
+                    osName = "Windows NT";
+                } else if (majorVersion == 5) {
+                    switch (minorVersion) {
+                        case 0:
+                            osName = "Windows 2000";
+                            break;
+                        case 1:
+                            osName = "Windows XP";
+                            break;
+                        case 2:
+                            if (isWorkstation && is64bit) {
+                                osName = "Windows XP"; /* 64 bit */
+                            } else {
+                                osName = "Windows 2003";
+                            }
+                            break;
+                        default:
+                            osName = "Windows NT (unknown)";
+                            break;
+                    }
+                } else if (majorVersion == 6) {
+                    if (isWorkstation) {
+                        switch (minorVersion) {
+                            case 0:
+                                osName = "Windows Vista";
+                                break;
+                            case 1:
+                                osName = "Windows 7";
+                                break;
+                            case 2:
+                                osName = "Windows 8";
+                                break;
+                            case 3:
+                                osName = "Windows 8.1";
+                                break;
+                            default:
+                                osName = "Windows NT (unknown)";
+                        }
+                    } else {
+                        switch (minorVersion) {
+                            case 0:
+                                osName = "Windows Server 2008";
+                                break;
+                            case 1:
+                                osName = "Windows Server 2008 R2";
+                                break;
+                            case 2:
+                                osName = "Windows Server 2012";
+                                break;
+                            case 3:
+                                osName = "Windows Server 2012 R2";
+                                break;
+                            default:
+                                osName = "Windows NT (unknown)";
+                        }
+                    }
+                } else if (majorVersion == 10) {
+                    if (isWorkstation) {
+                        switch (minorVersion) {
+                            case 0:
+                                osName = "Windows 10";
+                                break;
+                            default:
+                                osName = "Windows NT (unknown)";
+                        }
+                    } else {
+                        switch (minorVersion) {
+                            case 0:
+                                if (buildNumber > 17762) {
+                                    osName = "Windows Server 2019";
+                                } else {
+                                    osName = "Windows Server 2016";
+                                }
+                                break;
+                            default:
+                                osName = "Windows NT (unknown)";
+                        }
+                    }
+                } else {
+                    osName = "Windows NT (unknown)";
+                }
+                break;
+            default:
+                osName = "Windows (unknown)";
+                break;
+        }
+        return Pair.create(osName, osVersion);
+    }
+
+    @Override
+    protected String osNameValue() {
+        if (cachedOsNameAndVersion == null) {
+            cachedOsNameAndVersion = getOsNameAndVersion();
+        }
+        return cachedOsNameAndVersion.getLeft();
+    }
+
     @Override
     protected String osVersionValue() {
-        ByteBuffer versionBytes = ByteBuffer.allocate(4);
-        versionBytes.putInt(SysinfoAPI.GetVersion());
-        int majorVersion = versionBytes.get(3);
-        int minorVersion = versionBytes.get(2);
-        return majorVersion + "." + minorVersion;
+        if (cachedOsNameAndVersion == null) {
+            cachedOsNameAndVersion = getOsNameAndVersion();
+        }
+        return cachedOsNameAndVersion.getRight();
     }
 }
 

--- a/substratevm/src/com.oracle.svm.core.windows/src/com/oracle/svm/core/windows/WindowsSystemPropertiesSupport.java
+++ b/substratevm/src/com.oracle.svm.core.windows/src/com/oracle/svm/core/windows/WindowsSystemPropertiesSupport.java
@@ -53,7 +53,7 @@ import org.graalvm.word.WordFactory;
 
 import java.nio.charset.StandardCharsets;
 
-@Platforms(Platform.WINDOWS.class)
+@Platforms(Platform.WINDOWS_BASE.class)
 public class WindowsSystemPropertiesSupport extends SystemPropertiesSupport {
 
     /* Null-terminated wide-character string. */
@@ -333,7 +333,7 @@ public class WindowsSystemPropertiesSupport extends SystemPropertiesSupport {
     }
 }
 
-@Platforms(Platform.WINDOWS.class)
+@Platforms(Platform.WINDOWS_BASE.class)
 @AutomaticFeature
 class WindowsSystemPropertiesFeature implements Feature {
     @Override

--- a/substratevm/src/com.oracle.svm.core.windows/src/com/oracle/svm/core/windows/WindowsUnmanagedMemorySupportImpl.java
+++ b/substratevm/src/com.oracle.svm.core.windows/src/com/oracle/svm/core/windows/WindowsUnmanagedMemorySupportImpl.java
@@ -65,7 +65,7 @@ class WindowsUnmanagedMemorySupportImpl implements UnmanagedMemorySupport {
 }
 
 @AutomaticFeature
-@Platforms(Platform.WINDOWS.class)
+@Platforms(Platform.WINDOWS_BASE.class)
 class UnmanagedMemoryFeature implements Feature {
     @Override
     public void afterRegistration(AfterRegistrationAccess access) {

--- a/substratevm/src/com.oracle.svm.core.windows/src/com/oracle/svm/core/windows/WindowsUtils.java
+++ b/substratevm/src/com.oracle.svm.core.windows/src/com/oracle/svm/core/windows/WindowsUtils.java
@@ -51,7 +51,7 @@ import com.oracle.svm.core.windows.headers.WinBase;
 import jdk.vm.ci.meta.MetaAccessProvider;
 import jdk.vm.ci.meta.ResolvedJavaField;
 
-@Platforms(Platform.WINDOWS.class)
+@Platforms(Platform.WINDOWS_BASE.class)
 public class WindowsUtils {
 
     @TargetClass(className = "java.lang.ProcessImpl")

--- a/substratevm/src/com.oracle.svm.core.windows/src/com/oracle/svm/core/windows/WindowsVMLockSupport.java
+++ b/substratevm/src/com.oracle.svm.core.windows/src/com/oracle/svm/core/windows/WindowsVMLockSupport.java
@@ -59,7 +59,7 @@ import jdk.vm.ci.meta.JavaKind;
  * implemented via Windows locking primitives.
  */
 @AutomaticFeature
-@Platforms(Platform.WINDOWS.class)
+@Platforms(Platform.WINDOWS_BASE.class)
 final class WindowsVMLockFeature implements Feature {
 
     private final ClassInstanceReplacer<VMMutex, WindowsVMMutex> mutexReplacer = new ClassInstanceReplacer<VMMutex, WindowsVMMutex>(VMMutex.class) {

--- a/substratevm/src/com.oracle.svm.core.windows/src/com/oracle/svm/core/windows/WindowsVMThreads.java
+++ b/substratevm/src/com.oracle.svm.core.windows/src/com/oracle/svm/core/windows/WindowsVMThreads.java
@@ -95,7 +95,7 @@ public final class WindowsVMThreads extends VMThreads {
 }
 
 @AutomaticFeature
-@Platforms(Platform.WINDOWS.class)
+@Platforms(Platform.WINDOWS_BASE.class)
 class WindowsVMThreadsFeature implements Feature {
     @Override
     public void afterRegistration(AfterRegistrationAccess access) {

--- a/substratevm/src/com.oracle.svm.core.windows/src/com/oracle/svm/core/windows/headers/FileAPI.java
+++ b/substratevm/src/com.oracle.svm.core.windows/src/com/oracle/svm/core/windows/headers/FileAPI.java
@@ -44,7 +44,7 @@ import com.oracle.svm.core.windows.headers.LibC.WCharPointer;
  * Definitions manually translated from the Windows header file fileapi.h.
  */
 @CContext(WindowsDirectives.class)
-@Platforms(Platform.WINDOWS.class)
+@Platforms(Platform.WINDOWS_BASE.class)
 public class FileAPI {
 
     @CFunction

--- a/substratevm/src/com.oracle.svm.core.windows/src/com/oracle/svm/core/windows/headers/LibC.java
+++ b/substratevm/src/com.oracle.svm.core.windows/src/com/oracle/svm/core/windows/headers/LibC.java
@@ -77,4 +77,7 @@ public class LibC {
 
     @CFunction(transition = CFunction.Transition.NO_TRANSITION)
     public static native UnsignedWord wcslen(WCharPointer varname);
+
+    @CFunction(transition = CFunction.Transition.NO_TRANSITION)
+    public static native WCharPointer wcsncat(WCharPointer strDest, WCharPointer strSource, UnsignedWord count);
 }

--- a/substratevm/src/com.oracle.svm.core.windows/src/com/oracle/svm/core/windows/headers/LibC.java
+++ b/substratevm/src/com.oracle.svm.core.windows/src/com/oracle/svm/core/windows/headers/LibC.java
@@ -41,7 +41,7 @@ import com.oracle.svm.core.annotate.Uninterruptible;
  * Basic functions from the standard Visual Studio C Run-Time library
  */
 @CContext(WindowsDirectives.class)
-@Platforms(Platform.WINDOWS.class)
+@Platforms(Platform.WINDOWS_BASE.class)
 public class LibC {
     @CFunction(transition = CFunction.Transition.NO_TRANSITION)
     public static native <T extends PointerBase> T malloc(UnsignedWord size);

--- a/substratevm/src/com.oracle.svm.core.windows/src/com/oracle/svm/core/windows/headers/SynchAPI.java
+++ b/substratevm/src/com.oracle.svm.core.windows/src/com/oracle/svm/core/windows/headers/SynchAPI.java
@@ -38,7 +38,7 @@ import org.graalvm.word.PointerBase;
  * Definitions for Windows syncapi.h header file
  */
 @CContext(WindowsDirectives.class)
-@Platforms(Platform.WINDOWS.class)
+@Platforms(Platform.WINDOWS_BASE.class)
 public class SynchAPI {
 
     @CFunction

--- a/substratevm/src/com.oracle.svm.core.windows/src/com/oracle/svm/core/windows/headers/SysinfoAPI.java
+++ b/substratevm/src/com.oracle.svm.core.windows/src/com/oracle/svm/core/windows/headers/SysinfoAPI.java
@@ -30,6 +30,8 @@ import org.graalvm.nativeimage.c.CContext;
 import org.graalvm.nativeimage.c.function.CFunction;
 import org.graalvm.nativeimage.c.struct.CField;
 import org.graalvm.nativeimage.c.struct.CStruct;
+import org.graalvm.nativeimage.c.type.CCharPointer;
+import com.oracle.svm.core.windows.headers.LibC.WCharPointer;
 import org.graalvm.word.PointerBase;
 
 // Checkstyle: stop
@@ -43,6 +45,10 @@ public class SysinfoAPI {
     /** Return information about the current computer system. */
     @CFunction(transition = NO_TRANSITION)
     public static native void GetSystemInfo(SYSTEM_INFO lpSystemInfo);
+
+    /** Retrieves the path of the system directory.. */
+    @CFunction(transition = NO_TRANSITION)
+    public static native int GetSystemDirectoryW(WCharPointer lpBuffer, int uSize);
 
     /** Structure containing information about the current computer system. */
     @CStruct
@@ -119,6 +125,46 @@ public class SysinfoAPI {
         long ullAvailExtendedVirtual();
     }
 
+    @CStruct
+    public interface OSVERSIONINFOEX extends PointerBase {
+        @CField
+        int dwOSVersionInfoSize();
+
+        @CField
+        void dwOSVersionInfoSize(int value);
+
+        @CField
+        int dwMajorVersion();
+
+        @CField
+        int dwMinorVersion();
+
+        @CField
+        int dwBuildNumber();
+
+        @CField
+        int dwPlatformId();
+
+        @CField
+        CCharPointer szCSDVersion();
+
+        @CField
+        short wServicePackMajor();
+
+        @CField
+        short wServicePackMinor();
+
+        @CField
+        short wSuiteMask();
+
+        @CField
+        byte wProductType();
+
+        @CField
+        byte wReserved();
+    }
+
     @CFunction(transition = NO_TRANSITION)
-    public static native int GetVersion();
+    public static native int GetVersionEx(OSVERSIONINFOEX lpVersionInformation);
+
 }

--- a/substratevm/src/com.oracle.svm.core.windows/src/com/oracle/svm/core/windows/headers/VerRsrc.java
+++ b/substratevm/src/com.oracle.svm.core.windows/src/com/oracle/svm/core/windows/headers/VerRsrc.java
@@ -1,0 +1,56 @@
+package com.oracle.svm.core.windows.headers;
+
+// Checkstyle: stop
+
+import org.graalvm.nativeimage.c.struct.CField;
+import org.graalvm.nativeimage.c.struct.CStruct;
+import org.graalvm.word.PointerBase;
+
+/**
+ * Definitions for Windows verrsrc.h
+ */
+
+public class VerRsrc {
+
+    @CStruct
+    public interface VS_FIXEDFILEINFO extends PointerBase {
+        @CField
+        int dwSignature();
+
+        @CField
+        int dwStrucVersion();
+
+        @CField
+        int dwFileVersionMS();
+
+        @CField
+        int dwFileVersionLS();
+
+        @CField
+        int dwProductVersionMS();
+
+        @CField
+        int dwProductVersionLS();
+
+        @CField
+        int dwFileFlagsMask();
+
+        @CField
+        int dwFileFlags();
+
+        @CField
+        int dwFileOS();
+
+        @CField
+        int dwFileType();
+
+        @CField
+        int dwFileSubtype();
+
+        @CField
+        int dwFileDateMS();
+
+        @CField
+        int dwFileDateLS();
+    }
+}

--- a/substratevm/src/com.oracle.svm.core.windows/src/com/oracle/svm/core/windows/headers/WinSock.java
+++ b/substratevm/src/com.oracle.svm.core.windows/src/com/oracle/svm/core/windows/headers/WinSock.java
@@ -38,7 +38,7 @@ import org.graalvm.nativeimage.c.type.CCharPointer;
 // Checkstyle: stop
 
 @CContext(WindowsDirectives.class)
-@Platforms(Platform.WINDOWS.class)
+@Platforms(Platform.WINDOWS_BASE.class)
 public class WinSock {
 
     /**

--- a/substratevm/src/com.oracle.svm.core.windows/src/com/oracle/svm/core/windows/headers/WinVer.java
+++ b/substratevm/src/com.oracle.svm.core.windows/src/com/oracle/svm/core/windows/headers/WinVer.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2020, 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package com.oracle.svm.core.windows.headers;
+
+import static org.graalvm.nativeimage.c.function.CFunction.Transition.NO_TRANSITION;
+
+import org.graalvm.nativeimage.c.CContext;
+import org.graalvm.nativeimage.c.function.CFunction;
+import org.graalvm.nativeimage.c.type.CIntPointer;
+import org.graalvm.nativeimage.c.type.CShortPointer;
+import com.oracle.svm.core.windows.headers.LibC.WCharPointer;
+import org.graalvm.nativeimage.c.type.VoidPointer;
+import org.graalvm.nativeimage.c.type.WordPointer;
+import org.graalvm.word.PointerBase;
+
+// Checkstyle: stop
+
+/**
+ * Definitions for Windows winver.h
+ */
+@CContext(WindowsDirectives.class)
+public class WinVer {
+
+    @CFunction(transition = NO_TRANSITION)
+    public static native int GetFileVersionInfoSizeW(WCharPointer lptstrFilename, CIntPointer lpdwHandle);
+
+    @CFunction(transition = NO_TRANSITION)
+    public static native int GetFileVersionInfoW(WCharPointer lptstrFilename, int dwHandle, int dwLen, VoidPointer lpData);
+
+    @CFunction(transition = NO_TRANSITION)
+    public static native int VerQueryValueW(VoidPointer pBlock, WCharPointer lpSubBlock, WordPointer lplpBuffer, CIntPointer puLen);
+
+}

--- a/substratevm/src/com.oracle.svm.core.windows/src/com/oracle/svm/core/windows/headers/WindowsDirectives.java
+++ b/substratevm/src/com.oracle.svm.core.windows/src/com/oracle/svm/core/windows/headers/WindowsDirectives.java
@@ -34,7 +34,7 @@ import org.graalvm.nativeimage.c.CContext;
 
 import com.oracle.svm.core.util.VMError;
 
-@Platforms(Platform.WINDOWS.class)
+@Platforms(Platform.WINDOWS_BASE.class)
 public class WindowsDirectives implements CContext.Directives {
 
     private static final String[] windowsLibs = new String[]{
@@ -49,12 +49,12 @@ public class WindowsDirectives implements CContext.Directives {
 
     @Override
     public boolean isInConfiguration() {
-        return Platform.includedIn(Platform.WINDOWS.class);
+        return Platform.includedIn(Platform.WINDOWS_BASE.class);
     }
 
     @Override
     public List<String> getHeaderFiles() {
-        if (Platform.includedIn(Platform.WINDOWS.class)) {
+        if (Platform.includedIn(Platform.WINDOWS_BASE.class)) {
             List<String> result = new ArrayList<>(Arrays.asList(windowsLibs));
             return result;
         } else {

--- a/substratevm/src/com.oracle.svm.core.windows/src/com/oracle/svm/core/windows/headers/WindowsErrno.java
+++ b/substratevm/src/com.oracle.svm.core.windows/src/com/oracle/svm/core/windows/headers/WindowsErrno.java
@@ -31,7 +31,7 @@ import org.graalvm.nativeimage.c.type.CIntPointer;
 
 // Checkstyle: stop
 
-@Platforms(Platform.WINDOWS.class)
+@Platforms(Platform.WINDOWS_BASE.class)
 public class WindowsErrno {
 
     @CFunction(transition = CFunction.Transition.NO_TRANSITION)

--- a/substratevm/src/com.oracle.svm.core.windows/src/com/oracle/svm/core/windows/headers/package-info.java
+++ b/substratevm/src/com.oracle.svm.core.windows/src/com/oracle/svm/core/windows/headers/package-info.java
@@ -23,7 +23,7 @@
  * questions.
  */
 
-@Platforms(Platform.WINDOWS.class)
+@Platforms(Platform.WINDOWS_BASE.class)
 package com.oracle.svm.core.windows.headers;
 
 import org.graalvm.nativeimage.Platform;

--- a/substratevm/src/com.oracle.svm.core.windows/src/com/oracle/svm/core/windows/package-info.java
+++ b/substratevm/src/com.oracle.svm.core.windows/src/com/oracle/svm/core/windows/package-info.java
@@ -23,7 +23,7 @@
  * questions.
  */
 
-@Platforms(Platform.WINDOWS.class)
+@Platforms(Platform.WINDOWS_BASE.class)
 package com.oracle.svm.core.windows;
 
 import org.graalvm.nativeimage.Platform;

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/Containers.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/Containers.java
@@ -117,7 +117,7 @@ public class Containers {
         int cpuCount = Jvm.JVM_ActiveProcessorCount();
 
         int limitCount = cpuCount;
-        if (UseContainerSupport.getValue() && Platform.includedIn(Platform.LINUX.class)) {
+        if (UseContainerSupport.getValue() && Platform.includedIn(Platform.LINUX_BASE.class)) {
             ContainerInfo info = new ContainerInfo();
             if (info.isContainerized()) {
                 long quota = info.getCpuQuota();
@@ -198,7 +198,7 @@ final class ContainerInfo {
 }
 
 @AutomaticFeature
-@Platforms(Platform.LINUX.class)
+@Platforms(Platform.LINUX_BASE.class)
 class ContainersFeature implements Feature {
     @Override
     public void duringSetup(DuringSetupAccess access) {

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/JavaMainWrapper.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/JavaMainWrapper.java
@@ -183,7 +183,7 @@ public class JavaMainWrapper {
     }
 
     private static boolean isArgumentBlockSupported() {
-        if (!Platform.includedIn(Platform.LINUX.class) && !Platform.includedIn(Platform.DARWIN.class)) {
+        if (!Platform.includedIn(Platform.LINUX_BASE.class) && !Platform.includedIn(Platform.DARWIN_BASE.class)) {
             return false;
         }
         CEntryPointCreateIsolateParameters args = MAIN_ISOLATE_PARAMETERS.get();

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/SubstrateOptions.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/SubstrateOptions.java
@@ -72,6 +72,10 @@ public class SubstrateOptions {
     @Option(help = "Build statically linked executable (requires static libc and zlib)")//
     public static final HostedOptionKey<Boolean> StaticExecutable = new HostedOptionKey<>(false);
 
+    @APIOption(name = "target")//
+    @Option(help = "Selects native-image compilation target (in <OS>-<architecture> format). Defaults to host's OS-architecture pair.")//
+    public static final HostedOptionKey<String> TargetPlatform = new HostedOptionKey<>("");
+
     @Option(help = "Builds a statically linked executable with libc dynamically linked", type = Expert, stability = OptionStability.EXPERIMENTAL)//
     public static final HostedOptionKey<Boolean> StaticExecutableWithDynamicLibC = new HostedOptionKey<Boolean>(false) {
         @Override
@@ -139,6 +143,9 @@ public class SubstrateOptions {
 
     @Option(help = "Path passed to the linker as the -rpath (list of comma-separated directories)")//
     public static final HostedOptionKey<String[]> LinkerRPath = new HostedOptionKey<>(null);
+
+    @Option(help = "String which would be appended to linker call")//
+    public static final HostedOptionKey<String> AdditionalLinkerOptions = new HostedOptionKey<>("");
 
     @Option(help = "Directory of the image file to be generated", type = OptionType.User)//
     public static final HostedOptionKey<String> Path = new HostedOptionKey<>(null);

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/VMInspection.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/VMInspection.java
@@ -39,7 +39,7 @@ import org.graalvm.compiler.options.OptionType;
 import org.graalvm.nativeimage.CurrentIsolate;
 import org.graalvm.nativeimage.IsolateThread;
 import org.graalvm.nativeimage.Platform;
-import org.graalvm.nativeimage.Platform.WINDOWS;
+import org.graalvm.nativeimage.Platform.WINDOWS_BASE;
 import org.graalvm.nativeimage.ProcessProperties;
 import org.graalvm.nativeimage.VMRuntime;
 import org.graalvm.nativeimage.hosted.Feature;
@@ -71,7 +71,7 @@ public class VMInspection implements Feature {
     public void beforeAnalysis(BeforeAnalysisAccess access) {
         RuntimeSupport.getRuntimeSupport().addStartupHook(() -> {
             DumpAllStacks.install();
-            if (VMInspectionOptions.AllowVMInspection.getValue() && !Platform.includedIn(WINDOWS.class)) {
+            if (VMInspectionOptions.AllowVMInspection.getValue() && !Platform.includedIn(WINDOWS_BASE.class)) {
                 /* We have enough signals to enable the rest. */
                 DumpHeapReport.install();
                 if (DeoptimizationSupport.enabled()) {
@@ -97,7 +97,7 @@ class VMInspectionOptions {
 
 class DumpAllStacks implements SignalHandler {
     static void install() {
-        Signal.handle(Platform.includedIn(WINDOWS.class) ? new Signal("BREAK") : new Signal("QUIT"), new DumpAllStacks());
+        Signal.handle(Platform.includedIn(Platform.WINDOWS_BASE.class) ? new Signal("BREAK") : new Signal("QUIT"), new DumpAllStacks());
     }
 
     @Override

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/c/libc/LibCBase.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/c/libc/LibCBase.java
@@ -115,6 +115,10 @@ public interface LibCBase {
     @Platforms(Platform.HOSTED_ONLY.class)
     boolean requiresLibCSpecificStaticJDKLibraries();
 
+    @Platforms(Platform.HOSTED_ONLY.class)
+    default void checkIfLibCSupported() {
+    }
+
     static LibCBase singleton() {
         return ImageSingletons.lookup(LibCBase.class);
     }

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/FileSystemProviderSupport.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/FileSystemProviderSupport.java
@@ -175,7 +175,7 @@ final class Target_jdk_internal_jrtfs_JrtFileSystemProvider {
  * approach is implemented here.
  */
 @TargetClass(className = "sun.nio.fs.UnixFileSystem")
-@Platforms({Platform.LINUX.class, Platform.DARWIN.class})
+@Platforms({Platform.LINUX_BASE.class, Platform.DARWIN_BASE.class})
 final class Target_sun_nio_fs_UnixFileSystem {
 
     @Alias //
@@ -221,12 +221,12 @@ final class Target_sun_nio_fs_UnixFileSystem {
 }
 
 @TargetClass(className = "sun.nio.fs.UnixFileSystemProvider")
-@Platforms({Platform.LINUX.class, Platform.DARWIN.class})
+@Platforms({Platform.LINUX_BASE.class, Platform.DARWIN_BASE.class})
 final class Target_sun_nio_fs_UnixFileSystemProvider {
 }
 
 @TargetClass(className = "sun.nio.fs.UnixPath")
-@Platforms({Platform.LINUX.class, Platform.DARWIN.class})
+@Platforms({Platform.LINUX_BASE.class, Platform.DARWIN_BASE.class})
 final class Target_sun_nio_fs_UnixPath {
 }
 
@@ -245,7 +245,7 @@ class NeedsReinitializationProvider implements RecomputeFieldValue.CustomFieldVa
     }
 }
 
-@Platforms({Platform.LINUX.class, Platform.DARWIN.class})
+@Platforms({Platform.LINUX_BASE.class, Platform.DARWIN_BASE.class})
 class UnixFileSystemAccessors {
 
     /*
@@ -329,7 +329,7 @@ class UnixFileSystemAccessors {
  */
 
 @TargetClass(className = "sun.nio.fs.WindowsFileSystem")
-@Platforms({Platform.WINDOWS.class})
+@Platforms({Platform.WINDOWS_BASE.class})
 final class Target_sun_nio_fs_WindowsFileSystem {
 
     @Alias //
@@ -354,11 +354,11 @@ final class Target_sun_nio_fs_WindowsFileSystem {
 }
 
 @TargetClass(className = "sun.nio.fs.WindowsFileSystemProvider")
-@Platforms({Platform.WINDOWS.class})
+@Platforms({Platform.WINDOWS_BASE.class})
 final class Target_sun_nio_fs_WindowsFileSystemProvider {
 }
 
-@Platforms({Platform.WINDOWS.class})
+@Platforms({Platform.WINDOWS_BASE.class})
 class WindowsFileSystemAccessors {
     static String getDefaultDirectory(Target_sun_nio_fs_WindowsFileSystem that) {
         if (that.needsReinitialization != NeedsReinitializationProvider.STATUS_REINITIALIZED) {
@@ -399,7 +399,7 @@ class WindowsFileSystemAccessors {
 }
 
 @TargetClass(className = "java.io.UnixFileSystem")
-@Platforms({Platform.LINUX.class, Platform.DARWIN.class})
+@Platforms({Platform.LINUX_BASE.class, Platform.DARWIN_BASE.class})
 final class Target_java_io_UnixFileSystem {
 
     @Alias @InjectAccessors(UserDirAccessors.class) //
@@ -431,7 +431,7 @@ final class Target_java_io_FileSystem {
      * Linux/MacOS only: disable the usage of the javaHomePrefixCache. On Windows, the prefix cache
      * is not specific to the Java home directory and therefore can remain enabled.
      */
-    @Platforms({Platform.LINUX.class, Platform.DARWIN.class}) //
+    @Platforms({Platform.LINUX_BASE.class, Platform.DARWIN_BASE.class}) //
     @Alias @RecomputeFieldValue(kind = Kind.FromAlias, isFinal = true) //
     static boolean useCanonPrefixCache = false;
 
@@ -446,14 +446,14 @@ class UserDirAccessors {
          * Note that on Windows, we normalize the property value (JDK-8198997) and do not use the
          * `StaticProperty.userDir()` like the rest (JDK-8066709).
          */
-        return Platform.includedIn(Platform.WINDOWS.class)
+        return Platform.includedIn(Platform.WINDOWS_BASE.class)
                         ? that.normalize(System.getProperty("user.dir"))
                         : ImageSingletons.lookup(SystemPropertiesSupport.class).userDir();
     }
 }
 
 @TargetClass(className = "java.io.WinNTFileSystem")
-@Platforms(Platform.WINDOWS.class)
+@Platforms(Platform.WINDOWS_BASE.class)
 final class Target_java_io_WinNTFileSystem {
 
     @Alias @InjectAccessors(UserDirAccessors.class) //

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/JNIPlatformNativeLibrarySupport.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/JNIPlatformNativeLibrarySupport.java
@@ -135,7 +135,7 @@ final class Target_java_io_FileOutputStream_JNI {
     static native void initIDs();
 }
 
-@Platforms({Platform.DARWIN.class, Platform.LINUX.class})
+@Platforms({Platform.DARWIN_BASE.class, Platform.LINUX_BASE.class})
 @CLibrary("z")
 class ZLib {
 }

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/JNIRegistrationUtil.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/JNIRegistrationUtil.java
@@ -52,19 +52,19 @@ import com.oracle.svm.util.ReflectionUtil;
 public class JNIRegistrationUtil {
 
     protected static boolean isPosix() {
-        return Platform.includedIn(Platform.LINUX.class) || Platform.includedIn(Platform.DARWIN.class);
+        return Platform.includedIn(Platform.LINUX_BASE.class) || Platform.includedIn(Platform.DARWIN_BASE.class);
     }
 
     protected static boolean isLinux() {
-        return Platform.includedIn(Platform.LINUX.class);
+        return Platform.includedIn(Platform.LINUX_BASE.class);
     }
 
     protected static boolean isDarwin() {
-        return Platform.includedIn(Platform.DARWIN.class);
+        return Platform.includedIn(Platform.DARWIN_BASE.class);
     }
 
     protected static boolean isWindows() {
-        return Platform.includedIn(Platform.WINDOWS.class);
+        return Platform.includedIn(Platform.WINDOWS_BASE.class);
     }
 
     protected static void rerunClassInit(FeatureAccess access, String... classNames) {

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/Jvm.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/Jvm.java
@@ -51,7 +51,7 @@ public class Jvm {
     @CFunction(transition = CFunction.Transition.NO_TRANSITION)
     public static native int JVM_ActiveProcessorCount();
 
-    @Platforms(Platform.WINDOWS.class)
+    @Platforms(Platform.WINDOWS_BASE.class)
     @CFunction(transition = CFunction.Transition.NO_TRANSITION)
     public static native VoidPointer JVM_RegisterSignal(int sig, VoidPointer handler);
 }

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/SystemPropertiesSupport.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/SystemPropertiesSupport.java
@@ -33,6 +33,7 @@ import java.util.function.Supplier;
 import com.oracle.svm.core.OS;
 import org.graalvm.compiler.serviceprovider.JavaVersionUtil;
 import org.graalvm.nativeimage.ImageInfo;
+import org.graalvm.nativeimage.ImageSingletons;
 import org.graalvm.nativeimage.Platform;
 import org.graalvm.nativeimage.Platforms;
 
@@ -104,11 +105,6 @@ public abstract class SystemPropertiesSupport {
         // Some JDK libraries throws an error if 'java.home' is null.
         initializeProperty("java.home", "undefined");
 
-        String targetName = System.getProperty("svm.targetName");
-        String targetArch = System.getProperty("svm.targetArch");
-        initializeProperty("os.name", targetName != null ? targetName : System.getProperty("os.name"));
-        initializeProperty("os.arch", targetArch != null ? targetArch : System.getProperty("os.arch"));
-
         initializeProperty(ImageInfo.PROPERTY_IMAGE_CODE_KEY, ImageInfo.PROPERTY_IMAGE_CODE_VALUE_RUNTIME);
 
         if (OS.getCurrent() == OS.LINUX || JavaVersionUtil.JAVA_SPEC >= 11) {
@@ -124,6 +120,20 @@ public abstract class SystemPropertiesSupport {
         lazyRuntimeValues.put("java.io.tmpdir", this::tmpdirValue);
         lazyRuntimeValues.put("os.version", this::osVersionValue);
         lazyRuntimeValues.put("java.vm.version", VM::getVersion);
+
+        String targetName = System.getProperty("svm.targetName");
+        if (targetName != null) {
+            initializeProperty("os.name", targetName);
+        } else {
+            lazyRuntimeValues.put("os.name", this::osNameValue);
+        }
+
+        String targetArch = System.getProperty("svm.targetArch");
+        if (targetArch != null) {
+            initializeProperty("os.arch", targetArch);
+        } else {
+            initializeProperty("os.arch", ImageSingletons.lookup(Platform.class).getArchitecture());
+        }
     }
 
     private void ensureFullyInitialized() {
@@ -244,6 +254,8 @@ public abstract class SystemPropertiesSupport {
     protected abstract String userDirValue();
 
     protected abstract String tmpdirValue();
+
+    protected abstract String osNameValue();
 
     protected abstract String osVersionValue();
 }

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/os/IsDefined.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/os/IsDefined.java
@@ -38,12 +38,12 @@ public class IsDefined {
 
     @Fold
     public static final boolean isDarwin() {
-        return Platform.includedIn(Platform.DARWIN.class);
+        return Platform.includedIn(Platform.DARWIN_BASE.class);
     }
 
     @Fold
     public static final boolean isLinux() {
-        return Platform.includedIn(Platform.LINUX.class);
+        return Platform.includedIn(Platform.LINUX_BASE.class);
     }
 
     @Fold

--- a/substratevm/src/com.oracle.svm.driver/src/com/oracle/svm/driver/NativeImage.java
+++ b/substratevm/src/com.oracle.svm.driver/src/com/oracle/svm/driver/NativeImage.java
@@ -71,8 +71,10 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
+import com.oracle.svm.core.util.UserError;
 import org.graalvm.compiler.options.OptionKey;
 import org.graalvm.compiler.serviceprovider.JavaVersionUtil;
+import org.graalvm.nativeimage.Platform;
 import org.graalvm.nativeimage.ProcessProperties;
 
 import com.oracle.graal.pointsto.api.PointstoOptions;
@@ -180,6 +182,7 @@ public class NativeImage {
     final String oRRuntimeJavaArg = oR(Options.FallbackExecutorRuntimeJavaArg);
     final String oHTraceClassInitialization = oH(SubstrateOptions.TraceClassInitialization);
     final String oHTraceObjectInstantiation = oH(SubstrateOptions.TraceObjectInstantiation);
+    final String oHTargetPlatform = oH(SubstrateOptions.TargetPlatform);
 
     /* List arguments */
     final String oHSubstitutionFiles = oH(ConfigurationFiles.Options.SubstitutionFiles);
@@ -746,11 +749,7 @@ public class NativeImage {
         addImageBuilderJavaArgs("-Xshare:off");
         config.getBuilderClasspath().forEach(this::addImageBuilderClasspath);
         config.getImageProvidedClasspath().forEach(this::addImageProvidedClasspath);
-        String clibrariesBuilderArg = config.getBuilderCLibrariesPaths()
-                        .stream()
-                        .map(path -> canonicalize(path.resolve(platform)).toString())
-                        .collect(Collectors.joining(",", oHCLibraryPath, ""));
-        addPlainImageBuilderArg(clibrariesBuilderArg);
+
         if (config.getBuilderInspectServerPath() != null) {
             addPlainImageBuilderArg(oHInspectServerContentPath + config.getBuilderInspectServerPath());
         }
@@ -1041,6 +1040,14 @@ public class NativeImage {
         List<String> leftoverArgs = processNativeImageArgs();
 
         completeOptionArgs();
+        addTargetArguments();
+
+        String clibrariesPath = (targetPlatform != null) ? targetPlatform : platform;
+        String clibrariesBuilderArg = config.getBuilderCLibrariesPaths()
+                        .stream()
+                        .map(path -> canonicalize(path.resolve(clibrariesPath)).toString())
+                        .collect(Collectors.joining(",", oHCLibraryPath, ""));
+        addPlainImageBuilderArg(clibrariesBuilderArg);
 
         if (printFlagsOptionQuery != null) {
             addPlainImageBuilderArg(NativeImage.oH + enablePrintFlags + printFlagsOptionQuery);
@@ -1199,13 +1206,21 @@ public class NativeImage {
         return customImageClasspath.isEmpty();
     }
 
+    private static boolean isListArgumentSet(Collection<String> list, String argPrefix) {
+        return list.stream().anyMatch(arg -> arg.startsWith(argPrefix) && !arg.equals(argPrefix));
+    }
+
     private boolean isListArgumentSet(String argPrefix) {
-        return imageBuilderArgs.stream().anyMatch(arg -> arg.startsWith(argPrefix) && !arg.equals(argPrefix));
+        return isListArgumentSet(imageBuilderArgs, argPrefix);
+    }
+
+    private static String getListArgumentValue(Collection<String> list, String argPrefix) {
+        VMError.guarantee(isListArgumentSet(list, argPrefix));
+        return list.stream().filter(arg -> arg.startsWith(argPrefix)).map(arg -> arg.substring(argPrefix.length())).collect(Collectors.joining());
     }
 
     private String getListArgumentValue(String argPrefix) {
-        VMError.guarantee(isListArgumentSet(argPrefix));
-        return imageBuilderArgs.stream().filter(arg -> arg.startsWith(argPrefix)).map(arg -> arg.substring(argPrefix.length())).collect(Collectors.joining());
+        return getListArgumentValue(imageBuilderArgs, argPrefix);
     }
 
     private List<String> getAgentArguments() {
@@ -1231,6 +1246,43 @@ public class NativeImage {
 
     private static String getAgentOptions(String options, String optionName) {
         return Arrays.stream(options.split(",")).map(option -> optionName + "=" + option).collect(Collectors.joining(","));
+    }
+
+    private String targetPlatform = null;
+    private String targetOS = null;
+    private String targetArch = null;
+
+    private void addTargetArguments() {
+        /*
+         * Since regular hosted options are parsed at a later phase of NativeImageGeneratorRunner
+         * process (see comments for NativeImageGenerator.defaultPlatform), we are parsing the
+         * --target argument here, and generating required internal arguments.
+         */
+
+        if (!isListArgumentSet(oHTargetPlatform)) {
+            return;
+        }
+
+        targetPlatform = getListArgumentValue(oHTargetPlatform).toLowerCase();
+
+        String[] parts = targetPlatform.split("-");
+        if (parts.length != 2) {
+            throw UserError.abort("--target argument must be in format <OS>-<architecture>");
+        }
+
+        targetOS = parts[0];
+        targetArch = parts[1];
+
+        if (isListArgumentSet(customJavaArgs, "-D" + Platform.PLATFORM_PROPERTY_NAME)) {
+            NativeImage.showWarning("Usage of -D" + Platform.PLATFORM_PROPERTY_NAME + " might conflict with --target parameter.");
+        }
+
+        if (targetOS != null) {
+            customJavaArgs.add("-Dsvm.targetPlatformOS=" + targetOS);
+        }
+        if (targetArch != null) {
+            customJavaArgs.add("-Dsvm.targetPlatformArch=" + targetArch);
+        }
     }
 
     private String mainClass;

--- a/substratevm/src/com.oracle.svm.driver/src/com/oracle/svm/driver/NativeImage.java
+++ b/substratevm/src/com.oracle.svm.driver/src/com/oracle/svm/driver/NativeImage.java
@@ -1255,7 +1255,7 @@ public class NativeImage {
     private void addTargetArguments() {
         /*
          * Since regular hosted options are parsed at a later phase of NativeImageGeneratorRunner
-         * process (see comments for NativeImageGenerator.defaultPlatform), we are parsing the
+         * process (see comments for NativeImageGenerator.getTargetPlatform), we are parsing the
          * --target argument here, and generating required internal arguments.
          */
 

--- a/substratevm/src/com.oracle.svm.driver/src/com/oracle/svm/driver/NativeImageServerHelper.java
+++ b/substratevm/src/com.oracle.svm.driver/src/com/oracle/svm/driver/NativeImageServerHelper.java
@@ -37,13 +37,13 @@ import org.graalvm.nativeimage.c.function.CFunction;
 public class NativeImageServerHelper {
     @Fold
     public static boolean isInConfiguration() {
-        return Platform.includedIn(Platform.LINUX.class) || Platform.includedIn(Platform.DARWIN.class);
+        return Platform.includedIn(Platform.LINUX_BASE.class) || Platform.includedIn(Platform.DARWIN_BASE.class);
     }
 
     /*
      * Ensures started server keeps running even after native-image completes.
      */
-    @Platforms({Platform.LINUX.class, Platform.DARWIN.class})
+    @Platforms({Platform.LINUX_BASE.class, Platform.DARWIN_BASE.class})
     static int daemonize(Runnable runnable) {
         int pid = Unistd.fork();
         switch (pid) {
@@ -62,7 +62,7 @@ public class NativeImageServerHelper {
     }
 }
 
-@Platforms({Platform.LINUX.class, Platform.DARWIN.class})
+@Platforms({Platform.LINUX_BASE.class, Platform.DARWIN_BASE.class})
 class UnistdDirectives implements CContext.Directives {
     @Override
     public boolean isInConfiguration() {
@@ -80,7 +80,7 @@ class UnistdDirectives implements CContext.Directives {
     }
 }
 
-@Platforms({Platform.LINUX.class, Platform.DARWIN.class})
+@Platforms({Platform.LINUX_BASE.class, Platform.DARWIN_BASE.class})
 @CContext(UnistdDirectives.class)
 class Unistd {
     /**

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/NativeImageGenerator.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/NativeImageGenerator.java
@@ -45,6 +45,7 @@ import java.util.EnumSet;
 import java.util.List;
 import java.util.ListIterator;
 import java.util.Map;
+import java.util.ServiceLoader;
 import java.util.Set;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.ExecutionException;
@@ -335,6 +336,17 @@ public class NativeImageGenerator {
         return (Platform) result;
     }
 
+    public static Platform loadPlatform(String os, String arch) {
+        ServiceLoader<Platform> loader = ServiceLoader.load(Platform.class);
+        for (Platform platform : loader) {
+            if (platform.getOS().equals(os) && platform.getArchitecture().equals(arch)) {
+                return platform;
+            }
+        }
+        throw UserError.abort("Platform specified as " + os + "-" + arch +
+                        " isn't supported.");
+    }
+
     public static Platform getTargetPlatform(ClassLoader classLoader) {
         /*
          * We cannot use a regular hosted option for the platform class: The code that instantiates
@@ -363,13 +375,7 @@ public class NativeImageGenerator {
             arch = System.getProperty("os.arch");
         }
 
-        platformClassName = "org.graalvm.nativeimage.Platform$" + os.toUpperCase() + "_" + arch.toUpperCase();
-        try {
-            return loadPlatform(classLoader, platformClassName);
-        } catch (ClassNotFoundException ex) {
-            throw UserError.abort("Platform specified as " + os + "-" + arch +
-                            " isn't supported.");
-        }
+        return loadPlatform(os, arch);
     }
 
     /**

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/NativeImageGenerator.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/NativeImageGenerator.java
@@ -156,7 +156,6 @@ import com.oracle.svm.core.ClassLoaderQuery;
 import com.oracle.svm.core.FrameAccess;
 import com.oracle.svm.core.JavaMainWrapper.JavaMainSupport;
 import com.oracle.svm.core.LinkerInvocation;
-import com.oracle.svm.core.OS;
 import com.oracle.svm.core.SubstrateOptions;
 import com.oracle.svm.core.SubstrateTargetDescription;
 import com.oracle.svm.core.SubstrateUtil;
@@ -318,56 +317,58 @@ public class NativeImageGenerator {
         optionProvider.getRuntimeValues().put(GraalOptions.EagerSnippets, true);
     }
 
-    public static Platform defaultPlatform(ClassLoader classLoader) {
+    public static Platform loadPlatform(ClassLoader classLoader, String platformClassName) throws ClassNotFoundException {
+        Class<?> platformClass;
+
+        platformClass = classLoader.loadClass(platformClassName);
+
+        Object result;
+        try {
+            result = ReflectionUtil.newInstance(platformClass);
+        } catch (ReflectionUtilError ex) {
+            throw UserError.abort(ex.getCause(), "Could not instantiate platform class %s. Ensure the class is not abstract and has a no-argument constructor.", platformClassName);
+        }
+
+        if (!(result instanceof Platform)) {
+            throw UserError.abort("Platform class %s does not implement %s", platformClassName, Platform.class.getTypeName());
+        }
+        return (Platform) result;
+    }
+
+    public static Platform getTargetPlatform(ClassLoader classLoader) {
         /*
          * We cannot use a regular hosted option for the platform class: The code that instantiates
          * the platform class runs before options are parsed, because option parsing depends on the
          * platform (there can be platform-specific options). So we need to use a regular system
          * property to specify a platform class explicitly on the command line.
          */
+
         String platformClassName = System.getProperty(Platform.PLATFORM_PROPERTY_NAME);
         if (platformClassName != null) {
-            Class<?> platformClass;
             try {
-                platformClass = classLoader.loadClass(platformClassName);
+                return loadPlatform(classLoader, platformClassName);
             } catch (ClassNotFoundException ex) {
                 throw UserError.abort("Could not find platform class %s that was specified explicitly on the command line using the system property %s",
                                 platformClassName, Platform.PLATFORM_PROPERTY_NAME);
             }
-
-            Object result;
-            try {
-                result = ReflectionUtil.newInstance(platformClass);
-            } catch (ReflectionUtilError ex) {
-                throw UserError.abort(ex.getCause(), "Could not instantiate platform class %s. Ensure the class is not abstract and has a no-argument constructor.", platformClassName);
-            }
-
-            if (!(result instanceof Platform)) {
-                throw UserError.abort("Platform class %s does not implement %s", platformClassName, Platform.class.getTypeName());
-            }
-            return (Platform) result;
         }
 
-        final Architecture hostedArchitecture = GraalAccess.getOriginalTarget().arch;
-        final OS currentOs = OS.getCurrent();
-        if (hostedArchitecture instanceof AMD64) {
-            if (currentOs == OS.LINUX) {
-                return new Platform.LINUX_AMD64();
-            } else if (currentOs == OS.DARWIN) {
-                return new Platform.DARWIN_AMD64();
-            } else if (currentOs == OS.WINDOWS) {
-                return new Platform.WINDOWS_AMD64();
-            } else {
-                throw VMError.shouldNotReachHere("Unsupported architecture/operating system: " + hostedArchitecture.getName() + "/" + currentOs.className);
-            }
-        } else if (hostedArchitecture instanceof AArch64) {
-            if (OS.getCurrent() == OS.LINUX) {
-                return new Platform.LINUX_AARCH64();
-            } else {
-                throw VMError.shouldNotReachHere("Unsupported architecture/operating system: " + hostedArchitecture.getName() + "/" + currentOs.className);
-            }
-        } else {
-            throw VMError.shouldNotReachHere("Unsupported architecture: " + hostedArchitecture.getClass().getSimpleName());
+        String os = System.getProperty("svm.targetPlatformOS");
+        if (os == null) {
+            os = System.getProperty("os.name").toLowerCase();
+        }
+
+        String arch = System.getProperty("svm.targetPlatformArch");
+        if (arch == null) {
+            arch = System.getProperty("os.arch");
+        }
+
+        platformClassName = "org.graalvm.nativeimage.Platform$" + os.toUpperCase() + "_" + arch.toUpperCase();
+        try {
+            return loadPlatform(classLoader, platformClassName);
+        } catch (ClassNotFoundException ex) {
+            throw UserError.abort("Platform specified as " + os + "-" + arch +
+                            " isn't supported.");
         }
     }
 

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/NativeImageGeneratorRunner.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/NativeImageGeneratorRunner.java
@@ -169,7 +169,7 @@ public class NativeImageGeneratorRunner implements ImageBuildTask {
          */
         NativeImageGenerator.setSystemPropertiesForImageEarly();
 
-        return new ImageClassLoader(NativeImageGenerator.defaultPlatform(nativeImageClassLoader), nativeImageClassLoaderSupport);
+        return new ImageClassLoader(NativeImageGenerator.getTargetPlatform(nativeImageClassLoader), nativeImageClassLoaderSupport);
     }
 
     public static String[] extractImagePathEntries(List<String> arguments, String pathPrefix) {

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/c/CAnnotationProcessor.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/c/CAnnotationProcessor.java
@@ -158,7 +158,7 @@ public class CAnnotationProcessor {
         Path binary = tempDirectory.resolve(compilerInvoker.asExecutableName(fileName.substring(0, fileName.lastIndexOf("."))));
         ArrayList<String> options = new ArrayList<>();
         options.addAll(codeCtx.getDirectives().getOptions());
-        if (Platform.includedIn(Platform.LINUX.class)) {
+        if (Platform.includedIn(Platform.LINUX_BASE.class)) {
             options.addAll(LibCBase.singleton().getAdditionalQueryCodeCompilerOptions());
         }
         compilerInvoker.compileAndParseError(SubstrateOptions.StrictQueryCodeCompilation.getValue(), options, queryFile, binary, this::reportCompilerError);

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/c/CAnnotationProcessorCache.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/c/CAnnotationProcessorCache.java
@@ -39,6 +39,7 @@ import java.nio.file.SimpleFileVisitor;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.List;
 
+import org.graalvm.collections.UnmodifiableEconomicMap;
 import org.graalvm.compiler.options.Option;
 
 import com.oracle.svm.core.option.HostedOptionKey;
@@ -46,6 +47,10 @@ import com.oracle.svm.core.option.SubstrateOptionsParser;
 import com.oracle.svm.core.util.UserError;
 import com.oracle.svm.hosted.c.info.NativeCodeInfo;
 import com.oracle.svm.hosted.c.query.QueryResultParser;
+import org.graalvm.compiler.options.OptionKey;
+import org.graalvm.compiler.options.OptionValues;
+import org.graalvm.nativeimage.ImageSingletons;
+import org.graalvm.nativeimage.Platform;
 
 /**
  * Cache of pre-computed information for the {@link CAnnotationProcessor}. The cache is helpful to
@@ -66,7 +71,23 @@ public final class CAnnotationProcessorCache {
 
     public static class Options {
         @Option(help = "Indicate the C Annotation Processor to use previously cached native information when generating C Type information.")//
-        public static final HostedOptionKey<Boolean> UseCAPCache = new HostedOptionKey<>(false);
+        public static final HostedOptionKey<Boolean> UseCAPCache = new HostedOptionKey<Boolean>(false) {
+            @Override
+            public Boolean getValueOrDefault(UnmodifiableEconomicMap<OptionKey<?>, Object> values) {
+                if (!values.containsKey(this)) {
+                    return !NewCAPCache.getValue() && !ExitAfterQueryCodeGeneration.getValue() &&
+                                    !ImageSingletons.lookup(Platform.class).getArchitecture().equals(System.getProperty("os.arch"));
+                    // We need CAP cache for cross-arch builds, since we cannot run query code.
+                }
+                return (Boolean) values.get(this);
+            }
+
+            @Override
+            public Boolean getValue(OptionValues values) {
+                assert checkDescriptorExists();
+                return getValueOrDefault(values.getMap());
+            }
+        };
 
         @Option(help = "Create a C Annotation Processor Cache. Will erase any previous cache at that same location.")//
         public static final HostedOptionKey<Boolean> NewCAPCache = new HostedOptionKey<>(false);
@@ -89,7 +110,8 @@ public final class CAnnotationProcessorCache {
 
     public CAnnotationProcessorCache() {
         if ((Options.UseCAPCache.getValue() || Options.NewCAPCache.getValue())) {
-            if (Options.CAPCacheDir.getValue() == null || Options.CAPCacheDir.getValue().isEmpty()) {
+            if (!Options.ExitAfterQueryCodeGeneration.getValue() &&
+                            (Options.CAPCacheDir.getValue() == null || Options.CAPCacheDir.getValue().isEmpty())) {
                 throw UserError.abort("Path to C Annotation Processor Cache must be specified using %s when the option %s or %s is used.",
                                 SubstrateOptionsParser.commandArgument(Options.CAPCacheDir, ""), SubstrateOptionsParser.commandArgument(Options.UseCAPCache, "+"),
                                 SubstrateOptionsParser.commandArgument(Options.NewCAPCache, "+"));

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/c/NativeLibraries.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/c/NativeLibraries.java
@@ -293,7 +293,7 @@ public final class NativeLibraries {
         if (JavaVersionUtil.JAVA_SPEC > 8) {
             Path staticLibPath = baseSearchPath.resolve("static");
             Path platformDependentPath = staticLibPath.resolve((ImageSingletons.lookup(Platform.class).getOS() + "-" + ImageSingletons.lookup(Platform.class).getArchitecture()).toLowerCase());
-            if (ImageSingletons.lookup(Platform.class) instanceof Platform.LINUX) {
+            if (ImageSingletons.lookup(Platform.class) instanceof Platform.LINUX_BASE) {
                 platformDependentPath = platformDependentPath.resolve(LibCBase.singleton().getName());
                 if (LibCBase.singleton().requiresLibCSpecificStaticJDKLibraries()) {
                     return platformDependentPath;
@@ -341,7 +341,7 @@ public final class NativeLibraries {
                             !CAnnotationProcessorCache.Options.ExitAfterCAPCache.getValue()) {
                 /* Fail if we will statically link JDK libraries but do not have them available */
                 String libCMessage = "";
-                if (Platform.includedIn(Platform.LINUX.class)) {
+                if (Platform.includedIn(Platform.LINUX_BASE.class)) {
                     libCMessage = " (target libc: " + LibCBase.singleton().getName() + ")";
                 }
                 String jdkDownloadURL = (JavaVersionUtil.JAVA_SPEC > 8 ? JVMCIVersionCheck.JVMCI11_RELEASES_URL : JVMCIVersionCheck.JVMCI8_RELEASES_URL);

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/c/codegen/CCompilerInvoker.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/c/codegen/CCompilerInvoker.java
@@ -237,7 +237,7 @@ public abstract class CCompilerInvoker {
                 }
 
                 String[] triplet = guessTargetTriplet(scanner);
-                while (scanner.findInLine("gcc version ") == null || scanner.findInLine("clang version ") == null) {
+                while (scanner.findInLine("gcc version ") == null) {
                     scanner.nextLine();
                 }
 

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/c/codegen/CCompilerInvoker.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/c/codegen/CCompilerInvoker.java
@@ -226,10 +226,21 @@ public abstract class CCompilerInvoker {
                     int minor1 = scanner.nextInt();
                     return new CompilerInfo(compilerPath, "intel", "Intel(R) C++ Compiler", "icc", major, minor0, minor1, "x86_64");
                 }
+
+                if (scanner.findInLine("clang version ") != null) {
+                    scanner.useDelimiter("[. ]");
+                    int major = scanner.nextInt();
+                    int minor0 = scanner.nextInt();
+                    int minor1 = scanner.nextInt();
+                    String[] triplet = guessTargetTriplet(scanner);
+                    return new CompilerInfo(compilerPath, "llvm", "Clang C++ Compiler", "clang", major, minor0, minor1, triplet[0]);
+                }
+
                 String[] triplet = guessTargetTriplet(scanner);
-                while (scanner.findInLine("gcc version ") == null) {
+                while (scanner.findInLine("gcc version ") == null || scanner.findInLine("clang version ") == null) {
                     scanner.nextLine();
                 }
+
                 scanner.useDelimiter("[. ]");
                 int major = scanner.nextInt();
                 int minor0 = scanner.nextInt();

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/c/codegen/CSourceCodeWriter.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/c/codegen/CSourceCodeWriter.java
@@ -83,7 +83,7 @@ public class CSourceCodeWriter {
 
     public void writeCStandardHeaders() {
         if (NativeImageOptions.getCStandard().compatibleWith(C99)) {
-            if (!Platform.includedIn(Platform.WINDOWS.class)) {
+            if (!Platform.includedIn(Platform.WINDOWS_BASE.class)) {
                 /*
                  * CStandard says we are C99 compatible yet we cannot include stdbool.h because old
                  * Windows native compilers do not support it. This should be fixed.

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/c/codegen/QueryCodeWriter.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/c/codegen/QueryCodeWriter.java
@@ -70,7 +70,7 @@ public class QueryCodeWriter extends InfoTreeVisitor {
     public QueryCodeWriter(Path tempDirectory) {
         writer = new CSourceCodeWriter(tempDirectory);
         elementForLineNumber = new ArrayList<>();
-        isWindows = Platform.includedIn(Platform.WINDOWS.class);
+        isWindows = Platform.includedIn(Platform.WINDOWS_BASE.class);
 
         String formatL64 = "%" + (isWindows ? "ll" : "l");
         formatSInt64 = formatL64 + "d";

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/image/NativeBootImageViaCC.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/image/NativeBootImageViaCC.java
@@ -83,7 +83,7 @@ public abstract class NativeBootImageViaCC extends NativeBootImage {
          * The Darwin linker sometimes segfaults when option -dead_strip is used. Thus, Linux is the
          * only platform were RemoveUnusedSymbols can be safely enabled per default.
          */
-        return Platform.includedIn(Platform.LINUX.class);
+        return Platform.includedIn(Platform.LINUX_BASE.class);
     }
 
     class BinutilsCCLinkerInvocation extends CCLinkerInvocation {
@@ -232,7 +232,7 @@ public abstract class NativeBootImageViaCC extends NativeBootImage {
                     throw UserError.abort("%s does not support building static executable images.", OS.getCurrent().name());
                 case SHARED_LIBRARY:
                     cmd.add("-shared");
-                    if (Platform.includedIn(Platform.DARWIN.class)) {
+                    if (Platform.includedIn(Platform.DARWIN_BASE.class)) {
                         cmd.add("-undefined");
                         cmd.add("dynamic_lookup");
                     }

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/image/NativeBootImageViaCC.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/image/NativeBootImageViaCC.java
@@ -43,6 +43,7 @@ import java.util.stream.Collectors;
 
 import org.graalvm.compiler.debug.DebugContext;
 import org.graalvm.compiler.debug.Indent;
+import org.graalvm.nativeimage.ImageSingletons;
 import org.graalvm.nativeimage.Platform;
 
 import com.oracle.objectfile.ObjectFile;
@@ -333,6 +334,10 @@ public abstract class NativeBootImageViaCC extends NativeBootImage {
                 break;
         }
 
+        if (SubstrateOptions.AdditionalLinkerOptions.hasBeenSet()) {
+            inv.additionalPreOptions.add(SubstrateOptions.AdditionalLinkerOptions.getValue());
+        }
+
         Path outputFile = outputDirectory.resolve(imageName + getBootImageKind().getFilenameSuffix());
         UserError.guarantee(!Files.isDirectory(outputFile), "Cannot write image to %s. Path exists as directory. (Use -H:Name=<image name>)", outputFile);
         inv.setOutputFile(outputFile);
@@ -349,6 +354,10 @@ public abstract class NativeBootImageViaCC extends NativeBootImage {
         }
 
         for (String library : nativeLibs.getLibraries()) {
+            if (ImageSingletons.lookup(Platform.class) instanceof Platform.ANDROID &&
+                            (library.equals("pthread") || library.equals("rt"))) {
+                continue;
+            }
             inv.addLinkedLibrary(library);
         }
 

--- a/substratevm/src/com.oracle.svm.thirdparty/src/com/oracle/svm/thirdparty/jline/JLineFeature.java
+++ b/substratevm/src/com.oracle.svm.thirdparty/src/com/oracle/svm/thirdparty/jline/JLineFeature.java
@@ -84,7 +84,7 @@ final class JLineFeature implements Feature {
 
     @Override
     public void duringSetup(DuringSetupAccess access) {
-        if (Platform.includedIn(Platform.WINDOWS.class)) {
+        if (Platform.includedIn(Platform.WINDOWS_BASE.class)) {
             Stream.concat(JNI_CLASS_NAMES.stream(), RUNTIME_INIT_CLASS_NAMES.stream())
                             .map(access::findClassByName)
                             .filter(Objects::nonNull)
@@ -99,7 +99,7 @@ final class JLineFeature implements Feature {
                         .toArray();
         access.registerReachabilityHandler(JLineFeature::registerTerminalConstructor, createMethods);
 
-        if (Platform.includedIn(Platform.WINDOWS.class)) {
+        if (Platform.includedIn(Platform.WINDOWS_BASE.class)) {
             /*
              * Each listed class has a native method named "init" that initializes all declared
              * fields of the class using JNI. So when the "init" method gets reachable (which means
@@ -121,7 +121,7 @@ final class JLineFeature implements Feature {
          * implementation class, they also need to provide a reflection configuration for that
          * class.
          */
-        Class<?> terminalClass = access.findClassByName(Platform.includedIn(Platform.WINDOWS.class) ? "jline.AnsiWindowsTerminal" : "jline.UnixTerminal");
+        Class<?> terminalClass = access.findClassByName(Platform.includedIn(Platform.WINDOWS_BASE.class) ? "jline.AnsiWindowsTerminal" : "jline.UnixTerminal");
         if (terminalClass != null) {
             RuntimeReflection.register(terminalClass);
             RuntimeReflection.register(terminalClass.getDeclaredConstructors());

--- a/substratevm/src/com.oracle.svm.truffle.nfi.posix/src/com/oracle/svm/truffle/nfi/posix/PosixTruffleNFIFeature.java
+++ b/substratevm/src/com.oracle.svm.truffle.nfi.posix/src/com/oracle/svm/truffle/nfi/posix/PosixTruffleNFIFeature.java
@@ -52,7 +52,7 @@ import com.oracle.svm.truffle.nfi.TruffleNFISupport;
 import com.oracle.truffle.api.CompilerDirectives;
 
 @AutomaticFeature
-@Platforms({Platform.LINUX.class, Platform.DARWIN.class})
+@Platforms({Platform.LINUX_BASE.class, Platform.DARWIN_BASE.class})
 public final class PosixTruffleNFIFeature implements Feature {
 
     @Override
@@ -69,7 +69,7 @@ final class PosixTruffleNFISupport extends TruffleNFISupport {
     static int isolatedNamespaceFlag = ISOLATED_NAMESPACE_NOT_SUPPORTED_FLAG;
 
     static void initialize() {
-        if (Platform.includedIn(Platform.LINUX.class)) {
+        if (Platform.includedIn(Platform.LINUX_BASE.class)) {
             isolatedNamespaceFlag = LibCBase.singleton().hasIsolatedNamespaces() ? ISOLATED_NAMESPACE_FLAG : ISOLATED_NAMESPACE_NOT_SUPPORTED_FLAG;
         }
         ImageSingletons.add(TruffleNFISupport.class, new PosixTruffleNFISupport());
@@ -80,10 +80,10 @@ final class PosixTruffleNFISupport extends TruffleNFISupport {
     }
 
     private static String getErrnoGetterFunctionName() {
-        if (Platform.includedIn(Platform.LINUX.class)) {
+        if (Platform.includedIn(Platform.LINUX_BASE.class)) {
             return "__errno_location";
         }
-        if (Platform.includedIn(Platform.DARWIN.class)) {
+        if (Platform.includedIn(Platform.DARWIN_BASE.class)) {
             return "__error";
         }
         throw VMError.unsupportedFeature("unsupported platform for TruffleNFIFeature");
@@ -144,7 +144,7 @@ final class PosixTruffleNFISupport extends TruffleNFISupport {
     @Override
     protected long loadLibraryImpl(long nativeContext, String name, int flags) {
         PointerBase handle;
-        if (Platform.includedIn(Platform.LINUX.class) && LibCBase.targetLibCIs(GLibC.class) && (flags & isolatedNamespaceFlag) != 0) {
+        if (Platform.includedIn(Platform.LINUX_BASE.class) && LibCBase.targetLibCIs(GLibC.class) && (flags & isolatedNamespaceFlag) != 0) {
             handle = loadLibraryInNamespace(nativeContext, name, flags & ~isolatedNamespaceFlag);
         } else {
             handle = PosixUtils.dlopen(name, flags);

--- a/substratevm/src/com.oracle.svm.truffle.nfi.posix/src/com/oracle/svm/truffle/nfi/posix/Target_com_oracle_truffle_nfi_impl_NFIContextLinux.java
+++ b/substratevm/src/com.oracle.svm.truffle.nfi.posix/src/com/oracle/svm/truffle/nfi/posix/Target_com_oracle_truffle_nfi_impl_NFIContextLinux.java
@@ -32,7 +32,7 @@ import com.oracle.svm.core.annotate.InjectAccessors;
 import com.oracle.svm.core.annotate.TargetClass;
 import com.oracle.svm.truffle.nfi.TruffleNFIFeature;
 
-@Platforms(Platform.LINUX.class)
+@Platforms(Platform.LINUX_BASE.class)
 @TargetClass(className = "com.oracle.truffle.nfi.impl.NFIContext", onlyWith = TruffleNFIFeature.IsEnabled.class)
 final class Target_com_oracle_truffle_nfi_impl_NFIContextLinux {
 

--- a/substratevm/src/com.oracle.svm.truffle.nfi.posix/src/com/oracle/svm/truffle/nfi/posix/Target_com_oracle_truffle_nfi_impl_NFIContextPosix.java
+++ b/substratevm/src/com.oracle.svm.truffle.nfi.posix/src/com/oracle/svm/truffle/nfi/posix/Target_com_oracle_truffle_nfi_impl_NFIContextPosix.java
@@ -34,7 +34,7 @@ import com.oracle.svm.core.posix.headers.Dlfcn;
 import com.oracle.svm.truffle.nfi.TruffleNFIFeature;
 
 @TargetClass(className = "com.oracle.truffle.nfi.impl.NFIContext", onlyWith = TruffleNFIFeature.IsEnabled.class)
-@Platforms({Platform.LINUX.class, Platform.DARWIN.class})
+@Platforms({Platform.LINUX_BASE.class, Platform.DARWIN_BASE.class})
 final class Target_com_oracle_truffle_nfi_impl_NFIContextPosix {
 
     // Checkstyle: stop

--- a/substratevm/src/com.oracle.svm.truffle.nfi.windows/src/com/oracle/svm/truffle/nfi/windows/WindowsTruffleNFIFeature.java
+++ b/substratevm/src/com.oracle.svm.truffle.nfi.windows/src/com/oracle/svm/truffle/nfi/windows/WindowsTruffleNFIFeature.java
@@ -45,7 +45,7 @@ import com.oracle.svm.truffle.nfi.TruffleNFISupport;
 import com.oracle.truffle.api.CompilerDirectives;
 
 @AutomaticFeature
-@Platforms(Platform.WINDOWS.class)
+@Platforms(Platform.WINDOWS_BASE.class)
 public final class WindowsTruffleNFIFeature implements Feature {
 
     @Override

--- a/substratevm/src/org.graalvm.polyglot.nativeapi/src/org/graalvm/polyglot/nativeapi/PolyglotNativeAPIFeature.java
+++ b/substratevm/src/org.graalvm.polyglot.nativeapi/src/org/graalvm/polyglot/nativeapi/PolyglotNativeAPIFeature.java
@@ -65,7 +65,7 @@ public class PolyglotNativeAPIFeature implements Feature {
                 throw new RuntimeException(e);
             }
         });
-        if (Platform.includedIn(Platform.DARWIN.class)) {
+        if (Platform.includedIn(Platform.DARWIN_BASE.class)) {
             // on Darwin, change the `id` install name
             String id = System.getProperty("org.graalvm.polyglot.install_name_id");
             if (id == null) {


### PR DESCRIPTION
This PR adds `--target` API option which is used to specify compilation target platform for `native-image`

Usage: 
```
native-image --target=linux-amd64 HelloWorld
```