### PR TITLE
[vscode] Fix injectTos and scopeNames

### DIFF
--- a/vscode/graalvm/package.json
+++ b/vscode/graalvm/package.json
@@ -222,10 +222,10 @@
 					"source.js",
 					"source.r",
 					"source.ruby",
-					"source.pyhon",
+					"source.python",
 					"source.sl"
 				],
-				"scopeName": "js.inline.polyglot-langauges",
+				"scopeName": "js.inline.polyglot-languages",
 				"embeddedLanguages": {
 					"meta.embedded.inline.python": "python",
 					"meta.embedded.inline.r": "r",
@@ -240,9 +240,9 @@
 					"source.js",
 					"source.r",
 					"source.ruby",
-					"source.pyhon"
+					"source.python"
 				],
-				"scopeName": "sl.inline.polyglot-langauges",
+				"scopeName": "sl.inline.polyglot-languages",
 				"embeddedLanguages": {
 					"meta.embedded.inline.js": "js",
 					"meta.embedded.inline.python": "python",
@@ -259,7 +259,7 @@
 					"source.ruby",
 					"source.sl"
 				],
-				"scopeName": "python-inline.polyglot-langauges",
+				"scopeName": "python-inline.polyglot-languages",
 				"embeddedLanguages": {
 					"meta.embedded.inline.js": "javascript",
 					"meta.embedded.inline.r": "r",
@@ -276,7 +276,7 @@
 					"source.python",
 					"source.sl"
 				],
-				"scopeName": "r-inline.polyglot-langauges",
+				"scopeName": "r-inline.polyglot-languages",
 				"embeddedLanguages": {
 					"meta.embedded.inline.js": "javascript",
 					"meta.embedded.inline.python": "python",
@@ -293,7 +293,7 @@
 					"source.python",
 					"source.sl"
 				],
-				"scopeName": "ruby-inline.polyglot-langauges",
+				"scopeName": "ruby-inline.polyglot-languages",
 				"embeddedLanguages": {
 					"meta.embedded.inline.js": "javascript",
 					"meta.embedded.inline.python": "python",

--- a/vscode/graalvm/syntaxes/js-polyglot-injection.json
+++ b/vscode/graalvm/syntaxes/js-polyglot-injection.json
@@ -1,6 +1,6 @@
 {
     "injectionSelector": "L:source.js -comment -(string - meta.embedded), L:source.r meta.embedded.inline.js, L:source.ruby meta.embedded.inline.js, L:source.python meta.embedded.inline.js, L:source.sl meta.embedded.inline.js",
-    "scopeName": "js.inline.polyglot-langauges",
+    "scopeName": "js.inline.polyglot-languages",
     "patterns": [
         {
             "begin": "((Polyglot)\\s*(\\.)\\s*(eval))\\s*(\\()",

--- a/vscode/graalvm/syntaxes/python-polyglot-injection.json
+++ b/vscode/graalvm/syntaxes/python-polyglot-injection.json
@@ -1,6 +1,6 @@
 {
     "injectionSelector": "L:source.python -comment -(string - meta.embedded), L:source.js meta.embedded.inline.python, L:source.r meta.embedded.inline.python, L:source.ruby meta.embedded.inline.python, L:source.sl meta.embedded.inline.python",
-    "scopeName": "python-inline.polyglot-langauges",
+    "scopeName": "python-inline.polyglot-languages",
     "patterns": [
         {
             "begin": "polyglot\\s*(\\.)\\s*((eval)\\s*(\\())",

--- a/vscode/graalvm/syntaxes/r-polyglot-injection.json
+++ b/vscode/graalvm/syntaxes/r-polyglot-injection.json
@@ -1,6 +1,6 @@
 {
     "injectionSelector": "L:source.r -comment -(string - meta.embedded), L:source.js meta.embedded.inline.r, L:source.ruby meta.embedded.inline.r, L:source.python meta.embedded.inline.r, L:source.sl meta.embedded.inline.r",
-    "scopeName": "r-inline.polyglot-langauges",
+    "scopeName": "r-inline.polyglot-languages",
     "patterns": [
         {
             "begin": "(eval\\s*\\.\\s*polyglot)\\s*(\\()",

--- a/vscode/graalvm/syntaxes/ruby-polyglot-injection.json
+++ b/vscode/graalvm/syntaxes/ruby-polyglot-injection.json
@@ -1,6 +1,6 @@
 {
     "injectionSelector": "L:source.ruby -comment -(string - meta.embedded), L:source.js meta.embedded.inline.ruby, L:source.r meta.embedded.inline.ruby, L:source.python meta.embedded.inline.ruby, L:source.sl meta.embedded.inline.ruby",
-    "scopeName": "ruby-inline.polyglot-langauges",
+    "scopeName": "ruby-inline.polyglot-languages",
     "patterns": [
         {
             "begin": "(Polyglot)\\s*(\\.)\\s*((eval)\\s*(\\())",

--- a/vscode/graalvm/syntaxes/sl-polyglot-injection.json
+++ b/vscode/graalvm/syntaxes/sl-polyglot-injection.json
@@ -1,6 +1,6 @@
 {
     "injectionSelector": "L:source.sl -comment -(string - meta.embedded), L:source.js meta.embedded.inline.sl, L:source.r meta.embedded.inline.sl, L:source.ruby meta.embedded.inline.sl, L:source.python meta.embedded.inline.sl",
-    "scopeName": "sl.inline.polyglot-langauges",
+    "scopeName": "sl.inline.polyglot-languages",
     "patterns": [
         {
             "begin": "(eval)\\s*(\\()",


### PR DESCRIPTION
Two `injectTo`s contained the wrong identifier for Python, and the `scopeName`s had a typo.

Please assign to @dbalek.