### PR TITLE
JNI - skip searching for hiding subclasses for constructors

### DIFF
--- a/substratevm/src/com.oracle.svm.jni/src/com/oracle/svm/jni/access/JNIAccessibleMethod.java
+++ b/substratevm/src/com.oracle.svm.jni/src/com/oracle/svm/jni/access/JNIAccessibleMethod.java
@@ -132,6 +132,9 @@ public final class JNIAccessibleMethod extends JNIAccessibleMember {
             arrayNonvirtualCallWrapper = MethodPointer.factory(hUniverse.lookup(aUniverse.lookup(arrayNonvirtualCallWrapperMethod)));
             valistNonvirtualCallWrapper = MethodPointer.factory(hUniverse.lookup(aUniverse.lookup(valistNonvirtualCallWrapperMethod)));
         }
+        if (descriptor.isConstructor() || descriptor.isClassInitializer()) {
+            return; // only hiding subclasses of methods need to be added
+        }
         setHidingSubclasses(access.getMetaAccess(), this::anyMatchIgnoreReturnType);
     }
 


### PR DESCRIPTION
`JNIAccessibleMethod#finishBeforeCompilation` searches for hiding subclasses for registered constructors/class initializers/methods, but only methods is relevant. The `anyMatchIgnoreReturnType` predicate checks against `sub.getDeclaredMethods` so it won't ever match with `<init>` or `<clinit>` anyway, so we can exit early.

While somewhat unrelated, this does partially fix https://github.com/gluonhq/client-maven-plugin/issues/200 as the issue there is a class that's reachable through service-loading that simply can't be loaded, so the `getDeclaredMethods` call fails. But adding `Object#getClass` for JNI will fail just as hard there.