### PR TITLE
Replace getdtablesize with sysconf(_SC_OPEN_MAX)

### DIFF
--- a/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/PosixSubstrateOperatingSystemMXBean.java
+++ b/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/PosixSubstrateOperatingSystemMXBean.java
@@ -80,7 +80,7 @@ class PosixSubstrateOperatingSystemMXBean extends SubstrateOperatingSystemMXBean
 
     @Override
     public long getOpenFileDescriptorCount() {
-        int maxFileDescriptor = Unistd.getdtablesize();
+        int maxFileDescriptor = (int)Unistd.sysconf(Unistd._SC_OPEN_MAX());
         long count = 0;
         for (int i = 0; i <= maxFileDescriptor; i++) {
             if (fstat(i) == 0 || CErrorNumber.getCErrorNumber() != Errno.EBADF()) {

--- a/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/PosixSubstrateOperatingSystemMXBean.java
+++ b/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/PosixSubstrateOperatingSystemMXBean.java
@@ -80,7 +80,7 @@ class PosixSubstrateOperatingSystemMXBean extends SubstrateOperatingSystemMXBean
 
     @Override
     public long getOpenFileDescriptorCount() {
-        int maxFileDescriptor = (int)Unistd.sysconf(Unistd._SC_OPEN_MAX());
+        int maxFileDescriptor = (int) Unistd.sysconf(Unistd._SC_OPEN_MAX());
         long count = 0;
         for (int i = 0; i <= maxFileDescriptor; i++) {
             if (fstat(i) == 0 || CErrorNumber.getCErrorNumber() != Errno.EBADF()) {

--- a/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/headers/Unistd.java
+++ b/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/headers/Unistd.java
@@ -113,9 +113,6 @@ public class Unistd {
     public static native int getpagesize();
 
     @CFunction
-    public static native int getdtablesize();
-
-    @CFunction
     public static native int sleep(int seconds);
 
     public static class NoTransitions {

--- a/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/headers/Unistd.java
+++ b/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/headers/Unistd.java
@@ -66,6 +66,9 @@ public class Unistd {
     public static native int _SC_CLK_TCK();
 
     @CConstant
+    public static native int _SC_OPEN_MAX();
+
+    @CConstant
     public static native int _SC_PAGESIZE();
 
     @CConstant


### PR DESCRIPTION
Replace getdtablesize with sysconf(_SC_OPEN_MAX)
Fix for #2812