### PR TITLE
Adding java.net.URL for reflection can cause "Unsupported field java.net.URL.handlers is reachable"

### DIFF
--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/JavaNetSubstitutions.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/JavaNetSubstitutions.java
@@ -33,6 +33,7 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLConnection;
 import java.net.URLStreamHandler;
+import java.net.URLStreamHandlerFactory;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Hashtable;
@@ -68,6 +69,12 @@ final class Target_java_net_URL {
          * available, and how to add a protocol at image build time.
          */
         return JavaNetSubstitutions.getURLStreamHandler(protocol);
+    }
+
+    @SuppressWarnings("unused")
+    @Substitute
+    public static void setURLStreamHandlerFactory(URLStreamHandlerFactory fac) {
+        throw VMError.unsupportedFeature("java.net.URL.setURLStreamHandlerFactory(URLStreamHandlerFactory)");
     }
 }
 


### PR DESCRIPTION
The commit in this PR tries to solve the issue reported in Quarkus https://github.com/quarkusio/quarkus/issues/12447. As I noted in my comment in that issue https://github.com/quarkusio/quarkus/issues/12447#issuecomment-702799851, native-image generation runs into the following failure:
```
Caused by: com.oracle.graal.pointsto.constraints.UnsupportedFeatureException: com.oracle.svm.hosted.substitute.DeletedElementException: Unsupported field java.net.URL.handlers is reachable
To diagnose the issue, you can add the option --report-unsupported-elements-at-runtime. The unsupported element is then reported at run time when it is accessed the first time.
Detailed message:
Trace: 
	at parsing java.net.URL.setURLStreamHandlerFactory(URL.java:1213)
Call path from entry point to java.net.URL.setURLStreamHandlerFactory(URLStreamHandlerFactory): 
	at java.net.URL.setURLStreamHandlerFactory(URL.java:1205)
	at com.oracle.svm.reflect.URL_setURLStreamHandlerFactory_8b4d2aa28c41f22bcb499464d696277608a31df4_43.invoke(Unknown Source)
```
due to `URL.setURLStreamHandlerFactory` using the `handlers` field which has been `@Deleted` by a GraalVM substitution.
The commit in this PR, `@Substitutes` the `setURLStreamHandlerFactory` to prevent `handlers` from being reachable from here.
