### PR TITLE
Log reason for java.lang.UnsatisfiedLinkError

### DIFF
--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/NativeLibrarySupport.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/NativeLibrarySupport.java
@@ -136,6 +136,7 @@ public final class NativeLibrarySupport {
         try {
             canonical = asBuiltin ? file.getName() : file.getCanonicalPath();
         } catch (IOException e) {
+            System.err.println("Could not load library:" + e.toString());
             return false;
         }
         return addLibrary(asBuiltin, canonical, true);


### PR DESCRIPTION
Log reason for java.lang.UnsatisfiedLinkError in loadLibrary0 method.
This helps debugging dependencies between shared libraries which are displayed in the error message.