### PR TITLE
Don't use a container image to produce the native-images

### DIFF
--- a/.github/workflows/quarkus.yml
+++ b/.github/workflows/quarkus.yml
@@ -16,7 +16,7 @@ env:
   DB_USER: hibernate_orm_test
   DB_PASSWORD: hibernate_orm_test
   DB_NAME: hibernate_orm_test
-  NATIVE_TEST_MAVEN_OPTS: "-B --settings ${GITHUB_WORKSPACE}/quarkus/.github/mvn-settings.xml --fail-at-end -Dquarkus.native.container-build=true -Dtest-postgresql -Dtest-elasticsearch -Dtest-keycloak -Dtest-amazon-services -Dtest-db2 -Dtest-mysql -Dtest-mariadb -Dmariadb.base_url='jdbc:mariadb://localhost:3308' -Dmariadb.url='jdbc:mariadb://localhost:3308/hibernate_orm_test'  -Dtest-mssql -Dtest-vault -Dtest-neo4j -Dtest-kafka -Dtest-redis -Dnative-image.xmx=5g -Dnative -Dnative.surefire.skip -Dformat.skip -Dno-descriptor-tests install"
+  NATIVE_TEST_MAVEN_OPTS: "-B --settings ${GITHUB_WORKSPACE}/quarkus/.github/mvn-settings.xml --fail-at-end -Dtest-postgresql -Dtest-elasticsearch -Dtest-keycloak -Dtest-amazon-services -Dtest-db2 -Dtest-mysql -Dtest-mariadb -Dmariadb.base_url='jdbc:mariadb://localhost:3308' -Dmariadb.url='jdbc:mariadb://localhost:3308/hibernate_orm_test'  -Dtest-mssql -Dtest-vault -Dtest-neo4j -Dtest-kafka -Dtest-redis -Dnative-image.xmx=5g -Dnative -Dnative.surefire.skip -Dformat.skip -Dno-descriptor-tests install"
   MX_GIT_CACHE: refcache
 
 jobs:
@@ -368,7 +368,7 @@ jobs:
           # done because there is no good way to pass strings with empty values to the previous command
           # so this hack is as good as any
           if [ "$CATEGORY" == "Misc1" ]; then
-            mvn -Dnative -Dquarkus.native.container-build=true -B --settings ${GITHUB_WORKSPACE}/quarkus/.github/mvn-settings.xml -f 'integration-tests/simple with space/' verify
+            mvn -Dnative -B --settings ${GITHUB_WORKSPACE}/quarkus/.github/mvn-settings.xml -f 'integration-tests/simple with space/' verify
           fi
       - name: Prepare failure archive (if maven failed)
         if: failure()


### PR DESCRIPTION
Currently the workflow uses `-Dquarkus.native.container-build=true`
which uses a container image from
https://quay.io/repository/quarkus/ubi-quarkus-native-image?tab=tags
instead of using the build we just created.