### PR TITLE
Produce debug entries for inlined methods

### DIFF
--- a/substratevm/mx.substratevm/testhello.py
+++ b/substratevm/mx.substratevm/testhello.py
@@ -169,27 +169,28 @@ def test():
     # enable pretty printing of structures
     execute("set print pretty on")
     # set a break point at hello.Hello::main
-    # expect "Breakpoint 1 at 0x[0-9a-f]+: file hello.Hello.java, line 67."
+    # expect "Breakpoint 1 at 0x[0-9a-f]+: file hello.Hello.java, line 70."
     exec_string = execute("break hello.Hello::main")
-    rexp = r"Breakpoint 1 at %s: file hello/Hello\.java, line 67\."%address_pattern
+    rexp = r"Breakpoint 1 at %s: file hello/Hello\.java, line 70\."%address_pattern
     checker = Checker('break main', rexp)
     checker.check(exec_string)
 
-    # run the program
+    # run the program till the breakpoint
     execute("run")
+    execute("delete breakpoints")
 
     # list the line at the breakpoint
-    # expect "67	        Greeter greeter = Greeter.greeter(args);"
+    # expect "70	        Greeter greeter = Greeter.greeter(args);"
     exec_string = execute("list")
-    checker = Checker(r"list bp 1", "67%sGreeter greeter = Greeter\.greeter\(args\);"%spaces_pattern)
+    checker = Checker(r"list bp 1", "70%sGreeter greeter = Greeter\.greeter\(args\);"%spaces_pattern)
     checker.check(exec_string, skip_fails=False)
 
     # run a backtrace
-    # expect "#0  hello.Hello.main(java.lang.String[] *).* at hello.Hello.java:67"
+    # expect "#0  hello.Hello.main(java.lang.String[] *).* at hello.Hello.java:70"
     # expect "#1  0x[0-9a-f]+ in com.oracle.svm.core.code.IsolateEnterStub.JavaMainWrapper_run_.* at [a-z/]+/JavaMainWrapper.java:[0-9]+"
     exec_string = execute("backtrace")
     checker = Checker("backtrace hello.Hello::main",
-                      [r"#0%shello\.Hello::main\(java\.lang\.String\[\] \*\)%s at hello/Hello\.java:67"%(spaces_pattern, wildcard_pattern),
+                      [r"#0%shello\.Hello::main\(java\.lang\.String\[\] \*\)%s at hello/Hello\.java:70"%(spaces_pattern, wildcard_pattern),
                        r"#1%s%s in com\.oracle\.svm\.core\.JavaMainWrapper::runCore%s at %sJavaMainWrapper\.java:[0-9]+"%(spaces_pattern, address_pattern, wildcard_pattern, package_pattern),
                        r"#2%s com\.oracle\.svm\.core\.JavaMainWrapper::run%s at %sJavaMainWrapper\.java:[0-9]+"%(spaces_pattern, wildcard_pattern, package_pattern),
                        r"#3%s%s in com\.oracle\.svm\.core\.code\.IsolateEnterStub::JavaMainWrapper_run_%s%s"%(spaces_pattern, address_pattern, hex_digits_pattern, wildcard_pattern)
@@ -266,14 +267,6 @@ def test():
                           r"%s = 1000"%(wildcard_pattern))
         checker.check(exec_string, skip_fails=False)
 
-
-    # set a break point at hello.Hello$DefaultGreeter::greet
-    # expect "Breakpoint 2 at 0x[0-9a-f]+: file hello/Target_Hello_DefaultGreeter.java, line [0-9]+."
-    exec_string = execute("break hello.Hello$DefaultGreeter::greet")
-    rexp = r"Breakpoint 2 at %s: file hello/Target_hello_Hello_DefaultGreeter\.java, line %s\."%(address_pattern, digits_pattern)
-    checker = Checker("break on substituted method", rexp)
-    checker.check(exec_string, skip_fails=False)
-
     # look up greet methods
     # expect "All functions matching regular expression "greet":"
     # expect ""
@@ -290,7 +283,7 @@ def test():
             r"File hello/Target_hello_Hello_DefaultGreeter\.java:",
             r"%svoid hello.Hello\$DefaultGreeter::greet\(void\);"%maybe_spaces_pattern]
     checker = Checker("info func greet", rexp)
-    checker.check(exec_string, skip_fails=True)
+    checker.check(exec_string)
 
     # look up PrintStream.println methods
     # expect "All functions matching regular expression "java.io.PrintStream.println":"
@@ -303,20 +296,13 @@ def test():
     checker = Checker("info func java.io.PrintStream::println", rexp)
     checker.check(exec_string)
 
-    # set a break point at PrintStream.println(String)
-    # expect "Breakpoint 3 at 0x[0-9a-f]+: java.base/java/io/PrintStream.java, line [0-9]+."
-    exec_string = execute("break java.io.PrintStream::println(java.lang.String *)")
-    rexp = r"Breakpoint 3 at %s: file .*java/io/PrintStream\.java, line %s\."%(address_pattern, digits_pattern)
-    checker = Checker('break println', rexp)
-    checker.check(exec_string, skip_fails=False)
-
     # step into method call
     execute("step")
 
     # list current line
-    # expect "34	            if (args.length == 0) {"
+    # expect "37	            if (args.length == 0) {"
     exec_string = execute("list")
-    rexp = r"34%sif \(args\.length == 0\) {"%spaces_pattern
+    rexp = r"37%sif \(args\.length == 0\) {"%spaces_pattern
     checker = Checker('list hello.Hello$Greeter.greeter', rexp)
     checker.check(exec_string, skip_fails=False)
 
@@ -397,8 +383,8 @@ def test():
     # run a backtrace
     exec_string = execute("backtrace")
     checker = Checker("backtrace hello.Hello.Greeter::greeter",
-                      [r"#0%shello\.Hello\$Greeter::greeter\(java\.lang\.String\[\] \*\)%s at hello/Hello\.java:34"%(spaces_pattern, wildcard_pattern),
-                       r"#1%s%s in hello\.Hello::main\(java\.lang\.String\[\] \*\)%s at hello/Hello\.java:67"%(spaces_pattern, address_pattern, wildcard_pattern),
+                      [r"#0%shello\.Hello\$Greeter::greeter\(java\.lang\.String\[\] \*\)%s at hello/Hello\.java:37"%(spaces_pattern, wildcard_pattern),
+                       r"#1%s%s in hello\.Hello::main\(java\.lang\.String\[\] \*\)%s at hello/Hello\.java:70"%(spaces_pattern, address_pattern, wildcard_pattern),
                        r"#2%s%s in com\.oracle\.svm\.core\.JavaMainWrapper::runCore%s at %sJavaMainWrapper\.java:[0-9]+"%(spaces_pattern, address_pattern, wildcard_pattern, package_pattern),
                        r"#3%scom\.oracle\.svm\.core\.JavaMainWrapper::run%s at %sJavaMainWrapper\.java:[0-9]+"%(spaces_pattern, wildcard_pattern, package_pattern),
                        r"#4%s%s in com\.oracle\.svm\.core\.code\.IsolateEnterStub::JavaMainWrapper_run_%s%s"%(spaces_pattern, address_pattern, hex_digits_pattern, wildcard_pattern)
@@ -421,16 +407,35 @@ def test():
         print(checker)
         sys.exit(1)
 
-    # continue to next 2 breakpoints
-    execute("continue")
+    # set breakpoint at substituted method hello.Hello$DefaultGreeter::greet
+    # expect "Breakpoint 2 at 0x[0-9a-f]+: file hello/Target_Hello_DefaultGreeter.java, line [0-9]+."
+    exec_string = execute("break hello.Hello$DefaultGreeter::greet")
+    rexp = r"Breakpoint %s at %s: file hello/Target_hello_Hello_DefaultGreeter\.java, line %s\."%(digits_pattern, address_pattern, digits_pattern)
+    checker = Checker("break on substituted method", rexp)
+    checker.check(exec_string, skip_fails=False)
+    execute("delete breakpoints")
+
+    # set a break point at standard library PrintStream.println(String)
+    # expect "Breakpoint 3 at 0x[0-9a-f]+: java.base/java/io/PrintStream.java, line [0-9]+."
+    exec_string = execute("break java.io.PrintStream::println(java.lang.String *)")
+    rexp = r"Breakpoint %s at %s: file .*java/io/PrintStream\.java, line %s\."%(digits_pattern, address_pattern, digits_pattern)
+    checker = Checker('break println', rexp)
+    checker.check(exec_string, skip_fails=False)
+
     execute("continue")
 
     # run backtrace to check we are in java.io.PrintStream::println(java.lang.String)
     # expect "#0  java.io.PrintStream::println(java.lang.String).* at java.base/java/io/PrintStream.java:[0-9]+"
-    exec_string = execute("backtrace 1")
-    checker = Checker("backtrace 1 PrintStream::println",
-                      [r"#0%sjava\.io\.PrintStream::println\(java\.lang\.String \*\)%s at %sjava/io/PrintStream.java:%s"%(spaces_pattern, wildcard_pattern, wildcard_pattern, digits_pattern)])
-    checker.check(exec_string, skip_fails=False)
+    exec_string = execute("backtrace 5")
+    rexp = [r"#0%sjava\.io\.PrintStream::println\(java\.lang\.String \*\)%s at %sjava/io/PrintStream.java:%s"%(spaces_pattern, wildcard_pattern, wildcard_pattern, digits_pattern),
+            r"#1%s%s in hello\.SubstituteHelperClass::nestedGreet\(void\) \(\) at hello/Target_hello_Hello_DefaultGreeter\.java:59"%(spaces_pattern, address_pattern),
+            # FIXME: Ideally we should see the following two lines in the backtrace as well!
+            # r"#2%s%s in hello\.SubstituteHelperClass::staticInlineGreet\(void\) \(\) at hello/Target_hello_Hello_DefaultGreeter\.java:53"%(digits_pattern, spaces_pattern, address_pattern),
+            # r"#3%s%s in hello\.SubstituteHelperClass::inlineGreet\(void\) \(\) at hello/Target_hello_Hello_DefaultGreeter\.java:48"%(digits_pattern, spaces_pattern, address_pattern),
+            r"#%s%s%s in hello\.Hello\$DefaultGreeter::greet\(void\) \(\) at hello/Target_hello_Hello_DefaultGreeter\.java:39"%(digits_pattern, spaces_pattern, address_pattern),
+            r"#%s%s%s in hello\.Hello::main\(java\.lang\.String\[\] \*\) \(\) at hello/Hello\.java:70"%(digits_pattern, spaces_pattern, address_pattern)]
+    checker = Checker("backtrace PrintStream::println", rexp)
+    checker.check(exec_string)
 
     # list current line
     # expect "[0-9]+        synchronized (this) {"
@@ -485,6 +490,191 @@ def test():
         checker = Checker("print PrintStream hub name",
                           r"%s:%s\"java.io.PrintStream.*\""%(address_pattern, spaces_pattern))
         checker.check(exec_string, skip_fails=False)
+
+    ###
+    # Tests for inlined methods
+    ###
+
+    # print details of Hello type
+    exec_string = execute("ptype 'hello.Hello'")
+    rexp = [r"type = class hello\.Hello : public java\.lang\.Object {",
+            # ptype lists inlined methods allthrough they are not listed with info func
+            r"%sprivate:"%spaces_pattern,
+            r"%sstatic void inlineCallChain\(void\);"%spaces_pattern,
+            r"%sstatic void inlineFrom\(void\);"%spaces_pattern,
+            r"%sstatic void inlineHere\(int\);"%spaces_pattern,
+            r"%sstatic void inlineMee\(void\);"%spaces_pattern,
+            r"%sstatic void inlineMixTo\(int\);"%spaces_pattern,
+            r"%sstatic void inlineMoo\(void\);"%spaces_pattern,
+            r"%sstatic void inlineTailRecursion\(int\);"%spaces_pattern,
+            r"%sstatic void inlineTo\(int\);"%spaces_pattern,
+            r"%spublic:"%spaces_pattern,
+            r"%sstatic void main\(java\.lang\.String\[\] \*\);"%spaces_pattern,
+            r"%sprivate:"%spaces_pattern,
+            r"%sstatic void noInlineFoo\(void\);"%spaces_pattern,
+            r"%sstatic void noInlineHere\(int\);"%spaces_pattern,
+            r"%sstatic void noInlineTest\(void\);"%spaces_pattern,
+            r"%sstatic void noInlineThis\(void\);"%spaces_pattern,
+            r"}"]
+    checker = Checker('ptype hello.Hello', rexp)
+    checker.check(exec_string, skip_fails=False)
+
+    # list methods matching regural expression "nlined", inline methods are not listed
+    exec_string = execute("info func nline")
+    rexp = [r"All functions matching regular expression \"nline\":",
+            r"File hello/Hello\.java:",
+            r"%svoid hello\.Hello::noInlineFoo\(void\);"%spaces_pattern,
+            r"%svoid hello\.Hello::noInlineHere\(int\);"%spaces_pattern,
+            r"%svoid hello\.Hello::noInlineTest\(void\);"%spaces_pattern,
+            r"%svoid hello\.Hello::noInlineThis\(void\);"%spaces_pattern]
+    checker = Checker('ptype info func nline', rexp)
+    checker.check(exec_string)
+
+    # list inlineMee and inlineMoo and check that the listing maps to the inlined code instead of the actual code,
+    # although not ideal this is how GDB treats inlined code in C/C++ as well
+    rexp = [r"109%sSystem\.out\.println\(\"This is a cow\"\);"%spaces_pattern]
+    checker = Checker('list inlineMee', rexp)
+    checker.check(execute("list inlineMee"))
+    checker = Checker('list inlineMoo', rexp)
+    checker.check(execute("list inlineMoo"))
+
+    execute("delete breakpoints")
+    # Set breakpoint at inlined method and step through its nested inline methods
+    exec_string = execute("break hello.Hello::inlineMee")
+    rexp = r"Breakpoint %s at %s: hello\.Hello::inlineMee\. \(2 locations\)"%(digits_pattern, address_pattern)
+    checker = Checker('break inlineMee', rexp)
+    checker.check(exec_string, skip_fails=False)
+
+    exec_string = execute("info break 4")
+    # The breakpoint will be set to the inlined code instead of the actual code,
+    # although not ideal this is how GDB treats inlined code in C/C++ as well
+    rexp = [r"4.1%sy%s%s in hello\.Hello::inlineMee at hello/Hello\.java:109"%(spaces_pattern, spaces_pattern, address_pattern),
+            r"4.2%sy%s%s in hello\.Hello::inlineMee at hello/Hello\.java:109"%(spaces_pattern, spaces_pattern, address_pattern)]
+    checker = Checker('info break inlineMee', rexp)
+    checker.check(exec_string)
+
+    execute("continue")
+    exec_string = execute("list")
+    rexp = [r"104%sinlineMoo\(\);"%spaces_pattern]
+    checker = Checker('hit break at inlineMee', rexp)
+    checker.check(exec_string, skip_fails=False)
+    execute("step")
+    exec_string = execute("list")
+    rexp = [r"109%sSystem\.out\.println\(\"This is a cow\"\);"%spaces_pattern]
+    checker = Checker('step in inlineMee', rexp)
+    checker.check(exec_string, skip_fails=False)
+    exec_string = execute("backtrace 4")
+    rexp = [r"#0%shello\.Hello::inlineMoo \(\) at hello/Hello\.java:109"%spaces_pattern,
+            r"#1%shello\.Hello::inlineMee \(\) at hello/Hello\.java:104"%spaces_pattern,
+            r"#2%shello\.Hello::noInlineFoo\(void\) \(\) at hello/Hello\.java:94"%spaces_pattern,
+            r"#3%s%s in hello\.Hello::main\(java\.lang\.String\[\] \*\) \(\) at hello/Hello\.java:70"%(spaces_pattern, address_pattern)]
+    checker = Checker('backtrace inlineMee', rexp)
+    checker.check(exec_string, skip_fails=False)
+
+    execute("continue")
+    exec_string = execute("list")
+    rexp = [r"104%sinlineMoo\(\);"%spaces_pattern]
+    checker = Checker('hit break at inlineMee', rexp)
+    checker.check(exec_string, skip_fails=False)
+    execute("step")
+    exec_string = execute("list")
+    rexp = [r"109%sSystem\.out\.println\(\"This is a cow\"\);"%spaces_pattern]
+    checker = Checker('step in inlineMee', rexp)
+    checker.check(exec_string, skip_fails=False)
+    exec_string = execute("backtrace 4")
+    rexp = [r"#0%shello\.Hello::inlineMoo \(\) at hello/Hello\.java:109"%spaces_pattern,
+            r"#1%shello\.Hello::inlineMee \(\) at hello/Hello\.java:104"%spaces_pattern,
+            r"#2%shello\.Hello::inlineCallChain \(\) at hello/Hello\.java:99"%spaces_pattern,
+            r"#3%shello\.Hello::main\(java\.lang\.String\[\] \*\) \(\) at hello/Hello\.java:86"%spaces_pattern]
+    checker = Checker('backtrace inlineMee 2', rexp)
+    checker.check(exec_string, skip_fails=False)
+
+    execute("delete breakpoints")
+    exec_string = execute("break hello.Hello::noInlineTest")
+    rexp = r"Breakpoint %s at %s: file hello/Hello\.java, line 129\."%(digits_pattern, address_pattern)
+    checker = Checker('break noInlineTest', rexp)
+    checker.check(exec_string, skip_fails=False)
+
+    execute("continue")
+    exec_string = execute("list")
+    rexp = r"129%sSystem.out.println\(\"This is a test\"\);"%spaces_pattern
+    checker = Checker('hig breakpoint in noInlineTest', rexp)
+    checker.check(exec_string, skip_fails=False)
+    exec_string = execute("backtrace 4")
+    rexp = [r"#0%shello\.Hello::noInlineTest\(void\) \(\) at hello/Hello\.java:129"%(spaces_pattern),
+            # FIXME: the following two lines should appear in the backtrace as well!
+            # r"#%s%shello\.Hello::inlinedA \(\) at hello/Hello\.java:124"%(digits_pattern, spaces_pattern),
+            # r"#%s%shello\.Hello::inlinedIs \(\) at hello/Hello\.java:119"%(digits_pattern, spaces_pattern),
+            r"#%s%s%s in hello\.Hello::noInlineThis\(void\) \(\) at hello/Hello\.java:114"%(digits_pattern, spaces_pattern, address_pattern),
+            r"#%s%s%s in hello\.Hello::main\(java\.lang\.String\[\] \*\) \(\) at hello/Hello\.java:109"%(digits_pattern, spaces_pattern, address_pattern)]
+    checker = Checker('backtrace in inlinedMethod2', rexp)
+    checker.check(exec_string, skip_fails=False)
+
+    execute("delete breakpoints")
+    exec_string = execute("break Hello.java:149")
+    rexp = r"Breakpoint %s at %s: file hello/Hello\.java, line 149\."%(digits_pattern, address_pattern)
+    checker = Checker('break Hello.java:149', rexp)
+    checker.check(exec_string)
+
+    execute("continue 5")
+    exec_string = execute("backtrace 8")
+    rexp = [r"#0%shello\.Hello::inlineMixTo \(\) at hello/Hello\.java:149"%(spaces_pattern), # FIXME why is inlineMixTo missing the int arg here?
+            r"#1%shello\.Hello::noInlineHere\(int\) \(\) at hello/Hello\.java:141"%(spaces_pattern),
+            # FIXME: the commented lines should also appear in the backtrace!
+            # r"#%s%shello\.Hello::inlineMixTo \(\) at hello/Hello\.java:147"%(digits_pattern, spaces_pattern),
+            r"#%s%s%s in hello\.Hello::noInlineHere\(int\) \(\) at hello/Hello\.java:147"%(digits_pattern, spaces_pattern, address_pattern), # FIXME the line number here should be 141
+            # r"#%s%shello\.Hello::inlineMixTo \(\) at hello/Hello\.java:147"%(digits_pattern, spaces_pattern),
+            r"#%s%s%s in hello\.Hello::noInlineHere\(int\) \(\) at hello/Hello\.java:147"%(digits_pattern, spaces_pattern, address_pattern),
+            # r"#%s%shello\.Hello::inlineMixTo \(\) at hello/Hello\.java:147"%(digits_pattern, spaces_pattern),
+            r"#%s%s%s in hello\.Hello::noInlineHere\(int\) \(\) at hello/Hello\.java:147"%(digits_pattern, spaces_pattern, address_pattern),
+            # r"#%s%shello\.Hello::inlineMixTo \(\) at hello/Hello\.java:147"%(digits_pattern, spaces_pattern),
+            r"#%s%s%s in hello\.Hello::noInlineHere\(int\) \(\) at hello/Hello\.java:147"%(digits_pattern, spaces_pattern, address_pattern),
+            # r"#%s%shello\.Hello::inlineMixTo \(\) at hello/Hello\.java:147"%(digits_pattern, spaces_pattern),
+            r"#%s%s%s in hello\.Hello::noInlineHere\(int\) \(\) at hello/Hello\.java:147"%(digits_pattern, spaces_pattern, address_pattern),
+            # r"#%s%shello\.Hello::inlineFrom \(\) at hello/Hello\.java:134"%(digits_pattern, spaces_pattern),
+            r"#%s%s%s in hello\.Hello::main\(java\.lang\.String\[\] \*\) \(\) at hello/Hello\.java:109"%(digits_pattern, spaces_pattern, address_pattern)]
+    checker = Checker('backtrace in recursive inlineMixTo', rexp)
+    checker.check(exec_string, skip_fails=False)
+
+    execute("delete breakpoints")
+    exec_string = execute("break Hello.java:162")
+    rexp = r"Breakpoint %s at %s: Hello\.java:162\. \(2 locations\)"%(digits_pattern, address_pattern)
+    checker = Checker('break Hello.java:162', rexp)
+    checker.check(exec_string)
+
+    execute("continue 5")
+    exec_string = execute("backtrace 8")
+    rexp = [r"#0%shello\.Hello::inlineTo\(int\) \(\) at hello/Hello\.java:162"%(spaces_pattern),
+            # FIXME: the commented lines should also appear in the backtrace!
+            # r"#%s%s in hello\.Hello::inlineHere\(int\) \(\) at hello/Hello\.java:154"%(digits_pattern, spaces_pattern),
+            r"#%s%s%s in hello\.Hello::inlineTo\(int\) \(\) at hello/Hello\.java:160"%(digits_pattern, spaces_pattern, address_pattern),
+            # r"#%s%s in hello\.Hello::inlineHere\(int\) \(\) at hello/Hello\.java:154"%(digits_pattern, spaces_pattern),
+            r"#%s%s%s in hello\.Hello::inlineTo\(int\) \(\) at hello/Hello\.java:160"%(digits_pattern, spaces_pattern, address_pattern),
+            # r"#%s%s in hello\.Hello::inlineHere\(int\) \(\) at hello/Hello\.java:154"%(digits_pattern, spaces_pattern),
+            r"#%s%s%s in hello\.Hello::inlineTo\(int\) \(\) at hello/Hello\.java:160"%(digits_pattern, spaces_pattern, address_pattern),
+            # r"#%s%s in hello\.Hello::inlineHere\(int\) \(\) at hello/Hello\.java:154"%(digits_pattern, spaces_pattern),
+            r"#%s%s%s in hello\.Hello::inlineTo\(int\) \(\) at hello/Hello\.java:160"%(digits_pattern, spaces_pattern, address_pattern),
+            # r"#%s%s in hello\.Hello::inlineHere\(int\) \(\) at hello/Hello\.java:154"%(digits_pattern, spaces_pattern),
+            r"#%s%s%s in hello\.Hello::main\(java\.lang\.String\[\] \*\) \(\) at hello/Hello\.java:109"%(digits_pattern, spaces_pattern, address_pattern)]
+    checker = Checker('backtrace in recursive inlineTo', rexp)
+    checker.check(exec_string, skip_fails=False)
+
+    execute("delete breakpoints")
+    exec_string = execute("break Hello.java:168")
+    rexp = r"Breakpoint %s at %s: file hello/Hello\.java, line 168\."%(digits_pattern, address_pattern)
+    checker = Checker('break Hello.java:168', rexp)
+    checker.check(exec_string)
+
+    execute("continue 5")
+    exec_string = execute("backtrace 8")
+    rexp = [r"#0%shello\.Hello::inlineTailRecursion\(int\) \(\) at hello/Hello\.java:168"%(spaces_pattern),
+            r"#%s%s%s in hello\.Hello::inlineTailRecursion\(int\) \(\) at hello/Hello\.java:171"%(digits_pattern, spaces_pattern, address_pattern),
+            r"#%s%s%s in hello\.Hello::inlineTailRecursion\(int\) \(\) at hello/Hello\.java:171"%(digits_pattern, spaces_pattern, address_pattern),
+            r"#%s%s%s in hello\.Hello::inlineTailRecursion\(int\) \(\) at hello/Hello\.java:171"%(digits_pattern, spaces_pattern, address_pattern),
+            r"#%s%s%s in hello\.Hello::inlineTailRecursion\(int\) \(\) at hello/Hello\.java:171"%(digits_pattern, spaces_pattern, address_pattern),
+            r"#%s%s%s in hello\.Hello::main\(java\.lang\.String\[\] \*\) \(\) at hello/Hello\.java:162"%(digits_pattern, spaces_pattern, address_pattern)]
+    checker = Checker('backtrace in recursive inlineTo', rexp)
+    checker.check(exec_string, skip_fails=False)
 
     print(execute("quit 0"))
 

--- a/substratevm/mx.substratevm/testhello.py
+++ b/substratevm/mx.substratevm/testhello.py
@@ -124,7 +124,7 @@ def test():
 
     # define some useful patterns
     address_pattern = '0x[0-9a-f]+'
-    hash_pattern = '[0-9a-f]+'
+    hex_digits_pattern = '[0-9a-f]+'
     spaces_pattern = '[ \t]+'
     maybe_spaces_pattern = '[ \t]*'
     digits_pattern = '[0-9]+'
@@ -192,7 +192,7 @@ def test():
                       [r"#0%shello\.Hello::main\(java\.lang\.String\[\] \*\)%s at hello/Hello\.java:67"%(spaces_pattern, wildcard_pattern),
                        r"#1%s%s in com\.oracle\.svm\.core\.JavaMainWrapper::runCore%s at %sJavaMainWrapper\.java:[0-9]+"%(spaces_pattern, address_pattern, wildcard_pattern, package_pattern),
                        r"#2%s com\.oracle\.svm\.core\.JavaMainWrapper::run%s at %sJavaMainWrapper\.java:[0-9]+"%(spaces_pattern, wildcard_pattern, package_pattern),
-                       r"#3%s%s in com\.oracle\.svm\.core\.code\.IsolateEnterStub::JavaMainWrapper_run_%s%s"%(spaces_pattern, address_pattern, hash_pattern, wildcard_pattern)
+                       r"#3%s%s in com\.oracle\.svm\.core\.code\.IsolateEnterStub::JavaMainWrapper_run_%s%s"%(spaces_pattern, address_pattern, hex_digits_pattern, wildcard_pattern)
                       ])
     checker.check(exec_string, skip_fails=False)
 
@@ -401,7 +401,7 @@ def test():
                        r"#1%s%s in hello\.Hello::main\(java\.lang\.String\[\] \*\)%s at hello/Hello\.java:67"%(spaces_pattern, address_pattern, wildcard_pattern),
                        r"#2%s%s in com\.oracle\.svm\.core\.JavaMainWrapper::runCore%s at %sJavaMainWrapper\.java:[0-9]+"%(spaces_pattern, address_pattern, wildcard_pattern, package_pattern),
                        r"#3%scom\.oracle\.svm\.core\.JavaMainWrapper::run%s at %sJavaMainWrapper\.java:[0-9]+"%(spaces_pattern, wildcard_pattern, package_pattern),
-                       r"#4%s%s in com\.oracle\.svm\.core\.code\.IsolateEnterStub::JavaMainWrapper_run_%s%s"%(spaces_pattern, address_pattern, hash_pattern, wildcard_pattern)
+                       r"#4%s%s in com\.oracle\.svm\.core\.code\.IsolateEnterStub::JavaMainWrapper_run_%s%s"%(spaces_pattern, address_pattern, hex_digits_pattern, wildcard_pattern)
                       ])
     checker.check(exec_string, skip_fails=False)
 

--- a/substratevm/mx.substratevm/testhello.py
+++ b/substratevm/mx.substratevm/testhello.py
@@ -192,7 +192,7 @@ def test():
                       [r"#0%shello\.Hello::main\(java\.lang\.String\[\] \*\)%s at hello/Hello\.java:67"%(spaces_pattern, wildcard_pattern),
                        r"#1%s%s in com\.oracle\.svm\.core\.JavaMainWrapper::runCore%s at %sJavaMainWrapper\.java:[0-9]+"%(spaces_pattern, address_pattern, wildcard_pattern, package_pattern),
                        r"#2%s com\.oracle\.svm\.core\.JavaMainWrapper::run%s at %sJavaMainWrapper\.java:[0-9]+"%(spaces_pattern, wildcard_pattern, package_pattern),
-                       r"#3%scom\.oracle\.svm\.core\.code\.IsolateEnterStub::JavaMainWrapper_run_%s%s at %sIsolateEnterStub\.java:[0-9]+"%(spaces_pattern, hash_pattern, wildcard_pattern, package_pattern)
+                       r"#3%smain \(\) at %sIsolateEnterStub\.java:[0-9]+"%(spaces_pattern, package_pattern)
                       ])
     checker.check(exec_string, skip_fails=False)
 
@@ -401,7 +401,7 @@ def test():
                        r"#1%s%s in hello\.Hello::main\(java\.lang\.String\[\] \*\)%s at hello/Hello\.java:67"%(spaces_pattern, address_pattern, wildcard_pattern),
                        r"#2%s%s in com\.oracle\.svm\.core\.JavaMainWrapper::runCore%s at %sJavaMainWrapper\.java:[0-9]+"%(spaces_pattern, address_pattern, wildcard_pattern, package_pattern),
                        r"#3%scom\.oracle\.svm\.core\.JavaMainWrapper::run%s at %sJavaMainWrapper\.java:[0-9]+"%(spaces_pattern, wildcard_pattern, package_pattern),
-                       r"#4%scom\.oracle\.svm\.core\.code\.IsolateEnterStub::JavaMainWrapper_run_%s%s at %sIsolateEnterStub\.java:[0-9]+"%(spaces_pattern, hash_pattern, wildcard_pattern, package_pattern)
+                       r"#4%smain \(\) at %sIsolateEnterStub\.java:[0-9]+"%(spaces_pattern, package_pattern)
                       ])
     checker.check(exec_string, skip_fails=False)
 

--- a/substratevm/mx.substratevm/testhello.py
+++ b/substratevm/mx.substratevm/testhello.py
@@ -192,7 +192,7 @@ def test():
                       [r"#0%shello\.Hello::main\(java\.lang\.String\[\] \*\)%s at hello/Hello\.java:67"%(spaces_pattern, wildcard_pattern),
                        r"#1%s%s in com\.oracle\.svm\.core\.JavaMainWrapper::runCore%s at %sJavaMainWrapper\.java:[0-9]+"%(spaces_pattern, address_pattern, wildcard_pattern, package_pattern),
                        r"#2%s com\.oracle\.svm\.core\.JavaMainWrapper::run%s at %sJavaMainWrapper\.java:[0-9]+"%(spaces_pattern, wildcard_pattern, package_pattern),
-                       r"#3%smain \(\) at %sIsolateEnterStub\.java:[0-9]+"%(spaces_pattern, package_pattern)
+                       r"#3%s%s in com\.oracle\.svm\.core\.code\.IsolateEnterStub::JavaMainWrapper_run_%s%s"%(spaces_pattern, address_pattern, hash_pattern, wildcard_pattern)
                       ])
     checker.check(exec_string, skip_fails=False)
 
@@ -401,7 +401,7 @@ def test():
                        r"#1%s%s in hello\.Hello::main\(java\.lang\.String\[\] \*\)%s at hello/Hello\.java:67"%(spaces_pattern, address_pattern, wildcard_pattern),
                        r"#2%s%s in com\.oracle\.svm\.core\.JavaMainWrapper::runCore%s at %sJavaMainWrapper\.java:[0-9]+"%(spaces_pattern, address_pattern, wildcard_pattern, package_pattern),
                        r"#3%scom\.oracle\.svm\.core\.JavaMainWrapper::run%s at %sJavaMainWrapper\.java:[0-9]+"%(spaces_pattern, wildcard_pattern, package_pattern),
-                       r"#4%smain \(\) at %sIsolateEnterStub\.java:[0-9]+"%(spaces_pattern, package_pattern)
+                       r"#4%s%s in com\.oracle\.svm\.core\.code\.IsolateEnterStub::JavaMainWrapper_run_%s%s"%(spaces_pattern, address_pattern, hash_pattern, wildcard_pattern)
                       ])
     checker.check(exec_string, skip_fails=False)
 

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/ClassEntry.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/ClassEntry.java
@@ -38,8 +38,6 @@ import org.graalvm.compiler.debug.DebugContext;
 import com.oracle.objectfile.debuginfo.DebugInfoProvider.DebugFieldInfo;
 import com.oracle.objectfile.debuginfo.DebugInfoProvider.DebugFrameSizeChange;
 import com.oracle.objectfile.debuginfo.DebugInfoProvider.DebugInstanceTypeInfo;
-import com.oracle.objectfile.debuginfo.DebugInfoProvider.DebugCodeInfo;
-import com.oracle.objectfile.debuginfo.DebugInfoProvider.DebugLineInfo;
 import com.oracle.objectfile.debuginfo.DebugInfoProvider.DebugMethodInfo;
 import com.oracle.objectfile.debuginfo.DebugInfoProvider.DebugRangeInfo;
 import com.oracle.objectfile.debuginfo.DebugInfoProvider.DebugTypeInfo;
@@ -276,14 +274,6 @@ public class ClassEntry extends StructureTypeEntry {
     }
 
     protected MethodEntry processMethod(DebugMethodInfo debugMethodInfo, DebugInfoBase debugInfoBase, DebugContext debugContext) {
-        boolean fromRange = debugMethodInfo instanceof DebugCodeInfo;
-        boolean fromInlineRange = false;
-        if (debugMethodInfo instanceof DebugLineInfo) {
-            DebugLineInfo lineInfo = (DebugLineInfo) debugMethodInfo;
-            if (lineInfo.getCaller() != null) {
-                fromInlineRange = true;
-            }
-        }
         String methodName = debugInfoBase.uniqueDebugString(debugMethodInfo.name());
         String resultTypeName = TypeEntry.canonicalize(debugMethodInfo.valueType());
         int modifiers = debugMethodInfo.modifiers();
@@ -307,8 +297,8 @@ public class ClassEntry extends StructureTypeEntry {
          * substitution
          */
         FileEntry methodFileEntry = debugInfoBase.ensureFileEntry(debugMethodInfo);
-        return new MethodEntry(methodFileEntry, debugMethodInfo.symbolNameForMethod(), methodName, this, resultType,
-                        paramTypeArray, paramNameArray, modifiers, debugMethodInfo.isDeoptTarget(), fromRange, fromInlineRange);
+        return new MethodEntry(debugInfoBase, debugMethodInfo, methodFileEntry, methodName, this, resultType,
+                        paramTypeArray, paramNameArray);
     }
 
     @Override

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/ClassEntry.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/ClassEntry.java
@@ -32,6 +32,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import jdk.vm.ci.meta.ResolvedJavaMethod;
 import org.graalvm.compiler.debug.DebugContext;
 
 import com.oracle.objectfile.debuginfo.DebugInfoProvider.DebugFieldInfo;
@@ -272,7 +273,7 @@ public class ClassEntry extends StructureTypeEntry {
     }
 
     protected MethodEntry processMethod(DebugMethodInfo debugMethodInfo, DebugInfoBase debugInfoBase, DebugContext debugContext) {
-        String methodName = debugInfoBase.uniqueDebugString(debugMethodInfo.name());
+        String methodName = debugMethodInfo.name();
         String resultTypeName = TypeEntry.canonicalize(debugMethodInfo.valueType());
         int modifiers = debugMethodInfo.modifiers();
         List<String> paramTypes = debugMethodInfo.paramTypes();
@@ -339,9 +340,7 @@ public class ClassEntry extends StructureTypeEntry {
 
     public MethodEntry ensureMethodEntryForDebugRangeInfo(DebugRangeInfo debugRangeInfo, DebugInfoBase debugInfoBase, DebugContext debugContext) {
         assert listIsSorted(methods);
-        String methodName = debugInfoBase.uniqueDebugString(debugRangeInfo.name());
-        String paramSignature = debugRangeInfo.paramSignature();
-        String returnTypeName = debugRangeInfo.valueType();
+        ResolvedJavaMethod javaMethod = debugRangeInfo.getJavaMethod();
         /* Since the methods list is sorted we perform a binary search */
         int start = 0;
         int end = methods.size() - 1;
@@ -349,7 +348,7 @@ public class ClassEntry extends StructureTypeEntry {
         while (start <= end) {
             int middle = (start + end) / 2;
             MethodEntry methodEntry = methods.get(middle);
-            int comparisonResult = methodEntry.compareTo(methodName, paramSignature, returnTypeName);
+            int comparisonResult = methodEntry.compareTo(javaMethod);
             if (comparisonResult == 0) {
                 methodEntry.updateRangeInfo(debugInfoBase, debugRangeInfo);
                 if (methodEntry.fileEntry != null) {

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/ClassEntry.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/ClassEntry.java
@@ -168,7 +168,6 @@ public class ClassEntry extends StructureTypeEntry {
         /* We should already have seen the primary range. */
         assert primaryEntry != null;
         assert primaryEntry.getClassEntry() == this;
-        primaryEntry.addSubRange(subrange);
         FileEntry subFileEntry = subrange.getFileEntry();
         if (subFileEntry != null) {
             indexLocalFileEntry(subFileEntry);

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/DebugInfoBase.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/DebugInfoBase.java
@@ -370,6 +370,7 @@ public abstract class DebugInfoBase {
             return primaryRange;
         }
         Range caller = addCallersSubRanges(lineInfo.getCaller(), primaryRange, classEntry, debugContext);
+        caller.setWithInlinedChildren(true);
         final String fileName = lineInfo.fileName();
         final Path filePath = lineInfo.filePath();
         final String className = lineInfo.ownerType();

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/DebugInfoBase.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/DebugInfoBase.java
@@ -255,7 +255,7 @@ public abstract class DebugInfoBase {
                 Path filePathAtLine = debugLineInfo.filePath();
                 String classNameAtLine = TypeEntry.canonicalize(debugLineInfo.ownerType());
                 String methodNameAtLine = debugLineInfo.name();
-                boolean isInlined = false;
+                boolean isInlined = debugLineInfo.getCaller() != null;
                 int loAtLine = lo + debugLineInfo.addressLo();
                 int hiAtLine = lo + debugLineInfo.addressHi();
                 int line = debugLineInfo.line();

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/DebugInfoBase.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/DebugInfoBase.java
@@ -264,9 +264,9 @@ public abstract class DebugInfoBase {
                  * Record all subranges even if they have no line or file so we at least get a
                  * symbol for them and don't see a break in the address range.
                  */
-                ClassEntry subClassEntry = ensureClassEntry(classNameAtLine);
-                MethodEntry subMethodEntry = subClassEntry.ensureMethodEntryForDebugRangeInfo(debugLineInfo, this, debugContext);
-                Range subRange = new Range(stringTable, subMethodEntry, loAtLine, hiAtLine, line, primaryRange, isInlined, false, caller);
+                ClassEntry subRangeClassEntry = ensureClassEntry(classNameAtLine);
+                MethodEntry subRangeMethodEntry = subRangeClassEntry.ensureMethodEntryForDebugRangeInfo(debugLineInfo, this, debugContext);
+                Range subRange = new Range(stringTable, subRangeMethodEntry, loAtLine, hiAtLine, line, primaryRange, isInlined, false, caller);
                 classEntry.indexSubRange(subRange);
                 try (DebugContext.Scope s = debugContext.scope("Subranges")) {
                     debugContext.log(DebugContext.VERBOSE_LEVEL, "SubRange %s.%s %s %s:%d 0x%x, 0x%x]", classNameAtLine, methodNameAtLine, filePathAtLine, fileNameAtLine, line, loAtLine, hiAtLine);
@@ -378,9 +378,9 @@ public abstract class DebugInfoBase {
         final int lo = primaryRange.getLo() + lineInfo.addressLo();
         final int hi = primaryRange.getLo() + lineInfo.addressHi();
         final int line = lineInfo.line();
-        ClassEntry subClassEntry = ensureClassEntry(className);
-        MethodEntry subMethodEntry = subClassEntry.ensureMethodEntryForDebugRangeInfo(lineInfo, this, debugContext);
-        Range subRange = new Range(stringTable, subMethodEntry, lo, hi, line, primaryRange, true, true, caller);
+        ClassEntry inlineClassEntry = ensureClassEntry(className);
+        MethodEntry inlineMethodEntry = inlineClassEntry.ensureMethodEntryForDebugRangeInfo(lineInfo, this, debugContext);
+        Range subRange = new Range(stringTable, inlineMethodEntry, lo, hi, line, primaryRange, true, true, caller);
         classEntry.indexSubRange(subRange);
         try (DebugContext.Scope s = debugContext.scope("Subranges")) {
             debugContext.log(DebugContext.VERBOSE_LEVEL, "SubRange %s.%s %s %s:%d 0x%x, 0x%x]",

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/DebugInfoBase.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/DebugInfoBase.java
@@ -255,6 +255,7 @@ public abstract class DebugInfoBase {
                 Path filePathAtLine = debugLineInfo.filePath();
                 String classNameAtLine = TypeEntry.canonicalize(debugLineInfo.ownerType());
                 String methodNameAtLine = debugLineInfo.name();
+                boolean isInlined = false;
                 int loAtLine = lo + debugLineInfo.addressLo();
                 int hiAtLine = lo + debugLineInfo.addressHi();
                 int line = debugLineInfo.line();
@@ -264,7 +265,7 @@ public abstract class DebugInfoBase {
                  */
                 ClassEntry subClassEntry = ensureClassEntry(classNameAtLine);
                 MethodEntry subMethodEntry = subClassEntry.ensureMethodEntryForDebugRangeInfo(debugLineInfo, this, debugContext);
-                Range subRange = new Range(stringTable, subMethodEntry, loAtLine, hiAtLine, line, primaryRange);
+                Range subRange = new Range(stringTable, subMethodEntry, loAtLine, hiAtLine, line, primaryRange, isInlined, false, null);
                 classEntry.indexSubRange(subRange);
                 try (DebugContext.Scope s = debugContext.scope("Subranges")) {
                     debugContext.log(DebugContext.VERBOSE_LEVEL, "SubRange %s.%s %s %s:%d 0x%x, 0x%x]", classNameAtLine, methodNameAtLine, filePathAtLine, fileNameAtLine, line, loAtLine, hiAtLine);

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/MethodEntry.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/MethodEntry.java
@@ -26,6 +26,8 @@
 
 package com.oracle.objectfile.debugentry;
 
+import com.oracle.objectfile.debuginfo.DebugInfoProvider.DebugCodeInfo;
+import com.oracle.objectfile.debuginfo.DebugInfoProvider.DebugLineInfo;
 import com.oracle.objectfile.debuginfo.DebugInfoProvider.DebugRangeInfo;
 
 import java.util.Arrays;
@@ -34,23 +36,32 @@ import java.util.stream.Collectors;
 public class MethodEntry extends MemberEntry implements Comparable<MethodEntry> {
     final TypeEntry[] paramTypes;
     final String[] paramNames;
-    public final boolean isDeoptTarget;
-    boolean isInRange;
-
+    static final int DEOPT = 1 << 0;
+    static final int IN_RANGE = 1 << 1;
+    static final int INLINED = 1 << 2;
+    int flags;
     final String symbolName;
     private String signature;
 
     public MethodEntry(FileEntry fileEntry, String symbolName, String methodName, ClassEntry ownerType,
                     TypeEntry valueType, TypeEntry[] paramTypes, String[] paramNames, int modifiers,
-                    boolean isDeoptTarget, boolean isInRange) {
+                    boolean isDeoptTarget, boolean fromRange, boolean fromInlineRange) {
         super(fileEntry, methodName, ownerType, valueType, modifiers);
         assert ((paramTypes == null && paramNames == null) ||
                         (paramTypes != null && paramNames != null && paramTypes.length == paramNames.length));
         this.paramTypes = paramTypes;
         this.paramNames = paramNames;
-        this.isDeoptTarget = isDeoptTarget;
-        this.isInRange = isInRange;
         this.symbolName = symbolName;
+        this.flags = 0;
+        if (isDeoptTarget) {
+            setIsDeopt();
+        }
+        if (fromRange) {
+            setIsInRange();
+        }
+        if (fromInlineRange) {
+            setIsInlined();
+        }
     }
 
     public String methodName() {
@@ -91,8 +102,28 @@ public class MethodEntry extends MemberEntry implements Comparable<MethodEntry> 
         return paramNames[idx];
     }
 
+    private void setIsDeopt() {
+        flags |= DEOPT;
+    }
+
+    public boolean isDeopt() {
+        return (flags & DEOPT) != 0;
+    }
+
+    private void setIsInRange() {
+        flags |= IN_RANGE;
+    }
+
     public boolean isInRange() {
-        return isInRange;
+        return (flags & IN_RANGE) != 0;
+    }
+
+    private void setIsInlined() {
+        flags |= INLINED;
+    }
+
+    public boolean isInlined() {
+        return (flags & INLINED) != 0;
     }
 
     /**
@@ -105,19 +136,30 @@ public class MethodEntry extends MemberEntry implements Comparable<MethodEntry> 
      * @param debugInfoBase
      * @param debugRangeInfo
      */
-    public void setInRangeAndUpdateFileEntry(DebugInfoBase debugInfoBase, DebugRangeInfo debugRangeInfo) {
-        if (isInRange) {
-            assert fileEntry == debugInfoBase.ensureFileEntry(debugRangeInfo);
-            return;
+    public void updateRangeInfo(DebugInfoBase debugInfoBase, DebugRangeInfo debugRangeInfo) {
+        if (debugRangeInfo instanceof DebugLineInfo) {
+            DebugLineInfo lineInfo = (DebugLineInfo) debugRangeInfo;
+            if (lineInfo.getCaller() != null) {
+                /* this is a real inlined method not just a top level primary range */
+                setIsInlined();
+            }
+        } else if (debugRangeInfo instanceof DebugCodeInfo) {
+            /* this method has been seen in a primary range */
+            if (isInRange()) {
+                /* it has already been seen -- just check for consistency */
+                assert fileEntry == debugInfoBase.ensureFileEntry(debugRangeInfo);
+            } else {
+                /*
+                 * If the MethodEntry was added by traversing the DeclaredMethods of a Class its
+                 * fileEntry may point to the original source file, which will be wrong for
+                 * substituted methods. As a result when setting a MethodEntry as isInRange we also
+                 * make sure that its fileEntry reflects the file info associated with the
+                 * corresponding Range.
+                 */
+                setIsInRange();
+                fileEntry = debugInfoBase.ensureFileEntry(debugRangeInfo);
+            }
         }
-        isInRange = true;
-        /*
-         * If the MethodEntry was added by traversing the DeclaredMethods of a Class its fileEntry
-         * will point to the original source file, thus it will be wrong for substituted methods. As
-         * a result when setting a MethodEntry as isInRange we also make sure that its fileEntry
-         * reflects the file info associated with the corresponding Range.
-         */
-        fileEntry = debugInfoBase.ensureFileEntry(debugRangeInfo);
     }
 
     public String getSymbolName() {

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/MethodEntry.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/MethodEntry.java
@@ -28,7 +28,7 @@ package com.oracle.objectfile.debugentry;
 
 import com.oracle.objectfile.debuginfo.DebugInfoProvider.DebugCodeInfo;
 import com.oracle.objectfile.debuginfo.DebugInfoProvider.DebugLineInfo;
-import com.oracle.objectfile.debuginfo.DebugInfoProvider.DebugRangeInfo;
+import com.oracle.objectfile.debuginfo.DebugInfoProvider.DebugMethodInfo;
 
 import java.util.Arrays;
 import java.util.stream.Collectors;
@@ -43,25 +43,20 @@ public class MethodEntry extends MemberEntry implements Comparable<MethodEntry> 
     final String symbolName;
     private String signature;
 
-    public MethodEntry(FileEntry fileEntry, String symbolName, String methodName, ClassEntry ownerType,
-                    TypeEntry valueType, TypeEntry[] paramTypes, String[] paramNames, int modifiers,
-                    boolean isDeoptTarget, boolean fromRange, boolean fromInlineRange) {
-        super(fileEntry, methodName, ownerType, valueType, modifiers);
+    public MethodEntry(DebugInfoBase debugInfoBase, DebugMethodInfo debugMethodInfo,
+                    FileEntry fileEntry, String methodName, ClassEntry ownerType,
+                    TypeEntry valueType, TypeEntry[] paramTypes, String[] paramNames) {
+        super(fileEntry, methodName, ownerType, valueType, debugMethodInfo.modifiers());
         assert ((paramTypes == null && paramNames == null) ||
                         (paramTypes != null && paramNames != null && paramTypes.length == paramNames.length));
         this.paramTypes = paramTypes;
         this.paramNames = paramNames;
-        this.symbolName = symbolName;
+        this.symbolName = debugMethodInfo.symbolNameForMethod();
         this.flags = 0;
-        if (isDeoptTarget) {
+        if (debugMethodInfo.isDeoptTarget()) {
             setIsDeopt();
         }
-        if (fromRange) {
-            setIsInRange();
-        }
-        if (fromInlineRange) {
-            setIsInlined();
-        }
+        updateRangeInfo(debugInfoBase, debugMethodInfo);
     }
 
     public String methodName() {
@@ -132,22 +127,22 @@ public class MethodEntry extends MemberEntry implements Comparable<MethodEntry> 
      * to the original source file, thus it will be wrong for substituted methods. As a result when
      * setting a MethodEntry as isInRange we also make sure that its fileEntry reflects the file
      * info associated with the corresponding Range.
-     *
+     * 
      * @param debugInfoBase
-     * @param debugRangeInfo
+     * @param debugMethodInfo
      */
-    public void updateRangeInfo(DebugInfoBase debugInfoBase, DebugRangeInfo debugRangeInfo) {
-        if (debugRangeInfo instanceof DebugLineInfo) {
-            DebugLineInfo lineInfo = (DebugLineInfo) debugRangeInfo;
+    public void updateRangeInfo(DebugInfoBase debugInfoBase, DebugMethodInfo debugMethodInfo) {
+        if (debugMethodInfo instanceof DebugLineInfo) {
+            DebugLineInfo lineInfo = (DebugLineInfo) debugMethodInfo;
             if (lineInfo.getCaller() != null) {
                 /* this is a real inlined method not just a top level primary range */
                 setIsInlined();
             }
-        } else if (debugRangeInfo instanceof DebugCodeInfo) {
+        } else if (debugMethodInfo instanceof DebugCodeInfo) {
             /* this method has been seen in a primary range */
             if (isInRange()) {
                 /* it has already been seen -- just check for consistency */
-                assert fileEntry == debugInfoBase.ensureFileEntry(debugRangeInfo);
+                assert fileEntry == debugInfoBase.ensureFileEntry(debugMethodInfo);
             } else {
                 /*
                  * If the MethodEntry was added by traversing the DeclaredMethods of a Class its
@@ -157,7 +152,7 @@ public class MethodEntry extends MemberEntry implements Comparable<MethodEntry> 
                  * corresponding Range.
                  */
                 setIsInRange();
-                fileEntry = debugInfoBase.ensureFileEntry(debugRangeInfo);
+                fileEntry = debugInfoBase.ensureFileEntry(debugMethodInfo);
             }
         }
     }

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/PrimaryEntry.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/PrimaryEntry.java
@@ -68,6 +68,12 @@ public class PrimaryEntry {
         return classEntry;
     }
 
+    /**
+     * Returns an iterator that traverses all the callees of the primary range associated with this
+     * entry. The iterator performs a depth-first pre-order traversal of the call tree.
+     *
+     * @return the iterator
+     */
     public Iterator<Range> topDownRangeIterator() {
         return new Iterator<Range>() {
             final ArrayDeque<Range> workStack = new ArrayDeque<>();
@@ -87,7 +93,7 @@ public class PrimaryEntry {
             }
 
             private void forward() {
-                Range sibling = current.getNextCallee();
+                Range sibling = current.getSiblingCallee();
                 assert sibling == null || (current.getHi() <= sibling.getLo()) : current.getHi() + " > " + sibling.getLo();
                 if (!current.isLeaf()) {
                     /* save next sibling while we process the children */
@@ -108,6 +114,13 @@ public class PrimaryEntry {
         };
     }
 
+    /**
+     * Returns an iterator that traverses the callees of the primary range associated with this
+     * entry and returns only the leafs. The iterator performs a depth-first pre-order traversal of
+     * the call tree returning only ranges with no callees.
+     *
+     * @return the iterator
+     */
     public Iterator<Range> leafRangeIterator() {
         final Iterator<Range> iter = topDownRangeIterator();
         return new Iterator<Range>() {

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/PrimaryEntry.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/PrimaryEntry.java
@@ -28,7 +28,8 @@ package com.oracle.objectfile.debugentry;
 
 import com.oracle.objectfile.debuginfo.DebugInfoProvider.DebugFrameSizeChange;
 
-import java.util.ArrayList;
+import java.util.ArrayDeque;
+import java.util.Iterator;
 import java.util.List;
 
 /**
@@ -44,10 +45,6 @@ public class PrimaryEntry {
      */
     private ClassEntry classEntry;
     /**
-     * A list of subranges associated with the primary range.
-     */
-    private List<Range> subranges;
-    /**
      * Details of of compiled method frame size changes.
      */
     private List<DebugFrameSizeChange> frameSizeInfos;
@@ -59,20 +56,8 @@ public class PrimaryEntry {
     public PrimaryEntry(Range primary, List<DebugFrameSizeChange> frameSizeInfos, int frameSize, ClassEntry classEntry) {
         this.primary = primary;
         this.classEntry = classEntry;
-        this.subranges = new ArrayList<>();
         this.frameSizeInfos = frameSizeInfos;
         this.frameSize = frameSize;
-    }
-
-    public void addSubRange(Range subrange) {
-        /*
-         * We should not see a subrange more than once.
-         */
-        assert !subranges.contains(subrange);
-        /*
-         * We need to generate a file table entry for all ranges.
-         */
-        subranges.add(subrange);
     }
 
     public Range getPrimary() {
@@ -83,8 +68,75 @@ public class PrimaryEntry {
         return classEntry;
     }
 
-    public List<Range> getSubranges() {
-        return subranges;
+    public Iterator<Range> topDownRangeIterator() {
+        return new Iterator<Range>() {
+            final ArrayDeque<Range> workStack = new ArrayDeque<>();
+            Range current = primary.getFirstCallee();
+
+            @Override
+            public boolean hasNext() {
+                return current != null;
+            }
+
+            @Override
+            public Range next() {
+                assert hasNext();
+                Range result = current;
+                forward();
+                return result;
+            }
+
+            private void forward() {
+                Range sibling = current.getNextCallee();
+                assert sibling == null || (current.getHi() <= sibling.getLo()) : current.getHi() + " > " + sibling.getLo();
+                if (!current.isLeaf()) {
+                    /* save next sibling while we process the children */
+                    if (sibling != null) {
+                        workStack.push(sibling);
+                    }
+                    current = current.getFirstCallee();
+                } else if (sibling != null) {
+                    current = sibling;
+                } else {
+                    /*
+                     * Return back up to parents' siblings, use pollFirst instead of pop to return
+                     * null in case the work stack is empty
+                     */
+                    current = workStack.pollFirst();
+                }
+            }
+        };
+    }
+
+    public Iterator<Range> leafRangeIterator() {
+        final Iterator<Range> iter = topDownRangeIterator();
+        return new Iterator<Range>() {
+            Range current = forwardLeaf(iter);
+
+            @Override
+            public boolean hasNext() {
+                return current != null;
+            }
+
+            @Override
+            public Range next() {
+                assert hasNext();
+                Range result = current;
+                current = forwardLeaf(iter);
+                return result;
+            }
+
+            private Range forwardLeaf(Iterator<Range> t) {
+                if (t.hasNext()) {
+                    Range next = t.next();
+                    while (next != null && !next.isLeaf()) {
+                        next = t.next();
+                    }
+                    return next;
+                }
+                return null;
+            }
+        };
     }
 
     public List<DebugFrameSizeChange> getFrameSizeInfos() {

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/Range.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/Range.java
@@ -36,6 +36,7 @@ public class Range {
     private static final String CLASS_DELIMITER = ".";
     private final Range caller;
     private final MethodEntry methodEntry;
+    private final String fullMethodName;
     private final String fullMethodNameWithParams;
     private final int lo;
     private final int hi;
@@ -64,6 +65,7 @@ public class Range {
             stringTable.uniqueDebugString(methodEntry.fileEntry.getPathName());
         }
         this.methodEntry = methodEntry;
+        this.fullMethodName = isInline ? stringTable.uniqueDebugString(constructClassAndMethodName()) : stringTable.uniqueString(constructClassAndMethodName());
         this.fullMethodNameWithParams = stringTable.uniqueString(constructClassAndMethodNameWithParams());
         this.lo = lo;
         this.hi = hi;
@@ -111,7 +113,7 @@ public class Range {
     }
 
     public String getFullMethodName() {
-        return constructClassAndMethodName();
+        return fullMethodName;
     }
 
     public String getFullMethodNameWithParams() {

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/Range.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/Range.java
@@ -34,11 +34,14 @@ package com.oracle.objectfile.debugentry;
 
 public class Range {
     private static final String CLASS_DELIMITER = ".";
+    private final Range caller;
     private final MethodEntry methodEntry;
     private final String fullMethodNameWithParams;
     private final int lo;
     private final int hi;
     private final int line;
+    private final boolean isInlined;
+    private final boolean withChildren;
     /*
      * This is null for a primary range.
      */
@@ -48,13 +51,13 @@ public class Range {
      * Create a primary range.
      */
     public Range(StringTable stringTable, MethodEntry methodEntry, int lo, int hi, int line) {
-        this(stringTable, methodEntry, lo, hi, line, null);
+        this(stringTable, methodEntry, lo, hi, line, null, false, false, null);
     }
 
     /*
      * Create a primary or secondary range.
      */
-    public Range(StringTable stringTable, MethodEntry methodEntry, int lo, int hi, int line, Range primary) {
+    public Range(StringTable stringTable, MethodEntry methodEntry, int lo, int hi, int line, Range primary, boolean isInline, boolean withChildren, Range caller) {
         assert methodEntry != null;
         if (methodEntry.fileEntry != null) {
             stringTable.uniqueDebugString(methodEntry.fileEntry.getFileName());
@@ -65,7 +68,10 @@ public class Range {
         this.lo = lo;
         this.hi = hi;
         this.line = line;
+        this.isInlined = isInline;
         this.primary = primary;
+        this.withChildren = withChildren;
+        this.caller = caller;
     }
 
     public boolean contains(Range other) {
@@ -166,5 +172,17 @@ public class Range {
 
     public MethodEntry getMethodEntry() {
         return methodEntry;
+    }
+
+    public boolean isInlined() {
+        return isInlined;
+    }
+
+    public boolean withChildren() {
+        return withChildren;
+    }
+
+    public Range getCaller() {
+        return caller;
     }
 }

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/Range.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/Range.java
@@ -123,7 +123,7 @@ public class Range {
     }
 
     public boolean isDeoptTarget() {
-        return methodEntry.isDeoptTarget;
+        return methodEntry.isDeopt();
     }
 
     private String getExtendedMethodName(boolean includeClass, boolean includeParams, boolean includeReturnType) {

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/Range.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/Range.java
@@ -43,6 +43,7 @@ public class Range {
     private final int line;
     private final boolean isInlined;
     private final boolean withChildren;
+    private boolean withInlinedChildren;
     /*
      * This is null for a primary range.
      */
@@ -73,6 +74,7 @@ public class Range {
         this.isInlined = isInline;
         this.primary = primary;
         this.withChildren = withChildren;
+        this.withInlinedChildren = false;
         this.caller = caller;
     }
 
@@ -182,6 +184,14 @@ public class Range {
 
     public boolean withChildren() {
         return withChildren;
+    }
+
+    public boolean withInlinedChildren() {
+        return withInlinedChildren;
+    }
+
+    public boolean setWithInlinedChildren(boolean withInlinedChildren) {
+        return this.withInlinedChildren = withInlinedChildren;
     }
 
     public Range getCaller() {

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debuginfo/DebugInfoProvider.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debuginfo/DebugInfoProvider.java
@@ -31,6 +31,7 @@ import java.util.List;
 import java.util.function.Consumer;
 import java.util.stream.Stream;
 
+import jdk.vm.ci.meta.ResolvedJavaMethod;
 import jdk.vm.ci.meta.ResolvedJavaType;
 import org.graalvm.compiler.debug.DebugContext;
 
@@ -201,9 +202,9 @@ public interface DebugInfoProvider {
 
     interface DebugMethodInfo extends DebugMemberInfo {
         /**
-         * @return a string identifying the method parameters.
+         * @return the JavaMethod of the method associated with this DebugMethodInfo.
          */
-        String paramSignature();
+        ResolvedJavaMethod getJavaMethod();
 
         /**
          * @return an array of Strings identifying the method parameters.

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debuginfo/DebugInfoProvider.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debuginfo/DebugInfoProvider.java
@@ -31,6 +31,7 @@ import java.util.List;
 import java.util.function.Consumer;
 import java.util.stream.Stream;
 
+import jdk.vm.ci.meta.ResolvedJavaType;
 import org.graalvm.compiler.debug.DebugContext;
 
 /**
@@ -187,8 +188,6 @@ public interface DebugInfoProvider {
 
         String name();
 
-        String ownerType();
-
         String valueType();
 
         int modifiers();
@@ -232,6 +231,7 @@ public interface DebugInfoProvider {
      * {@link com.oracle.objectfile.debugentry.Range}.
      */
     interface DebugRangeInfo extends DebugMethodInfo {
+        ResolvedJavaType ownerType();
     }
 
     /**

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debuginfo/DebugInfoProvider.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debuginfo/DebugInfoProvider.java
@@ -315,6 +315,11 @@ public interface DebugInfoProvider {
          * @return the line number for the outer or inlined segment.
          */
         int line();
+
+        /**
+         * @return the {@link DebugLineInfo} of the nested inline caller-line
+         */
+        DebugLineInfo getCaller();
     }
 
     interface DebugFrameSizeChange {

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfAbbrevSectionImpl.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfAbbrevSectionImpl.java
@@ -858,9 +858,9 @@ public class DwarfAbbrevSectionImpl extends DwarfSectionImpl {
         int pos = p;
         /* class compile unit with compiled methods and line info */
         pos = writeClassUnitAbbrev(context, DwarfDebugInfo.DW_ABBREV_CODE_class_unit1, buffer, pos);
-        /* class compile unit with line info but without line info */
+        /* class compile unit with compiled methods but without line info */
         pos = writeClassUnitAbbrev(context, DwarfDebugInfo.DW_ABBREV_CODE_class_unit2, buffer, pos);
-        /* class compile unit without line info and without line info */
+        /* class compile unit without compiled methods and without line info */
         pos = writeClassUnitAbbrev(context, DwarfDebugInfo.DW_ABBREV_CODE_class_unit3, buffer, pos);
         return pos;
     }

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfAbbrevSectionImpl.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfAbbrevSectionImpl.java
@@ -1349,7 +1349,7 @@ public class DwarfAbbrevSectionImpl extends DwarfSectionImpl {
         pos = writeTag(DwarfDebugInfo.DW_TAG_inlined_subroutine, buffer, pos);
         pos = writeFlag(withChildren ? DwarfDebugInfo.DW_CHILDREN_yes : DwarfDebugInfo.DW_CHILDREN_no, buffer, pos);
         pos = writeAttrType(DwarfDebugInfo.DW_AT_abstract_origin, buffer, pos);
-        pos = writeAttrForm(DwarfDebugInfo.DW_FORM_ref4, buffer, pos);
+        pos = writeAttrForm(DwarfDebugInfo.DW_FORM_ref_addr, buffer, pos);
         pos = writeAttrType(DwarfDebugInfo.DW_AT_low_pc, buffer, pos);
         pos = writeAttrForm(DwarfDebugInfo.DW_FORM_addr, buffer, pos);
         pos = writeAttrType(DwarfDebugInfo.DW_AT_hi_pc, buffer, pos);

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfDebugInfo.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfDebugInfo.java
@@ -78,6 +78,7 @@ public class DwarfDebugInfo extends DebugInfoBase {
     public static final int DW_ABBREV_CODE_class_layout2 = 9;
     public static final int DW_ABBREV_CODE_class_pointer = 10;
     public static final int DW_ABBREV_CODE_method_location = 11;
+    public static final int DW_ABBREV_CODE_method_location_inline = 32;
     public static final int DW_ABBREV_CODE_static_field_location = 12;
     public static final int DW_ABBREV_CODE_array_layout = 13;
     public static final int DW_ABBREV_CODE_array_pointer = 14;
@@ -86,8 +87,8 @@ public class DwarfDebugInfo extends DebugInfoBase {
     public static final int DW_ABBREV_CODE_indirect_layout = 17;
     public static final int DW_ABBREV_CODE_indirect_pointer = 18;
     /* Level 2 DIEs. */
-    public static final int DW_ABBREV_CODE_method_declaration1 = 19;
-    public static final int DW_ABBREV_CODE_method_declaration2 = 20;
+    public static final int DW_ABBREV_CODE_method_declaration = 19;
+    public static final int DW_ABBREV_CODE_method_declaration_static = 20;
     public static final int DW_ABBREV_CODE_field_declaration1 = 21;
     public static final int DW_ABBREV_CODE_field_declaration2 = 22;
     public static final int DW_ABBREV_CODE_field_declaration3 = 23;
@@ -100,6 +101,11 @@ public class DwarfDebugInfo extends DebugInfoBase {
     public static final int DW_ABBREV_CODE_method_parameter_declaration1 = 29;
     public static final int DW_ABBREV_CODE_method_parameter_declaration2 = 30;
     public static final int DW_ABBREV_CODE_method_parameter_declaration3 = 31;
+
+    /* Level X DIEs */
+    public static final int DW_ABBREV_CODE_inlined_subroutine = 33;
+    public static final int DW_ABBREV_CODE_inlined_subroutine_with_children = 34;
+
     /*
      * Define all the Dwarf tags we need for our DIEs.
      */
@@ -116,6 +122,7 @@ public class DwarfDebugInfo extends DebugInfoBase {
     public static final int DW_TAG_subprogram = 0x2e;
     public static final int DW_TAG_variable = 0x34;
     public static final int DW_TAG_unspecified_type = 0x3b;
+    public static final int DW_TAG_inlined_subroutine = 0x1d;
 
     /*
      * Define all the Dwarf attributes we need for our DIEs.
@@ -131,6 +138,8 @@ public class DwarfDebugInfo extends DebugInfoBase {
     public static final int DW_AT_language = 0x13;
     public static final int DW_AT_comp_dir = 0x1b;
     public static final int DW_AT_containing_type = 0x1d;
+    public static final int DW_AT_inline = 0x20;
+    public static final int DW_AT_abstract_origin = 0x31;
     public static final int DW_AT_accessibility = 0x32;
     public static final int DW_AT_artificial = 0x34;
     public static final int DW_AT_data_member_location = 0x38;
@@ -146,6 +155,8 @@ public class DwarfDebugInfo extends DebugInfoBase {
     public static final int DW_AT_type = 0x49;
     public static final int DW_AT_data_location = 0x50;
     public static final int DW_AT_use_UTF8 = 0x53;
+    public static final int DW_AT_call_file = 0x58;
+    public static final int DW_AT_call_line = 0x59;
     public static final int DW_AT_object_pointer = 0x64;
 
     /*
@@ -158,6 +169,10 @@ public class DwarfDebugInfo extends DebugInfoBase {
     @SuppressWarnings("unused") public static final int DW_FORM_data8 = 0x7;
     @SuppressWarnings("unused") private static final int DW_FORM_string = 0x8;
     @SuppressWarnings("unused") public static final int DW_FORM_block1 = 0x0a;
+    @SuppressWarnings("unused") public static final int DW_FORM_ref1 = 0x11;
+    @SuppressWarnings("unused") public static final int DW_FORM_ref2 = 0x12;
+    public static final int DW_FORM_ref4 = 0x13;
+    @SuppressWarnings("unused") public static final int DW_FORM_ref8 = 0x14;
     public static final int DW_FORM_ref_addr = 0x10;
     public static final int DW_FORM_data1 = 0x0b;
     public static final int DW_FORM_flag = 0xc;
@@ -181,6 +196,13 @@ public class DwarfDebugInfo extends DebugInfoBase {
      * Value for DW_AT_language attribute with form DATA1.
      */
     public static final byte DW_LANG_Java = 0xb;
+    /*
+     * Values for {@link DW_AT_inline} attribute with form DATA1.
+     */
+    @SuppressWarnings("unused") public static final byte DW_INL_not_inlined = 0;
+    public static final byte DW_INL_inlined = 1;
+    @SuppressWarnings("unused") public static final byte DW_INL_declared_not_inlined = 2;
+    @SuppressWarnings("unused") public static final byte DW_INL_declared_inlined = 3;
 
     /*
      * DW_AT_Accessibility attribute values.

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfDebugInfo.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfDebugInfo.java
@@ -69,42 +69,42 @@ public class DwarfDebugInfo extends DebugInfoBase {
     public static final int DW_ABBREV_CODE_builtin_unit = 1;
     public static final int DW_ABBREV_CODE_class_unit1 = 2;
     public static final int DW_ABBREV_CODE_class_unit2 = 3;
-    public static final int DW_ABBREV_CODE_array_unit = 4;
+    public static final int DW_ABBREV_CODE_class_unit3 = 4;
+    public static final int DW_ABBREV_CODE_array_unit = 5;
     /* Level 1 DIEs. */
-    public static final int DW_ABBREV_CODE_primitive_type = 5;
-    public static final int DW_ABBREV_CODE_void_type = 6;
-    public static final int DW_ABBREV_CODE_object_header = 7;
-    public static final int DW_ABBREV_CODE_class_layout1 = 8;
-    public static final int DW_ABBREV_CODE_class_layout2 = 9;
-    public static final int DW_ABBREV_CODE_class_pointer = 10;
-    public static final int DW_ABBREV_CODE_method_location = 11;
-    public static final int DW_ABBREV_CODE_method_location_inline = 32;
-    public static final int DW_ABBREV_CODE_static_field_location = 12;
-    public static final int DW_ABBREV_CODE_array_layout = 13;
-    public static final int DW_ABBREV_CODE_array_pointer = 14;
-    public static final int DW_ABBREV_CODE_interface_layout = 15;
-    public static final int DW_ABBREV_CODE_interface_pointer = 16;
-    public static final int DW_ABBREV_CODE_indirect_layout = 17;
-    public static final int DW_ABBREV_CODE_indirect_pointer = 18;
+    public static final int DW_ABBREV_CODE_primitive_type = 6;
+    public static final int DW_ABBREV_CODE_void_type = 7;
+    public static final int DW_ABBREV_CODE_object_header = 8;
+    public static final int DW_ABBREV_CODE_class_layout1 = 9;
+    public static final int DW_ABBREV_CODE_class_layout2 = 10;
+    public static final int DW_ABBREV_CODE_class_pointer = 11;
+    public static final int DW_ABBREV_CODE_method_location = 12;
+    public static final int DW_ABBREV_CODE_abstract_inline_method = 13;
+    public static final int DW_ABBREV_CODE_static_field_location = 14;
+    public static final int DW_ABBREV_CODE_array_layout = 15;
+    public static final int DW_ABBREV_CODE_array_pointer = 16;
+    public static final int DW_ABBREV_CODE_interface_layout = 17;
+    public static final int DW_ABBREV_CODE_interface_pointer = 18;
+    public static final int DW_ABBREV_CODE_indirect_layout = 19;
+    public static final int DW_ABBREV_CODE_indirect_pointer = 20;
     /* Level 2 DIEs. */
-    public static final int DW_ABBREV_CODE_method_declaration = 19;
-    public static final int DW_ABBREV_CODE_method_declaration_static = 20;
-    public static final int DW_ABBREV_CODE_field_declaration1 = 21;
-    public static final int DW_ABBREV_CODE_field_declaration2 = 22;
-    public static final int DW_ABBREV_CODE_field_declaration3 = 23;
-    public static final int DW_ABBREV_CODE_field_declaration4 = 24;
-    public static final int DW_ABBREV_CODE_header_field = 25;
-    public static final int DW_ABBREV_CODE_array_data_type = 26;
-    public static final int DW_ABBREV_CODE_super_reference = 27;
-    public static final int DW_ABBREV_CODE_interface_implementor = 28;
+    public static final int DW_ABBREV_CODE_method_declaration = 21;
+    public static final int DW_ABBREV_CODE_method_declaration_static = 22;
+    public static final int DW_ABBREV_CODE_field_declaration1 = 23;
+    public static final int DW_ABBREV_CODE_field_declaration2 = 24;
+    public static final int DW_ABBREV_CODE_field_declaration3 = 25;
+    public static final int DW_ABBREV_CODE_field_declaration4 = 26;
+    public static final int DW_ABBREV_CODE_header_field = 27;
+    public static final int DW_ABBREV_CODE_array_data_type = 28;
+    public static final int DW_ABBREV_CODE_super_reference = 29;
+    public static final int DW_ABBREV_CODE_interface_implementor = 30;
+    /* Level 2+K DIEs (where inline depth K >= 0) */
+    public static final int DW_ABBREV_CODE_inlined_subroutine = 31;
+    public static final int DW_ABBREV_CODE_inlined_subroutine_with_children = 32;
     /* Level 3 DIEs. */
-    public static final int DW_ABBREV_CODE_method_parameter_declaration1 = 29;
-    public static final int DW_ABBREV_CODE_method_parameter_declaration2 = 30;
-    public static final int DW_ABBREV_CODE_method_parameter_declaration3 = 31;
-
-    /* Level X DIEs */
-    public static final int DW_ABBREV_CODE_inlined_subroutine = 33;
-    public static final int DW_ABBREV_CODE_inlined_subroutine_with_children = 34;
+    public static final int DW_ABBREV_CODE_method_parameter_declaration1 = 33;
+    public static final int DW_ABBREV_CODE_method_parameter_declaration2 = 34;
+    public static final int DW_ABBREV_CODE_method_parameter_declaration3 = 35;
 
     /*
      * Define all the Dwarf tags we need for our DIEs.
@@ -687,7 +687,7 @@ public class DwarfDebugInfo extends DebugInfoBase {
             classProperties.fieldDeclarationIndex = fieldDeclarationIndex = new HashMap<>();
         }
         if (fieldDeclarationIndex.get(fieldName) != null) {
-            assert fieldDeclarationIndex.get(fieldName) == pos;
+            assert fieldDeclarationIndex.get(fieldName) == pos : entry.getTypeName() + fieldName;
         } else {
             fieldDeclarationIndex.put(fieldName, pos);
         }
@@ -698,8 +698,8 @@ public class DwarfDebugInfo extends DebugInfoBase {
         classProperties = lookupClassProperties(entry);
         assert classProperties.getTypeEntry() == entry;
         HashMap<String, Integer> fieldDeclarationIndex = classProperties.fieldDeclarationIndex;
-        assert fieldDeclarationIndex != null;
-        assert fieldDeclarationIndex.get(fieldName) != null;
+        assert fieldDeclarationIndex != null : fieldName;
+        assert fieldDeclarationIndex.get(fieldName) != null : entry.getTypeName() + fieldName;
         return fieldDeclarationIndex.get(fieldName);
     }
 
@@ -712,7 +712,7 @@ public class DwarfDebugInfo extends DebugInfoBase {
             classProperties.methodDeclarationIndex = methodDeclarationIndex = new HashMap<>();
         }
         if (methodDeclarationIndex.get(methodName) != null) {
-            assert methodDeclarationIndex.get(methodName) == pos;
+            assert methodDeclarationIndex.get(methodName) == pos : classEntry.getTypeName() + methodName;
         } else {
             methodDeclarationIndex.put(methodName, pos);
         }
@@ -723,8 +723,8 @@ public class DwarfDebugInfo extends DebugInfoBase {
         classProperties = lookupClassProperties(classEntry);
         assert classProperties.getTypeEntry() == classEntry;
         HashMap<String, Integer> methodDeclarationIndex = classProperties.methodDeclarationIndex;
-        assert methodDeclarationIndex != null;
-        assert methodDeclarationIndex.get(methodName) != null;
+        assert methodDeclarationIndex != null : classEntry.getTypeName() + methodName;
+        assert methodDeclarationIndex.get(methodName) != null : classEntry.getTypeName() + methodName;
         return methodDeclarationIndex.get(methodName);
     }
 

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfDebugInfo.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfDebugInfo.java
@@ -171,7 +171,7 @@ public class DwarfDebugInfo extends DebugInfoBase {
     @SuppressWarnings("unused") public static final int DW_FORM_block1 = 0x0a;
     @SuppressWarnings("unused") public static final int DW_FORM_ref1 = 0x11;
     @SuppressWarnings("unused") public static final int DW_FORM_ref2 = 0x12;
-    public static final int DW_FORM_ref4 = 0x13;
+    @SuppressWarnings("unused") public static final int DW_FORM_ref4 = 0x13;
     @SuppressWarnings("unused") public static final int DW_FORM_ref8 = 0x14;
     public static final int DW_FORM_ref_addr = 0x10;
     public static final int DW_FORM_data1 = 0x0b;
@@ -458,6 +458,10 @@ public class DwarfDebugInfo extends DebugInfoBase {
          * Map from method names to info section index for the field declaration.
          */
         private HashMap<String, Integer> methodDeclarationIndex;
+        /**
+         * Map from method names to info section index for the field declaration.
+         */
+        private HashMap<String, Integer> abstractInlineMethodIndex;
 
         DwarfClassProperties(StructureTypeEntry entry) {
             super(entry);
@@ -470,6 +474,7 @@ public class DwarfDebugInfo extends DebugInfoBase {
             this.lineSectionSize = -1;
             fieldDeclarationIndex = null;
             methodDeclarationIndex = null;
+            abstractInlineMethodIndex = null;
         }
     }
 
@@ -721,5 +726,30 @@ public class DwarfDebugInfo extends DebugInfoBase {
         assert methodDeclarationIndex != null;
         assert methodDeclarationIndex.get(methodName) != null;
         return methodDeclarationIndex.get(methodName);
+    }
+
+    public void setAbstractInlineMethodIndex(ClassEntry classEntry, String methodName, int pos) {
+        DwarfClassProperties classProperties;
+        classProperties = lookupClassProperties(classEntry);
+        assert classProperties.getTypeEntry() == classEntry;
+        HashMap<String, Integer> abstractInlineMethodIndex = classProperties.abstractInlineMethodIndex;
+        if (abstractInlineMethodIndex == null) {
+            classProperties.abstractInlineMethodIndex = abstractInlineMethodIndex = new HashMap<>();
+        }
+        if (abstractInlineMethodIndex.get(methodName) != null) {
+            assert abstractInlineMethodIndex.get(methodName) == pos : classEntry.getTypeName() + methodName;
+        } else {
+            abstractInlineMethodIndex.put(methodName, pos);
+        }
+    }
+
+    public int getAbstractInlineMethodIndex(ClassEntry classEntry, String methodName) {
+        DwarfClassProperties classProperties;
+        classProperties = lookupClassProperties(classEntry);
+        assert classProperties.getTypeEntry() == classEntry;
+        HashMap<String, Integer> abstractInlineMethodIndex = classProperties.abstractInlineMethodIndex;
+        assert abstractInlineMethodIndex != null : classEntry.getTypeName() + methodName;
+        assert abstractInlineMethodIndex.get(methodName) != null : classEntry.getTypeName() + methodName;
+        return abstractInlineMethodIndex.get(methodName);
     }
 }

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfInfoSectionImpl.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfInfoSectionImpl.java
@@ -661,7 +661,7 @@ public class DwarfInfoSectionImpl extends DwarfSectionImpl {
     private int writeMethodDeclarations(DebugContext context, ClassEntry classEntry, byte[] buffer, int p) {
         int pos = p;
         for (MethodEntry method : classEntry.getMethods()) {
-            if (method.isInRange()) {
+            if (method.isInRange() || method.isInlined()) {
                 /*
                  * Declare all methods including deopt targets even though they are written in
                  * separate CUs.
@@ -700,8 +700,8 @@ public class DwarfInfoSectionImpl extends DwarfSectionImpl {
         int retTypeIdx = getTypeIndex(returnTypeName);
         log(context, "  [0x%08x]     type 0x%x (%s)", pos, retTypeIdx, returnTypeName);
         pos = writeAttrRefAddr(retTypeIdx, buffer, pos);
-        log(context, "  [0x%08x]     artificial %s", pos, method.isDeoptTarget ? "true" : "false");
-        pos = writeFlag((method.isDeoptTarget ? (byte) 1 : (byte) 0), buffer, pos);
+        log(context, "  [0x%08x]     artificial %s", pos, method.isDeopt() ? "true" : "false");
+        pos = writeFlag((method.isDeopt() ? (byte) 1 : (byte) 0), buffer, pos);
         log(context, "  [0x%08x]     accessibility %s", pos, "public");
         pos = writeAttrAccessibility(modifiers, buffer, pos);
         log(context, "  [0x%08x]     declaration true", pos);

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfInfoSectionImpl.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfInfoSectionImpl.java
@@ -1335,6 +1335,7 @@ public class DwarfInfoSectionImpl extends DwarfSectionImpl {
     private int writeInlineSubroutine(DebugContext context, ClassEntry classEntry, Range range, int subprogramOffset, int depth, byte[] buffer, int p) {
         assert range.isInlined();
         int pos = p;
+        log(context, "  [0x%08x] concrete inline subroutine [0x%x, 0x%x] %s", pos, range.getLo(), range.getHi(), range.getSymbolName());
         final Range callerSubrange = range.getCaller();
         assert callerSubrange != null;
         int callLine = callerSubrange.getLine();
@@ -1358,17 +1359,17 @@ public class DwarfInfoSectionImpl extends DwarfSectionImpl {
         } else {
             code = DwarfDebugInfo.DW_ABBREV_CODE_inlined_subroutine;
         }
-        verboseLog(context, "  [0x%08x] <%d> Abbrev Number  %d", pos, depth + 2, code);
+        log(context, "  [0x%08x] <%d> Abbrev Number  %d", pos, depth + 1, code);
         pos = writeAbbrevCode(code, buffer, pos);
-        verboseLog(context, "  [0x%08x]     abstract_origin  0x%X", pos, subprogramOffset);
+        log(context, "  [0x%08x]     abstract_origin  0x%x", pos, subprogramOffset);
         pos = writeAttrRef4(subprogramOffset, buffer, pos);
-        verboseLog(context, "  [0x%08x]     lo_pc  0x%08x", pos, range.getLo());
+        log(context, "  [0x%08x]     lo_pc  0x%08x", pos, range.getLo());
         pos = writeAttrAddress(range.getLo(), buffer, pos);
-        verboseLog(context, "  [0x%08x]     hi_pc  0x%08x", pos, range.getHi());
+        log(context, "  [0x%08x]     hi_pc  0x%08x", pos, range.getHi());
         pos = writeAttrAddress(range.getHi(), buffer, pos);
-        verboseLog(context, "  [0x%08x]     call_file  %d", pos, fileIndex);
+        log(context, "  [0x%08x]     call_file  %d", pos, fileIndex);
         pos = writeAttrData4(fileIndex, buffer, pos);
-        verboseLog(context, "  [0x%08x]     call_line  %d", pos, callLine);
+        log(context, "  [0x%08x]     call_line  %d", pos, callLine);
         pos = writeAttrData4(callLine, buffer, pos);
         return pos;
     }
@@ -1414,12 +1415,13 @@ public class DwarfInfoSectionImpl extends DwarfSectionImpl {
             }
         }
         /* We should never get here. */
-        assert false;
+        assert false : "should not reach";
         return 0;
     }
 
     private static int findHi(List<PrimaryEntry> classPrimaryEntries, boolean includesDeoptTarget, boolean isDeoptTargetCU) {
         if (isDeoptTargetCU || !includesDeoptTarget) {
+            assert classPrimaryEntries.size() > 0 : "expected to find primary methods";
             /* Either way the last entry is the one we want. */
             return classPrimaryEntries.get(classPrimaryEntries.size() - 1).getPrimary().getHi();
         } else {
@@ -1435,7 +1437,7 @@ public class DwarfInfoSectionImpl extends DwarfSectionImpl {
             }
         }
         /* We should never get here. */
-        assert false;
+        assert false : "should not reach";
         return 0;
     }
 

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfInfoSectionImpl.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfInfoSectionImpl.java
@@ -679,7 +679,7 @@ public class DwarfInfoSectionImpl extends DwarfSectionImpl {
         int modifiers = method.getModifiers();
         boolean isStatic = Modifier.isStatic(modifiers);
         log(context, "  [0x%08x] method declaration %s", pos, methodKey);
-        int abbrevCode = (isStatic ? DwarfDebugInfo.DW_ABBREV_CODE_method_declaration2 : DwarfDebugInfo.DW_ABBREV_CODE_method_declaration1);
+        int abbrevCode = (isStatic ? DwarfDebugInfo.DW_ABBREV_CODE_method_declaration_static : DwarfDebugInfo.DW_ABBREV_CODE_method_declaration);
         log(context, "  [0x%08x] <2> Abbrev Number %d", pos, abbrevCode);
         pos = writeAbbrevCode(abbrevCode, buffer, pos);
         log(context, "  [0x%08x]     external  true", pos);
@@ -708,7 +708,7 @@ public class DwarfInfoSectionImpl extends DwarfSectionImpl {
         int typeIdx = getLayoutIndex(classEntry);
         log(context, "  [0x%08x]     containing_type 0x%x (%s)", pos, typeIdx, classEntry.getTypeName());
         pos = writeAttrRefAddr(typeIdx, buffer, pos);
-        if (abbrevCode == DwarfDebugInfo.DW_ABBREV_CODE_method_declaration1) {
+        if (abbrevCode == DwarfDebugInfo.DW_ABBREV_CODE_method_declaration) {
             /* Record the current position so we can back patch the object pointer. */
             int objectPointerIndex = pos;
             /*
@@ -1230,13 +1230,23 @@ public class DwarfInfoSectionImpl extends DwarfSectionImpl {
     private int writeMethodLocation(DebugContext context, ClassEntry classEntry, Range range, byte[] buffer, int p) {
         int pos = p;
         log(context, "  [0x%08x] method location", pos);
-        int abbrevCode = DwarfDebugInfo.DW_ABBREV_CODE_method_location;
-        log(context, "  [0x%08x] <1> Abbrev Number  %d", pos, abbrevCode);
+        int abbrevCode;
+        if (range.isInlined()) {
+            abbrevCode = DwarfDebugInfo.DW_ABBREV_CODE_method_location_inline;
+        } else {
+            abbrevCode = DwarfDebugInfo.DW_ABBREV_CODE_method_location;
+        }
+        log(context, "  [0x%08x] <1> Abbrev Number %d", pos, abbrevCode);
         pos = writeAbbrevCode(abbrevCode, buffer, pos);
-        log(context, "  [0x%08x]     lo_pc  0x%08x", pos, range.getLo());
-        pos = writeAttrAddress(range.getLo(), buffer, pos);
-        log(context, "  [0x%08x]     hi_pc  0x%08x", pos, range.getHi());
-        pos = writeAttrAddress(range.getHi(), buffer, pos);
+        if (range.isInlined()) {
+            verboseLog(context, "  [0x%08x]     inline  0x%X", pos, DwarfDebugInfo.DW_INL_inlined);
+            pos = writeAttrData1(DwarfDebugInfo.DW_INL_inlined, buffer, pos);
+        } else {
+            log(context, "  [0x%08x]     lo_pc  0x%08x", pos, range.getLo());
+            pos = writeAttrAddress(range.getLo(), buffer, pos);
+            log(context, "  [0x%08x]     hi_pc  0x%08x", pos, range.getHi());
+            pos = writeAttrAddress(range.getHi(), buffer, pos);
+        }
         /*
          * Should pass true only if method is non-private.
          */
@@ -1251,6 +1261,51 @@ public class DwarfInfoSectionImpl extends DwarfSectionImpl {
          * Write a terminating null attribute.
          */
         return writeAttrNull(buffer, pos);
+    }
+
+    private int writeInlineSubroutine(DebugContext context, ClassEntry classEntry, Range range, byte[] buffer, int p, int subprogramOffset, int depth) {
+        assert range.isInlined();
+        int pos = p;
+        final Range callerSubrange = range.getCaller();
+        assert callerSubrange != null;
+        int callLine = callerSubrange.getLine();
+        assert callLine >= -1 : callLine;
+        if (callLine == -1) {
+            log(context, "  Unable to retrieve call line for inlined method %s", range.getFullMethodName());
+            return p;
+        }
+        Integer fileIndex;
+        if (callerSubrange == range) {
+            fileIndex = 1;
+        } else {
+            FileEntry subFileEntry = callerSubrange.getFileEntry();
+            assert subFileEntry != null;
+            fileIndex = classEntry.localFilesIdx(subFileEntry);
+            assert fileIndex != null;
+        }
+        final int code;
+        if (range.withChildren()) {
+            code = DwarfDebugInfo.DW_ABBREV_CODE_inlined_subroutine_with_children;
+        } else {
+            code = DwarfDebugInfo.DW_ABBREV_CODE_inlined_subroutine;
+        }
+        verboseLog(context, "  [0x%08x] <%d> Abbrev Number  %d", pos, depth + 2, code);
+        pos = writeAbbrevCode(code, buffer, pos);
+        verboseLog(context, "  [0x%08x]     abstract_origin  0x%X", pos, subprogramOffset);
+        pos = writeAttrRef4(subprogramOffset, buffer, pos);
+        verboseLog(context, "  [0x%08x]     lo_pc  0x%08x", pos, range.getLo());
+        pos = writeAttrAddress(range.getLo(), buffer, pos);
+        verboseLog(context, "  [0x%08x]     hi_pc  0x%08x", pos, range.getHi());
+        pos = writeAttrAddress(range.getHi(), buffer, pos);
+        verboseLog(context, "  [0x%08x]     call_file  %d", pos, fileIndex);
+        pos = writeAttrData4(fileIndex, buffer, pos);
+        verboseLog(context, "  [0x%08x]     call_line  %d", pos, callLine);
+        pos = writeAttrData4(callLine, buffer, pos);
+        return pos;
+    }
+
+    private int writeAttrRef4(int reference, byte[] buffer, int p) {
+        return writeAttrData4(reference, buffer, p);
     }
 
     private int writeCUHeader(byte[] buffer, int p) {

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfInfoSectionImpl.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfInfoSectionImpl.java
@@ -936,26 +936,26 @@ public class DwarfInfoSectionImpl extends DwarfSectionImpl {
             if (range.isDeoptTarget() != deoptTargets) {
                 continue;
             }
-            boolean withInlinedMethods = false;
-            /*
-             * Go through the subranges and generate abstract debug entries for inlined methods.
-             */
-            for (Range subrange : primaryEntry.getSubranges()) {
-                if (!subrange.isInlined()) {
-                    continue;
-                }
-                withInlinedMethods = true;
-                final String symbolName = subrange.getSymbolName();
-                if (primaryMap.get(symbolName) == null) {
-                    primaryMap.put(symbolName, pos);
-                    ClassEntry inlinedClassEntry = (ClassEntry) lookupType(subrange.getClassName());
-                    pos = writeMethodLocation(context, inlinedClassEntry, subrange, buffer, pos);
-                    pos = writeAttrNull(buffer, pos);
+            if (range.withInlinedChildren()) {
+                /*
+                 * Go through the subranges and generate abstract debug entries for inlined methods.
+                 */
+                for (Range subrange : primaryEntry.getSubranges()) {
+                    if (!subrange.isInlined()) {
+                        continue;
+                    }
+                    final String symbolName = subrange.getSymbolName();
+                    if (primaryMap.get(symbolName) == null) {
+                        primaryMap.put(symbolName, pos);
+                        ClassEntry inlinedClassEntry = (ClassEntry) lookupType(subrange.getClassName());
+                        pos = writeMethodLocation(context, inlinedClassEntry, subrange, buffer, pos);
+                        pos = writeAttrNull(buffer, pos);
+                    }
                 }
             }
             primaryMap.put(range.getSymbolName(), pos);
             pos = writeMethodLocation(context, classEntry, range, buffer, pos);
-            if (withInlinedMethods) {
+            if (range.withInlinedChildren()) {
                 int depth = 0;
                 /*
                  * Go through the subranges and generate concrete debug entries for inlined methods.

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfLineSectionImpl.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfLineSectionImpl.java
@@ -516,6 +516,10 @@ public class DwarfLineSectionImpl extends DwarfSectionImpl {
              * Now write a row for each subrange lo and hi.
              */
             for (Range subrange : primaryEntry.getSubranges()) {
+                if (subrange.withChildren()) {
+                    /* skip caller subranges */
+                    continue;
+                }
                 assert subrange.getLo() >= primaryRange.getLo();
                 assert subrange.getHi() <= primaryRange.getHi();
                 FileEntry subFileEntry = subrange.getFileEntry();

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfLineSectionImpl.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfLineSectionImpl.java
@@ -455,7 +455,18 @@ public class DwarfLineSectionImpl extends DwarfSectionImpl {
              */
             long line = primaryRange.getLine();
             if (line < 0 && primaryEntry.getSubranges().size() > 0) {
-                line = primaryEntry.getSubranges().get(0).getLine();
+                final Range subRange = primaryEntry.getSubranges().get(0);
+                line = subRange.getLine();
+                /*
+                 * If line gets successfully retrieved from subrange get file index from there since
+                 * the line might be from a different file for inlined methods
+                 */
+                if (line > 0) {
+                    FileEntry subFileEntry = subRange.getFileEntry();
+                    if (subFileEntry != null) {
+                        fileIdx = classEntry.localFilesIdx(subFileEntry);
+                    }
+                }
             }
             if (line < 0) {
                 line = 0;

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfSectionImpl.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfSectionImpl.java
@@ -598,4 +598,15 @@ public abstract class DwarfSectionImpl extends BasicProgbitsSectionImpl {
         }
         return dwarfSections.getMethodDeclarationIndex(classEntry, methodName);
     }
+
+    protected void setAbstractInlineMethodIndex(ClassEntry classEntry, String methodName, int pos) {
+        dwarfSections.setAbstractInlineMethodIndex(classEntry, methodName, pos);
+    }
+
+    protected int getAbstractInlineMethodIndex(ClassEntry classEntry, String methodName) {
+        if (!contentByteArrayCreated()) {
+            return 0;
+        }
+        return dwarfSections.getAbstractInlineMethodIndex(classEntry, methodName);
+    }
 }

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/pecoff/cv/CVLineRecordBuilder.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/pecoff/cv/CVLineRecordBuilder.java
@@ -31,6 +31,8 @@ import com.oracle.objectfile.debugentry.FileEntry;
 import com.oracle.objectfile.debugentry.PrimaryEntry;
 import com.oracle.objectfile.debugentry.Range;
 
+import java.util.Iterator;
+
 /*
  * In CV4, the line table consists of a series of file headers followed by line number entries.
  * If this is a different file, then update the length of the previous file header, write the
@@ -67,7 +69,9 @@ public class CVLineRecordBuilder {
         debug("CVLineRecord.computeContents: processing primary range %s\n", primaryRange);
 
         processRange(primaryRange);
-        for (Range subRange : primaryEntry.getSubranges()) {
+        Iterator<Range> iterator = primaryEntry.leafRangeIterator();
+        while (iterator.hasNext()) {
+            Range subRange = iterator.next();
             debug("CVLineRecord.computeContents: processing range %s\n", subRange);
             processRange(subRange);
         }

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/image/NativeImageDebugInfoProvider.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/image/NativeImageDebugInfoProvider.java
@@ -649,8 +649,8 @@ class NativeImageDebugInfoProvider implements DebugInfoProvider {
             }
 
             @Override
-            public String paramSignature() {
-                return hostedMethod.format("%P");
+            public ResolvedJavaMethod getJavaMethod() {
+                return hostedMethod;
             }
 
             @Override
@@ -875,8 +875,8 @@ class NativeImageDebugInfoProvider implements DebugInfoProvider {
         }
 
         @Override
-        public String paramSignature() {
-            return hostedMethod.format("%P");
+        public ResolvedJavaMethod getJavaMethod() {
+            return hostedMethod;
         }
 
         @Override
@@ -1099,8 +1099,8 @@ class NativeImageDebugInfoProvider implements DebugInfoProvider {
         }
 
         @Override
-        public String paramSignature() {
-            return method.format("%P");
+        public ResolvedJavaMethod getJavaMethod() {
+            return method;
         }
 
         @Override

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/image/NativeImageDebugInfoProvider.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/image/NativeImageDebugInfoProvider.java
@@ -364,7 +364,7 @@ class NativeImageDebugInfoProvider implements DebugInfoProvider {
         }
 
         void addField(String name, String valueType, int offset, @SuppressWarnings("hiding") int size) {
-            NativeImageDebugHeaderFieldInfo fieldinfo = new NativeImageDebugHeaderFieldInfo(name, typeName, valueType, offset, size);
+            NativeImageDebugHeaderFieldInfo fieldinfo = new NativeImageDebugHeaderFieldInfo(name, valueType, offset, size);
             fieldInfos.add(fieldinfo);
         }
 
@@ -416,15 +416,13 @@ class NativeImageDebugInfoProvider implements DebugInfoProvider {
 
     private class NativeImageDebugHeaderFieldInfo implements DebugFieldInfo {
         private final String name;
-        private final String ownerType;
         private final String valueType;
         private final int offset;
         private final int size;
         private final int modifiers;
 
-        NativeImageDebugHeaderFieldInfo(String name, String ownerType, String valueType, int offset, int size) {
+        NativeImageDebugHeaderFieldInfo(String name, String valueType, int offset, int size) {
             this.name = name;
-            this.ownerType = ownerType;
             this.valueType = valueType;
             this.offset = offset;
             this.size = size;
@@ -434,11 +432,6 @@ class NativeImageDebugInfoProvider implements DebugInfoProvider {
         @Override
         public String name() {
             return name;
-        }
-
-        @Override
-        public String ownerType() {
-            return ownerType;
         }
 
         @Override
@@ -586,11 +579,6 @@ class NativeImageDebugInfoProvider implements DebugInfoProvider {
             }
 
             @Override
-            public String ownerType() {
-                return typeName();
-            }
-
-            @Override
             public String valueType() {
                 HostedType valueType = field.getType();
                 return toJavaName(valueType);
@@ -653,11 +641,6 @@ class NativeImageDebugInfoProvider implements DebugInfoProvider {
                     }
                 }
                 return name;
-            }
-
-            @Override
-            public String ownerType() {
-                return typeName();
             }
 
             @Override
@@ -740,7 +723,7 @@ class NativeImageDebugInfoProvider implements DebugInfoProvider {
         }
 
         void addField(String name, String valueType, int offset, @SuppressWarnings("hiding") int size) {
-            NativeImageDebugHeaderFieldInfo fieldinfo = new NativeImageDebugHeaderFieldInfo(name, typeName(), valueType, offset, size);
+            NativeImageDebugHeaderFieldInfo fieldinfo = new NativeImageDebugHeaderFieldInfo(name, valueType, offset, size);
             fieldInfos.add(fieldinfo);
         }
 
@@ -861,8 +844,8 @@ class NativeImageDebugInfoProvider implements DebugInfoProvider {
         }
 
         @Override
-        public String ownerType() {
-            return getDeclaringClass(hostedMethod, true).toJavaName();
+        public ResolvedJavaType ownerType() {
+            return getDeclaringClass(hostedMethod, true);
         }
 
         @Override
@@ -1072,12 +1055,11 @@ class NativeImageDebugInfoProvider implements DebugInfoProvider {
         }
 
         @Override
-        public String ownerType() {
+        public ResolvedJavaType ownerType() {
             if (method instanceof HostedMethod) {
-                return getDeclaringClass((HostedMethod) method, true).toJavaName();
-            } else {
-                return method.getDeclaringClass().toJavaName();
+                return getDeclaringClass((HostedMethod) method, true);
             }
+            return method.getDeclaringClass();
         }
 
         @Override

--- a/substratevm/src/com.oracle.svm.test/src/hello/Hello.java
+++ b/substratevm/src/com.oracle.svm.test/src/hello/Hello.java
@@ -28,6 +28,9 @@ package hello;
 
 // Checkstyle: stop
 
+import com.oracle.svm.core.annotate.AlwaysInline;
+import com.oracle.svm.core.annotate.NeverInline;
+
 public class Hello {
     public abstract static class Greeter {
         static Greeter greeter(String[] args) {
@@ -53,7 +56,7 @@ public class Hello {
     public static class NamedGreeter extends Greeter {
         private String name;
 
-        NamedGreeter(String name) {
+        public NamedGreeter(String name) {
             this.name = name;
         }
 
@@ -66,6 +69,105 @@ public class Hello {
     public static void main(String[] args) {
         Greeter greeter = Greeter.greeter(args);
         greeter.greet();
+        /*
+         * Perform the following call chains
+         *
+         * main --no-inline--> noInlineFoo --inline--> inlineMee --inline--> inlineMoo
+         * main --inline--> inlineCallChain --inline--> inlineMee --inline--> inlineMoo
+         * main --no-inline--> noInlineThis --inline--> inlineIs --inline--> inlineA --no-inline--> noInlineTest
+         * main --inline--> inlineFrom --no-inline--> noInlineHere --inline--> inlineMixTo --no-inline--+
+         *                                                 ^                                            |
+         *                                                 +-------------(rec call n-times)-------------+
+         * main --inline--> inlineFrom --inline--> inlineHere --inline--> inlineTo --inline--+
+         *                                             ^                                     |
+         *                                             +---------(rec call n-times)----------+
+         */
+        noInlineFoo();
+        inlineCallChain();
+        noInlineThis();
+        inlineFrom();
         System.exit(0);
+    }
+
+    @NeverInline("For testing purposes")
+    private static void noInlineFoo() {
+        inlineMee();
+    }
+
+    @AlwaysInline("For testing purposes")
+    private static void inlineCallChain() {
+        inlineMee();
+    }
+
+    @AlwaysInline("For testing purposes")
+    private static void inlineMee() {
+        inlineMoo();
+    }
+
+    @AlwaysInline("For testing purposes")
+    private static void inlineMoo() {
+        System.out.println("This is a cow");
+    }
+
+    @NeverInline("For testing purposes")
+    private static void noInlineThis() {
+        inlineIs();
+    }
+
+    @AlwaysInline("For testing purposes")
+    private static void inlineIs() {
+        inlineA();
+    }
+
+    @AlwaysInline("For testing purposes")
+    private static void inlineA() {
+        noInlineTest();
+    }
+
+    @NeverInline("For testing purposes")
+    private static void noInlineTest() {
+        System.out.println("This is a test");
+    }
+
+    @AlwaysInline("For testing purposes")
+    private static void inlineFrom() {
+        noInlineHere(5);
+        inlineHere(5);
+        inlineTailRecursion(5);
+    }
+
+    @NeverInline("For testing purposes")
+    private static void noInlineHere(int n) {
+        inlineMixTo(n);
+    }
+
+    @AlwaysInline("For testing purposes")
+    private static void inlineMixTo(int n) {
+        if (n > 0) {
+            noInlineHere(n - 1);
+        }
+        System.out.println("Recursive mixed calls!");
+    }
+
+    @AlwaysInline("For testing purposes")
+    private static void inlineHere(int n) {
+        inlineTo(n);
+    }
+
+    @AlwaysInline("For testing purposes")
+    private static void inlineTo(int n) {
+        if (n > 0) {
+            inlineHere(n - 1);
+        }
+        System.out.println("Recursive inline calls!");
+    }
+
+    @AlwaysInline("For testing purposes")
+    private static void inlineTailRecursion(int n) {
+        if (n <= 0) {
+            System.out.println("Recursive inline calls!");
+            return;
+        }
+        inlineTailRecursion(n-1);
     }
 }

--- a/substratevm/src/com.oracle.svm.test/src/hello/Target_hello_Hello_DefaultGreeter.java
+++ b/substratevm/src/com.oracle.svm.test/src/hello/Target_hello_Hello_DefaultGreeter.java
@@ -26,6 +26,8 @@
 
 package hello;
 
+import com.oracle.svm.core.annotate.AlwaysInline;
+import com.oracle.svm.core.annotate.NeverInline;
 import com.oracle.svm.core.annotate.Substitute;
 import com.oracle.svm.core.annotate.TargetClass;
 
@@ -34,6 +36,25 @@ final class Target_hello_Hello_DefaultGreeter {
     @SuppressWarnings("static-method")
     @Substitute
     public void greet() {
+        SubstituteHelperClass substituteHelperClass = new SubstituteHelperClass();
+        substituteHelperClass.inlineGreet();
+    }
+
+}
+
+class SubstituteHelperClass {
+    @AlwaysInline("For testing purposes")
+    void inlineGreet() {
+        staticInlineGreet();
+    }
+
+    @AlwaysInline("For testing purposes")
+    private static void staticInlineGreet() {
+        nestedGreet();
+    }
+
+    @NeverInline("For testing purposes")
+    private static void nestedGreet() {
         // Checkstyle: stop
         System.out.println("Hello, substituted world!");
         // Checkstyle: resume


### PR DESCRIPTION
## Known Issues

* Given two call-chains:
  1. foo->bar->baz
  2. foo->bar->buz 
we could create a "concrete inlined instance tree" (per the DWARF spec) like this:
```
   foo
    |
   bar
    |
   / \
  /   \
baz   buz
```
instead we generate two separate trees, resulting in more DIEs (Debug Information Entries).

* Ideally an `DW_TAG_inlined_subroutine` would reference (through ` DW_AT_abstract_origin`) the `DW_TAG_subprogram` defining the corresponding subprogram even if it's declared in a different compilation unit. There are cases however where when creating the `DW_TAG_inlined_subroutine` the corresponding `DW_TAG_subprogram` has not been created yet (even worse the corresponding compilation unit might not have been created yet). To overcome this issue our current approach creates partial `DW_TAG_subprogram` entries in the compilation unit where the inlining happens. This however comes at the cost of having more DIEs.

Before this PR hello.hello with debug symbols is 10MB
After this PR hello.hello with debug symbols becomes 38MB
Without debug symbols hello.hello is 7.9MB

Closes #2701