### PR TITLE
Include a setter for @InjectAccessors for ThreadLocalRandomAccessors

### DIFF
--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/ThreadLocalRandomAccessors.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/ThreadLocalRandomAccessors.java
@@ -55,6 +55,16 @@ public class ThreadLocalRandomAccessors extends RandomAccessors {
         return SINGLETON.getOrInitializeSeeder();
     }
 
+    /**
+     * This set-accessor is just here to satisfy the contract of @InjectAccessors for
+     * ThreadLocalRandom.seeder. The seeder is actually set/initialized whenever the getSeeder
+     * accessor is called
+     */
+    @SuppressWarnings("unused")
+    public static void setSeeder(final AtomicLong seeder) {
+        // no-op
+    }
+
     @Override
     long mix64(long l) {
         return Target_java_util_concurrent_ThreadLocalRandom.mix64(l);


### PR DESCRIPTION
Fixes https://github.com/oracle/graal/issues/2841

Hello @cstancu, this fixes the issue reported in that linked issue. I was able to reproduce the issue against Quarkus and was to verify that the native build succeeds after this change. I haven't run the full round of runtime tests to verify more though.