### PR TITLE
--target parameter, Platform/LibC changes

### DIFF
--- a/sdk/src/org.graalvm.collections/src/org/graalvm/collections/Pair.java
+++ b/sdk/src/org.graalvm.collections/src/org/graalvm/collections/Pair.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * The Universal Permissive License (UPL), Version 1.0
@@ -169,6 +169,7 @@ public final class Pair<L, R> {
      */
     @Override
     public String toString() {
-        return String.format("(%s, %s)", left, right);
+        // String.format isn't used here since it tends to pull a lot of types into image.
+        return "(" + left + ", " + right + ")";
     }
 }

--- a/sdk/src/org.graalvm.nativeimage/snapshot.sigtest
+++ b/sdk/src/org.graalvm.nativeimage/snapshot.sigtest
@@ -209,28 +209,49 @@ CLSS public abstract interface org.graalvm.nativeimage.Platform
 fld public final static java.lang.String PLATFORM_PROPERTY_NAME = "svm.platform"
 innr public abstract interface static AARCH64
 innr public abstract interface static AMD64
+innr public abstract interface static ANDROID
 innr public abstract interface static DARWIN
+innr public abstract interface static IOS
 innr public abstract interface static LINUX
 innr public abstract interface static WINDOWS
+innr public final static ANDROID_AARCH64
 innr public final static DARWIN_AARCH64
+innr public final static DARWIN_AMD64
 innr public final static HOSTED_ONLY
+innr public final static IOS_AARCH64
 innr public final static LINUX_AARCH64
-innr public static DARWIN_AMD64
+innr public final static WINDOWS_AMD64
 innr public static LINUX_AMD64
-innr public static WINDOWS_AMD64
+meth public java.lang.String getArchitecture()
+meth public java.lang.String getOS()
 meth public static boolean includedIn(java.lang.Class<? extends org.graalvm.nativeimage.Platform>)
 
 CLSS public abstract interface static org.graalvm.nativeimage.Platform$AARCH64
  outer org.graalvm.nativeimage.Platform
 intf org.graalvm.nativeimage.Platform
+meth public java.lang.String getArchitecture()
 
 CLSS public abstract interface static org.graalvm.nativeimage.Platform$AMD64
  outer org.graalvm.nativeimage.Platform
 intf org.graalvm.nativeimage.Platform
+meth public java.lang.String getArchitecture()
+
+CLSS public abstract interface static org.graalvm.nativeimage.Platform$ANDROID
+ outer org.graalvm.nativeimage.Platform
+intf org.graalvm.nativeimage.Platform$LINUX
+meth public java.lang.String getOS()
+
+CLSS public final static org.graalvm.nativeimage.Platform$ANDROID_AARCH64
+ outer org.graalvm.nativeimage.Platform
+cons public init()
+intf org.graalvm.nativeimage.Platform$AARCH64
+intf org.graalvm.nativeimage.Platform$ANDROID
+supr java.lang.Object
 
 CLSS public abstract interface static org.graalvm.nativeimage.Platform$DARWIN
  outer org.graalvm.nativeimage.Platform
 intf org.graalvm.nativeimage.impl.InternalPlatform$PLATFORM_JNI
+meth public java.lang.String getOS()
 
 CLSS public final static org.graalvm.nativeimage.Platform$DARWIN_AARCH64
  outer org.graalvm.nativeimage.Platform
@@ -239,7 +260,7 @@ intf org.graalvm.nativeimage.Platform$AARCH64
 intf org.graalvm.nativeimage.Platform$DARWIN
 supr java.lang.Object
 
-CLSS public static org.graalvm.nativeimage.Platform$DARWIN_AMD64
+CLSS public final static org.graalvm.nativeimage.Platform$DARWIN_AMD64
  outer org.graalvm.nativeimage.Platform
 cons public init()
 intf org.graalvm.nativeimage.Platform$AMD64
@@ -251,9 +272,22 @@ CLSS public final static org.graalvm.nativeimage.Platform$HOSTED_ONLY
 intf org.graalvm.nativeimage.Platform
 supr java.lang.Object
 
+CLSS public abstract interface static org.graalvm.nativeimage.Platform$IOS
+ outer org.graalvm.nativeimage.Platform
+intf org.graalvm.nativeimage.Platform$DARWIN
+meth public java.lang.String getOS()
+
+CLSS public final static org.graalvm.nativeimage.Platform$IOS_AARCH64
+ outer org.graalvm.nativeimage.Platform
+cons public init()
+intf org.graalvm.nativeimage.Platform$AARCH64
+intf org.graalvm.nativeimage.Platform$IOS
+supr java.lang.Object
+
 CLSS public abstract interface static org.graalvm.nativeimage.Platform$LINUX
  outer org.graalvm.nativeimage.Platform
 intf org.graalvm.nativeimage.impl.InternalPlatform$PLATFORM_JNI
+meth public java.lang.String getOS()
 
 CLSS public final static org.graalvm.nativeimage.Platform$LINUX_AARCH64
  outer org.graalvm.nativeimage.Platform
@@ -272,8 +306,9 @@ supr java.lang.Object
 CLSS public abstract interface static org.graalvm.nativeimage.Platform$WINDOWS
  outer org.graalvm.nativeimage.Platform
 intf org.graalvm.nativeimage.impl.InternalPlatform$PLATFORM_JNI
+meth public java.lang.String getOS()
 
-CLSS public static org.graalvm.nativeimage.Platform$WINDOWS_AMD64
+CLSS public final static org.graalvm.nativeimage.Platform$WINDOWS_AMD64
  outer org.graalvm.nativeimage.Platform
 cons public init()
 intf org.graalvm.nativeimage.Platform$AMD64

--- a/sdk/src/org.graalvm.nativeimage/src/META-INF/services/org.graalvm.nativeimage.Platform
+++ b/sdk/src/org.graalvm.nativeimage/src/META-INF/services/org.graalvm.nativeimage.Platform
@@ -1,0 +1,7 @@
+org.graalvm.nativeimage.Platform$LINUX_AMD64
+org.graalvm.nativeimage.Platform$LINUX_AARCH64
+org.graalvm.nativeimage.Platform$ANDROID_AARCH64
+org.graalvm.nativeimage.Platform$DARWIN_AMD64
+org.graalvm.nativeimage.Platform$DARWIN_AARCH64
+org.graalvm.nativeimage.Platform$IOS_AARCH64
+org.graalvm.nativeimage.Platform$WINDOWS_AMD64

--- a/sdk/src/org.graalvm.nativeimage/src/org/graalvm/nativeimage/Platform.java
+++ b/sdk/src/org.graalvm.nativeimage/src/org/graalvm/nativeimage/Platform.java
@@ -84,6 +84,31 @@ public interface Platform {
         return platformGroup.isInstance(ImageSingletons.lookup(Platform.class));
     }
 
+    /**
+     * Returns the string representing Platform's OS name.
+     * <p>
+     * This method should be implemented either in a final class or as default method in respective
+     * OS interface.
+     *
+     * @since 21.0
+     */
+    default String getOS() {
+        throw new UnsupportedOperationException("Platform doesn't implement getOS");
+    }
+
+    /**
+     * Returns the string representing Platform's architecture name. This value should be the same
+     * as desired os.arch system property.
+     * <p>
+     * This method should be implemented either in final class or as default method in respective
+     * architecture interface.
+     *
+     * @since 21.0
+     */
+    default String getArchitecture() {
+        throw new UnsupportedOperationException("Platform doesn't implement getArchitecture");
+    }
+
     /*
      * The standard architectures that are supported.
      */
@@ -94,6 +119,14 @@ public interface Platform {
      */
     interface AMD64 extends Platform {
 
+        /**
+         * Returns string representing AMD64 architecture.
+         *
+         * @since 21.0
+         */
+        default String getArchitecture() {
+            return "amd64";
+        }
     }
 
     /**
@@ -103,6 +136,14 @@ public interface Platform {
      */
     interface AARCH64 extends Platform {
 
+        /**
+         * Returns string representing AARCH64 architecture.
+         *
+         * @since 21.0
+         */
+        default String getArchitecture() {
+            return "aarch64";
+        }
     }
 
     /*
@@ -115,6 +156,31 @@ public interface Platform {
      */
     interface LINUX extends InternalPlatform.PLATFORM_JNI {
 
+        /**
+         * Returns string representing LINUX OS.
+         *
+         * @since 21.0
+         */
+        default String getOS() {
+            return "linux";
+        }
+    }
+
+    /**
+     * Supported operating system: Android.
+     *
+     * @since 21.0
+     */
+    interface ANDROID extends LINUX {
+
+        /**
+         * Returns string representing ANDROID OS.
+         *
+         * @since 21.0
+         */
+        default String getOS() {
+            return "android";
+        }
     }
 
     /**
@@ -124,6 +190,31 @@ public interface Platform {
      */
     interface DARWIN extends InternalPlatform.PLATFORM_JNI {
 
+        /**
+         * Returns string representing DARWIN OS.
+         *
+         * @since 21.0
+         */
+        default String getOS() {
+            return "darwin";
+        }
+    }
+
+    /**
+     * Supported operating system: iOS.
+     *
+     * @since 21.0
+     */
+    interface IOS extends DARWIN {
+
+        /**
+         * Returns string representing IOS OS.
+         *
+         * @since 21.0
+         */
+        default String getOS() {
+            return "ios";
+        }
     }
 
     /**
@@ -133,6 +224,14 @@ public interface Platform {
      */
     interface WINDOWS extends InternalPlatform.PLATFORM_JNI {
 
+        /**
+         * Returns string representing WINDOWS OS.
+         *
+         * @since 21.0
+         */
+        default String getOS() {
+            return "windows";
+        }
     }
 
     /*
@@ -173,11 +272,28 @@ public interface Platform {
     }
 
     /**
+     * Supported leaf platform: Android on AArch64 64-bit.
+     *
+     * @since 21.0
+     */
+    final class ANDROID_AARCH64 implements ANDROID, AARCH64 {
+
+        /**
+         * Instantiates a marker instance of this platform.
+         *
+         * @since 21.0
+         */
+        public ANDROID_AARCH64() {
+        }
+
+    }
+
+    /**
      * Supported leaf platform: Darwin (MacOS) on x86 64-bit.
      *
      * @since 19.0
      */
-    class DARWIN_AMD64 implements DARWIN, AMD64 {
+    final class DARWIN_AMD64 implements DARWIN, AMD64 {
 
         /**
          * Instantiates a marker instance of this platform.
@@ -205,11 +321,27 @@ public interface Platform {
     }
 
     /**
+     * Supported leaf platform: iOS on AArch 64-bit.
+     *
+     * @since 21.0
+     */
+    final class IOS_AARCH64 implements IOS, AARCH64 {
+
+        /**
+         * Instantiates a marker instance of this platform.
+         *
+         * @since 21.0
+         */
+        public IOS_AARCH64() {
+        }
+    }
+
+    /**
      * Supported leaf platform: Windows on x86 64-bit.
      *
      * @since 19.0
      */
-    class WINDOWS_AMD64 implements WINDOWS, AMD64 {
+    final class WINDOWS_AMD64 implements WINDOWS, AMD64 {
 
         /**
          * Instantiates a marker instance of this platform.

--- a/sdk/src/org.graalvm.nativeimage/src/org/graalvm/nativeimage/Platform.java
+++ b/sdk/src/org.graalvm.nativeimage/src/org/graalvm/nativeimage/Platform.java
@@ -93,7 +93,7 @@ public interface Platform {
      * @since 21.0
      */
     default String getOS() {
-        throw new UnsupportedOperationException("Platform doesn't implement getOS");
+        throw new UnsupportedOperationException("Platform `" + this.getClass().getCanonicalName() + "`, doesn't implement getOS");
     }
 
     /**
@@ -106,7 +106,7 @@ public interface Platform {
      * @since 21.0
      */
     default String getArchitecture() {
-        throw new UnsupportedOperationException("Platform doesn't implement getArchitecture");
+        throw new UnsupportedOperationException("Platform `" + this.getClass().getCanonicalName() + "`, doesn't implement getArchitecture");
     }
 
     /*

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/ELFObjectFile.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/ELFObjectFile.java
@@ -52,6 +52,8 @@ import com.oracle.objectfile.elf.dwarf.DwarfDebugInfo;
 import com.oracle.objectfile.elf.dwarf.DwarfStrSectionImpl;
 import com.oracle.objectfile.io.AssemblyBuffer;
 import com.oracle.objectfile.io.OutputAssembler;
+import org.graalvm.nativeimage.ImageSingletons;
+import org.graalvm.nativeimage.Platform;
 
 /**
  * Represents an ELF object file (of any kind: relocatable, shared library, executable, core, ...).
@@ -102,7 +104,7 @@ public class ELFObjectFile extends ObjectFile {
     }
 
     public ELFObjectFile(int pageSize, boolean runtimeDebugInfoGeneration) {
-        this(pageSize, System.getProperty("svm.targetArch") == null ? ELFMachine.getSystemNativeValue() : ELFMachine.from(System.getProperty("svm.targetArch")), runtimeDebugInfoGeneration);
+        this(pageSize, ELFMachine.from(ImageSingletons.lookup(Platform.class).getArchitecture()), runtimeDebugInfoGeneration);
     }
 
     @Override

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/macho/MachOObjectFile.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/macho/MachOObjectFile.java
@@ -52,6 +52,8 @@ import com.oracle.objectfile.ObjectFile;
 import com.oracle.objectfile.SymbolTable;
 import com.oracle.objectfile.io.AssemblyBuffer;
 import com.oracle.objectfile.io.OutputAssembler;
+import org.graalvm.nativeimage.ImageSingletons;
+import org.graalvm.nativeimage.Platform;
 
 /**
  * Models a Mach-O relocatable object file.
@@ -80,7 +82,7 @@ public final class MachOObjectFile extends ObjectFile {
      * Create an empty Mach-O object file.
      */
     public MachOObjectFile(int pageSize) {
-        this(pageSize, MachOCpuType.from(System.getProperty("svm.targetArch") == null ? System.getProperty("os.arch") : System.getProperty("svm.targetArch")));
+        this(pageSize, MachOCpuType.from(ImageSingletons.lookup(Platform.class).getArchitecture()));
     }
 
     public MachOObjectFile(int pageSize, MachOCpuType cpuType) {

--- a/substratevm/src/com.oracle.svm.core.graal.llvm/src/com/oracle/svm/core/graal/llvm/util/LLVMTargetSpecific.java
+++ b/substratevm/src/com.oracle.svm.core.graal.llvm/src/com/oracle/svm/core/graal/llvm/util/LLVMTargetSpecific.java
@@ -24,6 +24,7 @@
  */
 package com.oracle.svm.core.graal.llvm.util;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
@@ -35,7 +36,6 @@ import org.graalvm.nativeimage.hosted.Feature;
 import com.oracle.svm.core.FrameAccess;
 import com.oracle.svm.core.SubstrateOptions;
 import com.oracle.svm.core.annotate.AutomaticFeature;
-import java.util.Arrays;
 
 /**
  * LLVM target-specific inline assembly snippets and information.
@@ -222,7 +222,13 @@ class LLVMAArch64TargetSpecificFeature implements Feature {
 
             @Override
             public List<String> getLLCAdditionalOptions() {
-                return Arrays.asList("--frame-pointer=all", "--aarch64-frame-record-on-top");
+                List<String> list = new ArrayList<>();
+                list.add("--frame-pointer=all");
+                list.add("--aarch64-frame-record-on-top");
+                if (Platform.includedIn(Platform.IOS.class)) {
+                    list.add("-mtriple=arm64-ios");
+                }
+                return list;
             }
 
             @Override

--- a/substratevm/src/com.oracle.svm.core.posix/src/META-INF/services/com.oracle.svm.core.c.libc.LibCBase
+++ b/substratevm/src/com.oracle.svm.core.posix/src/META-INF/services/com.oracle.svm.core.c.libc.LibCBase
@@ -1,0 +1,3 @@
+com.oracle.svm.core.posix.linux.libc.BionicLibC
+com.oracle.svm.core.posix.linux.libc.GLibC
+com.oracle.svm.core.posix.linux.libc.MuslLibC

--- a/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/aarch64/AArch64UContextRegisterDumper.java
+++ b/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/aarch64/AArch64UContextRegisterDumper.java
@@ -46,7 +46,7 @@ import com.oracle.svm.core.util.VMError;
 
 import jdk.vm.ci.aarch64.AArch64;
 
-@Platforms(Platform.LINUX_AARCH64.class)
+@Platforms({Platform.LINUX_AARCH64.class, Platform.ANDROID_AARCH64.class})
 @AutomaticFeature
 class AArch64UContextRegisterDumperFeature implements Feature {
     @Override

--- a/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/darwin/DarwinSystemPropertiesSupport.java
+++ b/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/darwin/DarwinSystemPropertiesSupport.java
@@ -25,6 +25,7 @@
 package com.oracle.svm.core.posix.darwin;
 
 import org.graalvm.nativeimage.ImageSingletons;
+import org.graalvm.nativeimage.Platform;
 import org.graalvm.nativeimage.StackValue;
 import org.graalvm.nativeimage.c.function.CLibrary;
 import org.graalvm.nativeimage.c.type.CCharPointer;
@@ -58,6 +59,11 @@ public class DarwinSystemPropertiesSupport extends PosixSystemPropertiesSupport 
              */
             return "/var/tmp";
         }
+    }
+
+    @Override
+    protected String osNameValue() {
+        return Platform.includedIn(Platform.IOS.class) ? "iOS" : "Mac OS X";
     }
 
     private static volatile String osVersionValue = null;

--- a/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/darwin/DarwinUContextRegisterDumper.java
+++ b/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/darwin/DarwinUContextRegisterDumper.java
@@ -45,7 +45,7 @@ import com.oracle.svm.core.util.VMError;
 
 import jdk.vm.ci.amd64.AMD64;
 
-@Platforms({Platform.DARWIN_AMD64.class, Platform.DARWIN_AARCH64.class})
+@Platforms({Platform.DARWIN.class})
 @AutomaticFeature
 class DarwinUContextRegisterDumperFeature implements Feature {
     @Override

--- a/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/headers/Signal.java
+++ b/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/headers/Signal.java
@@ -139,15 +139,15 @@ public class Signal {
         GregsPointer uc_mcontext_gregs();
 
         @CFieldAddress("uc_mcontext")
-        @Platforms({Platform.LINUX_AARCH64.class})
+        @Platforms({Platform.LINUX_AARCH64.class, Platform.ANDROID_AARCH64.class})
         mcontext_t uc_mcontext();
 
         @CField("uc_mcontext")
-        @Platforms({Platform.DARWIN_AMD64.class, Platform.DARWIN_AARCH64.class})
+        @Platforms({Platform.DARWIN.class})
         MContext64 uc_mcontext64();
     }
 
-    @Platforms({Platform.DARWIN_AMD64.class, Platform.DARWIN_AARCH64.class})
+    @Platforms({Platform.DARWIN.class})
     @CStruct(value = "__darwin_mcontext64", addStructKeyword = true)
     public interface MContext64 extends PointerBase {
 
@@ -207,7 +207,7 @@ public class Signal {
     }
 
     @CStruct
-    @Platforms({Platform.LINUX_AARCH64.class})
+    @Platforms({Platform.LINUX_AARCH64.class, Platform.ANDROID_AARCH64.class})
     public interface mcontext_t extends PointerBase {
         @CField
         long fault_address();

--- a/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/headers/linux/LinuxErrno.java
+++ b/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/headers/linux/LinuxErrno.java
@@ -24,6 +24,10 @@
  */
 package com.oracle.svm.core.posix.headers.linux;
 
+import com.oracle.svm.core.c.libc.LibC;
+import com.oracle.svm.core.posix.linux.libc.BionicLibC;
+import com.oracle.svm.core.posix.linux.libc.GLibC;
+import com.oracle.svm.core.posix.linux.libc.MuslLibC;
 import org.graalvm.nativeimage.c.function.CFunction;
 import org.graalvm.nativeimage.c.type.CIntPointer;
 
@@ -31,6 +35,11 @@ import org.graalvm.nativeimage.c.type.CIntPointer;
 
 public class LinuxErrno {
 
+    @LibC({GLibC.class, MuslLibC.class})
     @CFunction(transition = CFunction.Transition.NO_TRANSITION)
     public static native CIntPointer __errno_location();
+
+    @LibC(BionicLibC.class)
+    @CFunction(transition = CFunction.Transition.NO_TRANSITION)
+    public static native CIntPointer __errno();
 }

--- a/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/linux/LinuxCErrorNumberSupport.java
+++ b/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/linux/LinuxCErrorNumberSupport.java
@@ -26,7 +26,9 @@ package com.oracle.svm.core.posix.linux;
 
 import com.oracle.svm.core.CErrorNumber.CErrorNumberSupport;
 import com.oracle.svm.core.annotate.Uninterruptible;
+import com.oracle.svm.core.c.libc.LibC;
 import com.oracle.svm.core.posix.headers.linux.LinuxErrno;
+import com.oracle.svm.core.posix.linux.libc.BionicLibC;
 
 class LinuxCErrorNumberSupport implements CErrorNumberSupport {
 
@@ -40,5 +42,21 @@ class LinuxCErrorNumberSupport implements CErrorNumberSupport {
     @Override
     public void setCErrorNumber(int value) {
         LinuxErrno.__errno_location().write(value);
+    }
+}
+
+@LibC(BionicLibC.class)
+class BionicCErrorNumberSupport extends LinuxCErrorNumberSupport {
+
+    @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
+    @Override
+    public int getCErrorNumber() {
+        return LinuxErrno.__errno().read();
+    }
+
+    @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
+    @Override
+    public void setCErrorNumber(int value) {
+        LinuxErrno.__errno().write(value);
     }
 }

--- a/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/linux/LinuxImageSingletonsFeature.java
+++ b/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/linux/LinuxImageSingletonsFeature.java
@@ -24,17 +24,32 @@
  */
 package com.oracle.svm.core.posix.linux;
 
+import com.oracle.svm.core.c.libc.LibCBase;
+import com.oracle.svm.core.posix.linux.libc.BionicLibC;
+import com.oracle.svm.core.posix.linux.libc.LibCFeature;
 import org.graalvm.nativeimage.ImageSingletons;
 import org.graalvm.nativeimage.hosted.Feature;
 
 import com.oracle.svm.core.CErrorNumber.CErrorNumberSupport;
 import com.oracle.svm.core.annotate.AutomaticFeature;
 
+import java.util.Collections;
+import java.util.List;
+
 @AutomaticFeature
 class LinuxImageSingletonsFeature implements Feature {
 
     @Override
+    public List<Class<? extends Feature>> getRequiredFeatures() {
+        return Collections.singletonList(LibCFeature.class);
+    }
+
+    @Override
     public void afterRegistration(AfterRegistrationAccess access) {
-        ImageSingletons.add(CErrorNumberSupport.class, new LinuxCErrorNumberSupport());
+        if (LibCBase.singleton() instanceof BionicLibC) {
+            ImageSingletons.add(CErrorNumberSupport.class, new BionicCErrorNumberSupport());
+        } else {
+            ImageSingletons.add(CErrorNumberSupport.class, new LinuxCErrorNumberSupport());
+        }
     }
 }

--- a/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/linux/LinuxSystemPropertiesSupport.java
+++ b/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/linux/LinuxSystemPropertiesSupport.java
@@ -47,6 +47,15 @@ public class LinuxSystemPropertiesSupport extends PosixSystemPropertiesSupport {
     }
 
     @Override
+    protected String osNameValue() {
+        Utsname.utsname name = StackValue.get(Utsname.utsname.class);
+        if (Utsname.uname(name) >= 0) {
+            return CTypeConversion.toJavaString(name.sysname());
+        }
+        return "Unknown";
+    }
+
+    @Override
     protected String osVersionValue() {
         Utsname.utsname name = StackValue.get(Utsname.utsname.class);
         if (Utsname.uname(name) >= 0) {

--- a/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/linux/libc/BionicLibC.java
+++ b/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/linux/libc/BionicLibC.java
@@ -45,7 +45,7 @@ public class BionicLibC implements LibCBase {
 
     @Override
     public String getTargetCompiler() {
-        return "gcc";
+        return "clang";
     }
 
     @Override
@@ -55,6 +55,6 @@ public class BionicLibC implements LibCBase {
 
     @Override
     public boolean requiresLibCSpecificStaticJDKLibraries() {
-        return false;
+        return true;
     }
 }

--- a/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/linux/libc/MuslLibC.java
+++ b/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/linux/libc/MuslLibC.java
@@ -34,15 +34,6 @@ import org.graalvm.compiler.serviceprovider.JavaVersionUtil;
 
 public class MuslLibC implements LibCBase {
 
-    public MuslLibC() {
-        if (!SubstrateOptions.StaticExecutable.getValue()) {
-            throw UserError.abort("Musl can only be used for statically linked executables.");
-        }
-        if (JavaVersionUtil.JAVA_SPEC != 11) {
-            throw UserError.abort("Musl can only be used with labsjdk 11.");
-        }
-    }
-
     public static final String NAME = "musl";
 
     @Override
@@ -69,5 +60,15 @@ public class MuslLibC implements LibCBase {
     @Override
     public boolean requiresLibCSpecificStaticJDKLibraries() {
         return true;
+    }
+
+    @Override
+    public void checkIfLibCSupported() {
+        if (!SubstrateOptions.StaticExecutable.getValue()) {
+            throw UserError.abort("Musl can only be used for statically linked executables.");
+        }
+        if (JavaVersionUtil.JAVA_SPEC != 11) {
+            throw UserError.abort("Musl can only be used with labsjdk 11.");
+        }
     }
 }

--- a/substratevm/src/com.oracle.svm.core.windows/src/com/oracle/svm/core/windows/WindowsSystemPropertiesSupport.java
+++ b/substratevm/src/com.oracle.svm.core.windows/src/com/oracle/svm/core/windows/WindowsSystemPropertiesSupport.java
@@ -24,9 +24,9 @@
  */
 package com.oracle.svm.core.windows;
 
-import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 
+import org.graalvm.collections.Pair;
 import org.graalvm.nativeimage.ImageSingletons;
 import org.graalvm.nativeimage.Platform;
 import org.graalvm.nativeimage.Platforms;
@@ -35,6 +35,8 @@ import org.graalvm.nativeimage.c.struct.SizeOf;
 import org.graalvm.nativeimage.c.type.CCharPointer;
 import org.graalvm.nativeimage.c.type.CIntPointer;
 import org.graalvm.nativeimage.c.type.CTypeConversion;
+import org.graalvm.nativeimage.c.type.VoidPointer;
+import org.graalvm.nativeimage.c.type.WordPointer;
 import org.graalvm.nativeimage.hosted.Feature;
 import org.graalvm.word.UnsignedWord;
 import org.graalvm.word.WordFactory;
@@ -48,13 +50,21 @@ import com.oracle.svm.core.windows.headers.LibC;
 import com.oracle.svm.core.windows.headers.LibC.WCharPointer;
 import com.oracle.svm.core.windows.headers.Process;
 import com.oracle.svm.core.windows.headers.SysinfoAPI;
+import com.oracle.svm.core.windows.headers.VerRsrc;
 import com.oracle.svm.core.windows.headers.WinBase;
+import com.oracle.svm.core.windows.headers.WinVer;
 
 @Platforms(Platform.WINDOWS.class)
 public class WindowsSystemPropertiesSupport extends SystemPropertiesSupport {
 
-    /* Null-terminated wide-character string. */
+    /* Null-terminated wide-character string constants. */
     private static final byte[] USERNAME = "USERNAME\0".getBytes(StandardCharsets.UTF_16LE);
+    private static final byte[] KERNEL32_DLL = "\\kernel32.dll\0".getBytes(StandardCharsets.UTF_16LE);
+    private static final byte[] ROOT_PATH = "\\\0".getBytes(StandardCharsets.UTF_16LE);
+
+    private static final int VER_NT_WORKSTATION = 0x0000001;
+    private static final int VER_PLATFORM_WIN32_WINDOWS = 1;
+    private static final int VER_PLATFORM_WIN32_NT = 2;
 
     @Override
     protected String userNameValue() {
@@ -122,13 +132,194 @@ public class WindowsSystemPropertiesSupport extends SystemPropertiesSupport {
         return CTypeConversion.toJavaString((CCharPointer) wcString, SizeOf.unsigned(WCharPointer.class).multiply(length), StandardCharsets.UTF_16LE);
     }
 
+    private Pair<String, String> cachedOsNameAndVersion;
+
+    @Override
+    protected String osNameValue() {
+        if (cachedOsNameAndVersion == null) {
+            cachedOsNameAndVersion = getOsNameAndVersion();
+        }
+        return cachedOsNameAndVersion.getLeft();
+    }
+
     @Override
     protected String osVersionValue() {
-        ByteBuffer versionBytes = ByteBuffer.allocate(4);
-        versionBytes.putInt(SysinfoAPI.GetVersion());
-        int majorVersion = versionBytes.get(3);
-        int minorVersion = versionBytes.get(2);
-        return majorVersion + "." + minorVersion;
+        if (cachedOsNameAndVersion == null) {
+            cachedOsNameAndVersion = getOsNameAndVersion();
+        }
+        return cachedOsNameAndVersion.getRight();
+    }
+
+    public Pair<String, String> getOsNameAndVersion() {
+        /*
+         * Reimplementation of code from java_props_md.c
+         */
+        SysinfoAPI.OSVERSIONINFOEXA ver = StackValue.get(SysinfoAPI.OSVERSIONINFOEXA.class);
+        ver.dwOSVersionInfoSize(SizeOf.get(SysinfoAPI.OSVERSIONINFOEXA.class));
+        SysinfoAPI.GetVersionExA(ver);
+
+        boolean is64bit = ImageSingletons.lookup(Platform.class).getArchitecture().endsWith("64");
+        boolean isWorkstation = ver.wProductType() == VER_NT_WORKSTATION;
+        int platformId = ver.dwPlatformId();
+
+        int majorVersion = ver.dwMajorVersion();
+        int minorVersion = ver.dwMinorVersion();
+        int buildNumber = ver.dwBuildNumber();
+        do {
+            /* Get the full path to \Windows\System32\kernel32.dll ... */
+            LibC.WCharPointer kernel32Path = StackValue.get(WinBase.MAX_PATH, LibC.WCharPointer.class);
+            LibC.WCharPointer kernel32Dll = NonmovableArrays.addressOf(NonmovableArrays.fromImageHeap(KERNEL32_DLL), 0);
+            int len = WinBase.MAX_PATH - (int) LibC.wcslen(kernel32Dll).rawValue() - 1;
+            int ret = SysinfoAPI.GetSystemDirectoryW(kernel32Path, len);
+            if (ret == 0 || ret > len) {
+                break;
+            }
+            LibC.wcsncat(kernel32Path, kernel32Dll, WordFactory.unsigned(WinBase.MAX_PATH - ret));
+
+            /* ... and use that for determining what version of Windows we're running on. */
+            int versionSize = WinVer.GetFileVersionInfoSizeW(kernel32Path, WordFactory.nullPointer());
+            if (versionSize == 0) {
+                break;
+            }
+
+            VoidPointer versionInfo = LibC.malloc(WordFactory.unsigned(versionSize));
+            if (versionInfo.isNull()) {
+                break;
+            }
+
+            if (WinVer.GetFileVersionInfoW(kernel32Path, 0, versionSize, versionInfo) == 0) {
+                LibC.free(versionInfo);
+                break;
+            }
+
+            LibC.WCharPointer rootPath = NonmovableArrays.addressOf(NonmovableArrays.fromImageHeap(ROOT_PATH), 0);
+            WordPointer fileInfoPointer = StackValue.get(WordPointer.class);
+            CIntPointer lengthPointer = StackValue.get(CIntPointer.class);
+            if (WinVer.VerQueryValueW(versionInfo, rootPath, fileInfoPointer, lengthPointer) == 0) {
+                LibC.free(versionInfo);
+                break;
+            }
+
+            VerRsrc.VS_FIXEDFILEINFO fileInfo = fileInfoPointer.read();
+            majorVersion = (short) (fileInfo.dwProductVersionMS() >> 16); // HIWORD
+            minorVersion = (short) fileInfo.dwProductVersionMS(); // LOWORD
+            buildNumber = (short) (fileInfo.dwProductVersionLS() >> 16); // HIWORD
+            LibC.free(versionInfo);
+        } while (false);
+
+        String osVersion = majorVersion + "." + minorVersion;
+        String osName;
+
+        switch (platformId) {
+            case VER_PLATFORM_WIN32_WINDOWS:
+                if (majorVersion == 4) {
+                    switch (minorVersion) {
+                        case 0:
+                            osName = "Windows 95";
+                            break;
+                        case 10:
+                            osName = "Windows 98";
+                            break;
+                        case 90:
+                            osName = "Windows Me";
+                            break;
+                        default:
+                            osName = "Windows 9X (unknown)";
+                            break;
+                    }
+                } else {
+                    osName = "Windows 9X (unknown)";
+                }
+                break;
+            case VER_PLATFORM_WIN32_NT:
+                if (majorVersion <= 4) {
+                    osName = "Windows NT";
+                } else if (majorVersion == 5) {
+                    switch (minorVersion) {
+                        case 0:
+                            osName = "Windows 2000";
+                            break;
+                        case 1:
+                            osName = "Windows XP";
+                            break;
+                        case 2:
+                            if (isWorkstation && is64bit) {
+                                osName = "Windows XP"; /* 64 bit */
+                            } else {
+                                osName = "Windows 2003";
+                            }
+                            break;
+                        default:
+                            osName = "Windows NT (unknown)";
+                            break;
+                    }
+                } else if (majorVersion == 6) {
+                    if (isWorkstation) {
+                        switch (minorVersion) {
+                            case 0:
+                                osName = "Windows Vista";
+                                break;
+                            case 1:
+                                osName = "Windows 7";
+                                break;
+                            case 2:
+                                osName = "Windows 8";
+                                break;
+                            case 3:
+                                osName = "Windows 8.1";
+                                break;
+                            default:
+                                osName = "Windows NT (unknown)";
+                        }
+                    } else {
+                        switch (minorVersion) {
+                            case 0:
+                                osName = "Windows Server 2008";
+                                break;
+                            case 1:
+                                osName = "Windows Server 2008 R2";
+                                break;
+                            case 2:
+                                osName = "Windows Server 2012";
+                                break;
+                            case 3:
+                                osName = "Windows Server 2012 R2";
+                                break;
+                            default:
+                                osName = "Windows NT (unknown)";
+                        }
+                    }
+                } else if (majorVersion == 10) {
+                    if (isWorkstation) {
+                        switch (minorVersion) {
+                            case 0:
+                                osName = "Windows 10";
+                                break;
+                            default:
+                                osName = "Windows NT (unknown)";
+                        }
+                    } else {
+                        switch (minorVersion) {
+                            case 0:
+                                if (buildNumber > 17762) {
+                                    osName = "Windows Server 2019";
+                                } else {
+                                    osName = "Windows Server 2016";
+                                }
+                                break;
+                            default:
+                                osName = "Windows NT (unknown)";
+                        }
+                    }
+                } else {
+                    osName = "Windows NT (unknown)";
+                }
+                break;
+            default:
+                osName = "Windows (unknown)";
+                break;
+        }
+        return Pair.create(osName, osVersion);
     }
 }
 

--- a/substratevm/src/com.oracle.svm.core.windows/src/com/oracle/svm/core/windows/headers/LibC.java
+++ b/substratevm/src/com.oracle.svm.core.windows/src/com/oracle/svm/core/windows/headers/LibC.java
@@ -77,4 +77,7 @@ public class LibC {
 
     @CFunction(transition = CFunction.Transition.NO_TRANSITION)
     public static native UnsignedWord wcslen(WCharPointer varname);
+
+    @CFunction(transition = CFunction.Transition.NO_TRANSITION)
+    public static native WCharPointer wcsncat(WCharPointer strDest, WCharPointer strSource, UnsignedWord count);
 }

--- a/substratevm/src/com.oracle.svm.core.windows/src/com/oracle/svm/core/windows/headers/SysinfoAPI.java
+++ b/substratevm/src/com.oracle.svm.core.windows/src/com/oracle/svm/core/windows/headers/SysinfoAPI.java
@@ -29,8 +29,12 @@ import static org.graalvm.nativeimage.c.function.CFunction.Transition.NO_TRANSIT
 import org.graalvm.nativeimage.c.CContext;
 import org.graalvm.nativeimage.c.function.CFunction;
 import org.graalvm.nativeimage.c.struct.CField;
+import org.graalvm.nativeimage.c.struct.CFieldAddress;
 import org.graalvm.nativeimage.c.struct.CStruct;
+import org.graalvm.nativeimage.c.type.CCharPointer;
 import org.graalvm.word.PointerBase;
+
+import com.oracle.svm.core.windows.headers.LibC.WCharPointer;
 
 // Checkstyle: stop
 
@@ -39,6 +43,10 @@ import org.graalvm.word.PointerBase;
  */
 @CContext(WindowsDirectives.class)
 public class SysinfoAPI {
+
+    /** Retrieves the path of the system directory. */
+    @CFunction(transition = NO_TRANSITION)
+    public static native int GetSystemDirectoryW(WCharPointer lpBuffer, int uSize);
 
     /** Return information about the current computer system. */
     @CFunction(transition = NO_TRANSITION)
@@ -119,6 +127,47 @@ public class SysinfoAPI {
         long ullAvailExtendedVirtual();
     }
 
+    /** Returns version information about the currently running operating system. */
     @CFunction(transition = NO_TRANSITION)
-    public static native int GetVersion();
+    public static native int GetVersionExA(OSVERSIONINFOEXA lpVersionInformation);
+
+    /** Contains operating system version information. */
+    @CStruct
+    public interface OSVERSIONINFOEXA extends PointerBase {
+        @CField
+        int dwOSVersionInfoSize();
+
+        @CField
+        void dwOSVersionInfoSize(int value);
+
+        @CField
+        int dwMajorVersion();
+
+        @CField
+        int dwMinorVersion();
+
+        @CField
+        int dwBuildNumber();
+
+        @CField
+        int dwPlatformId();
+
+        @CFieldAddress
+        CCharPointer szCSDVersion();
+
+        @CField
+        short wServicePackMajor();
+
+        @CField
+        short wServicePackMinor();
+
+        @CField
+        short wSuiteMask();
+
+        @CField
+        byte wProductType();
+
+        @CField
+        byte wReserved();
+    }
 }

--- a/substratevm/src/com.oracle.svm.core.windows/src/com/oracle/svm/core/windows/headers/VerRsrc.java
+++ b/substratevm/src/com.oracle.svm.core.windows/src/com/oracle/svm/core/windows/headers/VerRsrc.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2020, 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package com.oracle.svm.core.windows.headers;
+
+// Checkstyle: stop
+
+import org.graalvm.nativeimage.c.CContext;
+import org.graalvm.nativeimage.c.struct.CField;
+import org.graalvm.nativeimage.c.struct.CStruct;
+import org.graalvm.word.PointerBase;
+
+/**
+ * Definitions for Windows verrsrc.h
+ */
+@CContext(WindowsDirectives.class)
+public class VerRsrc {
+
+    /** Contains version information for a file. */
+    @CStruct
+    public interface VS_FIXEDFILEINFO extends PointerBase {
+        @CField
+        int dwSignature();
+
+        @CField
+        int dwStrucVersion();
+
+        @CField
+        int dwFileVersionMS();
+
+        @CField
+        int dwFileVersionLS();
+
+        @CField
+        int dwProductVersionMS();
+
+        @CField
+        int dwProductVersionLS();
+
+        @CField
+        int dwFileFlagsMask();
+
+        @CField
+        int dwFileFlags();
+
+        @CField
+        int dwFileOS();
+
+        @CField
+        int dwFileType();
+
+        @CField
+        int dwFileSubtype();
+
+        @CField
+        int dwFileDateMS();
+
+        @CField
+        int dwFileDateLS();
+    }
+}

--- a/substratevm/src/com.oracle.svm.core.windows/src/com/oracle/svm/core/windows/headers/WinVer.java
+++ b/substratevm/src/com.oracle.svm.core.windows/src/com/oracle/svm/core/windows/headers/WinVer.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2020, 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package com.oracle.svm.core.windows.headers;
+
+import static org.graalvm.nativeimage.c.function.CFunction.Transition.NO_TRANSITION;
+
+import org.graalvm.nativeimage.c.CContext;
+import org.graalvm.nativeimage.c.function.CFunction;
+import org.graalvm.nativeimage.c.function.CLibrary;
+import org.graalvm.nativeimage.c.type.CIntPointer;
+import org.graalvm.nativeimage.c.type.VoidPointer;
+import org.graalvm.nativeimage.c.type.WordPointer;
+
+import com.oracle.svm.core.windows.headers.LibC.WCharPointer;
+
+// Checkstyle: stop
+
+/**
+ * Definitions for Windows winver.h
+ */
+@CLibrary("version")
+@CContext(WindowsDirectives.class)
+public class WinVer {
+
+    /** Determines the size of version information for a specified file if available. */
+    @CFunction(transition = NO_TRANSITION)
+    public static native int GetFileVersionInfoSizeW(WCharPointer lptstrFilename, CIntPointer lpdwHandle);
+
+    /** Retrieves version information for the specified file. */
+    @CFunction(transition = NO_TRANSITION)
+    public static native int GetFileVersionInfoW(WCharPointer lptstrFilename, int dwHandle, int dwLen, VoidPointer lpData);
+
+    /** Retrieves specified version information from the specified version-information resource. */
+    @CFunction(transition = NO_TRANSITION)
+    public static native int VerQueryValueW(VoidPointer pBlock, WCharPointer lpSubBlock, WordPointer lplpBuffer, CIntPointer puLen);
+}

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/SubstrateOptions.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/SubstrateOptions.java
@@ -72,6 +72,10 @@ public class SubstrateOptions {
     @Option(help = "Build statically linked executable (requires static libc and zlib)")//
     public static final HostedOptionKey<Boolean> StaticExecutable = new HostedOptionKey<>(false);
 
+    @APIOption(name = "target")//
+    @Option(help = "Selects native-image compilation target (in <OS>-<architecture> format). Defaults to host's OS-architecture pair.")//
+    public static final HostedOptionKey<String> TargetPlatform = new HostedOptionKey<>("");
+
     @Option(help = "Builds a statically linked executable with libc dynamically linked", type = Expert, stability = OptionStability.EXPERIMENTAL)//
     public static final HostedOptionKey<Boolean> StaticExecutableWithDynamicLibC = new HostedOptionKey<Boolean>(false) {
         @Override
@@ -139,6 +143,9 @@ public class SubstrateOptions {
 
     @Option(help = "Path passed to the linker as the -rpath (list of comma-separated directories)")//
     public static final HostedOptionKey<String[]> LinkerRPath = new HostedOptionKey<>(null);
+
+    @Option(help = "String which would be appended to the linker call")//
+    public static final HostedOptionKey<String> AdditionalLinkerOptions = new HostedOptionKey<>("");
 
     @Option(help = "Directory of the image file to be generated", type = OptionType.User)//
     public static final HostedOptionKey<String> Path = new HostedOptionKey<>(null);

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/c/libc/LibCBase.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/c/libc/LibCBase.java
@@ -115,6 +115,10 @@ public interface LibCBase {
     @Platforms(Platform.HOSTED_ONLY.class)
     boolean requiresLibCSpecificStaticJDKLibraries();
 
+    @Platforms(Platform.HOSTED_ONLY.class)
+    default void checkIfLibCSupported() {
+    }
+
     static LibCBase singleton() {
         return ImageSingletons.lookup(LibCBase.class);
     }

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/SystemPropertiesSupport.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/SystemPropertiesSupport.java
@@ -32,6 +32,7 @@ import java.util.function.Supplier;
 
 import org.graalvm.compiler.serviceprovider.JavaVersionUtil;
 import org.graalvm.nativeimage.ImageInfo;
+import org.graalvm.nativeimage.ImageSingletons;
 import org.graalvm.nativeimage.Platform;
 import org.graalvm.nativeimage.Platforms;
 
@@ -76,6 +77,8 @@ public abstract class SystemPropertiesSupport {
     private Properties properties;
     private final Map<String, String> savedProperties;
     private final Map<String, String> readOnlySavedProperties;
+    private final String hostOS = System.getProperty("os.name");
+    // needed as fallback for platforms that don't implement osNameValue
 
     private volatile boolean fullyInitialized;
 
@@ -102,11 +105,6 @@ public abstract class SystemPropertiesSupport {
         initializeProperty("java.library.path", "");
         initializeProperty("sun.arch.data.model", Integer.toString(ConfigurationValues.getTarget().wordJavaKind.getBitCount()));
 
-        String targetName = System.getProperty("svm.targetName");
-        String targetArch = System.getProperty("svm.targetArch");
-        initializeProperty("os.name", targetName != null ? targetName : System.getProperty("os.name"));
-        initializeProperty("os.arch", targetArch != null ? targetArch : System.getProperty("os.arch"));
-
         initializeProperty(ImageInfo.PROPERTY_IMAGE_CODE_KEY, ImageInfo.PROPERTY_IMAGE_CODE_VALUE_RUNTIME);
 
         if (OS.getCurrent() == OS.LINUX && JavaVersionUtil.JAVA_SPEC == 11) {
@@ -123,6 +121,20 @@ public abstract class SystemPropertiesSupport {
         lazyRuntimeValues.put("java.io.tmpdir", this::tmpdirValue);
         lazyRuntimeValues.put("os.version", this::osVersionValue);
         lazyRuntimeValues.put("java.vm.version", VM::getVersion);
+
+        String targetName = System.getProperty("svm.targetName");
+        if (targetName != null) {
+            initializeProperty("os.name", targetName);
+        } else {
+            lazyRuntimeValues.put("os.name", this::osNameValue);
+        }
+
+        String targetArch = System.getProperty("svm.targetArch");
+        if (targetArch != null) {
+            initializeProperty("os.arch", targetArch);
+        } else {
+            initializeProperty("os.arch", ImageSingletons.lookup(Platform.class).getArchitecture());
+        }
     }
 
     private void ensureFullyInitialized() {
@@ -243,6 +255,14 @@ public abstract class SystemPropertiesSupport {
     protected abstract String userDirValue();
 
     protected abstract String tmpdirValue();
+
+    protected String osNameValue() {
+        /*
+         * Fallback for systems that don't implement osNameValue in their SystemPropertiesSupport
+         * implementation.
+         */
+        return hostOS;
+    }
 
     protected abstract String osVersionValue();
 }

--- a/substratevm/src/com.oracle.svm.driver/src/com/oracle/svm/driver/NativeImage.java
+++ b/substratevm/src/com.oracle.svm.driver/src/com/oracle/svm/driver/NativeImage.java
@@ -70,8 +70,10 @@ import java.util.jar.Manifest;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import com.oracle.svm.core.util.UserError;
 import org.graalvm.compiler.options.OptionKey;
 import org.graalvm.compiler.serviceprovider.JavaVersionUtil;
+import org.graalvm.nativeimage.Platform;
 import org.graalvm.nativeimage.ProcessProperties;
 
 import com.oracle.graal.pointsto.api.PointstoOptions;
@@ -180,6 +182,7 @@ public class NativeImage {
     final String oRRuntimeJavaArg = oR(Options.FallbackExecutorRuntimeJavaArg);
     final String oHTraceClassInitialization = oH(SubstrateOptions.TraceClassInitialization);
     final String oHTraceObjectInstantiation = oH(SubstrateOptions.TraceObjectInstantiation);
+    final String oHTargetPlatform = oH(SubstrateOptions.TargetPlatform);
 
     /* List arguments */
     final String oHSubstitutionFiles = oH(ConfigurationFiles.Options.SubstitutionFiles);
@@ -746,11 +749,7 @@ public class NativeImage {
         addImageBuilderJavaArgs("-Xshare:off");
         config.getBuilderClasspath().forEach(this::addImageBuilderClasspath);
         config.getImageProvidedClasspath().forEach(this::addImageProvidedClasspath);
-        String clibrariesBuilderArg = config.getBuilderCLibrariesPaths()
-                        .stream()
-                        .map(path -> canonicalize(path.resolve(platform)).toString())
-                        .collect(Collectors.joining(",", oHCLibraryPath, ""));
-        addPlainImageBuilderArg(clibrariesBuilderArg);
+
         if (config.getBuilderInspectServerPath() != null) {
             addPlainImageBuilderArg(oHInspectServerContentPath + config.getBuilderInspectServerPath());
         }
@@ -1041,6 +1040,13 @@ public class NativeImage {
         List<String> leftoverArgs = processNativeImageArgs();
 
         completeOptionArgs();
+        addTargetArguments();
+
+        String clibrariesPath = (targetPlatform != null) ? targetPlatform : platform;
+        String clibrariesBuilderArg = config.getBuilderCLibrariesPaths().stream()
+                        .map(path -> canonicalize(path.resolve(clibrariesPath)).toString())
+                        .collect(Collectors.joining(",", oHCLibraryPath, ""));
+        addPlainImageBuilderArg(clibrariesBuilderArg);
 
         if (printFlagsOptionQuery != null) {
             addPlainImageBuilderArg(NativeImage.oH + enablePrintFlags + printFlagsOptionQuery);
@@ -1199,13 +1205,21 @@ public class NativeImage {
         return customImageClasspath.isEmpty();
     }
 
+    private static boolean isListArgumentSet(Collection<String> list, String argPrefix) {
+        return list.stream().anyMatch(arg -> arg.startsWith(argPrefix) && !arg.equals(argPrefix));
+    }
+
     private boolean isListArgumentSet(String argPrefix) {
-        return imageBuilderArgs.stream().anyMatch(arg -> arg.startsWith(argPrefix) && !arg.equals(argPrefix));
+        return isListArgumentSet(imageBuilderArgs, argPrefix);
+    }
+
+    private static String getListArgumentValue(Collection<String> list, String argPrefix) {
+        VMError.guarantee(isListArgumentSet(list, argPrefix));
+        return list.stream().filter(arg -> arg.startsWith(argPrefix)).map(arg -> arg.substring(argPrefix.length())).collect(Collectors.joining());
     }
 
     private String getListArgumentValue(String argPrefix) {
-        VMError.guarantee(isListArgumentSet(argPrefix));
-        return imageBuilderArgs.stream().filter(arg -> arg.startsWith(argPrefix)).map(arg -> arg.substring(argPrefix.length())).collect(Collectors.joining());
+        return getListArgumentValue(imageBuilderArgs, argPrefix);
     }
 
     private List<String> getAgentArguments() {
@@ -1234,6 +1248,43 @@ public class NativeImage {
 
     private static String getAgentOptions(String options, String optionName) {
         return Arrays.stream(options.split(",")).map(option -> optionName + "=" + option).collect(Collectors.joining(","));
+    }
+
+    private String targetPlatform = null;
+    private String targetOS = null;
+    private String targetArch = null;
+
+    private void addTargetArguments() {
+        /*
+         * Since regular hosted options are parsed at a later phase of NativeImageGeneratorRunner
+         * process (see comments for NativeImageGenerator.getTargetPlatform), we are parsing the
+         * --target argument here, and generating required internal arguments.
+         */
+
+        if (!isListArgumentSet(oHTargetPlatform)) {
+            return;
+        }
+
+        targetPlatform = getListArgumentValue(oHTargetPlatform).toLowerCase();
+
+        String[] parts = targetPlatform.split("-");
+        if (parts.length != 2) {
+            throw UserError.abort("--target argument must be in format <OS>-<architecture>");
+        }
+
+        targetOS = parts[0];
+        targetArch = parts[1];
+
+        if (isListArgumentSet(customJavaArgs, "-D" + Platform.PLATFORM_PROPERTY_NAME)) {
+            NativeImage.showWarning("Usage of -D" + Platform.PLATFORM_PROPERTY_NAME + " might conflict with --target parameter.");
+        }
+
+        if (targetOS != null) {
+            customJavaArgs.add("-Dsvm.targetPlatformOS=" + targetOS);
+        }
+        if (targetArch != null) {
+            customJavaArgs.add("-Dsvm.targetPlatformArch=" + targetArch);
+        }
     }
 
     private String mainClass;

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/NativeImageGenerator.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/NativeImageGenerator.java
@@ -45,6 +45,7 @@ import java.util.EnumSet;
 import java.util.List;
 import java.util.ListIterator;
 import java.util.Map;
+import java.util.ServiceLoader;
 import java.util.Set;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.ExecutionException;
@@ -332,6 +333,16 @@ public class NativeImageGenerator {
         return (Platform) result;
     }
 
+    public static Platform loadPlatform(String os, String arch) {
+        ServiceLoader<Platform> loader = ServiceLoader.load(Platform.class);
+        for (Platform platform : loader) {
+            if (platform.getOS().equals(os) && platform.getArchitecture().equals(arch)) {
+                return platform;
+            }
+        }
+        throw UserError.abort("Platform specified as " + os + "-" + arch + " isn't supported.");
+    }
+
     public static Platform getTargetPlatform(ClassLoader classLoader) {
         /*
          * We cannot use a regular hosted option for the platform class: The code that instantiates
@@ -360,13 +371,7 @@ public class NativeImageGenerator {
             arch = SubstrateUtil.getArchitectureName();
         }
 
-        platformClassName = "org.graalvm.nativeimage.Platform$" + os.toUpperCase() + "_" + arch.toUpperCase();
-        try {
-            return loadPlatform(classLoader, platformClassName);
-        } catch (ClassNotFoundException ex) {
-            throw UserError.abort("Platform specified as " + os + "-" + arch +
-                            " isn't supported.");
-        }
+        return loadPlatform(os, arch);
     }
 
     /**

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/NativeImageGeneratorRunner.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/NativeImageGeneratorRunner.java
@@ -173,7 +173,7 @@ public class NativeImageGeneratorRunner implements ImageBuildTask {
          */
         NativeImageGenerator.setSystemPropertiesForImageEarly();
 
-        return new ImageClassLoader(NativeImageGenerator.defaultPlatform(nativeImageClassLoader), nativeImageClassLoaderSupport);
+        return new ImageClassLoader(NativeImageGenerator.getTargetPlatform(nativeImageClassLoader), nativeImageClassLoaderSupport);
     }
 
     public static List<String> extractDriverArguments(List<String> args) {

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/ServiceLoaderFeature.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/ServiceLoaderFeature.java
@@ -103,8 +103,16 @@ public class ServiceLoaderFeature implements Feature {
      */
     private static final Set<String> SERVICES_TO_SKIP = new HashSet<>(Arrays.asList(
                     "java.security.Provider",                       // see SecurityServicesFeature
-                    "sun.util.locale.provider.LocaleDataMetaInfo"   // see LocaleSubstitutions
+                    "sun.util.locale.provider.LocaleDataMetaInfo",  // see LocaleSubstitutions
+                    "org.graalvm.nativeimage.Platform"  // shouldn't be reachable after
+                                                        // intrinsification
     ));
+
+    // NOTE: Platform class had to be added to this list since our analysis discovers that
+    // Platform.includedIn is reachable regardless of fact that it is constant folded at
+    // registerPlatformPlugins method of SubstrateGraphBuilderPlugins. This issue hasn't manifested
+    // before because implementation classes were instantiated using runtime reflection instead of
+    // ServiceLoader (and thus weren't reachable in analysis).
 
     private static final Set<String> SERVICE_PROVIDERS_TO_SKIP = new HashSet<>(Arrays.asList(
                     "com.sun.jndi.rmi.registry.RegistryContextFactory"      // GR-26547

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/c/NativeLibraries.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/c/NativeLibraries.java
@@ -76,9 +76,7 @@ import com.oracle.graal.pointsto.infrastructure.WrappedElement;
 import com.oracle.graal.pointsto.meta.AnalysisType;
 import com.oracle.svm.core.OS;
 import com.oracle.svm.core.SubstrateOptions;
-import com.oracle.svm.core.SubstrateTargetDescription;
 import com.oracle.svm.core.c.libc.LibCBase;
-import com.oracle.svm.core.config.ConfigurationValues;
 import com.oracle.svm.core.jdk.PlatformNativeLibrarySupport;
 import com.oracle.svm.core.option.OptionUtils;
 import com.oracle.svm.core.util.UserError;
@@ -294,9 +292,8 @@ public final class NativeLibraries {
         Path baseSearchPath = Paths.get(System.getProperty("java.home")).resolve("lib").toRealPath();
         if (JavaVersionUtil.JAVA_SPEC > 8) {
             Path staticLibPath = baseSearchPath.resolve("static");
-            SubstrateTargetDescription target = ConfigurationValues.getTarget();
-            Path platformDependentPath = staticLibPath.resolve((OS.getCurrent().className + "-" + target.arch.getName()).toLowerCase());
-            if (OS.getCurrent() == OS.LINUX) {
+            Path platformDependentPath = staticLibPath.resolve((ImageSingletons.lookup(Platform.class).getOS() + "-" + ImageSingletons.lookup(Platform.class).getArchitecture()).toLowerCase());
+            if (ImageSingletons.lookup(Platform.class) instanceof Platform.LINUX) {
                 platformDependentPath = platformDependentPath.resolve(LibCBase.singleton().getName());
                 if (LibCBase.singleton().requiresLibCSpecificStaticJDKLibraries()) {
                     return platformDependentPath;
@@ -325,7 +322,8 @@ public final class NativeLibraries {
             if (defaultBuiltInLibraries.stream().allMatch(hasStaticLibrary)) {
                 staticLibsDir = jdkLibDir;
             } else {
-                hint = defaultBuiltInLibraries.stream().filter(hasStaticLibrary.negate()).collect(Collectors.joining(", ", "Missing libraries:", ""));
+                String libraryLocationHint = System.lineSeparator() + "(search path: " + jdkLibDir + ")";
+                hint = defaultBuiltInLibraries.stream().filter(hasStaticLibrary.negate()).collect(Collectors.joining(", ", "Missing libraries: ", libraryLocationHint));
             }
         } catch (IOException e) {
             /* Fallthrough to next strategy */
@@ -344,7 +342,7 @@ public final class NativeLibraries {
                 /* Fail if we will statically link JDK libraries but do not have them available */
                 String libCMessage = "";
                 if (Platform.includedIn(Platform.LINUX.class)) {
-                    libCMessage = "(target libc: " + LibCBase.singleton().getName() + ")";
+                    libCMessage = " (target libc: " + LibCBase.singleton().getName() + ")";
                 }
                 String jdkDownloadURL = (JavaVersionUtil.JAVA_SPEC > 8 ? JVMCIVersionCheck.JVMCI11_RELEASES_URL : JVMCIVersionCheck.JVMCI8_RELEASES_URL);
                 UserError.guarantee(!Platform.includedIn(InternalPlatform.PLATFORM_JNI.class),

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/c/codegen/CCompilerInvoker.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/c/codegen/CCompilerInvoker.java
@@ -226,6 +226,16 @@ public abstract class CCompilerInvoker {
                     int minor1 = scanner.nextInt();
                     return new CompilerInfo(compilerPath, "intel", "Intel(R) C++ Compiler", "icc", major, minor0, minor1, "x86_64");
                 }
+
+                if (scanner.findInLine("clang version ") != null) {
+                    scanner.useDelimiter("[. ]");
+                    int major = scanner.nextInt();
+                    int minor0 = scanner.nextInt();
+                    int minor1 = scanner.nextInt();
+                    String[] triplet = guessTargetTriplet(scanner);
+                    return new CompilerInfo(compilerPath, "llvm", "Clang C++ Compiler", "clang", major, minor0, minor1, triplet[0]);
+                }
+
                 String[] triplet = guessTargetTriplet(scanner);
                 while (scanner.findInLine("gcc version ") == null) {
                     scanner.nextLine();


### PR DESCRIPTION
- Add `--target` parameter which can be used as:
    ```
    native-image --target=linux-amd64 HelloWorld
     ```
- Added initial Android/iOS Platform classes as part of initial mobile support.
- Load platforms and LibCs via ServiceLoader
- Add `os.name` system property support (as specified in JDK)