### PR TITLE
Fix grouping of javadoc for org.graalvm.nativeimage.hosted

### DIFF
--- a/sdk/src/org.graalvm.nativeimage/src/org/graalvm/nativeimage/hosted/package-info.java
+++ b/sdk/src/org.graalvm.nativeimage/src/org/graalvm/nativeimage/hosted/package-info.java
@@ -40,11 +40,11 @@
  */
 /*
  @ApiInfo(
- group="Graal SDK"
+ group="GraalVM SDK"
  )
  */
 /**
- * The Graal-SDK native-image API allows to customize the native image generation, i.e., the
+ * The GraalVM SDK Native Image API allows to customize the native image generation, i.e., the
  * ahead-of-time compilation of Java code to standalone executables:
  * <ul>
  * <li>{@link org.graalvm.nativeimage.hosted.Feature}s allow clients to intercept the native image

--- a/sdk/src/org.graalvm.nativeimage/src/org/graalvm/nativeimage/package-info.java
+++ b/sdk/src/org.graalvm.nativeimage/src/org/graalvm/nativeimage/package-info.java
@@ -44,7 +44,7 @@
  )
  */
 /**
- * The GraalVM SDK native-image API allows to customize the native image generation, i.e., the
+ * The GraalVM SDK Native Image API allows to customize the native image generation, i.e., the
  * ahead-of-time compilation of Java code to standalone executables. It also provides interfaces and
  * support classes that only work in the context of a native image.
  *


### PR DESCRIPTION
![Screenshot 2020-10-28 at 11 00 55 AM](https://user-images.githubusercontent.com/8035100/97422464-1e171d80-190e-11eb-88e3-03fddf7fa2e5.png)

Fixes the inconsistent grouping in the javadoc for Graal SDK.