### PR TITLE
[vscode] Add option to run GraalLS in debug mode

### DIFF
--- a/vscode/graalvm/package.json
+++ b/vscode/graalvm/package.json
@@ -55,6 +55,11 @@
 					"default": true,
 					"description": "Start GraalVM Language Server within processes being run or debugged"
 				},
+				"graalvm.languageServer.enableDebugMode": {
+					"type": "boolean",
+					"default": false,
+					"description": "Run GraalVM Language Server in debug mode (via JDWP and port 8000)"
+				},
 				"graalvm.languageServer.delegateServers": {
 					"type": "string",
 					"default": "",

--- a/vscode/graalvm/src/graalVMLanguageServer.ts
+++ b/vscode/graalvm/src/graalVMLanguageServer.ts
@@ -36,6 +36,9 @@ export function startLanguageServer(graalVMHome: string) {
                 lspArgs().then(args => {
 					const lspArg = args.find(arg => arg.startsWith('--lsp='));
 					const lsPort = lspArg ? parseInt(lspArg.substring(6)) : LSPORT;
+					if (vscode.workspace.getConfiguration('graalvm').get('languageServer.enableDebugMode')) {
+						args.push('--vm.Xrunjdwp:transport=dt_socket,server=y,address=8000,suspend=n');
+					}
 					const serverProcess = cp.spawn(re, args.concat(['--experimental-options', '--shell']), { cwd: serverWorkDir });
 					if (!serverProcess || !serverProcess.pid) {
 						reject(`Launching server using command ${re} failed.`);

--- a/vscode/graalvm/src/graalVMLanguageServer.ts
+++ b/vscode/graalvm/src/graalVMLanguageServer.ts
@@ -48,7 +48,7 @@ export function startLanguageServer(graalVMHome: string) {
 					} else {
 						languageServerPID = serverProcess.pid;
 						serverProcess.stderr.once('data', data => {
-							reject(data);
+							console.error('[GraalLSP process stderr] ' + new String(data));
 						});
 						serverProcess.stdout.once('data', () => {
 							connectAndRetryIfRefused(new net.Socket(), LSHOST, lsPort, resolve, reject, CONNECTION_NUM_RETRIES);

--- a/vscode/graalvm/src/graalVMLanguageServer.ts
+++ b/vscode/graalvm/src/graalVMLanguageServer.ts
@@ -100,8 +100,9 @@ export function connectToLanguageServer(connection: (() => Thenable<StreamInfo>)
 			prepareStatus.dispose();
 			vscode.window.setStatusBarMessage('GraalLS is ready.', 3000);
 			resolve(client);
-		}).catch(() => {
+		}).catch((e) => {
 			prepareStatus.dispose();
+			vscode.window.showErrorMessage('GraalLS error: ' + e);
 			vscode.window.setStatusBarMessage('GraalLS failed to initialize.', 3000);
 			resolve(client);
 		});


### PR DESCRIPTION
and make connection process more robust.

Also, avoid failing connection if GraalLS process produces stderr output, forward errors to extension's `console` instead. Occasionally, the process would print the following to stderr which would always fail the connection:

> org.graalvm.shadowed.org.jline.utils.Log logr
> WARNING: Unable to create a system terminal, creating a dumb terminal

Please assign to @dbalek.