### PR TITLE
Use the correct UserError.abort API

### DIFF
--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/config/ConfigurationParserUtils.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/config/ConfigurationParserUtils.java
@@ -35,6 +35,7 @@ import java.net.URLConnection;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Collections;
 import java.util.Enumeration;
 import java.util.Spliterator;
 import java.util.Spliterators.AbstractSpliterator;
@@ -135,9 +136,9 @@ public final class ConfigurationParserUtils {
             if (errorMessage == null || errorMessage.isEmpty()) {
                 errorMessage = e.toString();
             }
-            throw UserError.abort("Error parsing " + featureName + " configuration in " + location + ":\n" + errorMessage +
-                            "\nVerify that the configuration matches the schema described in the " +
-                            SubstrateOptionsParser.commandArgument(PrintFlags, "+") + " output for option " + option.getName() + ".");
+            throw UserError.abort(Collections.singleton(
+                            "Error parsing " + featureName + " configuration in " + location + ":\n" + errorMessage + "\nVerify that the configuration matches the schema described in the " +
+                                            SubstrateOptionsParser.commandArgument(PrintFlags, "+") + " output for option " + option.getName() + "."));
         }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/oracle/graal/issues/2836

Hello @dougxc, @cstancu, the commit in this PR should fix the error reported in that linked issue. This now uses an API which doesn't consider the passed string as a "format specifier" and instead considers it a message.