### PR TITLE
Rename HotSpotIntrinsicCandidate to IntrinsicCandidate

### DIFF
--- a/compiler/src/org.graalvm.compiler.replacements.amd64/src/org/graalvm/compiler/replacements/amd64/AMD64StringLatin1Substitutions.java
+++ b/compiler/src/org.graalvm.compiler.replacements.amd64/src/org/graalvm/compiler/replacements/amd64/AMD64StringLatin1Substitutions.java
@@ -131,7 +131,7 @@ public class AMD64StringLatin1Substitutions {
      * Intrinsic for {@code java.lang.StringLatin1.inflate([BI[CII)V}.
      *
      * <pre>
-     * &#64;HotSpotIntrinsicCandidate
+     * &#64;IntrinsicCandidate
      * public static void inflate(byte[] src, int src_indx, char[] dst, int dst_indx, int len)
      * </pre>
      */
@@ -155,7 +155,7 @@ public class AMD64StringLatin1Substitutions {
      * Intrinsic for {@code }java.lang.StringLatin1.inflate([BI[BII)V}.
      *
      * <pre>
-     * &#64;HotSpotIntrinsicCandidate
+     * &#64;IntrinsicCandidate
      * public static void inflate(byte[] src, int src_indx, byte[] dst, int dst_indx, int len)
      * </pre>
      *

--- a/compiler/src/org.graalvm.compiler.replacements.amd64/src/org/graalvm/compiler/replacements/amd64/AMD64StringUTF16Substitutions.java
+++ b/compiler/src/org.graalvm.compiler.replacements.amd64/src/org/graalvm/compiler/replacements/amd64/AMD64StringUTF16Substitutions.java
@@ -154,7 +154,7 @@ public class AMD64StringUTF16Substitutions {
      * Intrinsic for {@code java.lang.StringUTF16.compress([CI[BII)I}.
      *
      * <pre>
-     * &#64;HotSpotIntrinsicCandidate
+     * &#64;IntrinsicCandidate
      * public static int compress(char[] src, int src_indx, byte[] dst, int dst_indx, int len)
      * </pre>
      */
@@ -171,7 +171,7 @@ public class AMD64StringUTF16Substitutions {
      * Intrinsic for {@code }java.lang.StringUTF16.compress([BI[BII)I}.
      *
      * <pre>
-     * &#64;HotSpotIntrinsicCandidate
+     * &#64;IntrinsicCandidate
      * public static int compress(byte[] src, int src_indx, byte[] dst, int dst_indx, int len)
      * </pre>
      * <p>


### PR DESCRIPTION
JDK-8138732 renames HotSpotIntrinsicCandidate to IntrinsicCandidate and moves it to jdk.internal.vm.annotation.

It only seems to be referenced in comments. This change avoids the changes being overwritten the next time a "Update Graal" is done in the JDK.

See https://github.com/openjdk/jdk/pull/45