### PR TITLE
Add java.runtime.version to hosted properties

### DIFF
--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/SystemPropertiesSupport.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/SystemPropertiesSupport.java
@@ -53,6 +53,7 @@ public abstract class SystemPropertiesSupport {
     /** System properties that are taken from the VM hosting the image generator. */
     private static final String[] HOSTED_PROPERTIES = {
                     "java.version",
+                    "java.runtime.version",
                     ImageInfo.PROPERTY_IMAGE_KIND_KEY,
                     /*
                      * We do not support cross-compilation for now. Separator might also be cached


### PR DESCRIPTION
As of https://github.com/oracle/graal/pull/2614/commits/75f9a50c4552e652558cdf9c63df8fc1aac6ce49 `java.runtime.version` is being used by `native-image --version` so it should be added to the hosted properties to avoid returning `null` as the Java version.