### PR TITLE
Call tree analysis with Neo4j

### DIFF
--- a/substratevm/src/com.oracle.graal.pointsto/src/com/oracle/graal/pointsto/reports/CallTreeCypher.java
+++ b/substratevm/src/com.oracle.graal.pointsto/src/com/oracle/graal/pointsto/reports/CallTreeCypher.java
@@ -1,0 +1,67 @@
+package com.oracle.graal.pointsto.reports;
+
+import static com.oracle.graal.pointsto.reports.ReportUtils.methodComparator;
+
+import com.oracle.graal.pointsto.BigBang;
+import com.oracle.graal.pointsto.meta.AnalysisMethod;
+import com.oracle.graal.pointsto.reports.CallTreePrinter.MethodNode;
+
+import java.io.File;
+import java.io.PrintWriter;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+
+public class CallTreeCypher {
+
+    // TODO temporarily use a system property to try different values
+    private static final int BATCH_SIZE = Integer.getInteger("cypher.batch.size", 2);
+
+    public static void print(BigBang bigbang, String path, String reportName) {
+        CallTreePrinter printer = new CallTreePrinter(bigbang);
+        printer.buildCallTree();
+
+        ReportUtils.report("call tree cypher", path + File.separatorChar + "reports", "call_tree_" + reportName, "cypher",
+                writer -> printCypher(printer.methodToNode, writer));
+    }
+
+    private static void printCypher(Map<AnalysisMethod, MethodNode> methodToNode, PrintWriter writer) {
+        printMethodNodes(methodToNode.keySet(), writer);
+    }
+
+    private static void printMethodNodes(Set<AnalysisMethod> methods, PrintWriter writer) {
+        final AtomicInteger counter = new AtomicInteger();
+        final Collection<List<AnalysisMethod>> methodsBatches = methods.stream()
+                .collect(Collectors.groupingBy(m -> counter.getAndIncrement() / BATCH_SIZE))
+                .values();
+
+        final String unwindMethod = unwindMethod();
+        final String script = methodsBatches.stream()
+                .map(methodBatch -> methodBatch.stream()
+                        .map(method -> String.format("{_id:%d, %s}", method.getId(), methodProperties(method)))
+                        .collect(Collectors.joining(", ", ":param rows => [", "]"))
+                )
+                .collect(Collectors.joining(unwindMethod, "", unwindMethod));
+
+        writer.print(script);
+    }
+
+    private static String methodProperties(AnalysisMethod method) {
+        return method.format("properties:{name:'%n', class:'%H', parameters:'%P', return:'%R'}");
+    }
+
+    static String unwindMethod() {
+        return "\n\n:begin\n" +
+                "UNWIND $rows as row\n" +
+                "CREATE (n:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row._id})\n" +
+                "  SET n += row.properties SET n:Method;\n" +
+                ":commit\n";
+    }
+}

--- a/substratevm/src/com.oracle.graal.pointsto/src/com/oracle/graal/pointsto/reports/CallTreeCypher.java
+++ b/substratevm/src/com.oracle.graal.pointsto/src/com/oracle/graal/pointsto/reports/CallTreeCypher.java
@@ -1,18 +1,17 @@
 package com.oracle.graal.pointsto.reports;
 
-import static com.oracle.graal.pointsto.reports.ReportUtils.methodComparator;
-
 import com.oracle.graal.pointsto.BigBang;
 import com.oracle.graal.pointsto.meta.AnalysisMethod;
+import com.oracle.graal.pointsto.reports.CallTreePrinter.InvokeNode;
 import com.oracle.graal.pointsto.reports.CallTreePrinter.MethodNode;
+import com.oracle.graal.pointsto.reports.CallTreePrinter.Node;
 
 import java.io.File;
 import java.io.PrintWriter;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
 import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -25,6 +24,9 @@ public class CallTreeCypher {
     private static final int BATCH_SIZE = Integer.getInteger("cypher.batch.size", 2);
 
     public static void print(BigBang bigbang, String path, String reportName) {
+        // Re-initialize method ids back to 0 to better diagnose disparities
+        MethodNode.methodId = 0;
+
         CallTreePrinter printer = new CallTreePrinter(bigbang);
         printer.buildCallTree();
 
@@ -33,19 +35,19 @@ public class CallTreeCypher {
     }
 
     private static void printCypher(Map<AnalysisMethod, MethodNode> methodToNode, PrintWriter writer) {
-        printMethodNodes(methodToNode.keySet(), writer);
+        printMethodNodes(methodToNode.values(), writer);
+        printMethodEdges(methodToNode, writer);
     }
 
-    private static void printMethodNodes(Set<AnalysisMethod> methods, PrintWriter writer) {
-        final AtomicInteger counter = new AtomicInteger();
-        final Collection<List<AnalysisMethod>> methodsBatches = methods.stream()
-                .collect(Collectors.groupingBy(m -> counter.getAndIncrement() / BATCH_SIZE))
-                .values();
+    private static void printMethodNodes(Collection<MethodNode> methods, PrintWriter writer) {
+        final Collection<List<MethodNode>> methodsBatches = batched(methods);
+
+        writer.print(vmEntryPoint());
 
         final String unwindMethod = unwindMethod();
         final String script = methodsBatches.stream()
                 .map(methodBatch -> methodBatch.stream()
-                        .map(method -> String.format("{_id:%d, %s}", method.getId(), methodProperties(method)))
+                        .map(method -> String.format("{_id:%d, %s}", method.id, methodProperties(method)))
                         .collect(Collectors.joining(", ", ":param rows => [", "]"))
                 )
                 .collect(Collectors.joining(unwindMethod, "", unwindMethod));
@@ -53,15 +55,123 @@ public class CallTreeCypher {
         writer.print(script);
     }
 
-    private static String methodProperties(AnalysisMethod method) {
-        return method.format("properties:{name:'%n', class:'%H', parameters:'%P', return:'%R'}");
+    private static String methodProperties(MethodNode method) {
+        return method.method.format("properties:{name:'%n', signature:'" + CallTreePrinter.METHOD_FORMAT + "'}");
     }
 
-    static String unwindMethod() {
+    private static String vmEntryPoint() {
+        return ":begin\n" +
+                "CREATE (v:VM {name: 'VM'});\n" +
+                ":commit\n\n";
+    }
+
+    private static String unwindMethod() {
         return "\n\n:begin\n" +
                 "UNWIND $rows as row\n" +
                 "CREATE (n:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row._id})\n" +
                 "  SET n += row.properties SET n:Method;\n" +
-                ":commit\n";
+                ":commit\n\n";
     }
+
+    private static void printMethodEdges(Map<AnalysisMethod, MethodNode> methodToNode, PrintWriter writer) {
+        Map<Integer, Set<String>> direct = new HashMap<>();
+        Map<Integer, Set<String>> virtual = new HashMap<>();
+        Map<Integer, Set<Integer>> override = new HashMap<>();
+        final Iterator<MethodNode> iterator = methodToNode.values().stream().filter(n -> n.isEntryPoint).iterator();
+        while (iterator.hasNext()) {
+            final MethodNode node = iterator.next();
+            String entryEdge = entryEdge(node.method.format(CallTreePrinter.METHOD_FORMAT));
+            writer.print(entryEdge);
+            // addMethodEdges(iterator.next(), direct, virtual, override);
+        }
+
+        // printDirectEdges(direct, writer);
+    }
+
+    private static String entryEdge(String signature) {
+        return "\n\nMATCH (v:VM),(m:Method)\n" +
+                "  WHERE v.name = 'VM' AND m.signature = '" + signature + "'\n" +
+                "CREATE (v)-[r:ENTRY]->(m);\n\n";
+    }
+
+//    private static void addMethodEdges(MethodNode methodNode, Map<Integer, Set<String>> direct, Map<Integer, Set<String>> virtual, Map<Integer, Set<Integer>> override) {
+//        for (InvokeNode invoke : methodNode.invokes) {
+//            if (invoke.isDirectInvoke) {
+//                if (invoke.callees.size() > 0) {
+//                    Node calleeNode = invoke.callees.get(0);
+//                    addIdSignatureEdge(methodNode.id, calleeNode, direct);
+//                    if (calleeNode instanceof MethodNode) {
+//                        addMethodEdges((MethodNode) calleeNode, direct, virtual, override);
+//                    }
+//                }
+//            } else {
+////                addSignatureEdge(methodNode.id, invoke, virtual);
+////                for (Node calleeNode : invoke.callees) {
+////                    addIdEdge(methodNode.id, calleeNode, override);
+////                    if (calleeNode instanceof MethodNode) {
+////                        addMethodEdges((MethodNode) calleeNode, direct, virtual, override);
+////                    }
+////                }
+//            }
+//        }
+//    }
+
+//    private static void addIdSignatureEdge(int nodeId, Node calleeNode, Map<Integer, Set<String>> edges) {
+//        Set<String> nodeEdges = edges.computeIfAbsent(nodeId, k -> new HashSet<>());
+//        if (calleeNode instanceof MethodNode) {
+//            nodeEdges.add(((MethodNode) calleeNode).method.format(CallTreePrinter.METHOD_FORMAT));
+//        } else {
+//            nodeEdges.add(((CallTreePrinter.MethodNodeReference) calleeNode).methodNode.method.format(CallTreePrinter.METHOD_FORMAT));
+//        }
+//    }
+//
+//    private static void addSignatureEdge(int nodeId, InvokeNode invokeNode, Map<Integer, Set<String>> edges) {
+//        Set<String> nodeEdges = edges.computeIfAbsent(nodeId, k -> new HashSet<>());
+//        nodeEdges.add(invokeNode.formatTarget());
+//    }
+
+//    private static void printDirectEdges(Map<Integer, Set<String>> directEdges, PrintWriter writer) {
+//        final Set<Edge> idEdges = directEdges.entrySet().stream()
+//                .flatMap(entry -> entry.getValue().stream().map(signature -> new Edge(entry.getKey(), signature)))
+//                .collect(Collectors.toSet());
+//
+//        final Collection<List<Edge>> idEdgeBatches = batched(idEdges);
+//
+//        final String unwindEdge = unwindDirectEdge();
+//        final String script = idEdgeBatches.stream()
+//                .map(edges -> edges.stream()
+//                        .map(edge -> String.format("{start: {_id:%d}, end: {signature:'%s'}}", edge.id, edge.signature))
+//                        .collect(Collectors.joining(", ", ":param rows => [", "]"))
+//                )
+//                .collect(Collectors.joining(unwindEdge, "", unwindEdge));
+//
+//        writer.print(script);
+//    }
+//
+//    private static String unwindDirectEdge() {
+//        return "\n\n:begin\n" +
+//                "UNWIND $rows as row\n" +
+//                "MATCH (start:`UNIQUE IMPORT LABEL`\n" +
+//                "               {`UNIQUE IMPORT ID`: row.start._id})\n" +
+//                "MATCH (end:Method {signature: row.end.signature})\n" +
+//                "CREATE (start)-[r:DIRECT]->(end);\n" +
+//                ":commit\n\n";
+//    }
+
+    private static <E> Collection<List<E>> batched(Collection<E> methods) {
+        final AtomicInteger counter = new AtomicInteger();
+        return methods.stream()
+                .collect(Collectors.groupingBy(m -> counter.getAndIncrement() / BATCH_SIZE))
+                .values();
+    }
+
+//    private static final class Edge {
+//        final int id;
+//        final String signature;
+//
+//        private Edge(int id, String signature) {
+//            this.id = id;
+//            this.signature = signature;
+//        }
+//    }
 }

--- a/substratevm/src/com.oracle.graal.pointsto/src/com/oracle/graal/pointsto/reports/CallTreePrinter.java
+++ b/substratevm/src/com.oracle.graal.pointsto/src/com/oracle/graal/pointsto/reports/CallTreePrinter.java
@@ -141,7 +141,7 @@ public final class CallTreePrinter {
     }
 
     private final BigBang bigbang;
-    private final Map<AnalysisMethod, MethodNode> methodToNode;
+    protected final Map<AnalysisMethod, MethodNode> methodToNode;
 
     public CallTreePrinter(BigBang bigbang) {
         this.bigbang = bigbang;

--- a/substratevm/src/com.oracle.graal.pointsto/src/com/oracle/graal/pointsto/reports/CallTreePrinter.java
+++ b/substratevm/src/com.oracle.graal.pointsto/src/com/oracle/graal/pointsto/reports/CallTreePrinter.java
@@ -118,7 +118,7 @@ public final class CallTreePrinter {
         protected final AnalysisMethod targetMethod;
         protected final List<Node> callees;
         protected final boolean isDirectInvoke;
-        private final SourceReference[] sourceReferences;
+        protected final SourceReference[] sourceReferences;
 
         InvokeNode(AnalysisMethod targetMethod, boolean isDirectInvoke, SourceReference[] sourceReferences) {
             this.targetMethod = targetMethod;

--- a/substratevm/src/com.oracle.graal.pointsto/src/com/oracle/graal/pointsto/reports/CallTreePrinter.java
+++ b/substratevm/src/com.oracle.graal.pointsto/src/com/oracle/graal/pointsto/reports/CallTreePrinter.java
@@ -115,7 +115,7 @@ public final class CallTreePrinter {
     }
 
     static class InvokeNode {
-        private final AnalysisMethod targetMethod;
+        protected final AnalysisMethod targetMethod;
         protected final List<Node> callees;
         protected final boolean isDirectInvoke;
         private final SourceReference[] sourceReferences;

--- a/substratevm/src/com.oracle.graal.pointsto/src/com/oracle/graal/pointsto/reports/CallTreePrinter.java
+++ b/substratevm/src/com.oracle.graal.pointsto/src/com/oracle/graal/pointsto/reports/CallTreePrinter.java
@@ -73,7 +73,7 @@ public final class CallTreePrinter {
     }
 
     static class MethodNodeReference implements Node {
-        private final MethodNode methodNode;
+        protected final MethodNode methodNode;
 
         MethodNodeReference(MethodNode methodNode) {
             this.methodNode = methodNode;
@@ -88,10 +88,10 @@ public final class CallTreePrinter {
     static class MethodNode implements Node {
         static int methodId = 0;
 
-        private final int id;
-        private final AnalysisMethod method;
-        private final List<InvokeNode> invokes;
-        private final boolean isEntryPoint;
+        protected final int id;
+        protected final AnalysisMethod method;
+        protected final List<InvokeNode> invokes;
+        protected final boolean isEntryPoint;
 
         MethodNode(AnalysisMethod method) {
             this(method, false);
@@ -116,8 +116,8 @@ public final class CallTreePrinter {
 
     static class InvokeNode {
         private final AnalysisMethod targetMethod;
-        private final List<Node> callees;
-        private final boolean isDirectInvoke;
+        protected final List<Node> callees;
+        protected final boolean isDirectInvoke;
         private final SourceReference[] sourceReferences;
 
         InvokeNode(AnalysisMethod targetMethod, boolean isDirectInvoke, SourceReference[] sourceReferences) {
@@ -214,7 +214,7 @@ public final class CallTreePrinter {
         return sourceReference.toArray(new SourceReference[sourceReference.size()]);
     }
 
-    private static final String METHOD_FORMAT = "%H.%n(%P):%R";
+    protected static final String METHOD_FORMAT = "%H.%n(%P):%R";
 
     private void printMethods(PrintWriter out) {
         out.println("VM Entry Points");

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/NativeImageGenerator.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/NativeImageGenerator.java
@@ -54,6 +54,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
+import com.oracle.graal.pointsto.reports.CallTreeCypher;
 import org.graalvm.collections.EconomicSet;
 import org.graalvm.collections.Pair;
 import org.graalvm.compiler.api.replacements.Fold;
@@ -786,6 +787,7 @@ public class NativeImageGenerator {
 
                 if (AnalysisReportsOptions.PrintAnalysisCallTree.getValue(options)) {
                     CallTreePrinter.print(bigbang, SubstrateOptions.Path.getValue(), ReportUtils.extractImageName(imageName));
+                    CallTreeCypher.print(bigbang, SubstrateOptions.Path.getValue(), ReportUtils.extractImageName(imageName));
                 }
 
                 if (AnalysisReportsOptions.PrintImageObjectTree.getValue(options)) {


### PR DESCRIPTION
In order to improve debugging of analysis issues, I've been exploring producing neo4j graphs instead text based call graphs. This PR is an effort to do that and should be considered as a draft.

Functionality wise, it should be complete and equivalent to the existing call tree output. It includes:
* A VM entry point node.
* A `Method` node for each distinct direct, virtual and overriden method.
* Each `Method` includes the method name and the complete signature. 
* Entry relationships between VM and entry method nodes.
* Direct and virtual relationships between method nodes include bytecode index information.
* Bytecode index information expresses the possibility of a method calling another one from different locations within the origin method.
* Overriden relationships between virtual and override methods. These relationships have no bytecode index information.

The idea is to produce a cypher script that would load the equivalent of the existing call tree printer into a neo4j db. This adds not extra dependencies, it just produces an equivalent text file that can be loaded into neo4j via:

```
cat reports/call_tree_helloworld_20201102_115920.cypher | /opt/neo4j/bin/cypher-shell -u neo4j -p neo
```

It uses the techniques explained in [this article](https://medium.com/neo4j/efficient-neo4j-data-import-using-cypher-scripts-7d1268b0747) to efficiently batch data and take advantage of script caching. In spite of these efforts, loading data is not very fast right now. The hello world example has a total of ~8k method nodes (8869 to be precise, including virtual ones) and ~27k relationships. Loading that takes ~4m on my home server. For reference, my home server takes 12s to generate a hello world native image. I'm hoping @michael-simons or other neo4j experts (e.g. @DavideD) can help shape this into performing better.

Attaching a sample neo4j graph and a rough screenshot of the area it'd represent. You can find the full cypher output for hello world [here](https://www.dropbox.com/s/s4f8gf0nf8np6kg/call_tree_helloworld_20201102_115920.cypher?dl=0).

Implementation wise, it simply reuses the logic in `CallTreePrinter` to generate the graph and it uses the types referenced there.

TODO:
- [ ] Decide on granularity of elements on Methods. Right now it has name and signature, but the signature could be split into class name, parameters and returns, and each of the types there could be node themselves and link together. The cypher needs to process this faster to be usable.
- [ ] Improve performance.
- [ ] Decide on configuration options to get the output. Right now it just piggy backs on the print analysis call option.

![Screen Shot 2020-11-02 at 12 06 28](https://user-images.githubusercontent.com/50187/97877659-c87fae00-1d1d-11eb-8536-ea980ce30107.png)
![Screen Shot 2020-11-02 at 12 06 10](https://user-images.githubusercontent.com/50187/97877652-c584bd80-1d1d-11eb-98de-e4781bc655e4.png)
