### PR TITLE
Fix Micronaut typo in VS Code extension

### DIFF
--- a/vscode/micronaut/package.json
+++ b/vscode/micronaut/package.json
@@ -39,7 +39,7 @@
 				"micronaut.showWelcomePage": {
 					"type": "boolean",
 					"default": true,
-					"description": "Show Micornaut Tools page on extension activation"
+					"description": "Show Micronaut Tools page on extension activation"
 				},
 				"micronaut.home": {
 					"type": "string",


### PR DESCRIPTION
The settings of the Micronaut VS Code extension contain a typo of "Micronaut".