### PR TITLE
NodeClass equality optimizations

### DIFF
--- a/compiler/src/org.graalvm.compiler.core.common/src/org/graalvm/compiler/core/common/Fields.java
+++ b/compiler/src/org.graalvm.compiler.core.common/src/org/graalvm/compiler/core/common/Fields.java
@@ -33,6 +33,7 @@ import java.util.List;
 
 import org.graalvm.compiler.debug.GraalError;
 
+import org.graalvm.compiler.graph.Node;
 import sun.misc.Unsafe;
 
 /**
@@ -102,6 +103,31 @@ public class Fields {
         }
     }
 
+    public boolean equalInt(int i, Node a, Node b) {
+        assert types[i] == int.class;
+        final long offset = offsets[i];
+        return UNSAFE.getInt(a, offset) == UNSAFE.getInt(b, offset);
+    }
+    public boolean equalBoolean(int i, Node a, Node b) {
+        assert types[i] == boolean.class;
+        final long offset = offsets[i];
+        return UNSAFE.getBoolean(a, offset) == UNSAFE.getBoolean(b, offset);
+    }
+    public boolean equalLong(int i, Node a, Node b) {
+        assert types[i] == long.class;
+        final long offset = offsets[i];
+        return UNSAFE.getLong(a, offset) == UNSAFE.getLong(b, offset);
+    }
+    public boolean equalFloat(int i, Node a, Node b) {
+        assert types[i] == float.class;
+        final long offset = offsets[i];
+        return UNSAFE.getFloat(a, offset) == UNSAFE.getFloat(b, offset);
+    }
+    public boolean equalDouble(int i, Node a, Node b) {
+        assert types[i] == double.class;
+        final long offset = offsets[i];
+        return UNSAFE.getDouble(a, offset) == UNSAFE.getDouble(b, offset);
+    }
     /**
      * Function enabling an object field value to be replaced with another value when being copied
      * within {@link Fields#copy(Object, Object, ObjectTransformer)}.


### PR DESCRIPTION
boolean NodeClass.dataEquals(Node a, Node b) Defers equality test of non-primitive fields until after testing primitive fields.  This can elide more expensive deep equality tests for non-identical non-primitive fields when a primitive field can determine inequality first.
![Screenshot_2020-09-26_10-16-37](https://user-images.githubusercontent.com/157093/94351768-348a3a80-002b-11eb-9690-e1e33b8dc506.png)
![Screenshot_2020-09-26_10-12-17](https://user-images.githubusercontent.com/157093/94351770-35bb6780-002b-11eb-9a71-4369da6c3abc.png)

