### PR TITLE
[GR-32289] Programmatic serialization registration from inside features

### DIFF
--- a/sdk/mx.sdk/suite.py
+++ b/sdk/mx.sdk/suite.py
@@ -375,7 +375,7 @@ suite = {
           "org.graalvm.word",
           "org.graalvm.polyglot.impl to org.graalvm.truffle",
           "org.graalvm.word.impl to jdk.internal.vm.compiler",
-          "org.graalvm.nativeimage.impl to org.graalvm.nativeimage.builder,com.oracle.svm.svm_enterprise",
+          "org.graalvm.nativeimage.impl to org.graalvm.nativeimage.builder,org.graalvm.nativeimage.configure,com.oracle.svm.svm_enterprise",
         ],
         "uses" : [
           "org.graalvm.polyglot.impl.AbstractPolyglotImpl"

--- a/sdk/src/org.graalvm.nativeimage/snapshot.sigtest
+++ b/sdk/src/org.graalvm.nativeimage/snapshot.sigtest
@@ -910,6 +910,7 @@ supr java.lang.Object
 
 CLSS public final org.graalvm.nativeimage.hosted.RuntimeSerialization
 meth public !varargs static void register(java.lang.Class<?>[])
+meth public static void registerWithTargetConstructorClass(java.lang.Class<?>,java.lang.Class<?>)
 supr java.lang.Object
 
 CLSS public abstract interface org.graalvm.nativeimage.impl.InternalPlatform

--- a/sdk/src/org.graalvm.nativeimage/snapshot.sigtest
+++ b/sdk/src/org.graalvm.nativeimage/snapshot.sigtest
@@ -908,6 +908,10 @@ meth public !varargs static void register(java.lang.reflect.Field[])
 meth public !varargs static void registerForReflectiveInstantiation(java.lang.Class<?>[])
 supr java.lang.Object
 
+CLSS public final org.graalvm.nativeimage.hosted.RuntimeSerialization
+meth public !varargs static void register(java.lang.Class<?>[])
+supr java.lang.Object
+
 CLSS public abstract interface org.graalvm.nativeimage.impl.InternalPlatform
 innr public abstract interface static PLATFORM_JNI
 

--- a/sdk/src/org.graalvm.nativeimage/src/org/graalvm/nativeimage/hosted/RuntimeSerialization.java
+++ b/sdk/src/org.graalvm.nativeimage/src/org/graalvm/nativeimage/hosted/RuntimeSerialization.java
@@ -64,7 +64,13 @@ public final class RuntimeSerialization {
     }
 
     /**
-     * Makes the provided class available for serialization at runtime, using the customTargetConstructorClazz.
+     * Makes the provided class available for serialization at runtime but uses the provided
+     * customTargetConstructorClazz for deserialization.
+     * <p>
+     * In some cases an application might explicitly make calls to
+     * {@code ReflectionFactory.newConstructorForSerialization(Class<?> cl, Constructor<?> constructorToCall)}
+     * where the passed `constructorToCall` differs from what would automatically be used if regular
+     * deserialization of `cl` would happen. This method exists to also support such usecases.
      *
      * @since 21.3
      */

--- a/sdk/src/org.graalvm.nativeimage/src/org/graalvm/nativeimage/hosted/RuntimeSerialization.java
+++ b/sdk/src/org.graalvm.nativeimage/src/org/graalvm/nativeimage/hosted/RuntimeSerialization.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or
+ * data (collectively the "Software"), free of charge and under any and all
+ * copyright rights in the Software, and any and all patent rights owned or
+ * freely licensable by each licensor hereunder covering either (i) the
+ * unmodified Software as contributed to or provided by such licensor, or (ii)
+ * the Larger Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ *
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ *
+ * The above copyright notice and either this complete permission notice or at a
+ * minimum a reference to the UPL must be included in all copies or substantial
+ * portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.graalvm.nativeimage.hosted;
+
+import org.graalvm.nativeimage.ImageSingletons;
+import org.graalvm.nativeimage.Platform;
+import org.graalvm.nativeimage.Platforms;
+import org.graalvm.nativeimage.impl.RuntimeSerializationSupport;
+
+/**
+ * This class provides methods that can be called before and during analysis,
+ * to register classes for serialization at image runtime.
+ *
+ * @since 21.3
+ */
+@Platforms(Platform.HOSTED_ONLY.class)
+public final class RuntimeSerialization {
+
+    /**
+     * Makes the provided classes available for serialization at runtime.
+     *
+     * @since 21.3
+     */
+    public static void register(Class<?>... classes) {
+        ImageSingletons.lookup(RuntimeSerializationSupport.class).register(classes);
+    }
+
+    private RuntimeSerialization() {
+    }
+}

--- a/sdk/src/org.graalvm.nativeimage/src/org/graalvm/nativeimage/hosted/RuntimeSerialization.java
+++ b/sdk/src/org.graalvm.nativeimage/src/org/graalvm/nativeimage/hosted/RuntimeSerialization.java
@@ -63,6 +63,15 @@ public final class RuntimeSerialization {
         ImageSingletons.lookup(RuntimeSerializationSupport.class).register(classes);
     }
 
+    /**
+     * Makes the provided class available for serialization at runtime, using the customTargetConstructorClazz.
+     *
+     * @since 21.3
+     */
+    public static void registerWithTargetConstructorClass(Class<?> clazz, Class<?> customTargetConstructorClazz) {
+        ImageSingletons.lookup(RuntimeSerializationSupport.class).registerWithTargetConstructorClass(clazz, customTargetConstructorClazz);
+    }
+
     private RuntimeSerialization() {
     }
 }

--- a/sdk/src/org.graalvm.nativeimage/src/org/graalvm/nativeimage/hosted/RuntimeSerialization.java
+++ b/sdk/src/org.graalvm.nativeimage/src/org/graalvm/nativeimage/hosted/RuntimeSerialization.java
@@ -46,8 +46,8 @@ import org.graalvm.nativeimage.Platforms;
 import org.graalvm.nativeimage.impl.RuntimeSerializationSupport;
 
 /**
- * This class provides methods that can be called before and during analysis,
- * to register classes for serialization at image runtime.
+ * This class provides methods that can be called before and during analysis, to register classes
+ * for serialization at image runtime.
  *
  * @since 21.3
  */

--- a/sdk/src/org.graalvm.nativeimage/src/org/graalvm/nativeimage/impl/RuntimeSerializationSupport.java
+++ b/sdk/src/org.graalvm.nativeimage/src/org/graalvm/nativeimage/impl/RuntimeSerializationSupport.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or
+ * data (collectively the "Software"), free of charge and under any and all
+ * copyright rights in the Software, and any and all patent rights owned or
+ * freely licensable by each licensor hereunder covering either (i) the
+ * unmodified Software as contributed to or provided by such licensor, or (ii)
+ * the Larger Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ *
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ *
+ * The above copyright notice and either this complete permission notice or at a
+ * minimum a reference to the UPL must be included in all copies or substantial
+ * portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.graalvm.nativeimage.impl;
+
+public interface RuntimeSerializationSupport {
+
+    void register(Class<?>... classes);
+
+    void registerWithTargetConstructorClass(Class<?> clazz, Class<?> customTargetConstructorClazz);
+
+    void registerWithTargetConstructorClass(String className, String customTargetConstructorClassName);
+}

--- a/substratevm/src/com.oracle.svm.configure/src/com/oracle/svm/configure/config/ConfigurationSet.java
+++ b/substratevm/src/com.oracle.svm.configure/src/com/oracle/svm/configure/config/ConfigurationSet.java
@@ -130,7 +130,7 @@ public class ConfigurationSet {
 
     public SerializationConfiguration loadSerializationConfig(Function<IOException, Exception> exceptionHandler) throws Exception {
         SerializationConfiguration serializationConfiguration = new SerializationConfiguration();
-        loadConfig(serializationConfigPaths, new SerializationConfigurationParser(serializationConfiguration::add), exceptionHandler);
+        loadConfig(serializationConfigPaths, new SerializationConfigurationParser(serializationConfiguration), exceptionHandler);
         return serializationConfiguration;
     }
 

--- a/substratevm/src/com.oracle.svm.configure/src/com/oracle/svm/configure/config/SerializationConfiguration.java
+++ b/substratevm/src/com.oracle.svm.configure/src/com/oracle/svm/configure/config/SerializationConfiguration.java
@@ -26,19 +26,19 @@
 package com.oracle.svm.configure.config;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
 import com.oracle.svm.configure.ConfigurationBase;
 import com.oracle.svm.configure.json.JsonWriter;
-import com.oracle.svm.core.SubstrateUtil;
-import com.oracle.svm.core.configure.SerializationConfigurationParser;
+import org.graalvm.nativeimage.impl.RuntimeSerializationSupport;
 
-public class SerializationConfiguration implements ConfigurationBase {
+public class SerializationConfiguration implements ConfigurationBase, RuntimeSerializationSupport {
 
-    private static final String KEY_SEPARATOR = "|";
-
-    private final Set<String> serializations = ConcurrentHashMap.newKeySet();
+    private final Set<SerializationConfigurationType> serializations = ConcurrentHashMap.newKeySet();
 
     public SerializationConfiguration() {
     }
@@ -51,33 +51,20 @@ public class SerializationConfiguration implements ConfigurationBase {
         serializations.removeAll(other.serializations);
     }
 
-    public void add(String serializationTargetClass, String customTargetConstructorClass) {
-        serializations.add(mapNameAndConstructor(serializationTargetClass, customTargetConstructorClass));
-    }
-
     public boolean contains(String serializationTargetClass, String customTargetConstructorClass) {
-        return serializations.contains(mapNameAndConstructor(serializationTargetClass, customTargetConstructorClass));
-    }
-
-    private static String mapNameAndConstructor(String serializationTargetClass, String customTargetConstructorClass) {
-        return serializationTargetClass + (customTargetConstructorClass != null ? KEY_SEPARATOR + customTargetConstructorClass : "");
+        return serializations.contains(createConfigurationType(serializationTargetClass, customTargetConstructorClass));
     }
 
     @Override
     public void printJson(JsonWriter writer) throws IOException {
         writer.append('[').indent();
         String prefix = "";
-        for (String entry : serializations) {
-            writer.append(prefix);
-            writer.newline().append('{').newline();
-            String[] serializationKeyValues = SubstrateUtil.split(entry, KEY_SEPARATOR, 2);
-            String className = serializationKeyValues[0];
-            writer.quote(SerializationConfigurationParser.NAME_KEY).append(":").quote(className);
-            if (serializationKeyValues.length > 1) {
-                writer.append(",").newline();
-                writer.quote(SerializationConfigurationParser.CUSTOM_TARGET_CONSTRUCTOR_CLASS_KEY).append(":").quote(serializationKeyValues[1]);
-            }
-            writer.newline().append('}');
+        List<SerializationConfigurationType> list = new ArrayList<>(serializations);
+        list.sort(Comparator.comparing(SerializationConfigurationType::getQualifiedJavaName)
+                        .thenComparing(SerializationConfigurationType::getQualifiedCustomTargetConstructorJavaName));
+        for (SerializationConfigurationType type : list) {
+            writer.append(prefix).newline();
+            type.printJson(writer);
             prefix = ",";
         }
         writer.unindent().newline();
@@ -85,8 +72,30 @@ public class SerializationConfiguration implements ConfigurationBase {
     }
 
     @Override
+    public void register(Class<?>... classes) {
+        for (Class<?> clazz : classes) {
+            registerWithTargetConstructorClass(clazz, null);
+        }
+    }
+
+    @Override
+    public void registerWithTargetConstructorClass(Class<?> clazz, Class<?> customTargetConstructorClazz) {
+        registerWithTargetConstructorClass(clazz.getName(), customTargetConstructorClazz == null ? null : customTargetConstructorClazz.getName());
+    }
+
+    @Override
+    public void registerWithTargetConstructorClass(String className, String customTargetConstructorClassName) {
+        serializations.add(createConfigurationType(className, customTargetConstructorClassName));
+    }
+
+    @Override
     public boolean isEmpty() {
         return serializations.isEmpty();
     }
 
+    private static SerializationConfigurationType createConfigurationType(String className, String customTargetConstructorClassName) {
+        String convertedClassName = SignatureUtil.toInternalClassName(className);
+        String convertedCustomTargetConstructorClassName = customTargetConstructorClassName == null ? null : SignatureUtil.toInternalClassName(customTargetConstructorClassName);
+        return new SerializationConfigurationType(convertedClassName, convertedCustomTargetConstructorClassName);
+    }
 }

--- a/substratevm/src/com.oracle.svm.configure/src/com/oracle/svm/configure/config/SerializationConfiguration.java
+++ b/substratevm/src/com.oracle.svm.configure/src/com/oracle/svm/configure/config/SerializationConfiguration.java
@@ -27,7 +27,7 @@ package com.oracle.svm.configure.config;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Comparator;
+import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -60,8 +60,7 @@ public class SerializationConfiguration implements ConfigurationBase, RuntimeSer
         writer.append('[').indent();
         String prefix = "";
         List<SerializationConfigurationType> list = new ArrayList<>(serializations);
-        list.sort(Comparator.comparing(SerializationConfigurationType::getQualifiedJavaName)
-                        .thenComparing(SerializationConfigurationType::getQualifiedCustomTargetConstructorJavaName));
+        Collections.sort(list);
         for (SerializationConfigurationType type : list) {
             writer.append(prefix).newline();
             type.printJson(writer);

--- a/substratevm/src/com.oracle.svm.configure/src/com/oracle/svm/configure/config/SerializationConfigurationType.java
+++ b/substratevm/src/com.oracle.svm.configure/src/com/oracle/svm/configure/config/SerializationConfigurationType.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2021, 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package com.oracle.svm.configure.config;
+
+import com.oracle.svm.configure.json.JsonPrintable;
+import com.oracle.svm.configure.json.JsonWriter;
+import com.oracle.svm.core.configure.SerializationConfigurationParser;
+
+import java.io.IOException;
+import java.util.Objects;
+
+public class SerializationConfigurationType implements JsonPrintable {
+
+    private final String qualifiedJavaName;
+    private final String qualifiedCustomTargetConstructorJavaName;
+
+    public SerializationConfigurationType(String qualifiedJavaName, String qualifiedCustomTargetConstructorJavaName) {
+        assert qualifiedJavaName.indexOf('/') == -1 : "Requires qualified Java name, not internal representation";
+        assert !qualifiedJavaName.startsWith("[") : "Requires Java source array syntax, for example java.lang.String[]";
+        assert qualifiedCustomTargetConstructorJavaName == null || qualifiedCustomTargetConstructorJavaName.indexOf('/') == -1 : "Requires qualified Java name, not internal representation";
+        assert qualifiedCustomTargetConstructorJavaName == null || !qualifiedCustomTargetConstructorJavaName.startsWith("[") : "Requires Java source array syntax, for example java.lang.String[]";
+        this.qualifiedJavaName = qualifiedJavaName;
+        this.qualifiedCustomTargetConstructorJavaName = qualifiedCustomTargetConstructorJavaName;
+    }
+
+    public String getQualifiedJavaName() {
+        return qualifiedJavaName;
+    }
+
+    public String getQualifiedCustomTargetConstructorJavaName() {
+        return qualifiedCustomTargetConstructorJavaName;
+    }
+
+    @Override
+    public void printJson(JsonWriter writer) throws IOException {
+        writer.append('{').indent().newline();
+        writer.quote(SerializationConfigurationParser.NAME_KEY).append(':').quote(qualifiedJavaName);
+        if (qualifiedCustomTargetConstructorJavaName != null) {
+            writer.append(',').newline();
+            writer.quote(SerializationConfigurationParser.CUSTOM_TARGET_CONSTRUCTOR_CLASS_KEY).append(':')
+                            .quote(qualifiedCustomTargetConstructorJavaName);
+        }
+        writer.unindent().newline().append('}');
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        SerializationConfigurationType that = (SerializationConfigurationType) o;
+        return Objects.equals(qualifiedJavaName, that.qualifiedJavaName) &&
+                        Objects.equals(qualifiedCustomTargetConstructorJavaName, that.qualifiedCustomTargetConstructorJavaName);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(qualifiedJavaName, qualifiedCustomTargetConstructorJavaName);
+    }
+}

--- a/substratevm/src/com.oracle.svm.configure/src/com/oracle/svm/configure/config/SerializationConfigurationType.java
+++ b/substratevm/src/com.oracle.svm.configure/src/com/oracle/svm/configure/config/SerializationConfigurationType.java
@@ -29,9 +29,10 @@ import com.oracle.svm.configure.json.JsonWriter;
 import com.oracle.svm.core.configure.SerializationConfigurationParser;
 
 import java.io.IOException;
+import java.util.Comparator;
 import java.util.Objects;
 
-public class SerializationConfigurationType implements JsonPrintable {
+public class SerializationConfigurationType implements JsonPrintable, Comparable<SerializationConfigurationType> {
 
     private final String qualifiedJavaName;
     private final String qualifiedCustomTargetConstructorJavaName;
@@ -81,5 +82,15 @@ public class SerializationConfigurationType implements JsonPrintable {
     @Override
     public int hashCode() {
         return Objects.hash(qualifiedJavaName, qualifiedCustomTargetConstructorJavaName);
+    }
+
+    @Override
+    public int compareTo(SerializationConfigurationType other) {
+        int compareName = qualifiedJavaName.compareTo(other.qualifiedJavaName);
+        if (compareName != 0) {
+            return compareName;
+        }
+        Comparator<String> nullsFirstCompare = Comparator.nullsFirst(Comparator.naturalOrder());
+        return nullsFirstCompare.compare(qualifiedCustomTargetConstructorJavaName, other.qualifiedCustomTargetConstructorJavaName);
     }
 }

--- a/substratevm/src/com.oracle.svm.configure/src/com/oracle/svm/configure/config/SignatureUtil.java
+++ b/substratevm/src/com.oracle.svm.configure/src/com/oracle/svm/configure/config/SignatureUtil.java
@@ -69,4 +69,29 @@ public class SignatureUtil {
         }
         return sb.append(')').toString();
     }
+
+    public static String toInternalClassName(String qualifiedForNameString) {
+        assert qualifiedForNameString.indexOf('/') == -1 : "Requires qualified Java name, not internal representation";
+        assert !qualifiedForNameString.endsWith("[]") : "Requires Class.forName syntax, for example '[Ljava.lang.String;'";
+        String s = qualifiedForNameString;
+        int n = 0;
+        while (n < s.length() && s.charAt(n) == '[') {
+            n++;
+        }
+        if (n > 0) { // transform to Java source syntax
+            StringBuilder sb = new StringBuilder(s.length() + n);
+            if (s.charAt(n) == 'L' && s.charAt(s.length() - 1) == ';') {
+                sb.append(s, n + 1, s.length() - 1); // cut off leading '[' and 'L' and trailing ';'
+            } else if (n == s.length() - 1) {
+                sb.append(JavaKind.fromPrimitiveOrVoidTypeChar(s.charAt(n)).getJavaName());
+            } else {
+                throw new IllegalArgumentException();
+            }
+            for (int i = 0; i < n; i++) {
+                sb.append("[]");
+            }
+            s = sb.toString();
+        }
+        return s;
+    }
 }

--- a/substratevm/src/com.oracle.svm.configure/src/com/oracle/svm/configure/trace/SerializationProcessor.java
+++ b/substratevm/src/com.oracle.svm.configure/src/com/oracle/svm/configure/trace/SerializationProcessor.java
@@ -58,7 +58,7 @@ public class SerializationProcessor extends AbstractProcessor {
                 return;
             }
 
-            serializationConfiguration.add((String) args.get(0), (String) args.get(1));
+            serializationConfiguration.registerWithTargetConstructorClass((String) args.get(0), (String) args.get(1));
         }
     }
 }

--- a/substratevm/src/com.oracle.svm.reflect/src/com/oracle/svm/reflect/serialize/SerializationRegistry.java
+++ b/substratevm/src/com.oracle.svm.reflect/src/com/oracle/svm/reflect/serialize/SerializationRegistry.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2020, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2020, Alibaba Group Holding Limited. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package com.oracle.svm.reflect.serialize;
+
+public interface SerializationRegistry {
+
+    Object getSerializationConstructorAccessor(Class<?> serializationTargetClass, Class<?> targetConstructorClass);
+
+}

--- a/substratevm/src/com.oracle.svm.reflect/src/com/oracle/svm/reflect/serialize/SerializationSupport.java
+++ b/substratevm/src/com.oracle.svm.reflect/src/com/oracle/svm/reflect/serialize/SerializationSupport.java
@@ -37,7 +37,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import org.graalvm.nativeimage.Platform;
 import org.graalvm.nativeimage.Platforms;
 
-import com.oracle.svm.core.jdk.serialize.SerializationRegistry;
 import com.oracle.svm.core.util.VMError;
 
 public class SerializationSupport implements SerializationRegistry {

--- a/substratevm/src/com.oracle.svm.reflect/src/com/oracle/svm/reflect/serialize/hosted/SerializationFeature.java
+++ b/substratevm/src/com.oracle.svm.reflect/src/com/oracle/svm/reflect/serialize/hosted/SerializationFeature.java
@@ -37,22 +37,26 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 
+import com.oracle.svm.core.TypeResult;
+import com.oracle.svm.core.util.json.JSONParserException;
+import com.oracle.svm.reflect.serialize.SerializationRegistry;
+import jdk.vm.ci.meta.MetaUtil;
 import org.graalvm.nativeimage.ImageSingletons;
 import org.graalvm.nativeimage.hosted.Feature;
 import org.graalvm.nativeimage.hosted.RuntimeReflection;
+import org.graalvm.nativeimage.impl.RuntimeSerializationSupport;
 
 import com.oracle.svm.core.annotate.AutomaticFeature;
 import com.oracle.svm.core.configure.ConfigurationFile;
 import com.oracle.svm.core.configure.ConfigurationFiles;
 import com.oracle.svm.core.configure.SerializationConfigurationParser;
-import com.oracle.svm.core.configure.SerializationConfigurationParser.SerializationParserFunction;
 import com.oracle.svm.core.jdk.Package_jdk_internal_reflect;
 import com.oracle.svm.core.jdk.RecordSupport;
-import com.oracle.svm.core.jdk.serialize.SerializationRegistry;
 import com.oracle.svm.core.util.UserError;
 import com.oracle.svm.core.util.VMError;
-import com.oracle.svm.core.util.json.JSONParserException;
 import com.oracle.svm.hosted.FallbackFeature;
 import com.oracle.svm.hosted.FeatureImpl;
 import com.oracle.svm.hosted.ImageClassLoader;
@@ -62,10 +66,11 @@ import com.oracle.svm.reflect.hosted.ReflectionFeature;
 import com.oracle.svm.reflect.serialize.SerializationSupport;
 import com.oracle.svm.util.ReflectionUtil;
 
-import jdk.vm.ci.meta.MetaUtil;
+import static com.oracle.svm.reflect.serialize.hosted.SerializationFeature.println;
 
 @AutomaticFeature
 public class SerializationFeature implements Feature {
+    private SerializationBuilder serializationBuilder;
     private int loadedConfigurations;
 
     @Override
@@ -76,55 +81,234 @@ public class SerializationFeature implements Feature {
     @Override
     public void duringSetup(DuringSetupAccess a) {
         FeatureImpl.DuringSetupAccessImpl access = (FeatureImpl.DuringSetupAccessImpl) a;
-        SerializationBuilder serializationBuilder = new SerializationBuilder(access);
 
-        Map<Class<?>, Boolean> deniedClasses = new HashMap<>();
-        SerializationConfigurationParser denyCollectorParser = new SerializationConfigurationParser((strTargetSerializationClass, strCustomTargetConstructorClass) -> {
-            Class<?> serializationTargetClass = resolveClass(strTargetSerializationClass, access);
-            if (serializationTargetClass != null) {
-                deniedClasses.put(serializationTargetClass, true);
-            }
-        });
         ImageClassLoader imageClassLoader = access.getImageClassLoader();
+        SerializationTypeResolver typeResolver = new SerializationTypeResolver(imageClassLoader, NativeImageOptions.AllowIncompleteClasspath.getValue());
+        SerializationDenyRegistry serializationDenyRegistry = new SerializationDenyRegistry(typeResolver);
+        serializationBuilder = new SerializationBuilder(serializationDenyRegistry, access, typeResolver);
+        ImageSingletons.add(RuntimeSerializationSupport.class, serializationBuilder);
+
+        SerializationConfigurationParser denyCollectorParser = new SerializationConfigurationParser(serializationDenyRegistry);
         ConfigurationParserUtils.parseAndRegisterConfigurations(denyCollectorParser, imageClassLoader, "serialization",
                         ConfigurationFiles.Options.SerializationDenyConfigurationFiles, ConfigurationFiles.Options.SerializationDenyConfigurationResources,
                         ConfigurationFile.SERIALIZATION_DENY.getFileName());
 
-        SerializationParserFunction serializationAdapter = (strTargetSerializationClass, strCustomTargetConstructorClass) -> {
-            Class<?> serializationTargetClass = resolveClass(strTargetSerializationClass, access);
-            UserError.guarantee(serializationTargetClass != null, "Cannot find serialization target class %s. The missing of this class can't be ignored even if -H:+AllowIncompleteClasspath is set." +
-                            " Please make sure it is in the classpath", strTargetSerializationClass);
-            if (Serializable.class.isAssignableFrom(serializationTargetClass)) {
-                if (deniedClasses.containsKey(serializationTargetClass)) {
-                    if (deniedClasses.get(serializationTargetClass)) {
-                        deniedClasses.put(serializationTargetClass, false); /* Warn only once */
-                        println("Warning: Serialization deny list contains " + serializationTargetClass.getName() + ". Image will not support serialization/deserialization of this class.");
-                    }
-                } else {
-                    Class<?> customTargetConstructorClass = null;
-                    if (strCustomTargetConstructorClass != null) {
-                        customTargetConstructorClass = resolveClass(strCustomTargetConstructorClass, access);
-                        UserError.guarantee(customTargetConstructorClass != null, "Cannot find " + SerializationConfigurationParser.CUSTOM_TARGET_CONSTRUCTOR_CLASS_KEY + " %s that was specified in" +
-                                        " the serialization configuration. The missing of this class can't be ignored even if -H:+AllowIncompleteClasspath is set. Please make sure it is in the classpath",
-                                        strCustomTargetConstructorClass);
-                        UserError.guarantee(customTargetConstructorClass.isAssignableFrom(serializationTargetClass),
-                                        "The given " + SerializationConfigurationParser.CUSTOM_TARGET_CONSTRUCTOR_CLASS_KEY +
-                                                        " %s that was specified in the serialization configuration is not a subclass of the serialization target class %s.",
-                                        strCustomTargetConstructorClass, strTargetSerializationClass);
-                    }
-                    Class<?> targetConstructor = serializationBuilder.addConstructorAccessor(serializationTargetClass, customTargetConstructorClass);
-                    addReflections(serializationTargetClass, targetConstructor);
-                }
-            }
-        };
-
-        SerializationConfigurationParser parser = new SerializationConfigurationParser(serializationAdapter);
+        SerializationConfigurationParser parser = new SerializationConfigurationParser(serializationBuilder);
         loadedConfigurations = ConfigurationParserUtils.parseAndRegisterConfigurations(parser, imageClassLoader, "serialization",
                         ConfigurationFiles.Options.SerializationConfigurationFiles, ConfigurationFiles.Options.SerializationConfigurationResources,
                         ConfigurationFile.SERIALIZATION.getFileName());
     }
 
-    public static void addReflections(Class<?> serializationTargetClass, Class<?> targetConstructorClass) {
+    @Override
+    public void duringAnalysis(DuringAnalysisAccess access) {
+        serializationBuilder.duringAnalysis(access);
+    }
+
+    @Override
+    public void afterAnalysis(AfterAnalysisAccess access) {
+        serializationBuilder.afterAnalysis();
+    }
+
+    @Override
+    public void beforeCompilation(BeforeCompilationAccess access) {
+        if (ImageSingletons.contains(FallbackFeature.class)) {
+            FallbackFeature.FallbackImageRequest serializationFallback = ImageSingletons.lookup(FallbackFeature.class).serializationFallback;
+            if (serializationFallback != null && loadedConfigurations == 0) {
+                throw serializationFallback;
+            }
+        }
+    }
+
+    static void println(String str) {
+        // Checkstyle: stop
+        System.out.println(str);
+        // Checkstyle: resume
+    }
+}
+
+final class SerializationTypeResolver {
+
+    private final ImageClassLoader classLoader;
+    private final boolean allowIncompleteClasspath;
+
+    SerializationTypeResolver(ImageClassLoader classLoader, boolean allowIncompleteClasspath) {
+        this.classLoader = classLoader;
+        this.allowIncompleteClasspath = allowIncompleteClasspath;
+    }
+
+    public Class<?> resolveType(String typeName) {
+        String name = typeName;
+        if (name.indexOf('[') != -1) {
+            /* accept "int[][]", "java.lang.String[]" */
+            name = MetaUtil.internalNameToJava(MetaUtil.toInternalName(name), true, true);
+        }
+        TypeResult<Class<?>> typeResult = classLoader.findClass(name);
+        if (!typeResult.isPresent()) {
+            handleError("Could not resolve " + name + " for serialization configuration.");
+        }
+        return typeResult.get();
+    }
+
+    private void handleError(String message) {
+        if (allowIncompleteClasspath) {
+            println("WARNING: " + message);
+        } else {
+            throw new JSONParserException(message + " To allow unresolvable reflection configuration, use option -H:+AllowIncompleteClasspath");
+        }
+    }
+}
+
+final class SerializationDenyRegistry implements RuntimeSerializationSupport {
+
+    private final Map<Class<?>, Boolean> deniedClasses = new HashMap<>();
+    private final SerializationTypeResolver typeResolver;
+
+    SerializationDenyRegistry(SerializationTypeResolver typeResolver) {
+        this.typeResolver = typeResolver;
+    }
+
+    @Override
+    public void register(Class<?>... classes) {
+        for (Class<?> clazz : classes) {
+            registerWithTargetConstructorClass(clazz, null);
+        }
+    }
+
+    @Override
+    public void registerWithTargetConstructorClass(String className, String customTargetConstructorClassName) {
+        registerWithTargetConstructorClass(typeResolver.resolveType(className), null);
+    }
+
+    @Override
+    public void registerWithTargetConstructorClass(Class<?> clazz, Class<?> customTargetConstructorClazz) {
+        if (clazz != null) {
+            deniedClasses.put(clazz, true);
+        }
+    }
+
+    public boolean isAllowed(Class<?> clazz) {
+        boolean denied = deniedClasses.containsKey(clazz);
+        if (denied && deniedClasses.get(clazz)) {
+            deniedClasses.put(clazz, false); /* Warn only once */
+            println("WARNING: Serialization deny list contains " + clazz.getName() + ". Image will not support serialization/deserialization of this class.");
+        }
+        return !denied;
+    }
+}
+
+final class SerializationBuilder implements RuntimeSerializationSupport {
+
+    private static final class ClassEntry {
+        private final Class<?> clazz;
+        private final Class<?> customTargetConstructorClazz;
+
+        private ClassEntry(Class<?> clazz, Class<?> customTargetConstructorClazz) {
+            this.clazz = clazz;
+            this.customTargetConstructorClazz = customTargetConstructorClazz;
+        }
+    }
+
+    private final Object reflectionFactory;
+    private final Method newConstructorForSerializationMethod1;
+    private final Method newConstructorForSerializationMethod2;
+    private final Method getConstructorAccessorMethod;
+    private final Method getExternalizableConstructorMethod;
+    private final Constructor<?> stubConstructor;
+
+    private final SerializationSupport serializationSupport;
+    private final SerializationDenyRegistry denyRegistry;
+    private final SerializationTypeResolver typeResolver;
+    private final Set<ClassEntry> newClasses;
+
+    private boolean sealed;
+
+    SerializationBuilder(SerializationDenyRegistry serializationDenyRegistry, FeatureImpl.DuringSetupAccessImpl access, SerializationTypeResolver typeResolver) {
+        try {
+            Class<?> reflectionFactoryClass = access.findClassByName(Package_jdk_internal_reflect.getQualifiedName() + ".ReflectionFactory");
+            Method getReflectionFactoryMethod = ReflectionUtil.lookupMethod(reflectionFactoryClass, "getReflectionFactory");
+            reflectionFactory = getReflectionFactoryMethod.invoke(null);
+            newConstructorForSerializationMethod1 = ReflectionUtil.lookupMethod(reflectionFactoryClass, "newConstructorForSerialization", Class.class);
+            newConstructorForSerializationMethod2 = ReflectionUtil.lookupMethod(reflectionFactoryClass, "newConstructorForSerialization", Class.class, Constructor.class);
+            getConstructorAccessorMethod = ReflectionUtil.lookupMethod(Constructor.class, "getConstructorAccessor");
+            getExternalizableConstructorMethod = ReflectionUtil.lookupMethod(ObjectStreamClass.class, "getExternalizableConstructor", Class.class);
+        } catch (ReflectiveOperationException e) {
+            throw VMError.shouldNotReachHere(e);
+        }
+        stubConstructor = newConstructorForSerialization(SerializationSupport.StubForAbstractClass.class, null);
+        this.denyRegistry = serializationDenyRegistry;
+        this.typeResolver = typeResolver;
+        newClasses = Collections.newSetFromMap(new ConcurrentHashMap<>());
+
+        serializationSupport = new SerializationSupport(stubConstructor);
+        ImageSingletons.add(SerializationRegistry.class, serializationSupport);
+    }
+
+    private void abortIfSealed() {
+        UserError.guarantee(!sealed, "Too late to add classes for serialization. Registration must happen in a Feature before the analysis has finished.");
+    }
+
+    @Override
+    public void register(Class<?>... classes) {
+        for (Class<?> clazz : classes) {
+            registerWithTargetConstructorClass(clazz, null);
+        }
+    }
+
+    @Override
+    public void registerWithTargetConstructorClass(String targetClassName, String customTargetConstructorClassName) {
+        abortIfSealed();
+        Class<?> serializationTargetClass = typeResolver.resolveType(targetClassName);
+        UserError.guarantee(serializationTargetClass != null, "Cannot find serialization target class %s. The missing of this class can't be ignored even if -H:+AllowIncompleteClasspath is set." +
+                        " Please make sure it is in the classpath", targetClassName);
+        if (customTargetConstructorClassName != null) {
+            Class<?> customTargetConstructorClass = typeResolver.resolveType(customTargetConstructorClassName);
+            UserError.guarantee(customTargetConstructorClass != null,
+                            "Cannot find targetConstructorClass %s. The missing of this class can't be ignored even if -H:+AllowIncompleteClasspath is set." +
+                                            " Please make sure it is in the classpath",
+                            customTargetConstructorClass);
+            registerWithTargetConstructorClass(serializationTargetClass, customTargetConstructorClass);
+        } else {
+            registerWithTargetConstructorClass(serializationTargetClass, null);
+        }
+    }
+
+    @Override
+    public void registerWithTargetConstructorClass(Class<?> serializationTargetClass, Class<?> customTargetConstructorClass) {
+        abortIfSealed();
+        if (!Serializable.class.isAssignableFrom(serializationTargetClass)) {
+            println("WARNING: Could not register " + serializationTargetClass.getName() + " for serialization as it does not implement Serializable.");
+        } else if (denyRegistry.isAllowed(serializationTargetClass)) {
+            if (customTargetConstructorClass != null) {
+                UserError.guarantee(customTargetConstructorClass.isAssignableFrom(serializationTargetClass),
+                                "The given targetConstructorClass %s is not a subclass of the serialization target class %s.",
+                                customTargetConstructorClass, serializationTargetClass);
+            }
+            ClassEntry entry = new ClassEntry(serializationTargetClass, customTargetConstructorClass);
+            newClasses.add(entry);
+        }
+    }
+
+    public void duringAnalysis(Feature.DuringAnalysisAccess a) {
+        if (newClasses.isEmpty()) {
+            return;
+        }
+        for (ClassEntry entry : newClasses) {
+            Class<?> targetConstructor = addConstructorAccessor(entry.clazz, entry.customTargetConstructorClazz);
+            addReflections(entry.clazz, targetConstructor);
+        }
+        newClasses.clear();
+
+        a.requireAnalysisIteration();
+    }
+
+    public void afterAnalysis() {
+        sealed = true;
+        if (!newClasses.isEmpty()) {
+            abortIfSealed();
+        }
+    }
+
+    private static void addReflections(Class<?> serializationTargetClass, Class<?> targetConstructorClass) {
         if (targetConstructorClass != null) {
             RuntimeReflection.register(ReflectionUtil.lookupConstructor(targetConstructorClass));
         }
@@ -164,75 +348,6 @@ public class SerializationFeature implements Feature {
 
     private static void registerFields(Class<?> serializationTargetClass) {
         RuntimeReflection.register(serializationTargetClass.getDeclaredFields());
-    }
-
-    private static Class<?> resolveClass(String typeName, FeatureAccess a) {
-        String name = typeName;
-        if (name.indexOf('[') != -1) {
-            /* accept "int[][]", "java.lang.String[]" */
-            name = MetaUtil.internalNameToJava(MetaUtil.toInternalName(name), true, true);
-        }
-        Class<?> ret = a.findClassByName(name);
-        if (ret == null) {
-            handleError("Could not resolve " + name + " for serialization configuration.");
-        }
-        return ret;
-    }
-
-    @Override
-    public void beforeCompilation(BeforeCompilationAccess access) {
-        if (!ImageSingletons.contains(FallbackFeature.class)) {
-            return;
-        }
-        FallbackFeature.FallbackImageRequest serializationFallback = ImageSingletons.lookup(FallbackFeature.class).serializationFallback;
-        if (serializationFallback != null && loadedConfigurations == 0) {
-            throw serializationFallback;
-        }
-    }
-
-    private static void handleError(String message) {
-        boolean allowIncompleteClasspath = NativeImageOptions.AllowIncompleteClasspath.getValue();
-        if (allowIncompleteClasspath) {
-            println("WARNING: " + message);
-        } else {
-            throw new JSONParserException(message + " To allow unresolvable reflection configuration, use option -H:+AllowIncompleteClasspath");
-        }
-    }
-
-    static void println(String str) {
-        // Checkstyle: stop
-        System.out.println(str);
-        // Checkstyle: resume
-    }
-}
-
-final class SerializationBuilder {
-
-    private final Object reflectionFactory;
-    private final Method newConstructorForSerializationMethod1;
-    private final Method newConstructorForSerializationMethod2;
-    private final Method getConstructorAccessorMethod;
-    private final Method getExternalizableConstructorMethod;
-    private final Constructor<?> stubConstructor;
-
-    private final SerializationSupport serializationSupport;
-
-    SerializationBuilder(FeatureImpl.DuringSetupAccessImpl access) {
-        try {
-            Class<?> reflectionFactoryClass = access.findClassByName(Package_jdk_internal_reflect.getQualifiedName() + ".ReflectionFactory");
-            Method getReflectionFactoryMethod = ReflectionUtil.lookupMethod(reflectionFactoryClass, "getReflectionFactory");
-            reflectionFactory = getReflectionFactoryMethod.invoke(null);
-            newConstructorForSerializationMethod1 = ReflectionUtil.lookupMethod(reflectionFactoryClass, "newConstructorForSerialization", Class.class);
-            newConstructorForSerializationMethod2 = ReflectionUtil.lookupMethod(reflectionFactoryClass, "newConstructorForSerialization", Class.class, Constructor.class);
-            getConstructorAccessorMethod = ReflectionUtil.lookupMethod(Constructor.class, "getConstructorAccessor");
-            getExternalizableConstructorMethod = ReflectionUtil.lookupMethod(ObjectStreamClass.class, "getExternalizableConstructor", Class.class);
-        } catch (ReflectiveOperationException e) {
-            throw VMError.shouldNotReachHere(e);
-        }
-        stubConstructor = newConstructorForSerialization(SerializationSupport.StubForAbstractClass.class, null);
-
-        serializationSupport = new SerializationSupport(stubConstructor);
-        ImageSingletons.add(SerializationRegistry.class, serializationSupport);
     }
 
     private Constructor<?> newConstructorForSerialization(Class<?> serializationTargetClass, Constructor<?> customConstructorToCall) {

--- a/substratevm/src/com.oracle.svm.reflect/src/com/oracle/svm/reflect/serialize/hosted/package-info.java
+++ b/substratevm/src/com.oracle.svm.reflect/src/com/oracle/svm/reflect/serialize/hosted/package-info.java
@@ -1,6 +1,5 @@
 /*
- * Copyright (c) 2020, 2020, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2020, 2020, Alibaba Group Holding Limited. All rights reserved.
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,10 +22,9 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
-package com.oracle.svm.core.jdk.serialize;
 
-public interface SerializationRegistry {
+@Platforms(Platform.HOSTED_ONLY.class)
+package com.oracle.svm.reflect.serialize.hosted;
 
-    Object getSerializationConstructorAccessor(Class<?> serializationTargetClass, Class<?> targetConstructorClass);
-
-}
+import org.graalvm.nativeimage.Platform;
+import org.graalvm.nativeimage.Platforms;

--- a/substratevm/src/com.oracle.svm.reflect/src/com/oracle/svm/reflect/target/Target_jdk_internal_reflect_AccessorGenerator.java
+++ b/substratevm/src/com.oracle.svm.reflect/src/com/oracle/svm/reflect/target/Target_jdk_internal_reflect_AccessorGenerator.java
@@ -22,13 +22,14 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
-package com.oracle.svm.core.jdk;
+package com.oracle.svm.reflect.target;
 
 import org.graalvm.nativeimage.ImageSingletons;
 
 import com.oracle.svm.core.annotate.Substitute;
 import com.oracle.svm.core.annotate.TargetClass;
-import com.oracle.svm.core.jdk.serialize.SerializationRegistry;
+import com.oracle.svm.core.jdk.Package_jdk_internal_reflect;
+import com.oracle.svm.reflect.serialize.SerializationRegistry;
 
 @TargetClass(classNameProvider = Package_jdk_internal_reflect.class, className = "AccessorGenerator")
 public final class Target_jdk_internal_reflect_AccessorGenerator {

--- a/substratevm/src/com.oracle.svm.test/src/META-INF/native-image/com.oracle.svm.test/native-image.properties
+++ b/substratevm/src/com.oracle.svm.test/src/META-INF/native-image/com.oracle.svm.test/native-image.properties
@@ -1,1 +1,1 @@
-Args = --initialize-at-run-time=com.oracle.svm.test --initialize-at-build-time=com.oracle.svm.test.AbstractClassSerializationTest,com.oracle.svm.test.SerializationRegistrationTest
+Args = --initialize-at-run-time=com.oracle.svm.test --initialize-at-build-time=com.oracle.svm.test.AbstractClassSerializationTest,com.oracle.svm.test.SerializationRegistrationTest --features=com.oracle.svm.test.SerializationRegistrationTestFeature

--- a/substratevm/src/com.oracle.svm.test/src/META-INF/native-image/com.oracle.svm.test/native-image.properties
+++ b/substratevm/src/com.oracle.svm.test/src/META-INF/native-image/com.oracle.svm.test/native-image.properties
@@ -1,1 +1,1 @@
-Args = --initialize-at-run-time=com.oracle.svm.test --initialize-at-build-time=com.oracle.svm.test.AbstractClassSerializationTest
+Args = --initialize-at-run-time=com.oracle.svm.test --initialize-at-build-time=com.oracle.svm.test.AbstractClassSerializationTest,com.oracle.svm.test.SerializationRegistrationTest

--- a/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/SerializationRegistrationTest.java
+++ b/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/SerializationRegistrationTest.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2021, 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package com.oracle.svm.test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+import com.oracle.svm.core.annotate.AutomaticFeature;
+import com.oracle.svm.core.util.VMError;
+import org.graalvm.nativeimage.hosted.Feature;
+import org.graalvm.nativeimage.hosted.RuntimeSerialization;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class SerializationRegistrationTest {
+
+    public static class SerializableTestClass implements Serializable {
+        private static final long serialVersionUID = 1L;
+        private final String content;
+
+        public SerializableTestClass(String content) {
+            this.content = content;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            SerializableTestClass that = (SerializableTestClass) o;
+            return Objects.equals(content, that.content);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(content);
+        }
+    }
+
+    private static final byte[] serializedObject;
+    private static final List<SerializableTestClass> list;
+
+    static {
+        list = new ArrayList<>();
+        list.add(new SerializableTestClass("Dummy"));
+        list.add(new SerializableTestClass("Test"));
+
+        ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+        try {
+            ObjectOutputStream objectOutputStream = new ObjectOutputStream(byteArrayOutputStream);
+            objectOutputStream.writeObject(list);
+            objectOutputStream.flush();
+        } catch (IOException e) {
+            VMError.shouldNotReachHere(e);
+        }
+
+        serializedObject = byteArrayOutputStream.toByteArray();
+    }
+
+    @Test
+    public void testSerializationRegistration() throws IOException, ClassNotFoundException {
+        ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(serializedObject);
+        ObjectInputStream objectInputStream = new ObjectInputStream(byteArrayInputStream);
+        Object deserializedObject = objectInputStream.readObject();
+        Assert.assertEquals(list, deserializedObject);
+    }
+}
+
+@AutomaticFeature
+class SerializationRegistrationTestFeature implements Feature {
+    @Override
+    public void beforeAnalysis(BeforeAnalysisAccess access) {
+        RuntimeSerialization.register(ArrayList.class, SerializationRegistrationTest.SerializableTestClass.class);
+    }
+}

--- a/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/SerializationRegistrationTest.java
+++ b/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/SerializationRegistrationTest.java
@@ -34,7 +34,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
-import com.oracle.svm.core.annotate.AutomaticFeature;
 import com.oracle.svm.core.util.VMError;
 import org.graalvm.nativeimage.hosted.Feature;
 import org.graalvm.nativeimage.hosted.RuntimeSerialization;
@@ -98,7 +97,6 @@ public class SerializationRegistrationTest {
     }
 }
 
-@AutomaticFeature
 class SerializationRegistrationTestFeature implements Feature {
     @Override
     public void beforeAnalysis(BeforeAnalysisAccess access) {


### PR DESCRIPTION
It is only possible to add serialization registrations from `serialization-config.json` files, these changes would add a `RuntimeSerialization` class which is accessible from within feature implementations so during image building, classes can be registered for serialization programatically using `RuntimeSerialization.register(YourClass.class)`.

This PR does 3 things:
* add programatical registration of serialization classes
* change the output of the serialization-config.json file to write out array classes as `org.example.ClassName[]` instead of `[org.example.ClassName;`
* support reading in the []-suffix syntax from the config file, so this also fixes https://github.com/oracle/graal/pull/3048