### PR TITLE
Do not use CLibrary annotations from inactive @CContexts

### DIFF
--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/NativeImageGenerator.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/NativeImageGenerator.java
@@ -115,7 +115,6 @@ import org.graalvm.nativeimage.c.constant.CEnum;
 import org.graalvm.nativeimage.c.function.CEntryPoint;
 import org.graalvm.nativeimage.c.function.CFunction;
 import org.graalvm.nativeimage.c.function.CFunctionPointer;
-import org.graalvm.nativeimage.c.function.CLibrary;
 import org.graalvm.nativeimage.c.struct.CPointerTo;
 import org.graalvm.nativeimage.c.struct.CStruct;
 import org.graalvm.nativeimage.c.struct.RawStructure;
@@ -1567,9 +1566,7 @@ public class NativeImageGenerator {
                 classInitializationSupport.initializeAtBuildTime(clazz, "classes annotated with " + CContext.class.getSimpleName() + " are always initialized");
             }
         }
-        for (CLibrary library : loader.findAnnotations(CLibrary.class)) {
-            nativeLibs.addAnnotated(library);
-        }
+        nativeLibs.processCLibraryAnnotations(loader);
 
         nativeLibs.finish();
         nativeLibs.reportErrors();

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/c/NativeLibraries.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/c/NativeLibraries.java
@@ -26,6 +26,7 @@ package com.oracle.svm.hosted.c;
 
 import java.io.IOException;
 import java.lang.reflect.AnnotatedElement;
+import java.lang.reflect.Method;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -81,6 +82,7 @@ import com.oracle.svm.core.config.ConfigurationValues;
 import com.oracle.svm.core.jdk.PlatformNativeLibrarySupport;
 import com.oracle.svm.core.option.OptionUtils;
 import com.oracle.svm.core.util.UserError;
+import com.oracle.svm.hosted.ImageClassLoader;
 import com.oracle.svm.hosted.NativeImageOptions;
 import com.oracle.svm.hosted.c.info.ElementInfo;
 import com.oracle.svm.hosted.classinitialization.ClassInitializationSupport;
@@ -403,8 +405,17 @@ public final class NativeLibraries {
         }
     }
 
-    public void addAnnotated(CLibrary library) {
-        annotated.add(library);
+    public void processCLibraryAnnotations(ImageClassLoader loader) {
+        for (Class<?> clazz : loader.findAnnotatedClasses(CLibrary.class, false)) {
+            if (makeContext(getDirectives(metaAccess.lookupJavaType(clazz))).isInConfiguration()) {
+                annotated.add(clazz.getAnnotation(CLibrary.class));
+            }
+        }
+        for (Method method : loader.findAnnotatedMethods(CLibrary.class)) {
+            if (makeContext(getDirectives(metaAccess.lookupJavaType(method.getDeclaringClass()))).isInConfiguration()) {
+                annotated.add(method.getAnnotation(CLibrary.class));
+            }
+        }
     }
 
     public void addStaticJniLibrary(String library, String... dependencies) {

--- a/substratevm/src/com.oracle.svm.truffle.nfi/src/com/oracle/svm/truffle/nfi/libffi/LibFFIHeaderDirectives.java
+++ b/substratevm/src/com.oracle.svm.truffle.nfi/src/com/oracle/svm/truffle/nfi/libffi/LibFFIHeaderDirectives.java
@@ -28,11 +28,18 @@ import java.io.File;
 import java.util.Collections;
 import java.util.List;
 
+import org.graalvm.nativeimage.ImageSingletons;
 import org.graalvm.nativeimage.c.CContext;
 
 import com.oracle.svm.core.c.ProjectHeaderFile;
+import com.oracle.svm.truffle.nfi.TruffleNFIFeature;
 
 public class LibFFIHeaderDirectives implements CContext.Directives {
+
+    @Override
+    public boolean isInConfiguration() {
+        return ImageSingletons.contains(TruffleNFIFeature.class);
+    }
 
     @Override
     public List<String> getHeaderFiles() {


### PR DESCRIPTION
Currently we always statically link against `libffi.a` even if there is no need for it (no use of TruffleNFI in the image). This PR fixes the issue.