### PR TITLE
Fix errors manifested in renaissance-native-image:chi-square benchmark

### DIFF
--- a/substratevm/src/com.oracle.svm.configure/src/com/oracle/svm/configure/trace/AccessAdvisor.java
+++ b/substratevm/src/com.oracle.svm.configure/src/com/oracle/svm/configure/trace/AccessAdvisor.java
@@ -57,7 +57,6 @@ public final class AccessAdvisor {
         internalCallerFilter.addOrGetChildren("java.nio.**", RuleNode.Inclusion.Exclude);
         internalCallerFilter.addOrGetChildren("java.text.**", RuleNode.Inclusion.Exclude);
         internalCallerFilter.addOrGetChildren("java.time.**", RuleNode.Inclusion.Exclude);
-        internalCallerFilter.addOrGetChildren("java.util.**", RuleNode.Inclusion.Exclude);
         internalCallerFilter.addOrGetChildren("javax.crypto.**", RuleNode.Inclusion.Exclude);
         internalCallerFilter.addOrGetChildren("javax.lang.model.**", RuleNode.Inclusion.Exclude);
         internalCallerFilter.addOrGetChildren("javax.net.**", RuleNode.Inclusion.Exclude);

--- a/substratevm/src/com.oracle.svm.jvmtiagentbase/src/com/oracle/svm/jvmtiagentbase/ConstantPoolTool.java
+++ b/substratevm/src/com.oracle.svm.jvmtiagentbase/src/com/oracle/svm/jvmtiagentbase/ConstantPoolTool.java
@@ -146,7 +146,7 @@ public class ConstantPoolTool {
             if (kind == ConstantKind.UTF8) {
                 length = Short.toUnsignedInt(buffer.getShort()); // in bytes; advances buffer
             }
-            if (length <= 0 || kind.tableEntries <= 0) {
+            if (length < 0 || kind.tableEntries <= 0) {
                 throw new ConstantPoolException("Invalid constant pool entry kind: " + kind);
             }
             buffer.position(buffer.position() + length);


### PR DESCRIPTION
This pull request fixes errors that manifest in the **renaissance-native-image:chi-square** benchmark. 
Native Image Agent did not register com.sun.security.auth security classes. 

Two concrete changes are proposed here. 

1. java.util.** is removed from the com.oracle.svm.configure.trace.AccessAdvisor internalCallerFilter, because it was incorrectly filtering out relevant classes. In this case, those were javax.security.auth.spi.LoginModule implementations, in particular com.sun.security.auth.module.UnixLoginModule . These modules are loaded in javax.security.auth.login.LoginContext, line 687, using a java.util.ServiceLoader. And that's why the java.util.** was removed from the filter.

2. In this benchmark, com.sun.security.auth.UnixPrincipal is being loaded via ClassLoader.loadClass Unfortunately, analyzing the access in com.oracle.svm.agent.BreakpointInterceptor.isLoadClassInvocation causes a ConstantPoolException, because com.oracle.svm.jvmtiagentbase.ConstantPoolTool.seekEntry encounters a UTF-8 tagged entry with length 0, which results in the exception. After allowing the length 0, the UnixPrincipal class is registered correctly.