### PR TITLE
Edited ProloGraal repository link

### DIFF
--- a/truffle/docs/Languages.md
+++ b/truffle/docs/Languages.md
@@ -29,7 +29,7 @@ The following language implementations exist already:
 * [Mozart-Graal](https://github.com/eregon/mozart-graal), an implementation of the Oz programming language.
 * [Mumbler](https://github.com/cesquivias/mumbler), an experimental Lisp programming language.
 * [PorcE](https://github.com/orc-lang/orc/tree/master/PorcE), an Orc language implementation.
-* [ProloGraal](https://gitlab.forge.hefr.ch/tony.licata/prolog-truffle) a Prolog language implementation supporting interoperability.
+* [ProloGraal](https://github.com/LicataT/ProloGraal) a Prolog language implementation supporting interoperability.
 * [PureScript](https://github.com/slamdata/truffled-purescript), a small strongly typed programming language.
 * [Reactive Ruby](https://github.com/guidosalva/ReactiveRubyTruffle), TruffleRuby meets Reactive Programming.
 * [shen-truffle](https://github.com/ragnard/shen-truffle), a port of the Shen programming language.


### PR DESCRIPTION
Dear GraalVM Developers,

I requested ProloGraal to this list some time ago, but the previous repository hosting ProloGraal would potentially be deleted (because of HEIA School decisions about project repositories). This is why I hosted ProloGraal on github by myself and edited the previous link.

Best regards,
Tony Licata