### PR TITLE
[lsp] Add support for LSPExtensions

### DIFF
--- a/tools/src/org.graalvm.tools.api.lsp/src/org/graalvm/tools/api/lsp/LSPCommand.java
+++ b/tools/src/org.graalvm.tools.api.lsp/src/org/graalvm/tools/api/lsp/LSPCommand.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.graalvm.tools.api.lsp;
+
+import java.util.List;
+
+import com.oracle.truffle.api.instrumentation.TruffleInstrument.Env;
+
+public interface LSPCommand {
+
+    String getName();
+
+    Object execute(LSPServer server, Env env, List<Object> arguments);
+
+    default int getTimeoutMillis() {
+        return -1;
+    }
+
+    default Object onTimeout(List<Object> arguments) {
+        String argumentString = String.join(", ", arguments.toArray(new String[0]));
+        if (getTimeoutMillis() > 0) {
+            throw new RuntimeException("onTimeout not overriden. Arguments: " + argumentString);
+        } else {
+            throw new AssertionError("onTimeout triggered on negative or zero timeout. Arguments: " + argumentString);
+        }
+    }
+}

--- a/tools/src/org.graalvm.tools.api.lsp/src/org/graalvm/tools/api/lsp/LSPCommand.java
+++ b/tools/src/org.graalvm.tools.api.lsp/src/org/graalvm/tools/api/lsp/LSPCommand.java
@@ -28,16 +28,32 @@ import java.util.List;
 
 import com.oracle.truffle.api.instrumentation.TruffleInstrument.Env;
 
+/**
+ * Command interface provided by a {@link LSPExtension}.
+ */
 public interface LSPCommand {
 
+    /**
+     * Get the name of the command.
+     */
     String getName();
 
-    Object execute(LSPServer server, Env env, List<Object> arguments);
+    /**
+     * Execute the command.
+     */
+    Object execute(LSPServerAccessor server, Env env, List<Object> arguments);
 
+    /**
+     * Define a timeout for the execution of the command.
+     */
     default int getTimeoutMillis() {
         return -1;
     }
 
+    /**
+     * Fallback behavior in case the command's execution exceeded the timeout. Only required if
+     * {@link #getTimeoutMillis()} is overridden and returns a value greater zero.
+     */
     default Object onTimeout(List<Object> arguments) {
         String argumentString = String.join(", ", arguments.toArray(new String[0]));
         if (getTimeoutMillis() > 0) {

--- a/tools/src/org.graalvm.tools.api.lsp/src/org/graalvm/tools/api/lsp/LSPExtension.java
+++ b/tools/src/org.graalvm.tools.api.lsp/src/org/graalvm/tools/api/lsp/LSPExtension.java
@@ -26,8 +26,17 @@ package org.graalvm.tools.api.lsp;
 
 import java.util.List;
 
+/**
+ * Service interface that Truffle instruments can provide to extend the GraalLS with additional
+ * commands.
+ *
+ * @since 1.0
+ */
 public interface LSPExtension {
 
+    /**
+     * Get a list of all {@link LSPCommand}s provided by the service.
+     */
     List<LSPCommand> getCommands();
 
 }

--- a/tools/src/org.graalvm.tools.api.lsp/src/org/graalvm/tools/api/lsp/LSPExtension.java
+++ b/tools/src/org.graalvm.tools.api.lsp/src/org/graalvm/tools/api/lsp/LSPExtension.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.graalvm.tools.api.lsp;
+
+import java.util.List;
+
+public interface LSPExtension {
+
+    List<LSPCommand> getCommands();
+
+}

--- a/tools/src/org.graalvm.tools.api.lsp/src/org/graalvm/tools/api/lsp/LSPServer.java
+++ b/tools/src/org.graalvm.tools.api.lsp/src/org/graalvm/tools/api/lsp/LSPServer.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.graalvm.tools.api.lsp;
+
+import java.net.URI;
+import java.util.Map;
+
+import com.oracle.truffle.api.source.Source;
+
+public interface LSPServer {
+
+    Map<URI, String> getOpenFileURI2LangId();
+
+    void sendCustomNotification(String method, Object params);
+
+    Source getSource(URI uri);
+
+}

--- a/tools/src/org.graalvm.tools.api.lsp/src/org/graalvm/tools/api/lsp/LSPServerAccessor.java
+++ b/tools/src/org.graalvm.tools.api.lsp/src/org/graalvm/tools/api/lsp/LSPServerAccessor.java
@@ -29,12 +29,24 @@ import java.util.Map;
 
 import com.oracle.truffle.api.source.Source;
 
-public interface LSPServer {
+/**
+ * Provides access to the GraalLS from within {@link LSPExtension}s.
+ */
+public interface LSPServerAccessor {
 
+    /**
+     * Get a map of fileURIs to languageIds for all files currently open in the LSP client.
+     */
     Map<URI, String> getOpenFileURI2LangId();
 
+    /**
+     * Instruct the GraalLS to send a custom notification to the LSP client.
+     */
     void sendCustomNotification(String method, Object params);
 
+    /**
+     * Get the {@link Source} for a given {@link URI}. Returns {@code null} if no source was found.
+     */
     Source getSource(URI uri);
 
 }

--- a/tools/src/org.graalvm.tools.lsp.test/src/org/graalvm/tools/lsp/test/server/LSPExtensionTest.java
+++ b/tools/src/org.graalvm.tools.lsp.test/src/org/graalvm/tools/lsp/test/server/LSPExtensionTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.graalvm.tools.lsp.test.server;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import org.graalvm.tools.lsp.server.types.ExecuteCommandParams;
+import org.junit.Test;
+
+public class LSPExtensionTest extends TruffleLSPTest {
+
+    @Test
+    public void lspExtensionTest() {
+        Collection<String> names = truffleAdapter.getExtensionCommandNames();
+        assertEquals(names.size(), new LSPExtensionTestInstance().getCommands().size());
+        assertTrue(names.contains(LSPExtensionTestInstance.COMMAND_SIMPLE));
+        assertTrue(names.contains(LSPExtensionTestInstance.COMMAND_TIMEOUT));
+
+        List<Object> dummyArguments = Arrays.asList(true, false, 42);
+        ExecuteCommandParams params1 = createParameters(LSPExtensionTestInstance.COMMAND_SIMPLE, dummyArguments);
+        Future<?> future1 = truffleAdapter.createExtensionCommand(params1);
+        try {
+            Object result = future1.get();
+            assertTrue(result instanceof Integer && ((int) result) == dummyArguments.size());
+        } catch (InterruptedException | ExecutionException e) {
+            fail("" + e);
+        }
+
+        ExecuteCommandParams params2 = createParameters(LSPExtensionTestInstance.COMMAND_TIMEOUT, dummyArguments);
+        Future<?> future2 = truffleAdapter.createExtensionCommand(params2);
+        try {
+            Object result = future2.get(2, TimeUnit.SECONDS);
+            assertTrue(result == dummyArguments.get(0));
+        } catch (InterruptedException | ExecutionException | TimeoutException e) {
+            fail("" + e);
+        }
+    }
+
+    private static ExecuteCommandParams createParameters(String command, List<Object> arguments) {
+        ExecuteCommandParams params = ExecuteCommandParams.create(command);
+        params.setArguments(arguments);
+        return params;
+    }
+}

--- a/tools/src/org.graalvm.tools.lsp.test/src/org/graalvm/tools/lsp/test/server/LSPExtensionTest.java
+++ b/tools/src/org.graalvm.tools.lsp.test/src/org/graalvm/tools/lsp/test/server/LSPExtensionTest.java
@@ -42,30 +42,41 @@ import org.junit.Test;
 public class LSPExtensionTest extends TruffleLSPTest {
 
     @Test
-    public void lspExtensionTest() {
+    public void getExtensionCommandNamesTest() {
         Collection<String> names = truffleAdapter.getExtensionCommandNames();
         assertEquals(names.size(), new LSPExtensionTestInstance().getCommands().size());
         assertTrue(names.contains(LSPExtensionTestInstance.COMMAND_SIMPLE));
         assertTrue(names.contains(LSPExtensionTestInstance.COMMAND_TIMEOUT));
+    }
 
-        List<Object> dummyArguments = Arrays.asList(true, false, 42);
-        ExecuteCommandParams params1 = createParameters(LSPExtensionTestInstance.COMMAND_SIMPLE, dummyArguments);
-        Future<?> future1 = truffleAdapter.createExtensionCommand(params1);
+    @Test
+    public void simpleCommandTest() {
+        List<Object> dummyArguments = createDummyArguments();
+        ExecuteCommandParams params = createParameters(LSPExtensionTestInstance.COMMAND_SIMPLE, dummyArguments);
+        Future<?> future = truffleAdapter.createExtensionCommand(params);
         try {
-            Object result = future1.get();
+            Object result = future.get(2, TimeUnit.SECONDS);
             assertTrue(result instanceof Integer && ((int) result) == dummyArguments.size());
-        } catch (InterruptedException | ExecutionException e) {
+        } catch (InterruptedException | ExecutionException | TimeoutException e) {
             fail("" + e);
         }
+    }
 
-        ExecuteCommandParams params2 = createParameters(LSPExtensionTestInstance.COMMAND_TIMEOUT, dummyArguments);
-        Future<?> future2 = truffleAdapter.createExtensionCommand(params2);
+    @Test
+    public void timeoutCommandTest() {
+        List<Object> dummyArguments = createDummyArguments();
+        ExecuteCommandParams params = createParameters(LSPExtensionTestInstance.COMMAND_TIMEOUT, dummyArguments);
+        Future<?> future = truffleAdapter.createExtensionCommand(params);
         try {
-            Object result = future2.get(2, TimeUnit.SECONDS);
+            Object result = future.get(2, TimeUnit.SECONDS);
             assertTrue(result == dummyArguments.get(0));
         } catch (InterruptedException | ExecutionException | TimeoutException e) {
             fail("" + e);
         }
+    }
+
+    private static List<Object> createDummyArguments() {
+        return Arrays.asList(true, false, 42);
     }
 
     private static ExecuteCommandParams createParameters(String command, List<Object> arguments) {

--- a/tools/src/org.graalvm.tools.lsp.test/src/org/graalvm/tools/lsp/test/server/LSPExtensionTestInstance.java
+++ b/tools/src/org.graalvm.tools.lsp.test/src/org/graalvm/tools/lsp/test/server/LSPExtensionTestInstance.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.graalvm.tools.lsp.test.server;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.graalvm.tools.api.lsp.LSPCommand;
+import org.graalvm.tools.api.lsp.LSPExtension;
+import org.graalvm.tools.api.lsp.LSPServer;
+
+import com.oracle.truffle.api.instrumentation.TruffleInstrument;
+import com.oracle.truffle.api.instrumentation.TruffleInstrument.Registration;
+
+@Registration(id = "lsp-extension-test", name = "LSPExtension Test Instance", version = "0.1", services = LSPExtension.class)
+public class LSPExtensionTestInstance extends TruffleInstrument implements LSPExtension {
+    protected static final String COMMAND_SIMPLE = "lsp_test_extension_simple_command";
+    protected static final String COMMAND_TIMEOUT = "lsp_test_extension_timeout_command";
+
+    public List<LSPCommand> getCommands() {
+        return Arrays.asList(new LSPExtensionTestSimpleCommand(), new LSPExtensionTestTimeoutCommand());
+    }
+
+    private static class LSPExtensionTestSimpleCommand implements LSPCommand {
+
+        public String getName() {
+            return COMMAND_SIMPLE;
+        }
+
+        public Object execute(LSPServer server, Env env, List<Object> arguments) {
+            return arguments.size();
+        }
+    }
+
+    private static class LSPExtensionTestTimeoutCommand implements LSPCommand {
+
+        public String getName() {
+            return COMMAND_TIMEOUT;
+        }
+
+        public Object execute(LSPServer server, Env env, List<Object> arguments) {
+            try {
+                Thread.sleep(getTimeoutMillis() * 2);
+            } catch (InterruptedException e) {
+                e.printStackTrace();
+            }
+            return -1;
+        }
+
+        public int getTimeoutMillis() {
+            return 200;
+        }
+
+        public Object onTimeout(List<Object> arguments) {
+            return arguments.get(0);
+        }
+    }
+
+    @Override
+    protected void onCreate(Env env) {
+        env.registerService(this);
+    }
+}

--- a/tools/src/org.graalvm.tools.lsp.test/src/org/graalvm/tools/lsp/test/server/LSPExtensionTestInstance.java
+++ b/tools/src/org.graalvm.tools.lsp.test/src/org/graalvm/tools/lsp/test/server/LSPExtensionTestInstance.java
@@ -29,7 +29,7 @@ import java.util.List;
 
 import org.graalvm.tools.api.lsp.LSPCommand;
 import org.graalvm.tools.api.lsp.LSPExtension;
-import org.graalvm.tools.api.lsp.LSPServer;
+import org.graalvm.tools.api.lsp.LSPServerAccessor;
 
 import com.oracle.truffle.api.instrumentation.TruffleInstrument;
 import com.oracle.truffle.api.instrumentation.TruffleInstrument.Registration;
@@ -43,13 +43,18 @@ public class LSPExtensionTestInstance extends TruffleInstrument implements LSPEx
         return Arrays.asList(new LSPExtensionTestSimpleCommand(), new LSPExtensionTestTimeoutCommand());
     }
 
+    @Override
+    protected void onCreate(Env env) {
+        env.registerService(this);
+    }
+
     private static class LSPExtensionTestSimpleCommand implements LSPCommand {
 
         public String getName() {
             return COMMAND_SIMPLE;
         }
 
-        public Object execute(LSPServer server, Env env, List<Object> arguments) {
+        public Object execute(LSPServerAccessor server, Env env, List<Object> arguments) {
             return arguments.size();
         }
     }
@@ -60,7 +65,7 @@ public class LSPExtensionTestInstance extends TruffleInstrument implements LSPEx
             return COMMAND_TIMEOUT;
         }
 
-        public Object execute(LSPServer server, Env env, List<Object> arguments) {
+        public Object execute(LSPServerAccessor server, Env env, List<Object> arguments) {
             try {
                 Thread.sleep(getTimeoutMillis() * 2);
             } catch (InterruptedException e) {
@@ -76,10 +81,5 @@ public class LSPExtensionTestInstance extends TruffleInstrument implements LSPEx
         public Object onTimeout(List<Object> arguments) {
             return arguments.get(0);
         }
-    }
-
-    @Override
-    protected void onCreate(Env env) {
-        env.registerService(this);
     }
 }

--- a/tools/src/org.graalvm.tools.lsp/src/org/graalvm/tools/lsp/server/ContextAwareExecutor.java
+++ b/tools/src/org.graalvm.tools.lsp/src/org/graalvm/tools/lsp/server/ContextAwareExecutor.java
@@ -74,6 +74,19 @@ public interface ContextAwareExecutor {
     <T> Future<T> executeWithNestedContext(Callable<T> taskWithResult, boolean cached);
 
     /**
+     * Same as {@link ContextAwareExecutor#executeWithNestedContext(Callable)}, but allowing the
+     * definition of a timeout and an onTimeoutTask for the execution.
+     *
+     * @param taskWithResult a task which shall be executed in a Polyglot-Context-entered Thread,
+     *            which might have unwanted side-effects
+     * @param timeoutMillis time in milliseconds that taskWithResult is allowed to run.
+     * @param onTimeoutTask a task which is executed if the timeout is triggered.
+     * @return a {@link Future} to await the task's result, or the onTimeoutTask's result if the
+     *         timeout triggered.
+     */
+    <T> Future<T> executeWithNestedContext(Callable<T> taskWithResult, int timeoutMillis, Callable<T> onTimeoutTask);
+
+    /**
      * Explicitly closes and removes all cached nested Context instances.
      */
     void resetContextCache();

--- a/tools/src/org.graalvm.tools.lsp/src/org/graalvm/tools/lsp/server/LanguageServerImpl.java
+++ b/tools/src/org.graalvm.tools.lsp/src/org/graalvm/tools/lsp/server/LanguageServerImpl.java
@@ -32,7 +32,6 @@ import java.net.Socket;
 import java.net.SocketAddress;
 import java.net.URI;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -47,7 +46,9 @@ import java.util.function.Supplier;
 import java.util.logging.Level;
 
 import org.graalvm.collections.Pair;
-
+import org.graalvm.tools.api.lsp.LSPServer;
+import org.graalvm.tools.lsp.exceptions.DiagnosticsNotification;
+import org.graalvm.tools.lsp.exceptions.UnknownLanguageException;
 import org.graalvm.tools.lsp.server.types.CodeAction;
 import org.graalvm.tools.lsp.server.types.CodeActionParams;
 import org.graalvm.tools.lsp.server.types.CodeLens;
@@ -75,12 +76,12 @@ import org.graalvm.tools.lsp.server.types.InitializeResult;
 import org.graalvm.tools.lsp.server.types.LanguageClient;
 import org.graalvm.tools.lsp.server.types.LanguageServer;
 import org.graalvm.tools.lsp.server.types.Location;
-import org.graalvm.tools.lsp.server.types.ShowMessageParams;
 import org.graalvm.tools.lsp.server.types.MessageType;
 import org.graalvm.tools.lsp.server.types.PublishDiagnosticsParams;
 import org.graalvm.tools.lsp.server.types.ReferenceParams;
 import org.graalvm.tools.lsp.server.types.RenameParams;
 import org.graalvm.tools.lsp.server.types.ServerCapabilities;
+import org.graalvm.tools.lsp.server.types.ShowMessageParams;
 import org.graalvm.tools.lsp.server.types.SignatureHelp;
 import org.graalvm.tools.lsp.server.types.SignatureHelpOptions;
 import org.graalvm.tools.lsp.server.types.SymbolInformation;
@@ -91,9 +92,8 @@ import org.graalvm.tools.lsp.server.types.TextEdit;
 import org.graalvm.tools.lsp.server.types.WorkspaceEdit;
 import org.graalvm.tools.lsp.server.types.WorkspaceFolder;
 import org.graalvm.tools.lsp.server.types.WorkspaceSymbolParams;
-import org.graalvm.tools.lsp.exceptions.DiagnosticsNotification;
-import org.graalvm.tools.lsp.exceptions.UnknownLanguageException;
 
+import com.oracle.truffle.api.source.Source;
 import com.oracle.truffle.tools.utils.json.JSONObject;
 
 /**
@@ -128,7 +128,7 @@ public final class LanguageServerImpl extends LanguageServer {
     }
 
     @Override
-    public CompletableFuture<InitializeResult> initialize(InitializeParams params) {
+    public CompletableFuture<InitializeResult> initialize(InitializeParams initializeParams) {
         // TODO: Read params.getCapabilities();
 
         ServerCapabilities capabilities = ServerCapabilities.create();
@@ -143,10 +143,28 @@ public final class LanguageServerImpl extends LanguageServer {
         capabilities.setSignatureHelpProvider(SignatureHelpOptions.create());
         capabilities.setHoverProvider(true);
         capabilities.setReferencesProvider(false);
-        capabilities.setExecuteCommandProvider(ExecuteCommandOptions.create(Arrays.asList(DRY_RUN, GET_COVERAGE)));
+        List<String> commands = new ArrayList<>(truffleAdapter.getExtensionCommandNames());
+        commands.add(DRY_RUN);
+        commands.add(GET_COVERAGE);
+        capabilities.setExecuteCommandProvider(ExecuteCommandOptions.create(commands));
+
+        truffleAdapter.initializeLSPServer(new LSPServer() {
+
+            public void sendCustomNotification(String method, Object params) {
+                client.sendCustomNotification(method, params);
+            }
+
+            public Map<URI, String> getOpenFileURI2LangId() {
+                return openedFileUri2LangId;
+            }
+
+            public Source getSource(URI uri) {
+                return truffleAdapter.getSource(uri);
+            }
+        });
 
         this.serverCapabilities = capabilities;
-        CompletableFuture.runAsync(() -> parseWorkspace(params.getWorkspaceFolders()));
+        CompletableFuture.runAsync(() -> parseWorkspace(initializeParams.getWorkspaceFolders()));
 
         return CompletableFuture.completedFuture(InitializeResult.create(capabilities));
     }
@@ -348,8 +366,13 @@ public final class LanguageServerImpl extends LanguageServer {
                 Future<Coverage> futureCoverage = truffleAdapter.getCoverage(URI.create(uri));
                 return CompletableFuture.supplyAsync(() -> waitForResultAndHandleExceptions(futureCoverage));
             default:
-                err.println("Unkown command: " + params.getCommand());
-                return CompletableFuture.completedFuture(new Object());
+                Future<?> extensionCommand = truffleAdapter.createExtensionCommand(params);
+                if (extensionCommand != null) {
+                    return CompletableFuture.supplyAsync(() -> waitForResultAndHandleExceptions(extensionCommand));
+                } else {
+                    err.println("Unkown command: " + params.getCommand());
+                    return CompletableFuture.completedFuture(new Object());
+                }
         }
     }
 

--- a/tools/src/org.graalvm.tools.lsp/src/org/graalvm/tools/lsp/server/LanguageServerImpl.java
+++ b/tools/src/org.graalvm.tools.lsp/src/org/graalvm/tools/lsp/server/LanguageServerImpl.java
@@ -46,7 +46,7 @@ import java.util.function.Supplier;
 import java.util.logging.Level;
 
 import org.graalvm.collections.Pair;
-import org.graalvm.tools.api.lsp.LSPServer;
+import org.graalvm.tools.api.lsp.LSPServerAccessor;
 import org.graalvm.tools.lsp.exceptions.DiagnosticsNotification;
 import org.graalvm.tools.lsp.exceptions.UnknownLanguageException;
 import org.graalvm.tools.lsp.server.types.CodeAction;
@@ -148,7 +148,7 @@ public final class LanguageServerImpl extends LanguageServer {
         commands.add(GET_COVERAGE);
         capabilities.setExecuteCommandProvider(ExecuteCommandOptions.create(commands));
 
-        truffleAdapter.initializeLSPServer(new LSPServer() {
+        truffleAdapter.initializeLSPServer(new LSPServerAccessor() {
 
             public void sendCustomNotification(String method, Object params) {
                 client.sendCustomNotification(method, params);

--- a/tools/src/org.graalvm.tools.lsp/src/org/graalvm/tools/lsp/server/TruffleAdapter.java
+++ b/tools/src/org.graalvm.tools.lsp/src/org/graalvm/tools/lsp/server/TruffleAdapter.java
@@ -33,6 +33,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -41,16 +42,9 @@ import java.util.concurrent.Future;
 import java.util.function.Function;
 import java.util.logging.Level;
 
-import org.graalvm.tools.lsp.server.types.CompletionContext;
-import org.graalvm.tools.lsp.server.types.CompletionList;
-import org.graalvm.tools.lsp.server.types.CompletionOptions;
-import org.graalvm.tools.lsp.server.types.Coverage;
-import org.graalvm.tools.lsp.server.types.DocumentHighlight;
-import org.graalvm.tools.lsp.server.types.Hover;
-import org.graalvm.tools.lsp.server.types.ServerCapabilities;
-import org.graalvm.tools.lsp.server.types.SignatureHelp;
-import org.graalvm.tools.lsp.server.types.SignatureHelpOptions;
-import org.graalvm.tools.lsp.server.types.TextDocumentContentChangeEvent;
+import org.graalvm.tools.api.lsp.LSPCommand;
+import org.graalvm.tools.api.lsp.LSPExtension;
+import org.graalvm.tools.api.lsp.LSPServer;
 import org.graalvm.tools.lsp.exceptions.DiagnosticsNotification;
 import org.graalvm.tools.lsp.exceptions.UnknownLanguageException;
 import org.graalvm.tools.lsp.server.request.AbstractRequestHandler;
@@ -60,11 +54,23 @@ import org.graalvm.tools.lsp.server.request.HighlightRequestHandler;
 import org.graalvm.tools.lsp.server.request.HoverRequestHandler;
 import org.graalvm.tools.lsp.server.request.SignatureHelpRequestHandler;
 import org.graalvm.tools.lsp.server.request.SourceCodeEvaluator;
+import org.graalvm.tools.lsp.server.types.CompletionContext;
+import org.graalvm.tools.lsp.server.types.CompletionList;
+import org.graalvm.tools.lsp.server.types.CompletionOptions;
+import org.graalvm.tools.lsp.server.types.Coverage;
+import org.graalvm.tools.lsp.server.types.DocumentHighlight;
+import org.graalvm.tools.lsp.server.types.ExecuteCommandParams;
+import org.graalvm.tools.lsp.server.types.Hover;
+import org.graalvm.tools.lsp.server.types.ServerCapabilities;
+import org.graalvm.tools.lsp.server.types.SignatureHelp;
+import org.graalvm.tools.lsp.server.types.SignatureHelpOptions;
+import org.graalvm.tools.lsp.server.types.TextDocumentContentChangeEvent;
 import org.graalvm.tools.lsp.server.utils.SourceUtils;
 import org.graalvm.tools.lsp.server.utils.TextDocumentSurrogate;
 import org.graalvm.tools.lsp.server.utils.TextDocumentSurrogateMap;
 
 import com.oracle.truffle.api.CallTarget;
+import com.oracle.truffle.api.InstrumentInfo;
 import com.oracle.truffle.api.Truffle;
 import com.oracle.truffle.api.TruffleFile;
 import com.oracle.truffle.api.TruffleLogger;
@@ -93,6 +99,8 @@ public final class TruffleAdapter implements VirtualLanguageServerFileProvider {
     private SignatureHelpRequestHandler signatureHelpHandler;
     private CoverageRequestHandler coverageHandler;
     private HighlightRequestHandler highlightHandler;
+    private List<LSPCommand> extensionCommands;
+    private LSPServer lspServer;
     private TextDocumentSurrogateMap surrogateMap;
     private final LanguageTriggerCharacters completionTriggerCharacters = new LanguageTriggerCharacters();
     private final LanguageTriggerCharacters signatureTriggerCharacters = new LanguageTriggerCharacters();
@@ -408,6 +416,15 @@ public final class TruffleAdapter implements VirtualLanguageServerFileProvider {
         return surrogate != null ? surrogate.getEditorText() : null;
     }
 
+    public Source getSource(URI uri) {
+        if (surrogateMap == null) {
+            return null;
+        }
+
+        TextDocumentSurrogate surrogate = surrogateMap.get(uri);
+        return surrogate != null ? surrogate.getSource() : null;
+    }
+
     @Override
     public boolean isVirtualFile(Path path) {
         return surrogateMap.containsSurrogate(path.toUri());
@@ -417,5 +434,46 @@ public final class TruffleAdapter implements VirtualLanguageServerFileProvider {
         return (sourceUri) -> {
             return surrogateMap.getOrCreateSurrogate(sourceUri, () -> languageInfo);
         };
+    }
+
+    public void initializeLSPServer(LSPServer server) {
+        this.lspServer = server;
+    }
+
+    private List<LSPCommand> getExternalCommands() {
+        if (extensionCommands == null) {
+            extensionCommands = new ArrayList<>();
+            for (InstrumentInfo instrument : envMain.getInstruments().values()) {
+                if ("lsp".equals(instrument.getId())) {
+                    continue;
+                }
+                LSPExtension extension = envMain.lookup(instrument, LSPExtension.class);
+                if (extension != null) {
+                    for (LSPCommand command : extension.getCommands()) {
+                        extensionCommands.add(command);
+                    }
+                }
+            }
+        }
+        return extensionCommands;
+    }
+
+    public Collection<String> getExtensionCommandNames() {
+        ArrayList<String> result = new ArrayList<>();
+        for (LSPCommand command : getExternalCommands()) {
+            result.add(command.getName());
+        }
+        return result;
+    }
+
+    public Future<?> createExtensionCommand(ExecuteCommandParams params) {
+        String commandName = params.getCommand();
+        for (LSPCommand command : getExternalCommands()) {
+            if (commandName.equals(command.getName())) {
+                List<Object> args = params.getArguments();
+                return contextAwareExecutor.executeWithNestedContext(() -> command.execute(lspServer, envInternal, args), command.getTimeoutMillis(), () -> command.onTimeout(args));
+            }
+        }
+        return null;
     }
 }

--- a/tools/src/org.graalvm.tools.lsp/src/org/graalvm/tools/lsp/server/TruffleAdapter.java
+++ b/tools/src/org.graalvm.tools.lsp/src/org/graalvm/tools/lsp/server/TruffleAdapter.java
@@ -44,7 +44,7 @@ import java.util.logging.Level;
 
 import org.graalvm.tools.api.lsp.LSPCommand;
 import org.graalvm.tools.api.lsp.LSPExtension;
-import org.graalvm.tools.api.lsp.LSPServer;
+import org.graalvm.tools.api.lsp.LSPServerAccessor;
 import org.graalvm.tools.lsp.exceptions.DiagnosticsNotification;
 import org.graalvm.tools.lsp.exceptions.UnknownLanguageException;
 import org.graalvm.tools.lsp.server.request.AbstractRequestHandler;
@@ -100,7 +100,7 @@ public final class TruffleAdapter implements VirtualLanguageServerFileProvider {
     private CoverageRequestHandler coverageHandler;
     private HighlightRequestHandler highlightHandler;
     private List<LSPCommand> extensionCommands;
-    private LSPServer lspServer;
+    private LSPServerAccessor lspServer;
     private TextDocumentSurrogateMap surrogateMap;
     private final LanguageTriggerCharacters completionTriggerCharacters = new LanguageTriggerCharacters();
     private final LanguageTriggerCharacters signatureTriggerCharacters = new LanguageTriggerCharacters();
@@ -436,7 +436,7 @@ public final class TruffleAdapter implements VirtualLanguageServerFileProvider {
         };
     }
 
-    public void initializeLSPServer(LSPServer server) {
+    public void initializeLSPServer(LSPServerAccessor server) {
         this.lspServer = server;
     }
 

--- a/tools/src/org.graalvm.tools.lsp/src/org/graalvm/tools/lsp/server/types/LanguageClient.java
+++ b/tools/src/org.graalvm.tools.lsp/src/org/graalvm/tools/lsp/server/types/LanguageClient.java
@@ -55,4 +55,6 @@ public interface LanguageClient {
 
     // Diagnostics related methods
     void publishDiagnostics(PublishDiagnosticsParams params);
+
+    void sendCustomNotification(String method, Object params);
 }

--- a/tools/src/org.graalvm.tools.lsp/src/org/graalvm/tools/lsp/server/types/LanguageServer.java
+++ b/tools/src/org.graalvm.tools.lsp/src/org/graalvm/tools/lsp/server/types/LanguageServer.java
@@ -426,6 +426,11 @@ public class LanguageServer {
                 public void publishDiagnostics(PublishDiagnosticsParams params) {
                     sendNotification("textDocument/publishDiagnostics", params);
                 }
+
+                @Override
+                public void sendCustomNotification(String method, Object params) {
+                    sendNotification(method, params);
+                }
             });
         }
 


### PR DESCRIPTION
This adds the ability to extend the list of commands supported by the GraalLS through other instruments that provide the new `LSPExtension` service. See `LSPExtensionTestInstance` for an example.

Based on this change and #2906, we were able to implement Live Programming features on top of GraalLS and GraalVM's extension for VS Code.

Please assign to @dbalek and discuss! /cc @MartinBalin and @chumer