### PR TITLE
[vscode] Add public API to register LSP notification handlers

### DIFF
--- a/vscode/graalvm/src/extension.ts
+++ b/vscode/graalvm/src/extension.ts
@@ -10,7 +10,7 @@ import * as utils from './utils';
 import { toggleCodeCoverage, activeTextEditorChaged } from './graalVMCoverage';
 import { GraalVMConfigurationProvider, GraalVMDebugAdapterDescriptorFactory, GraalVMDebugAdapterTracker } from './graalVMDebug';
 import { installGraalVM, addExistingGraalVM, installGraalVMComponent, uninstallGraalVMComponent, selectInstalledGraalVM, findGraalVMs, InstallationNodeProvider, Component, Installation, setupProxy, removeGraalVMInstallation } from './graalVMInstall';
-import { startLanguageServer, stopLanguageServer } from './graalVMLanguageServer';
+import { registerLSPNotificationHandler, startLanguageServer, stopLanguageServer } from './graalVMLanguageServer';
 import { installRPackage, rConfig, R_LANGUAGE_SERVER_PACKAGE_NAME } from './graalVMR';
 import { installRubyGem, rubyConfig, RUBY_LANGUAGE_SERVER_GEM_NAME } from './graalVMRuby';
 import { addNativeImageToPOM } from './graalVMNativeImage';
@@ -52,6 +52,7 @@ export function activate(context: vscode.ExtensionContext) {
 			vscode.window.showErrorMessage("Ruby isn't present in GraalVM Installation.");
 		}
 	}));
+	context.subscriptions.push(vscode.commands.registerCommand('extension.graalvm.registerLSPNotificationHandler', registerLSPNotificationHandler));
 	context.subscriptions.push(vscode.window.onDidChangeActiveTextEditor(e => {
 		if (e) {
 			activeTextEditorChaged(e);

--- a/vscode/graalvm/src/extension.ts
+++ b/vscode/graalvm/src/extension.ts
@@ -10,7 +10,7 @@ import * as utils from './utils';
 import { toggleCodeCoverage, activeTextEditorChaged } from './graalVMCoverage';
 import { GraalVMConfigurationProvider, GraalVMDebugAdapterDescriptorFactory, GraalVMDebugAdapterTracker } from './graalVMDebug';
 import { installGraalVM, addExistingGraalVM, installGraalVMComponent, uninstallGraalVMComponent, selectInstalledGraalVM, findGraalVMs, InstallationNodeProvider, Component, Installation, setupProxy, removeGraalVMInstallation } from './graalVMInstall';
-import { registerLSPNotificationHandler, startLanguageServer, stopLanguageServer } from './graalVMLanguageServer';
+import { onClientNotification, startLanguageServer, stopLanguageServer } from './graalVMLanguageServer';
 import { installRPackage, rConfig, R_LANGUAGE_SERVER_PACKAGE_NAME } from './graalVMR';
 import { installRubyGem, rubyConfig, RUBY_LANGUAGE_SERVER_GEM_NAME } from './graalVMRuby';
 import { addNativeImageToPOM } from './graalVMNativeImage';
@@ -52,7 +52,6 @@ export function activate(context: vscode.ExtensionContext) {
 			vscode.window.showErrorMessage("Ruby isn't present in GraalVM Installation.");
 		}
 	}));
-	context.subscriptions.push(vscode.commands.registerCommand('extension.graalvm.registerLSPNotificationHandler', registerLSPNotificationHandler));
 	context.subscriptions.push(vscode.window.onDidChangeActiveTextEditor(e => {
 		if (e) {
 			activeTextEditorChaged(e);
@@ -110,6 +109,11 @@ export function activate(context: vscode.ExtensionContext) {
 		startLanguageServer(graalVMHome);
 	}
 	vscode.window.setStatusBarMessage('GraalVM extension activated', 3000);
+	
+	// Public API
+	return {
+		onClientNotification: onClientNotification,
+	};
 }
 
 export function deactivate(): Thenable<void> {

--- a/vscode/graalvm/src/graalVMLanguageServer.ts
+++ b/vscode/graalvm/src/graalVMLanguageServer.ts
@@ -9,7 +9,7 @@ import * as vscode from 'vscode';
 import * as cp from 'child_process';
 import * as utils from './utils';
 import * as net from 'net';
-import { LanguageClient, LanguageClientOptions, StreamInfo } from 'vscode-languageclient';
+import { GenericNotificationHandler, LanguageClient, LanguageClientOptions, StreamInfo } from 'vscode-languageclient';
 
 export const LSPORT: number = 8123;
 const POLYGLOT: string = 'polyglot';
@@ -144,6 +144,16 @@ async function hasRSource(): Promise<boolean> {
 		}
 	}
 	return hasR;
+}
+
+export async function registerLSPNotificationHandler(method: string, handler: GenericNotificationHandler): Promise<boolean> {
+	if (languageClient) {
+		let isSuccessful = false;
+		await languageClient.then((client) => client.onNotification(method, handler)).then(() => isSuccessful = true);
+		return isSuccessful;
+	} else {
+		return false;
+	}
 }
 
 function terminateLanguageServer() {

--- a/vscode/graalvm/src/graalVMLanguageServer.ts
+++ b/vscode/graalvm/src/graalVMLanguageServer.ts
@@ -146,7 +146,7 @@ async function hasRSource(): Promise<boolean> {
 	return hasR;
 }
 
-export async function registerLSPNotificationHandler(method: string, handler: GenericNotificationHandler): Promise<boolean> {
+export async function onClientNotification(method: string, handler: GenericNotificationHandler): Promise<boolean> {
 	if (languageClient) {
 		let isSuccessful = false;
 		await languageClient.then((client) => client.onNotification(method, handler)).then(() => isSuccessful = true);


### PR DESCRIPTION
This PR lets GraalVM's extension for VS Code expose a public API that other extensions can use to register handlers for custom client notifications from the GraalLS backend. For this, extensions should depend on the GraalVM extension using `extensionDependencies` (see [here](https://code.visualstudio.com/api/references/vscode-api#extensions)).

Here's how the API can be used in a third-party extension:

```typescript
const graalVMExtension = vscode.extensions.getExtension('oracle-labs-graalvm.graalvm');
if (!graalVMExtension) {
    return console.error('Unable to find GraalVM extension.');
}
graalVMExtension.exports.onClientNotification('my_notification', (response: any) => console.log(response)).then((result: boolean) => {
    if (!result) {
        console.error('Failed to register 'my_notification' handler.');
    }
});
```

The current change is all we need for our Babylonian analysis use case on the client side at this point. In an earlier version, we exposed this functionality through a VS Code command, but exports seem to be the better solution. I am not sure there are any good alternatives, exposing the `languageClient` object to third-parties didn't seem like a good idea.

Please assign to @dbalek. /cc @MartinBalin