### PR TITLE
[WIP] Add JDK Flight Recorder support for Java native images

### DIFF
--- a/substratevm/JFR.md
+++ b/substratevm/JFR.md
@@ -1,0 +1,43 @@
+## JFR Implementation Notes
+
+Implementation is based off of jdk/jdk commit rev
+
+d2816784605b
+
+## JDK Matrix
+
+This branch builds with:
+labsjdk-ce-11.0.9-jvmci-20.3-b06
+
+Tarballs can be found at:
+https://github.com/graalvm/labs-openjdk-11/releases
+
+For example:
+https://github.com/graalvm/labs-openjdk-11/releases/download/jvmci-20.3-b06/labsjdk-ce-11.0.9+10-jvmci-20.3-b06-linux-amd64.tar.gz
+
+## Testing the JFR code
+
+Clone the graalvm-jfr-tests repo somewhere to be used in the -cp argument. Use a JDK 11 to compile into class files.
+
+```
+javac /path/to/graalvm-jfr-tests/flat/EventCommit.java
+
+
+mx clean
+mx build
+mx native-image --allow-incomplete-classpath "-J-XX:FlightRecorderOptions=retransform=false" --no-fallback -ea -cp /path/to/graalvm-jfr-tests/flat/ EventCommit
+```
+
+See `/tmp` for a `my-recording...` jfr file
+
+## Logging
+
+The JFR implementation supports log levels via runtime flag:
+```
+-XX:FlightRecorderLogging=<value>
+```
+
+Values include:
+```
+trace, debug, info, warning, error
+```

--- a/substratevm/JFR.md
+++ b/substratevm/JFR.md
@@ -15,24 +15,26 @@ https://github.com/graalvm/labs-openjdk-11/releases
 For example:
 https://github.com/graalvm/labs-openjdk-11/releases/download/jvmci-20.3-b06/labsjdk-ce-11.0.9+10-jvmci-20.3-b06-linux-amd64.tar.gz
 
-## Testing the JFR code
+## Building a native image with JFR
 
-Clone the graalvm-jfr-tests repo somewhere to be used in the -cp argument. Use a JDK 11 to compile into class files.
+The JFR implementation is included at compile time via the flag:
+`-H:+FlightRecorder`
 
+## Running tests from the jfr-tests repo
+Clone the https://github.com/rh-jmc-team/jfr-tests repo to be used in the -cp argument. Follow its readme to compile class files via Maven.
+
+Then compile the classes to a native image, for example:
 ```
-javac /path/to/graalvm-jfr-tests/flat/EventCommit.java
-
-
-mx clean
 mx build
-mx native-image --allow-incomplete-classpath "-J-XX:FlightRecorderOptions=retransform=false" --no-fallback -ea -cp /path/to/graalvm-jfr-tests/flat/ EventCommit
+mx native-image -H:+FlightRecorder --no-fallback -cp /path/to/jfr-tests/target/classes com.redhat.jfr.tests.event.TestConcurrentEvents
+./com.redhat.jfr.tests.event.testconcurrentevents
 ```
 
-See `/tmp` for a `my-recording...` jfr file
+See `/tmp` for the jfr file
 
 ## Logging
 
-The JFR implementation supports log levels via runtime flag:
+The JFR implementation supports log levels via the runtime flag:
 ```
 -XX:FlightRecorderLogging=<value>
 ```
@@ -40,4 +42,11 @@ The JFR implementation supports log levels via runtime flag:
 Values include:
 ```
 trace, debug, info, warning, error
+```
+
+An empty value is treated as `error`
+
+For example:
+```
+./com.redhat.jfr.tests.event.testconcurrentevents -XX:FlightRecorderLogging=
 ```

--- a/substratevm/mx.substratevm/suite.py
+++ b/substratevm/mx.substratevm/suite.py
@@ -581,6 +581,24 @@ suite = {
             "spotbugs": "false",
         },
 
+        "com.oracle.svm.core.jdk.jfr.test": {
+            "subDir": "src",
+            "sourceDirs": ["src"],
+            "dependencies": [
+                "com.oracle.svm.core",
+                "mx:JUNIT",
+                "sdk:GRAAL_SDK",
+            ],
+            "checkstyle": "com.oracle.svm.core",
+            "workingSets": "SVM_CORE",
+            "annotationProcessors": [
+                "compiler:GRAAL_PROCESSOR",
+            ],
+            "javaCompliance": "8+",
+            "spotbugs": "false",
+        },
+
+
         "com.oracle.svm.test.jdk11": {
             "subDir": "src",
             "sourceDirs": ["src"],
@@ -1193,11 +1211,13 @@ suite = {
             "com.oracle.svm.test.jdk11",
             "com.oracle.svm.configure.test",
             "com.oracle.svm.graal.test",
+            "com.oracle.svm.core.jdk.jfr.test",
           ],
           "distDependencies": [
             "mx:JUNIT_TOOL",
             "sdk:GRAAL_SDK",
             "SVM_CONFIGURE",
+            "SVM_CORE",
           ],
           "testDistribution" : True,
         },

--- a/substratevm/src/com.oracle.svm.core.jdk.jfr.test/src/com/oracle/svm/core/jdk/jfr/test/JfrOptionsTest.java
+++ b/substratevm/src/com.oracle.svm.core.jdk.jfr.test/src/com/oracle/svm/core/jdk/jfr/test/JfrOptionsTest.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, Red Hat Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package com.oracle.svm.core.jdk.jfr.test;
+
+import org.graalvm.collections.EconomicMap;
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.oracle.svm.core.jdk.jfr.JfrOptions;
+
+public class JfrOptionsTest {
+
+    // Taken from GlobalDefinitions.hpp
+    private static final long K = 1024;
+    private static final long M = K*K;
+    private static final long G = M*K;
+
+    @Test
+    public void testBasicOptions() {
+        JfrOptions.StartFlightRecordingOption.update(EconomicMap.create(), "dumponexit=true");
+        Assert.assertEquals(JfrOptions.getDumpOnExit(), true);
+    }
+
+    @Test
+    public void testValidMemoryOptions() {
+        JfrOptions.StartFlightRecordingOption.update(EconomicMap.create(), "memorysize=256m," +
+                "globalbuffersize=128m,globalbuffercount=2,threadbuffersize=8k");
+        Assert.assertEquals(JfrOptions.getGlobalBufferSize(), 128 * M);
+        Assert.assertEquals(JfrOptions.getMemorySize(), 256*M);
+        Assert.assertEquals(JfrOptions.getGlobalBufferCount(), 2);
+    }
+
+    @Test
+    public void testInvalidMemoryOptions() {
+        try {
+            JfrOptions.StartFlightRecordingOption.update(EconomicMap.create(), "memorysize=1k");
+        } catch (IllegalArgumentException e) {
+            // Pass
+            return;
+        }
+        Assert.fail();
+    }
+
+    @Test
+    public void testBadInput() {
+        try {
+            JfrOptions.StartFlightRecordingOption.update(EconomicMap.create(), "memorysize=thisShouldFail");
+        } catch (Exception e) {
+            // Pass
+            return;
+        }
+        Assert.fail();
+    }
+
+    @Test
+    public void testTimeOptions() {
+        JfrOptions.StartFlightRecordingOption.update(EconomicMap.create(),"delay=10s,maxage=1h,duration=2m");
+        Assert.assertEquals(10, JfrOptions.getRecordingDelay());
+        Assert.assertEquals(360, JfrOptions.getMaxAge());
+        Assert.assertEquals(120, JfrOptions.getDuration());
+    }
+
+    @Test
+    public void testMaxStackDepth() {
+        try {
+            JfrOptions.StartFlightRecordingOption.update(EconomicMap.create(),"stackdepth=9000");
+        } catch (Exception e) {
+            // Pass
+            return;
+        }
+        Assert.fail();
+    }
+
+    @Test
+    public void testNegativeStackDepth() {
+        try {
+            JfrOptions.StartFlightRecordingOption.update(EconomicMap.create(),"stackdepth=-10");
+        } catch (Exception e) {
+            // Pass
+            return;
+        }
+        Assert.fail();
+    }
+
+    @Test
+    public void testAllArguments() {
+        JfrOptions.StartFlightRecordingOption.update(EconomicMap.create(),
+                "maxchunksize=1k,globalbuffersize=1m,memorysize=2m,retransform=true," +
+                        "stackdepth=10,sampleprotection=true,samplethreads=true,old-object-queue-size=100," +
+                        "numglobalbuffers=2,threadbuffersize=4k,repository=/path/to/repository,dumponexit=false," +
+                        "name=recording,settings=/path/to/settings,delay=10s,duration=1m,disk=true,maxage=1h," +
+                        "maxsize=10k,path-to-gc-roots=true");
+        Assert.assertEquals(1*K, JfrOptions.getMaxChunkSize());
+        Assert.assertEquals(1*M, JfrOptions.getGlobalBufferSize());
+        Assert.assertEquals(2, JfrOptions.getGlobalBufferCount());
+        Assert.assertEquals(2*M, JfrOptions.getMemorySize());
+        Assert.assertEquals(true, JfrOptions.isRetransformEnabled());
+        Assert.assertEquals(10, JfrOptions.getStackDepth());
+        Assert.assertEquals(true, JfrOptions.isSampleProtectionEnabled());
+        Assert.assertEquals(true, JfrOptions.isSampleThreadsEnabled());
+        Assert.assertEquals(100, JfrOptions.getObjectQueueSize());
+        Assert.assertEquals(2, JfrOptions.getGlobalBufferCount());
+        Assert.assertEquals(4*K, JfrOptions.getThreadBufferSize());
+        Assert.assertEquals("/path/to/repository", JfrOptions.getRepositoryLocation());
+        Assert.assertEquals(false, JfrOptions.getDumpOnExit());
+        Assert.assertEquals("recording", JfrOptions.getRecordingName());
+        Assert.assertEquals("/path/to/settings", JfrOptions.getRecordingSettingsFile());
+        Assert.assertEquals(10, JfrOptions.getRecordingDelay());
+        Assert.assertEquals(60, JfrOptions.getDuration());
+        Assert.assertEquals(true, JfrOptions.isPersistedToDisk());
+        Assert.assertEquals(360, JfrOptions.getMaxAge());
+        Assert.assertEquals(10*K, JfrOptions.getMaxRecordingSize());
+        Assert.assertEquals(true, JfrOptions.trackPathToGcRoots());
+    }
+
+}

--- a/substratevm/src/com.oracle.svm.core.jdk.jfr.test/src/com/oracle/svm/core/jdk/jfr/test/JfrOptionsTest.java
+++ b/substratevm/src/com.oracle.svm.core.jdk.jfr.test/src/com/oracle/svm/core/jdk/jfr/test/JfrOptionsTest.java
@@ -79,9 +79,9 @@ public class JfrOptionsTest {
     @Test
     public void testTimeOptions() {
         JfrOptions.StartFlightRecordingOption.update(EconomicMap.create(),"delay=10s,maxage=1h,duration=2m");
-        Assert.assertEquals(10, JfrOptions.getRecordingDelay());
-        Assert.assertEquals(360, JfrOptions.getMaxAge());
-        Assert.assertEquals(120, JfrOptions.getDuration());
+        Assert.assertEquals(10000, JfrOptions.getRecordingDelay());
+        Assert.assertEquals(360000, JfrOptions.getMaxAge());
+        Assert.assertEquals(120000, JfrOptions.getDuration());
     }
 
     @Test
@@ -129,10 +129,10 @@ public class JfrOptionsTest {
         Assert.assertEquals(false, JfrOptions.getDumpOnExit());
         Assert.assertEquals("recording", JfrOptions.getRecordingName());
         Assert.assertEquals("/path/to/settings", JfrOptions.getRecordingSettingsFile());
-        Assert.assertEquals(10, JfrOptions.getRecordingDelay());
-        Assert.assertEquals(60, JfrOptions.getDuration());
+        Assert.assertEquals(10000, JfrOptions.getRecordingDelay());
+        Assert.assertEquals(60000, JfrOptions.getDuration());
         Assert.assertEquals(true, JfrOptions.isPersistedToDisk());
-        Assert.assertEquals(360, JfrOptions.getMaxAge());
+        Assert.assertEquals(360000, JfrOptions.getMaxAge());
         Assert.assertEquals(10*K, JfrOptions.getMaxRecordingSize());
         Assert.assertEquals(true, JfrOptions.trackPathToGcRoots());
     }

--- a/substratevm/src/com.oracle.svm.core.jdk.jfr.test/src/com/oracle/svm/core/jdk/jfr/test/event/TestConcurrentEvents.java
+++ b/substratevm/src/com.oracle.svm.core.jdk.jfr.test/src/com/oracle/svm/core/jdk/jfr/test/event/TestConcurrentEvents.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2020, 2021, Red Hat, Inc.
+ *
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This file is part of the Red Hat GraalVM Testing Suite (the suite).
+ *
+ * The suite is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ * Foobar is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Foobar.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.oracle.svm.core.jdk.jfr.test.event;
+
+import com.oracle.svm.core.jdk.jfr.test.utils.events.StringEvent;
+import com.oracle.svm.core.jdk.jfr.test.utils.JFR;
+import com.oracle.svm.core.jdk.jfr.test.utils.LocalJFR;
+import com.oracle.svm.core.jdk.jfr.test.utils.Stressor;
+
+import jdk.jfr.Recording;
+import jdk.jfr.consumer.RecordedEvent;
+import jdk.jfr.consumer.RecordingFile;
+
+import static org.junit.Assert.assertEquals;
+import org.junit.Test;
+
+public class TestConcurrentEvents {
+
+    @Test
+    public void test() throws Exception {
+        JFR jfr = new LocalJFR();
+        int threadCount = 8;
+        Recording recording = jfr.startRecording("TestConcurrentEvents");
+
+        int count = 1024 * 1024;
+        Runnable r = () -> {
+            for (int i = 0; i < count; i++) {
+                StringEvent event = new StringEvent();
+                event.message = "Event has been generated!";
+                event.commit();
+            }
+        };
+        Thread.UncaughtExceptionHandler eh = (t, e) -> e.printStackTrace();
+        Stressor.execute(threadCount, eh, r);
+
+        jfr.endRecording(recording);
+
+        try (RecordingFile recordingFile = new RecordingFile(recording.getDestination())) {
+            long numEvents = 0;
+            while (recordingFile.hasMoreEvents()) {
+                RecordedEvent recordedEvent = recordingFile.readEvent();
+                if ("com.oracle.svm.core.jdk.jfr.test.utils.events.StringEvent".equals(recordedEvent.getEventType().getName())) {
+                    numEvents++;
+                    assertEquals("Event has been generated!", recordedEvent.getValue("message"));
+                }
+            }
+            assertEquals(threadCount * count, numEvents);
+        } finally {
+            jfr.cleanupRecording(recording);
+        }
+    }
+}

--- a/substratevm/src/com.oracle.svm.core.jdk.jfr.test/src/com/oracle/svm/core/jdk/jfr/test/event/TestMultipleEvents.java
+++ b/substratevm/src/com.oracle.svm.core.jdk.jfr.test/src/com/oracle/svm/core/jdk/jfr/test/event/TestMultipleEvents.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2020, 2021, Red Hat, Inc.
+ *
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This file is part of the Red Hat GraalVM Testing Suite (the suite).
+ *
+ * The suite is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ * Foobar is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Foobar.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.oracle.svm.core.jdk.jfr.test.event;
+
+import com.oracle.svm.core.jdk.jfr.test.utils.events.StringEvent;
+import com.oracle.svm.core.jdk.jfr.test.utils.JFR;
+import com.oracle.svm.core.jdk.jfr.test.utils.LocalJFR;
+
+import jdk.jfr.Recording;
+import jdk.jfr.consumer.RecordedEvent;
+import jdk.jfr.consumer.RecordingFile;
+
+import static org.junit.Assert.assertEquals;
+import org.junit.Test;
+
+public class TestMultipleEvents {
+
+    @Test
+    public void test() throws Exception {
+        long s0 = System.currentTimeMillis();
+        JFR jfr = new LocalJFR();
+        Recording recording = jfr.startRecording("TestMultipleEvents");
+
+        int count = 1024 * 1024;
+
+
+        for (int i = 0; i < count; i++) {
+            StringEvent event = new StringEvent();
+            event.message = "Event has been generated!";
+            event.commit();
+        }
+
+        jfr.endRecording(recording);
+
+        try (RecordingFile recordingFile = new RecordingFile(recording.getDestination())) {
+            long numEvents = 0;
+            while (recordingFile.hasMoreEvents()) {
+                RecordedEvent recordedEvent = recordingFile.readEvent();
+                if ("com.oracle.svm.core.jdk.jfr.test.utils.events.StringEvent".equals(recordedEvent.getEventType().getName())) {
+                    numEvents++;
+                    assertEquals("Event has been generated!", recordedEvent.getValue("message"));
+                }
+            }
+            assertEquals(count, numEvents);
+        } finally {
+            jfr.cleanupRecording(recording);
+        }
+    }
+}

--- a/substratevm/src/com.oracle.svm.core.jdk.jfr.test/src/com/oracle/svm/core/jdk/jfr/test/event/TestSingleEvent.java
+++ b/substratevm/src/com.oracle.svm.core.jdk.jfr.test/src/com/oracle/svm/core/jdk/jfr/test/event/TestSingleEvent.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2020, 2021, Red Hat, Inc.
+ *
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This file is part of the Red Hat GraalVM Testing Suite (the suite).
+ *
+ * The suite is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ * Foobar is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Foobar.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.oracle.svm.core.jdk.jfr.test.event;
+
+import com.oracle.svm.core.jdk.jfr.test.utils.events.StringEvent;
+import com.oracle.svm.core.jdk.jfr.test.utils.JFR;
+import com.oracle.svm.core.jdk.jfr.test.utils.LocalJFR;
+
+import jdk.jfr.Recording;
+import jdk.jfr.consumer.RecordedEvent;
+import jdk.jfr.consumer.RecordingFile;
+
+import static org.junit.Assert.assertEquals;
+import org.junit.Test;
+
+public class TestSingleEvent {
+
+    @Test
+    public void test() throws Exception {
+        JFR jfr = new LocalJFR();
+        Recording recording = jfr.startRecording("TestSingleEvent");
+
+        StringEvent event = new StringEvent();
+        event.message = "Event has been generated!";
+        event.commit();
+
+        jfr.endRecording(recording);
+
+        try (RecordingFile recordingFile = new RecordingFile(recording.getDestination())) {
+            long numEvents = 0;
+            while (recordingFile.hasMoreEvents()) {
+                RecordedEvent recordedEvent = recordingFile.readEvent();
+                if ("com.oracle.svm.core.jdk.jfr.test.utils.events.StringEvent".equals(recordedEvent.getEventType().getName())) {
+                    numEvents++;
+                    assertEquals("Event has been generated!", recordedEvent.getValue("message"));
+                }
+            }
+            assertEquals(1, numEvents);
+        } finally {
+            jfr.cleanupRecording(recording);
+        }
+    }
+}

--- a/substratevm/src/com.oracle.svm.core.jdk.jfr.test/src/com/oracle/svm/core/jdk/jfr/test/recording/TestConsecutiveRecordings.java
+++ b/substratevm/src/com.oracle.svm.core.jdk.jfr.test/src/com/oracle/svm/core/jdk/jfr/test/recording/TestConsecutiveRecordings.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2020, 2021, Red Hat, Inc.
+ *
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This file is part of the Red Hat GraalVM Testing Suite (the suite).
+ *
+ * The suite is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ * Foobar is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Foobar.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.oracle.svm.core.jdk.jfr.test.recording;
+
+import com.oracle.svm.core.jdk.jfr.test.utils.JFR;
+import com.oracle.svm.core.jdk.jfr.test.utils.LocalJFR;
+import com.oracle.svm.core.jdk.jfr.test.utils.events.StringEvent;
+
+import jdk.jfr.Recording;
+
+import jdk.jfr.consumer.RecordedEvent;
+import jdk.jfr.consumer.RecordingFile;
+
+import static org.junit.Assert.assertEquals;
+import org.junit.Test;
+
+public class TestConsecutiveRecordings {
+    @Test
+    public void test() throws Exception {
+        JFR jfr = new LocalJFR();
+        Recording recording1 = jfr.startRecording("One");
+        for (int i = 0; i < 2; i++) {
+            StringEvent event = new StringEvent();
+            event.message = "Event has been generated!";
+            event.commit();
+        }
+        jfr.endRecording(recording1);
+
+        Recording recording2 = jfr.startRecording("Two");
+        for (int i = 0; i < 2; i++) {
+            StringEvent event = new StringEvent();
+            event.message = "Event has been generated!";
+            event.commit();
+        }
+        jfr.endRecording(recording2);
+
+        try (RecordingFile recordingFile = new RecordingFile(recording1.getDestination())) {
+            long numEvents = 0;
+            while (recordingFile.hasMoreEvents()) {
+                RecordedEvent recordedEvent = recordingFile.readEvent();
+                if ("com.oracle.svm.core.jdk.jfr.test.utils.events.StringEvent".equals(recordedEvent.getEventType().getName())) {
+                    numEvents++;
+                    assertEquals("Event has been generated!", recordedEvent.getValue("message"));
+                }
+            }
+            assertEquals(2, numEvents);
+        } finally {
+            jfr.cleanupRecording(recording1);
+        }
+        try (RecordingFile recordingFile = new RecordingFile(recording2.getDestination())) {
+            long numEvents = 0;
+            while (recordingFile.hasMoreEvents()) {
+                RecordedEvent recordedEvent = recordingFile.readEvent();
+                if ("com.oracle.svm.core.jdk.jfr.test.utils.events.StringEvent".equals(recordedEvent.getEventType().getName())) {
+                    numEvents++;
+                    assertEquals("Event has been generated!", recordedEvent.getValue("message"));
+                }
+            }
+            assertEquals(2, numEvents);
+        } finally {
+            jfr.cleanupRecording(recording2);
+        }
+    }
+}

--- a/substratevm/src/com.oracle.svm.core.jdk.jfr.test/src/com/oracle/svm/core/jdk/jfr/test/recording/TestInterspersedRecordings.java
+++ b/substratevm/src/com.oracle.svm.core.jdk.jfr.test/src/com/oracle/svm/core/jdk/jfr/test/recording/TestInterspersedRecordings.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2020, 2021, Red Hat, Inc.
+ *
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This file is part of the Red Hat GraalVM Testing Suite (the suite).
+ *
+ * The suite is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ * Foobar is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Foobar.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.oracle.svm.core.jdk.jfr.test.recording;
+
+import com.oracle.svm.core.jdk.jfr.test.utils.JFR;
+import com.oracle.svm.core.jdk.jfr.test.utils.LocalJFR;
+import com.oracle.svm.core.jdk.jfr.test.utils.events.StringEvent;
+
+import jdk.jfr.Recording;
+import jdk.jfr.consumer.RecordedEvent;
+import jdk.jfr.consumer.RecordingFile;
+
+import static org.junit.Assert.assertEquals;
+import org.junit.Test;
+
+public class TestInterspersedRecordings {
+    @Test
+    public void test() throws Exception {
+        JFR jfr = new LocalJFR();
+        Recording recording1 = jfr.startRecording("One");
+        Recording recording2 = jfr.startRecording("Two");
+
+        for (int i = 0; i < 2; i++) {
+            StringEvent event = new StringEvent();
+            event.message = "Event has been generated!";
+            event.commit();
+        }
+
+        jfr.endRecording(recording1);
+
+        for (int i = 0; i < 2; i++) {
+            StringEvent event = new StringEvent();
+            event.message = "Event has been generated!";
+            event.commit();
+        }
+
+        jfr.endRecording(recording2);
+
+        try (RecordingFile recordingFile = new RecordingFile(recording1.getDestination())) {
+            long numEvents = 0;
+            while (recordingFile.hasMoreEvents()) {
+                RecordedEvent recordedEvent = recordingFile.readEvent();
+                if ("com.oracle.svm.core.jdk.jfr.test.utils.events.StringEvent".equals(recordedEvent.getEventType().getName())) {
+                    numEvents++;
+                    assertEquals("Event has been generated!", recordedEvent.getValue("message"));
+                }
+            }
+            assertEquals(2, numEvents);
+        } finally {
+            jfr.cleanupRecording(recording1);
+        }
+        try (RecordingFile recordingFile = new RecordingFile(recording2.getDestination())) {
+            long numEvents = 0;
+            while (recordingFile.hasMoreEvents()) {
+                RecordedEvent recordedEvent = recordingFile.readEvent();
+                if ("com.oracle.svm.core.jdk.jfr.test.utils.events.StringEvent".equals(recordedEvent.getEventType().getName())) {
+                    numEvents++;
+                    assertEquals("Event has been generated!", recordedEvent.getValue("message"));
+                }
+            }
+            assertEquals(4, numEvents);
+        } finally {
+            jfr.cleanupRecording(recording2);
+        }
+    }
+}

--- a/substratevm/src/com.oracle.svm.core.jdk.jfr.test/src/com/oracle/svm/core/jdk/jfr/test/utils/JFR.java
+++ b/substratevm/src/com.oracle.svm.core.jdk.jfr.test/src/com/oracle/svm/core/jdk/jfr/test/utils/JFR.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2020, 2021, Red Hat, Inc.
+ *
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This file is part of the Red Hat GraalVM Testing Suite (the suite).
+ *
+ * The suite is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ * Foobar is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Foobar.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.oracle.svm.core.jdk.jfr.test.utils;
+
+import java.io.IOException;
+
+import jdk.jfr.Recording;
+
+/**
+ * Utility class to handle recording.
+ */
+public interface JFR {
+    Recording startRecording(String recordingName) throws Exception;
+
+    Recording startRecording(String recordingName, String configName) throws Exception;
+
+    void endRecording(Recording recording) throws Exception;
+
+    void cleanupRecording(Recording recording) throws IOException;
+}

--- a/substratevm/src/com.oracle.svm.core.jdk.jfr.test/src/com/oracle/svm/core/jdk/jfr/test/utils/LocalJFR.java
+++ b/substratevm/src/com.oracle.svm.core.jdk.jfr.test/src/com/oracle/svm/core/jdk/jfr/test/utils/LocalJFR.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2020, 2021, Red Hat, Inc.
+ *
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This file is part of the Red Hat GraalVM Testing Suite (the suite).
+ *
+ * The suite is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ * Foobar is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Foobar.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.oracle.svm.core.jdk.jfr.test.utils;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import jdk.jfr.Configuration;
+import jdk.jfr.Recording;
+
+public class LocalJFR implements JFR {
+
+    @Override
+    public Recording startRecording(String recordingName) throws Exception {
+        return startRecording(new Recording(), recordingName);
+    }
+
+    @Override
+    public Recording startRecording(String recordingName, String configName) throws Exception {
+        Configuration c = Configuration.getConfiguration(configName);
+        return startRecording(new Recording(c), recordingName);
+    }
+
+    private Recording startRecording(Recording recording, String name) throws Exception {
+        long id = recording.getId();
+
+        Path destination = File.createTempFile(name + "-" + id, ".jfr").toPath();
+        recording.setDestination(destination);
+
+        recording.start();
+        return recording;
+    }
+
+    @Override
+    public void endRecording(Recording recording) {
+        recording.stop();
+        recording.close();
+    }
+
+    @Override
+    public void cleanupRecording(Recording recording) throws IOException {
+        String debugRecording = System.getenv("DEBUG_RECORDING");
+        if (debugRecording != null && !"false".equals(debugRecording)) {
+            System.out.println("Recording: " + recording);
+        } else {
+            Files.deleteIfExists(recording.getDestination());
+        }
+    }
+}

--- a/substratevm/src/com.oracle.svm.core.jdk.jfr.test/src/com/oracle/svm/core/jdk/jfr/test/utils/Stressor.java
+++ b/substratevm/src/com.oracle.svm.core.jdk.jfr.test/src/com/oracle/svm/core/jdk/jfr/test/utils/Stressor.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package com.oracle.svm.core.jdk.jfr.test.utils;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Class to help run multiple threads executing some task
+ *
+ * @since 1.9
+ */
+public class Stressor {
+    public static void execute(int numberOfThreads, Thread.UncaughtExceptionHandler eh, Runnable task) throws Exception {
+        List<Thread> threads = new ArrayList<>();
+        for (int n = 0; n < numberOfThreads; ++n) {
+            Thread t = new Thread(task);
+            t.setUncaughtExceptionHandler(eh);
+            threads.add(t);
+            t.start();
+        }
+        for (Thread t : threads) {
+            t.join();
+        }
+    }
+}

--- a/substratevm/src/com.oracle.svm.core.jdk.jfr.test/src/com/oracle/svm/core/jdk/jfr/test/utils/events/StringEvent.java
+++ b/substratevm/src/com.oracle.svm.core.jdk.jfr.test/src/com/oracle/svm/core/jdk/jfr/test/utils/events/StringEvent.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2020, 2021, Red Hat, Inc.
+ *
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This file is part of the Red Hat GraalVM Testing Suite (the suite).
+ *
+ * The suite is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ * Foobar is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Foobar.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.oracle.svm.core.jdk.jfr.test.utils.events;
+
+import jdk.jfr.Description;
+import jdk.jfr.Event;
+import jdk.jfr.Label;
+import jdk.jfr.StackTrace;
+
+@Label("String Event")
+@Description("An event with a string payload")
+@StackTrace(false)
+public class StringEvent extends Event {
+
+    @Label("Message")
+    public String message;
+}

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/jfr/JavaJfrUtils.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/jfr/JavaJfrUtils.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, Red Hat Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package com.oracle.svm.core.jdk.jfr;
+
+public class JavaJfrUtils {
+    public static boolean isJFRClass(Class<?> clazz) {
+
+        if (clazz.isInterface()) {
+            return false;
+        }
+
+        Class<?> targetClass = clazz;
+        String targetClassName = targetClass.getCanonicalName();
+
+        // a bit convoluted but needed to avoid referencing classes by name so we don't need to open internal
+        // jfr packages
+
+        while (targetClassName != null && !targetClassName.equals("java.lang.Object")) {
+            if (targetClassName.equals("jdk.internal.event.Event") ||
+                targetClassName.equals("jdk.jfr.internal.handlers.EventHandler")) {
+                return true;
+            }
+
+            targetClass = targetClass.getSuperclass();
+            targetClassName = targetClass.getCanonicalName();
+        }
+
+        return false;
+    }
+
+}

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/jfr/Jfr.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/jfr/Jfr.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, Red Hat Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package com.oracle.svm.core.jdk.jfr;
+
+import com.oracle.svm.core.jdk.jfr.recorder.JfrRecorder;
+import com.oracle.svm.core.jdk.jfr.support.JfrThreadLocal;
+
+public class Jfr {
+
+    public static boolean isEnabled() {
+        return JfrRecorder.isEnabled();
+    }
+
+    public static boolean isDisabled() {
+        return JfrRecorder.isDisabled();
+    }
+
+    public static boolean isRecording() {
+        return JfrRecorder.isRecording();
+    }
+
+    public static void excludeThread(Thread t) {
+        JfrThreadLocal.excludeThread(t);
+    }
+
+}

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/jfr/JfrAvailability.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/jfr/JfrAvailability.java
@@ -1,0 +1,15 @@
+package com.oracle.svm.core.jdk.jfr;
+
+import java.util.function.BooleanSupplier;
+
+import org.graalvm.compiler.serviceprovider.JavaVersionUtil;
+
+public class JfrAvailability {
+    public static boolean withJfr = false;
+    public static class WithJfr implements BooleanSupplier {
+        @Override
+        public boolean getAsBoolean() {
+            return JavaVersionUtil.JAVA_SPEC >= 11 && withJfr;
+        }
+    }
+}

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/jfr/JfrFeature.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/jfr/JfrFeature.java
@@ -32,12 +32,14 @@ import java.lang.reflect.Method;
 import java.util.HashSet;
 import java.util.Set;
 
+import com.oracle.svm.core.jdk.RuntimeSupport;
 import org.graalvm.nativeimage.ImageSingletons;
 import org.graalvm.nativeimage.hosted.Feature;
 import org.graalvm.nativeimage.hosted.RuntimeReflection;
 
 import com.oracle.svm.core.annotate.AutomaticFeature;
 import com.oracle.svm.core.jdk.jfr.logging.JfrLogger;
+import com.oracle.svm.core.jdk.jfr.remote.JfrAutoSessionManager;
 import com.oracle.svm.core.jdk.jfr.recorder.checkpoint.types.traceid.JfrTraceId;
 
 import jdk.internal.event.Event;
@@ -47,6 +49,15 @@ public class JfrFeature implements Feature {
     @Override
     public void afterRegistration(AfterRegistrationAccess access) {
         ImageSingletons.add(JfrRuntimeAccess.class, new JfrRuntimeAccessImpl());
+    }
+
+    @Override
+    public void beforeAnalysis(BeforeAnalysisAccess access) {
+        if (JfrAvailability.withJfr) {
+            // JFR-TODO: test command line options for startup timer, file output, etc.
+            RuntimeSupport.getRuntimeSupport().addStartupHook(JfrAutoSessionManager::startupHook);
+            RuntimeSupport.getRuntimeSupport().addShutdownHook(JfrAutoSessionManager::shutdownHook);
+        }
     }
 
     @Override

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/jfr/JfrFeature.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/jfr/JfrFeature.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, Red Hat Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package com.oracle.svm.core.jdk.jfr;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.graalvm.nativeimage.ImageSingletons;
+import org.graalvm.nativeimage.hosted.Feature;
+import org.graalvm.nativeimage.hosted.RuntimeReflection;
+
+import com.oracle.svm.core.annotate.AutomaticFeature;
+import com.oracle.svm.core.jdk.jfr.logging.JfrLogger;
+import com.oracle.svm.core.jdk.jfr.recorder.checkpoint.types.traceid.JfrTraceId;
+
+import jdk.internal.event.Event;
+
+@AutomaticFeature
+public class JfrFeature implements Feature {
+    @Override
+    public void afterRegistration(AfterRegistrationAccess access) {
+        ImageSingletons.add(JfrRuntimeAccess.class, new JfrRuntimeAccessImpl());
+    }
+
+    @Override
+    public void afterAnalysis(AfterAnalysisAccess access) {
+        if (!JfrAvailability.withJfr) {
+            return;
+        }
+        Class<?> eventClass = access.findClassByName("jdk.internal.event.Event");
+        JfrRuntimeAccess jfrRuntime = ImageSingletons.lookup(JfrRuntimeAccess.class);
+        if (eventClass != null && access.isReachable(eventClass)) {
+            Set<Class<?>> s = access.reachableSubtypes(eventClass);
+            s.forEach(c -> jfrRuntime.addEventClass((Class<? extends Event>) c));
+        }
+        Set<Class<?>> reachableClasses = access.reachableSubtypes(Object.class);
+        Set<ClassLoader> classLoaders = new HashSet<>();
+        Set<Module> modules = new HashSet<>();
+        for (Class<?> clazz : reachableClasses) {
+            if (JfrTraceId.getTraceId(clazz) == -1) {
+                JfrTraceId.assign(clazz);
+            }
+            ClassLoader cl = clazz.getClassLoader();
+            if (cl != null && !classLoaders.contains(cl)) {
+                JfrTraceId.assign(cl);
+                classLoaders.add(cl);
+                if (access.isReachable(cl.getClass())) {
+                    jfrRuntime.addClassloader(cl);
+                }
+            }
+            Module module = clazz.getModule();
+            if (module != null && !modules.contains(module)) {
+                JfrTraceId.assign(module);
+                modules.add(module);
+            }
+            // Packages are assigned a TraceId at runtime when first used in a constant pool
+        }
+
+    }
+
+    @Override
+    public void duringAnalysis(DuringAnalysisAccess access) {
+        if (!JfrAvailability.withJfr) {
+            return;
+        }
+        Class<?> eventClass = access.findClassByName("jdk.jfr.internal.instrument.JDKEvents");
+        if (eventClass != null && access.isReachable(eventClass)) {
+            try {
+                Method initialize = eventClass.getMethod("initialize");
+                initialize.setAccessible(true);
+                initialize.invoke(null);
+
+            } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
+                e.printStackTrace();
+            }
+        }
+
+        eventClass = access.findClassByName("jdk.internal.event.Event");
+        if (eventClass != null && access.isReachable(eventClass)) {
+            Set<Class<?>> s = access.reachableSubtypes(eventClass);
+            for (Class<?> c : s) {
+                if (c.getCanonicalName().equals("jdk.jfr.Event")
+                        || c.getCanonicalName().equals("jdk.internal.event.Event")
+                        || c.getCanonicalName().equals("jdk.jfr.events.AbstractJDKEvent")) {
+                    continue;
+                }
+                try {
+                    Field f = c.getDeclaredField("eventHandler");
+                    RuntimeReflection.register(f);
+                } catch (Exception e) {
+                    JfrLogger.logError("Unable to register eventHandler for:", c.getCanonicalName());
+                }
+            }
+        } else {
+            JfrLogger.logError("Unable to register fields for jfr event subclasses");
+        }
+    }
+}

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/jfr/JfrOptions.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/jfr/JfrOptions.java
@@ -79,6 +79,7 @@ public class JfrOptions {
     private static final String REPOSITORY = "repository";
     // Arguments from JfrDcmds.cpp
     private static final String DUMPONEXIT = "dumponexit";
+    private static final String FILENAME = "filename";
     private static final String NAME = "name";
     private static final String SETTINGS = "settings";
     private static final String DELAY = "delay";
@@ -179,7 +180,6 @@ public class JfrOptions {
         return true;
     }
 
-
     public static boolean parseStartFlightRecordingOption(String args) {
         if (args.equals("")) {
             // -XX:StartFlightRecording without any delimiter and values
@@ -236,6 +236,9 @@ public class JfrOptions {
                         break;
                     case DISK:
                         persistToDisk = Boolean.parseBoolean(val);
+                        break;
+                    case FILENAME:
+                        filename = val;
                         break;
                     case GCROOTS:
                         pathToGcRoots = Boolean.parseBoolean(val);

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/jfr/JfrOptions.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/jfr/JfrOptions.java
@@ -271,16 +271,18 @@ public class JfrOptions {
 
     private static long parseTimeOption(String arg) {
         String adjusted = arg.toLowerCase();
-        if (adjusted.contains("s")) {
-            return Long.parseLong(adjusted.split("s")[0]);
-        } else if (adjusted.contains("m")) {
-            return Long.parseLong(adjusted.split("m")[0]) * 60;
-        } else if (adjusted.contains("h")) {
-            return Long.parseLong(adjusted.split("h")[0]) * 360;
-        } else if (adjusted.contains("d")) {
-            return Long.parseLong(adjusted.split("d")[0]) * 60 * 60 * 24;
+        if (adjusted.endsWith("ms")) {
+            return Long.parseLong(adjusted.split("ms")[0]);
+        } else if (adjusted.endsWith("s")) {
+            return Long.parseLong(adjusted.split("s")[0]) * 1000;
+        } else if (adjusted.endsWith("m")) {
+            return Long.parseLong(adjusted.split("m")[0]) * 1000 * 60;
+        } else if (adjusted.endsWith("h")) {
+            return Long.parseLong(adjusted.split("h")[0]) * 1000 * 360;
+        } else if (adjusted.endsWith("d")) {
+            return Long.parseLong(adjusted.split("d")[0]) * 1000 * 60 * 60 * 24;
         } else {
-            throw new IllegalArgumentException("Invalid time specified for " + arg + " specify time lengths with s, m, h, or d");
+            throw new IllegalArgumentException("Invalid time specified for " + arg + " specify time lengths with ms, s, m, h, or d");
         }
     }
 

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/jfr/JfrOptions.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/jfr/JfrOptions.java
@@ -1,0 +1,566 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, Red Hat Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package com.oracle.svm.core.jdk.jfr;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.graalvm.collections.EconomicMap;
+import org.graalvm.compiler.options.Option;
+import org.graalvm.compiler.options.OptionKey;
+
+import com.oracle.svm.core.jdk.jfr.logging.JfrLogger;
+import com.oracle.svm.core.option.RuntimeOptionKey;
+
+// Translated from JfrOptionSet.cpp
+public class JfrOptions {
+
+    // Taken from GlobalDefinitions.hpp
+    private static final int K = 1024;
+    private static final int M = K * K;
+    private static final int G = M * K;
+
+    private static final int MIN_STACK_DEPTH = 1;
+    private static final int MAX_STACK_DEPTH = 2048;
+
+    // Taken from JfrMemorySizer.cpp
+    private static final int MAX_ADJUSTED_GLOBAL_BUFFER_SIZE = 1 * M;
+    private static final int MIN_ADJUSTED_GLOBAL_BUFFER_SIZE_CUTOFF = 512 * K;
+    private static final int MIN_GLOBAL_BUFFER_SIZE = 64 * K;
+    // implies at least 2 * MIN_GLOBAL_BUFFER SIZE
+    private static final int MIN_BUFFER_COUNT = 2;
+    // MAX global buffer count open ended
+    private static final int DEFAULT_BUFFER_COUNT = 20;
+    // MAX thread local buffer size == size of a single global buffer (runtime determined)
+    // DEFAULT thread local buffer size = 2 * os page size (runtime determined)
+    private static final int MIN_THREAD_BUFFER_SIZE = 4 * K;
+    private static final int MIN_MEMORY_SIZE = 1 * M;
+
+    private static final int DEFAULT_MAX_CHUNK_SIZE = 12 * 1024 * 1024;
+    private static final int MIN_MAX_CHUNKSIZE = 1024 * 1024;
+
+    private static final String DELIMITER = ",";
+    private static final String ARGUMENT_DELIMITER = "=";
+    private static final String CHUNK_SIZE_ARG = "maxchunksize";
+    private static final String GLOBAL_BUFFER_SIZE_ARG = "globalbuffersize";
+    private static final String MEMORY_SIZE_ARG = "memorysize";
+    private static final String RETRANSFORM = "retransform";
+    private static final String STACK_DEPTH = "stackdepth";
+    private static final String SAMPLE_PROTECTION = "sampleprotection";
+    private static final String SAMPLE_THREADS = "samplethreads";
+    private static final String OLD_OBJECT_QUEUE_SIZE = "old-object-queue-size";
+    private static final String NUM_GLOBAL_BUFFERS = "numglobalbuffers";
+    private static final String THREAD_BUFFER_SIZE = "threadbuffersize";
+    private static final String REPOSITORY = "repository";
+    // Arguments from JfrDcmds.cpp
+    private static final String DUMPONEXIT = "dumponexit";
+    private static final String NAME = "name";
+    private static final String SETTINGS = "settings";
+    private static final String DELAY = "delay";
+    private static final String DURATION = "duration";
+    private static final String DISK = "disk";
+    private static final String MAXAGE = "maxage";
+    private static final String MAXSIZE = "maxsize";
+    private static final String GCROOTS = "path-to-gc-roots";
+
+    // Thread Buffer Size, Memory Size, Global Buffer size, Max Chunk Size, Max Recording size are memory arguments
+    private static int maxChunkSize = DEFAULT_MAX_CHUNK_SIZE;
+    private static int globalBufferSize = 512 * K;
+    private static int memorySize = 10 * M;
+    private static int threadBufferSize = 8 * K;
+    private static int globalBufferCount = 20;
+    private static int oldObjectQueueSize = 256;
+    private static int maxRecordingSize = 0; // 0 is a special value indicating no limit
+    private static int stackDepth = 64;
+
+    // Delay, Duration, Max Age are time arguments
+    private static long delay = 0;
+    private static long duration = 0;
+    private static long maxAge = 0; // 0 is a special value indicating no limit
+
+    private static boolean sampleThreads = true;
+    private static boolean retransform = true;
+    private static boolean sampleProtection = false; // Defaults to false if ASSERT is defined, otherwise defaults to true
+    private static boolean dumpOnExit = false;
+    private static boolean persistToDisk = false;
+    private static boolean pathToGcRoots = false;
+
+    private static String repositoryLocation = "";
+    private static String filename = "";
+    private static String recordingName = "";
+    private static String recordingSettingsFile = "";
+
+    private static int logLevel = Integer.MAX_VALUE;
+
+    private static final ArrayList<String> startFlightRecordingOptionsArray = new ArrayList<>();
+
+    static {
+        // has a side effect call to jdk.jfr.internal.JVM
+        setMaxChunkSize(DEFAULT_MAX_CHUNK_SIZE);
+    }
+
+    @Option(help = "Enable flight recorder logging with options")
+    public static final RuntimeOptionKey<String> FlightRecorderLogging = new RuntimeOptionKey<String>("") {
+        @Override
+        protected void onValueUpdate(EconomicMap<OptionKey<?>, Object> values, String oldValue, String newValue) {
+            parseFlightRecorderLoggingOption(newValue);
+        }
+    };
+
+    @Option(help = "Start a flight recording with the given parameters")
+    public static final RuntimeOptionKey<String> StartFlightRecordingOption = new RuntimeOptionKey<String>("") {
+        @Override
+        protected void onValueUpdate(EconomicMap<OptionKey<?>, Object> values, String oldValue, String newValue) {
+            // Substrate parses it into option=value,option2=value,.... We can pass it on to our own parsing methods from here
+            parseStartFlightRecordingOption(newValue);
+            // Do the sanity checks to make sure we have valid options
+            if (!adjustMemoryOptions()) {
+                throw new IllegalArgumentException("Failed to validate memory arguments");
+            }
+        }
+    };
+
+    @Option(help = "Pass an option to flight recorder")
+    public static final RuntimeOptionKey<String> FlightRecorderOption = new RuntimeOptionKey<String>(""){
+        @Override
+        protected void onValueUpdate(EconomicMap<OptionKey<?>, Object> values, String oldValue, String newValue) {
+            parseStartFlightRecordingOption(newValue);
+            // Do the sanity checks to make sure we have valid options
+            if (!adjustMemoryOptions()) {
+                throw new IllegalArgumentException("Failed to validate memory arguments");
+            }
+        }
+    };
+
+    public static boolean parseFlightRecorderLoggingOption(String value) {
+        switch (value) {
+            case "":
+            case "error":
+                logLevel = JfrLogger.Level.ERROR.id;
+                break;
+            case "warning":
+                logLevel = JfrLogger.Level.WARNING.id;
+                break;
+            case "info":
+                logLevel = JfrLogger.Level.INFO.id;
+                break;
+            case "debug":
+                logLevel = JfrLogger.Level.DEBUG.id;
+                break;
+            case "trace":
+                logLevel = JfrLogger.Level.TRACE.id;
+                break;
+        }
+        return true;
+    }
+
+
+    public static boolean parseStartFlightRecordingOption(String args) {
+        if (args.equals("")) {
+            // -XX:StartFlightRecording without any delimiter and values
+            // No need to do anything here, just return and use defaults.
+            return true;
+        }
+        // This argument has the form -XX:StartFlightRecording=arg1=value,arg2=value,...
+        List<String> splitOptions = Arrays.asList(args.split(DELIMITER));
+        startFlightRecordingOptionsArray.addAll(splitOptions);
+        try {
+            for (String opt : splitOptions) {
+                String arg = opt.split(ARGUMENT_DELIMITER)[0];
+                String val = opt.split(ARGUMENT_DELIMITER)[1];
+                switch (arg) {
+                    case REPOSITORY:
+                        repositoryLocation = val;
+                        break;
+                    case DUMPONEXIT:
+                        dumpOnExit = Boolean.parseBoolean(val);
+                        break;
+                    case THREAD_BUFFER_SIZE:
+                        threadBufferSize = parseMemoryOption(val);
+                        break;
+                    case CHUNK_SIZE_ARG:
+                        maxChunkSize = parseMemoryOption(val);
+                        break;
+                    case GLOBAL_BUFFER_SIZE_ARG:
+                        globalBufferSize = parseMemoryOption(val);
+                        break;
+                    case MEMORY_SIZE_ARG:
+                        memorySize = parseMemoryOption(val);
+                        break;
+                    case RETRANSFORM:
+                        retransform = Boolean.parseBoolean(val);
+                        break;
+                    case STACK_DEPTH:
+                        if (verifyStackArguments(Integer.parseInt(val))) {
+                            stackDepth = Integer.parseInt(val);
+                        } else {
+                            throw new RuntimeException("Invalid Stack Depth specified. Stack depth must be between 1 and 2048.");
+                        }
+                        break;
+                    case SAMPLE_PROTECTION:
+                        sampleProtection = Boolean.parseBoolean(val);
+                        break;
+                    case SAMPLE_THREADS:
+                        sampleThreads = Boolean.parseBoolean(val);
+                        break;
+                    case OLD_OBJECT_QUEUE_SIZE:
+                        oldObjectQueueSize = Integer.parseInt(val);
+                        break;
+                    case NUM_GLOBAL_BUFFERS:
+                        globalBufferCount = Integer.parseInt(val);
+                        break;
+                    case DISK:
+                        persistToDisk = Boolean.parseBoolean(val);
+                        break;
+                    case GCROOTS:
+                        pathToGcRoots = Boolean.parseBoolean(val);
+                        break;
+                    case NAME:
+                        recordingName = val;
+                        break;
+                    case SETTINGS:
+                        recordingSettingsFile = val;
+                        break;
+                    case DELAY:
+                        delay = parseTimeOption(val);
+                        break;
+                    case DURATION:
+                        duration = parseTimeOption(val);
+                        break;
+                    case MAXAGE:
+                        maxAge = parseTimeOption(val);
+                        break;
+                    case MAXSIZE:
+                        maxRecordingSize = parseMemoryOption(val);
+                        break;
+                }
+            }
+        } catch (Exception e) {
+            throw e;
+        }
+        return true;
+    }
+
+    private static long parseTimeOption(String arg) {
+        String adjusted = arg.toLowerCase();
+        if (adjusted.contains("s")) {
+            return Long.parseLong(adjusted.split("s")[0]);
+        } else if (adjusted.contains("m")) {
+            return Long.parseLong(adjusted.split("m")[0]) * 60;
+        } else if (adjusted.contains("h")) {
+            return Long.parseLong(adjusted.split("h")[0]) * 360;
+        } else if (adjusted.contains("d")) {
+            return Long.parseLong(adjusted.split("d")[0]) * 60 * 60 * 24;
+        } else {
+            throw new IllegalArgumentException("Invalid time specified for " + arg + " specify time lengths with s, m, h, or d");
+        }
+    }
+
+    private static int parseMemoryOption(String arg) {
+        String adjusted = arg.toLowerCase();
+        if (adjusted.contains("k")) {
+            return Integer.parseInt(adjusted.split("k")[0]) * K;
+        } else if (arg.contains("m")) {
+            return Integer.parseInt(adjusted.split("m")[0]) * M;
+        } else if (arg.contains("g")) {
+            return Integer.parseInt(adjusted.split("g")[0]) * G;
+        } else {
+            throw new RuntimeException("Invalid memory format specified for " + arg + " specify memory sizes with M, K, or G");
+        }
+    }
+
+    // TODO: public static boolean configure() {
+    // Configure sets up and executes a dcmd with all of the currently specified values, we'll leave it alone for now
+
+    public static ArrayList<String> startFlightRecordingOptions() {
+        return startFlightRecordingOptionsArray;
+    }
+
+    public static boolean initialize() {
+        // Reference the Runtime Options so that they will be available at runtime
+        JfrOptions.StartFlightRecordingOption.getValue();
+        JfrOptions.FlightRecorderOption.getValue();
+        JfrOptions.FlightRecorderLogging.getValue();
+        // This is where we would register the jfr options with the dcmd parser, we don't need to do that here
+        // We can still run the sanity checks on the memory options though.
+        return adjustMemoryOptions();
+    }
+
+    // In the jfr sources this function adds all of the dcmd jfr options (repository, thread buffer size,
+    // memory size, global buffer size, number of global buffers, max chunk size, stackdepth, sample threads,
+    // retransform, old object queue size, and sample protection)
+    // If we don't want to support, or can't support dcmd control of jfr in substrate then we can skip this
+    // TODO: Implement this if it makes sense to do so
+    //  private static void registerParserOptions()
+
+    // In the jfr sources this function relies on the Dcmd parser for the heavy lifting, the bulk of it
+    // is memory wrangling and string manipulation to grab and log the pending exception, this makes our job
+    // here a bit easier. It's not needed unless we can/plan to support dcmd in substrate.
+    // TODO: Implement this if it makes sense to do so
+    // private static void parseFlightRecorderOptionsInternal()
+
+    public static int getMaxChunkSize() {
+        return maxChunkSize;
+    }
+
+    public static void setMaxChunkSize(int chunkSize) {
+        if (chunkSize < MIN_MAX_CHUNKSIZE) {
+            throw new IllegalArgumentException("Max chunk size must be at least " + MIN_MAX_CHUNKSIZE);
+        }
+        Target_jdk_jfr_internal_JVM.getJVM().setFileNotification(chunkSize);
+        maxChunkSize = chunkSize;
+    }
+
+    public static int getGlobalBufferSize() {
+        return globalBufferSize;
+    }
+
+    public static void setGlobalBufferSize(int bufferSize) {
+        globalBufferSize = bufferSize;
+    }
+
+    public static int getMemorySize() {
+        return memorySize;
+    }
+
+    public static void setMemorySize(int memorySize) {
+        JfrOptions.memorySize = memorySize;
+    }
+
+    public static int getThreadBufferSize() {
+        return threadBufferSize;
+    }
+
+    public static void setThreadBufferSize(int bufferSize) {
+        threadBufferSize = bufferSize;
+    }
+
+    public static int getGlobalBufferCount() {
+        return globalBufferCount;
+    }
+
+    public static void setGlobalBufferCount(int bufferCount) {
+        globalBufferCount = bufferCount;
+    }
+
+    public static long getObjectQueueSize() {
+        return oldObjectQueueSize;
+    }
+
+    public static void setObjectQueueSize(int queueSize) {
+        oldObjectQueueSize = queueSize;
+    }
+
+    public static int getStackDepth() {
+        return stackDepth;
+    }
+
+    public static void setStackDepth(int depth) {
+        if (depth < MIN_STACK_DEPTH) {
+            stackDepth = MIN_STACK_DEPTH;
+        } else if (depth > MAX_STACK_DEPTH) {
+            stackDepth = MAX_STACK_DEPTH;
+        } else {
+            stackDepth = depth;
+        }
+    }
+
+    public static boolean isSampleThreadsEnabled() {
+        return sampleThreads;
+    }
+
+    public static void setSampleThreads(boolean sampling) {
+        sampleThreads = sampling;
+    }
+
+    public static boolean isRetransformEnabled() {
+        return retransform;
+    }
+
+    public static void setRetransform(boolean retransformEnabled) {
+        retransform = retransformEnabled;
+    }
+
+    public static boolean isSampleProtectionEnabled() {
+        return sampleProtection;
+    }
+
+    // This is wrapped in an #ifdef ASSERT in the jdk sources
+    public static void setSampleProtection(boolean sampleProtection) {
+        JfrOptions.sampleProtection = sampleProtection;
+    }
+
+    public static boolean allowRetransforms() {
+        //TODO: Do we have a way of checking if JVMTI is present/enabled?
+        // #if INCLUDE_JVMTI
+        // return true
+        // #else
+        // return false
+        return false;
+    }
+
+    public static boolean allowEventRetransforms() {
+        // return allow_retransforms() && (DumpSharedSpaces || can_retransform());
+        return false;
+    }
+
+    public static boolean isPersistedToDisk() {
+        return persistToDisk;
+    }
+
+    public static boolean trackPathToGcRoots() {
+        return pathToGcRoots;
+    }
+
+    public static String getRecordingFileName() {
+        return filename;
+    }
+
+    public static String getRecordingName() {
+        return recordingName;
+    }
+
+    public static String getRecordingSettingsFile() {
+        return recordingSettingsFile;
+    }
+
+    public static String getRepositoryLocation() {
+        return repositoryLocation;
+    }
+
+    public static long getRecordingDelay() {
+        return delay;
+    }
+
+    public static long getDuration() {
+        return duration;
+    }
+
+    public static long getMaxAge() {
+        return maxAge;
+    }
+
+    public static long getMaxRecordingSize() {
+        return maxRecordingSize;
+    }
+
+    public static boolean getDumpOnExit() {
+        return dumpOnExit;
+    }
+
+    public static boolean compressedIntegers() {
+        return true;
+    }
+
+    public static int getLogLevel() {
+        return logLevel;
+    }
+
+     /* Starting with the initial set of memory values from the user,
+      * sanitize, enforce min/max rules and adjust to a set of consistent options.
+      *
+      * Adjusted memory sizes will be page aligned.
+      */
+    static boolean adjustMemoryOptions() {
+        if (!ensureValidMinimumSizes()) {
+            return false;
+        }
+        if (!validMemoryRelations()) {
+            return false;
+        }
+        if (!verifyStackArguments(stackDepth)) {
+            return false;
+        }
+
+        /* TODO: Revisit once JfrMemorySizer is rewritten
+        if (!JfrMemorySizer::adjust_options(&options)) {
+            if (!check_for_ambiguity(_dcmd_memorysize, _dcmd_globalbuffersize, _dcmd_numglobalbuffers)) {
+                return false;
+            }
+        }*/
+        if (!checkForAmbiguity()) {
+            return false;
+        }
+
+        return true;
+    }
+
+    private static boolean verifyStackArguments(int stackDepth) {
+        if (stackDepth < MIN_STACK_DEPTH) {
+            return false;
+        } else if (stackDepth > MAX_STACK_DEPTH) {
+            return false;
+        } else {
+            return true;
+        }
+    }
+
+    private static boolean ensureValidMinimumSizes() {
+        // ensure valid minimum memory sizes
+        if (!(memorySize >= MIN_MEMORY_SIZE)) {
+            return false;
+        }
+        if (!(globalBufferSize >= MIN_GLOBAL_BUFFER_SIZE)) {
+            return false;
+        }
+        if (!(globalBufferCount >= MIN_BUFFER_COUNT)) {
+            return false;
+        }
+        if (!(threadBufferSize >= MIN_THREAD_BUFFER_SIZE)) {
+            return false;
+        }
+        return true;
+    }
+
+    private static boolean validMemoryRelations() {
+        if (!(memorySize >= globalBufferSize)) {
+            return false;
+        }
+        if (!(globalBufferSize >= threadBufferSize)) {
+            return false;
+        }
+        if (!(globalBufferSize * globalBufferCount >= MIN_MEMORY_SIZE)) {
+            return false;
+        }
+        return true;
+    }
+
+    private static boolean checkForAmbiguity() {
+        long calcSize = globalBufferSize * globalBufferCount;
+        if (calcSize != memorySize) {
+            // ambiguous
+            JfrLogger.logError("Value specified for number of global buffers, global buffer size, and" +
+            "memory size are causing ambiguity when trying to determine how much memory to use. " +
+            "global buffer count * global buffer size do not equal memory size. Try to remove one of the " +
+            "involved options or make sure they are unambiguous.");
+            return false;
+        }
+        return true;
+    }
+
+}

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/jfr/JfrOptions.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/jfr/JfrOptions.java
@@ -100,6 +100,7 @@ public class JfrOptions {
     private static int stackDepth = 64;
 
     // Delay, Duration, Max Age are time arguments
+    private static boolean startRecordingAutomatically = false;
     private static long delay = 0;
     private static long duration = 0;
     private static long maxAge = 0; // 0 is a special value indicating no limit
@@ -139,6 +140,7 @@ public class JfrOptions {
         protected void onValueUpdate(EconomicMap<OptionKey<?>, Object> values, String oldValue, String newValue) {
             // Substrate parses it into option=value,option2=value,.... We can pass it on to our own parsing methods from here
             parseStartFlightRecordingOption(newValue);
+            startRecordingAutomatically = true;
             // Do the sanity checks to make sure we have valid options
             if (!adjustMemoryOptions()) {
                 throw new IllegalArgumentException("Failed to validate memory arguments");
@@ -339,6 +341,10 @@ public class JfrOptions {
         }
         Target_jdk_jfr_internal_JVM.getJVM().setFileNotification(chunkSize);
         maxChunkSize = chunkSize;
+    }
+
+    public static boolean getStartRecordingAutomatically() {
+        return startRecordingAutomatically;
     }
 
     public static int getGlobalBufferSize() {

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/jfr/JfrRuntimeAccess.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/jfr/JfrRuntimeAccess.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, Red Hat Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package com.oracle.svm.core.jdk.jfr;
+
+import java.util.List;
+import java.util.Set;
+
+import com.oracle.svm.core.jdk.jfr.recorder.checkpoint.types.traceid.JfrTraceIdMap;
+
+import jdk.internal.event.Event;
+
+public interface JfrRuntimeAccess {
+    List<Class<? extends Event>> getEventClasses();
+    void addEventClass(Class<? extends Event> eventClass);
+    JfrTraceIdMap getTraceIdMap();
+    Set<ClassLoader> getReachableClassloaders();
+    void addClassloader(ClassLoader c);
+}

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/jfr/JfrRuntimeAccessImpl.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/jfr/JfrRuntimeAccessImpl.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, Red Hat Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package com.oracle.svm.core.jdk.jfr;
+
+import java.lang.reflect.Modifier;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import com.oracle.svm.core.jdk.jfr.recorder.checkpoint.types.traceid.JfrTraceIdMap;
+
+import jdk.internal.event.Event;
+
+class JfrRuntimeAccessImpl implements JfrRuntimeAccess {
+
+    private final List<Class<? extends Event>> eventClasses = new ArrayList<>();
+
+    private final Set<ClassLoader> reachableClassloaders = new HashSet<>();
+    private final JfrTraceIdMap traceIdMap = new JfrTraceIdMap();
+
+    @Override
+    public List<Class<? extends Event>> getEventClasses() {
+        return new ArrayList<>(eventClasses);
+    }
+
+    @Override
+    public void addEventClass(Class<? extends Event> eventClass) {
+        if (!Modifier.isAbstract(eventClass.getModifiers())) {
+            eventClasses.add(eventClass);
+        }
+    }
+
+    @Override
+    public JfrTraceIdMap getTraceIdMap() {
+        return traceIdMap;
+    }
+
+    @Override
+    public Set<ClassLoader> getReachableClassloaders() {
+        return reachableClassloaders;
+    }
+
+    @Override
+    public void addClassloader(ClassLoader c) {
+        this.reachableClassloaders.add(c);
+    }
+}

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/jfr/JfrSubstitutions.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/jfr/JfrSubstitutions.java
@@ -116,16 +116,6 @@ final class Target_jdk_jfr_internal_Logger {
     }
 }
 
-@TargetClass(className = "jdk.jfr.internal.MetadataRepository", onlyWith = JfrAvailability.WithJfr.class)
-final class Target_jdk_jfr_internal_MetadataRepository {
-    @Substitute
-    private void unregisterUnloaded() {
-        // JFR.TODO: once traceid related work is fixed, this
-        // substitution should be removed in favor of the original
-        // implementation
-    }
-}
-
 @Substitute
 @TargetClass(className = "jdk.jfr.internal.EventWriter", onlyWith = JfrAvailability.WithJfr.class)
 final class Target_jdk_jfr_internal_EventWriter {

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/jfr/JfrSubstitutions.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/jfr/JfrSubstitutions.java
@@ -1,0 +1,907 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, Red Hat Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package com.oracle.svm.core.jdk.jfr;
+
+import java.lang.management.ManagementFactory;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.function.Supplier;
+
+import org.graalvm.nativeimage.ImageSingletons;
+
+import com.oracle.svm.core.annotate.Alias;
+import com.oracle.svm.core.annotate.KeepOriginal;
+import com.oracle.svm.core.annotate.RecomputeFieldValue;
+import com.oracle.svm.core.annotate.Substitute;
+import com.oracle.svm.core.annotate.TargetClass;
+import com.oracle.svm.core.annotate.TargetElement;
+import com.oracle.svm.core.jdk.jfr.logging.JfrLogger;
+import com.oracle.svm.core.jdk.jfr.recorder.JfrRecorder;
+import com.oracle.svm.core.jdk.jfr.recorder.checkpoint.JfrMetadataEvent;
+import com.oracle.svm.core.jdk.jfr.recorder.checkpoint.types.traceid.JfrTraceId;
+import com.oracle.svm.core.jdk.jfr.recorder.checkpoint.types.traceid.JfrTraceIdEpoch;
+import com.oracle.svm.core.jdk.jfr.recorder.repository.JfrChunkRotation;
+import com.oracle.svm.core.jdk.jfr.recorder.repository.JfrRepository;
+import com.oracle.svm.core.jdk.jfr.recorder.storage.JfrBuffer;
+import com.oracle.svm.core.jdk.jfr.recorder.storage.JfrStorage;
+import com.oracle.svm.core.jdk.jfr.recorder.stringpool.JfrStringPool;
+import com.oracle.svm.core.jdk.jfr.support.JfrThreadLocal;
+import com.oracle.svm.core.thread.JavaThreads;
+
+import jdk.internal.event.Event;
+import jdk.jfr.internal.LogLevel;
+import jdk.jfr.internal.LogTag;
+
+@TargetClass(className = "jdk.jfr.internal.Type", onlyWith = JfrAvailability.WithJfr.class)
+final class Target_jdk_jfr_internal_Type {
+    @Alias
+    public long getId() {
+        return 0;
+    }
+}
+
+@TargetClass(className = "jdk.jfr.internal.PlatformEventType", onlyWith = JfrAvailability.WithJfr.class)
+final class Target_jdk_jfr_internal_PlatformEventType {
+    @Alias
+    public boolean getStackTraceEnabled() {
+        return false;
+    }
+
+    @Alias
+    public int getStackTraceOffset() {
+        return 0;
+    }
+}
+
+@TargetClass(className = "jdk.jfr.internal.StringPool", onlyWith = JfrAvailability.WithJfr.class)
+final class Target_jdk_jfr_internal_StringPool {
+    @Substitute
+    private static boolean getCurrentEpoch() {
+        return JfrTraceIdEpoch.getEpoch();
+    }
+
+    @Alias
+    public static long addString(String s) {
+        return 0;
+    }
+
+}
+
+@Substitute
+@TargetClass(className = "jdk.jfr.internal.Logger", onlyWith = JfrAvailability.WithJfr.class)
+final class Target_jdk_jfr_internal_Logger {
+
+    @Substitute
+    private static final int MAX_SIZE = 10000;
+
+    @Substitute
+    public static boolean shouldLog(LogTag tag, LogLevel level) {
+        return true;
+    }
+
+    @KeepOriginal
+    public static void log(LogTag logTag, LogLevel logLevel, String message) {
+    }
+
+    @KeepOriginal
+    public static void log(LogTag logTag, LogLevel logLevel, Supplier<String> messageSupplier) {
+    }
+
+    @KeepOriginal
+    private static void logInternal(LogTag logTag, LogLevel logLevel, String message) {
+    }
+}
+
+@TargetClass(className = "jdk.jfr.internal.MetadataRepository", onlyWith = JfrAvailability.WithJfr.class)
+final class Target_jdk_jfr_internal_MetadataRepository {
+    @Substitute
+    private void unregisterUnloaded() {
+        // JFR.TODO: once traceid related work is fixed, this
+        // substitution should be removed in favor of the original
+        // implementation
+    }
+}
+
+@Substitute
+@TargetClass(className = "jdk.jfr.internal.EventWriter", onlyWith = JfrAvailability.WithJfr.class)
+final class Target_jdk_jfr_internal_EventWriter {
+    private static final Target_jdk_jfr_internal_JVM jvm = Target_jdk_jfr_internal_JVM.getJVM();
+
+    private final long threadID;
+    private int maxEventSize;
+
+    private boolean started;
+    private boolean valid;
+    private boolean flushOnEnd;
+
+    private Target_jdk_jfr_internal_PlatformEventType eventType;
+
+    private int startPosition;
+    private JfrBuffer buffer;
+
+    private final JfrThreadLocal jtl;
+
+    @Substitute
+    public static Target_jdk_jfr_internal_EventWriter getEventWriter() {
+        JfrThreadLocal jtl = JavaThreads.getThreadLocal(Thread.currentThread());
+        assert (jtl != null);
+        Target_jdk_jfr_internal_EventWriter writer = (Target_jdk_jfr_internal_EventWriter) jtl.getEventWriter();
+        if (writer != null) {
+            return writer;
+        }
+
+        assert (!jtl.hasBuffer());
+        JfrBuffer b = jtl.buffer();
+        if (b == null) {
+            throw new OutOfMemoryError("OOME for thread local buffer");
+        }
+
+        jtl.setEventWriter(new Target_jdk_jfr_internal_EventWriter(b, true, jtl));
+        assert (jtl.getEventWriter() != null);
+
+        return ((Target_jdk_jfr_internal_EventWriter) jtl.getEventWriter());
+    }
+
+    Target_jdk_jfr_internal_EventWriter(JfrBuffer buffer, boolean valid, JfrThreadLocal parent) {
+        this.threadID = buffer.identity();
+        this.valid = valid;
+        this.started = false;
+
+        this.buffer = buffer;
+        this.startPosition = this.buffer.getCommittedPosition();
+
+        // event may not exceed size for a padded integer
+        this.maxEventSize = (1 << 28) - 1;
+
+        this.jtl = parent;
+    }
+
+    @Substitute
+    public void putBoolean(boolean i) {
+        if (isValidForSize(Byte.BYTES)) {
+            buffer.getBuffer().put(i ? (byte) 1 : (byte) 0);
+        }
+    }
+
+    @Substitute
+    public void putByte(byte i) {
+        if (isValidForSize(Byte.BYTES)) {
+            buffer.getBuffer().put(i);
+        }
+    }
+
+    @Substitute
+    public void putChar(char v) {
+        if (isValidForSize(Character.BYTES + 1)) {
+            putUncheckedLong(v);
+        }
+    }
+
+    @Substitute
+    private void putUncheckedChar(char v) {
+        putUncheckedLong(v);
+    }
+
+    @Substitute
+    public void putShort(short v) {
+        if (isValidForSize(Short.BYTES + 1)) {
+            putUncheckedLong(v & 0xFFFF);
+        }
+    }
+
+    @Substitute
+    public void putInt(int v) {
+        if (isValidForSize(Integer.BYTES + 1)) {
+            putUncheckedLong(v & 0x00000000ffffffffL);
+        }
+    }
+
+    @Substitute
+    private void putUncheckedInt(int v) {
+        putUncheckedLong(v & 0x00000000ffffffffL);
+    }
+
+    @Substitute
+    public void putFloat(float i) {
+        if (isValidForSize(Float.BYTES)) {
+            buffer.getBuffer().putFloat(i);
+        }
+    }
+
+    @Substitute
+    public void putLong(long v) {
+        if (isValidForSize(Long.BYTES + 1)) {
+            putUncheckedLong(v);
+        }
+    }
+
+    @Substitute
+    public void putDouble(double i) {
+        if (isValidForSize(Double.BYTES)) {
+            buffer.getBuffer().putDouble(i);
+        }
+    }
+
+    @Substitute
+    public void putString(String s, Target_jdk_jfr_internal_StringPool pool) {
+        if (s == null) {
+            byte b = 0;
+            putByte(b);
+            return;
+        }
+        int length = s.length();
+        if (length == 0) {
+            byte b = 1;
+            putByte(b);
+            return;
+        }
+        if (length > 16 && length < 128) {
+            long l = Target_jdk_jfr_internal_StringPool.addString(s);
+            if (l > -1) {
+                byte b = 2;
+                putByte(b);
+                putLong(l);
+                return;
+            }
+        }
+        putStringValue(s);
+    }
+
+    @KeepOriginal
+    private void putStringValue(String s) {
+    }
+
+    @Substitute
+    public void putEventThread() {
+        putLong(threadID);
+    }
+
+    @Substitute
+    public void putThread(Thread aThread) {
+        if (aThread == null) {
+            putLong(0L);
+        } else {
+            putLong(jvm.getThreadId(aThread));
+        }
+    }
+
+    @Substitute
+    public void putClass(Class<?> aClass) {
+        if (aClass == null) {
+            putLong(0L);
+        } else {
+            putLong(Target_jdk_jfr_internal_JVM.getClassIdNonIntrinsic(aClass));
+        }
+    }
+
+    @Substitute
+    public void putStackTrace() {
+        if (this.eventType.getStackTraceEnabled()) {
+            putLong(jvm.getStackTraceId(this.eventType.getStackTraceOffset()));
+        } else {
+            putLong(0L);
+        }
+    }
+
+    @Substitute
+    private void reserveEventSizeField() {
+        try {
+            // move currentPosition Integer.Bytes offset from start position
+            if (isValidForSize(Integer.BYTES)) {
+                buffer.getBuffer().position(buffer.getBuffer().position() + Integer.BYTES);
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+            throw e;
+        }
+    }
+
+    @Substitute
+    private void reset() {
+        buffer.getBuffer().position(buffer.getCommittedPosition());
+        if (flushOnEnd) {
+            flushOnEnd = flush();
+        }
+        valid = true;
+        started = false;
+    }
+
+    @Substitute
+    private boolean isValidForSize(int requestedSize) {
+        if (!valid) {
+            return false;
+        }
+        if (buffer.getBuffer().position() + requestedSize > buffer.getBuffer().limit()) {
+            flushOnEnd = flush(usedSize(), requestedSize);
+            if (buffer.getBuffer().position() + requestedSize > buffer.getBuffer().limit()) {
+                valid = false;
+                return false;
+            }
+        }
+        return true;
+    }
+
+    @Substitute
+    private boolean isNotified() {
+        return this.jtl.isNotified();
+    }
+
+    @Substitute
+    private void resetNotified() {
+        this.jtl.setNotified(false);
+    }
+
+    @Substitute
+    private int usedSize() {
+        return buffer.getBuffer().position() - buffer.getCommittedPosition();
+    }
+
+    @KeepOriginal
+    private boolean flush() {
+        return false;
+    }
+
+    // usedSize: buffer position - committed position
+    // requestedSize: size to write into buffer
+    @Substitute
+    private boolean flush(int usedSize, int requestedSize) {
+        this.buffer = JfrStorage.instance().flush(this.buffer, usedSize, requestedSize, Thread.currentThread());
+
+        boolean isValid = this.buffer.getFreeSize() >= usedSize + requestedSize;
+        int newPos = isValid ? this.buffer.getCommittedPosition() + usedSize : this.buffer.getCommittedPosition();
+
+        // ByteBuffer specific
+        if (this.buffer.getBuffer().position() != newPos) {
+            JfrLogger.logWarning("Unexpected flush occurred. Data may be lost");
+            this.buffer.getBuffer().position(newPos);
+        }
+        this.startPosition = this.buffer.getCommittedPosition();
+
+        if (!isValid) {
+            this.valid = false;
+            return false;
+        }
+
+        return this.buffer.isLeased();
+    }
+
+    @Substitute
+    public boolean beginEvent(Target_jdk_jfr_internal_PlatformEventType eventType) {
+        try {
+            if (this.started) {
+                return false;
+            }
+            this.started = true;
+
+            this.eventType = eventType;
+            reserveEventSizeField();
+            Target_jdk_jfr_internal_Type type = Target_jdk_jfr_internal_Type.class.cast(eventType);
+            putLong(type.getId());
+        } catch (Exception e) {
+            e.printStackTrace();
+            throw e;
+        }
+        return true;
+    }
+
+    @Substitute
+    public boolean endEvent() {
+        if (!valid) {
+            this.reset();
+            return true;
+        }
+        final int eventSize = usedSize();
+        if (eventSize > maxEventSize) {
+            this.reset();
+            return true;
+        }
+        buffer.getBuffer().putInt(startPosition, makePaddedInt(eventSize));
+        if (isNotified()) {
+            resetNotified();
+            this.reset();
+            // returning false will trigger restart of the event write attempt
+            return false;
+        }
+        startPosition = buffer.getBuffer().position();
+        buffer.setCommittedPosition(startPosition);
+        // the event is now committed
+        if (flushOnEnd) {
+            flushOnEnd = flush();
+        }
+        started = false;
+
+        return true;
+    }
+
+    @Substitute
+    private static int makePaddedInt(int v) {
+        // bit 0-6 + pad => bit 24 - 31
+        long b1 = (((v >>> 0) & 0x7F) | 0x80) << 24;
+
+        // bit 7-13 + pad => bit 16 - 23
+        long b2 = (((v >>> 7) & 0x7F) | 0x80) << 16;
+
+        // bit 14-20 + pad => bit 8 - 15
+        long b3 = (((v >>> 14) & 0x7F) | 0x80) << 8;
+
+        // bit 21-28 => bit 0 - 7
+        long b4 = (((v >>> 21) & 0x7F)) << 0;
+
+        return (int) (b1 + b2 + b3 + b4);
+    }
+
+    @Substitute
+    private void putUncheckedLong(long v) {
+        if ((v & ~0x7FL) == 0L) {
+            putUncheckedByte((byte) v); // 0-6
+            return;
+        }
+        putUncheckedByte((byte) (v | 0x80L)); // 0-6
+        v >>>= 7;
+        if ((v & ~0x7FL) == 0L) {
+            putUncheckedByte((byte) v); // 7-13
+            return;
+        }
+        putUncheckedByte((byte) (v | 0x80L)); // 7-13
+        v >>>= 7;
+        if ((v & ~0x7FL) == 0L) {
+            putUncheckedByte((byte) v); // 14-20
+            return;
+        }
+        putUncheckedByte((byte) (v | 0x80L)); // 14-20
+        v >>>= 7;
+        if ((v & ~0x7FL) == 0L) {
+            putUncheckedByte((byte) v); // 21-27
+            return;
+        }
+        putUncheckedByte((byte) (v | 0x80L)); // 21-27
+        v >>>= 7;
+        if ((v & ~0x7FL) == 0L) {
+            putUncheckedByte((byte) v); // 28-34
+            return;
+        }
+        putUncheckedByte((byte) (v | 0x80L)); // 28-34
+        v >>>= 7;
+        if ((v & ~0x7FL) == 0L) {
+            putUncheckedByte((byte) v); // 35-41
+            return;
+        }
+        putUncheckedByte((byte) (v | 0x80L)); // 35-41
+        v >>>= 7;
+        if ((v & ~0x7FL) == 0L) {
+            putUncheckedByte((byte) v); // 42-48
+            return;
+        }
+        putUncheckedByte((byte) (v | 0x80L)); // 42-48
+        v >>>= 7;
+
+        if ((v & ~0x7FL) == 0L) {
+            putUncheckedByte((byte) v); // 49-55
+            return;
+        }
+        putUncheckedByte((byte) (v | 0x80L)); // 49-55
+        putUncheckedByte((byte) (v >>> 7)); // 56-63, last byte as is.
+    }
+
+    @Substitute
+    private void putUncheckedByte(byte i) {
+        buffer.getBuffer().put(i);
+    }
+}
+
+@Substitute
+@TargetClass(className = "jdk.jfr.internal.JVM", onlyWith = JfrAvailability.WithJfr.class)
+final class Target_jdk_jfr_internal_JVM {
+
+    private static final Target_jdk_jfr_internal_JVM jvm = new Target_jdk_jfr_internal_JVM();
+
+    @Alias @RecomputeFieldValue(kind = RecomputeFieldValue.Kind.Reset)
+    private volatile boolean nativeOK;
+
+    static final Object FILE_DELTA_CHANGE = new Object();
+
+    @TargetElement(name = TargetElement.CONSTRUCTOR_NAME)
+    private Target_jdk_jfr_internal_JVM() {
+    }
+
+    @Substitute
+    @TargetElement(name = "getJVM")
+    public static Target_jdk_jfr_internal_JVM getJVM() {
+        return jvm;
+    }
+
+    @Substitute
+    @TargetElement(name = "beginRecording")
+    public void beginRecording() {
+        if (!JfrRecorder.isRecording()) {
+            JfrRecorder.startRecording();
+        }
+    }
+
+    @Substitute
+    @TargetElement(name = "counterTime")
+    public static long counterTime() {
+        return ManagementFactory.getRuntimeMXBean().getStartTime();
+    }
+
+    @Substitute
+    @TargetElement(name = "emitEvent")
+    public boolean emitEvent(long eventTypeId, long timestamp, long when) {
+        return false;
+    }
+
+    @Substitute
+    @TargetElement(name = "endRecording")
+    public void endRecording() {
+        if (!JfrRecorder.isRecording()) {
+            return;
+        }
+        JfrRecorder.stopRecording();
+    }
+
+    @Substitute
+    @TargetElement(name = "getAllEventClasses")
+    public List<Class<? extends Event>> getAllEventClasses() {
+        JfrRuntimeAccess jfrRuntime = ImageSingletons.lookup(JfrRuntimeAccess.class);
+        return jfrRuntime.getEventClasses();
+    }
+
+    @Substitute
+    @TargetElement(name = "getUnloadedEventClassCount")
+    public long getUnloadedEventClassCount() {
+        return 0;
+    }
+
+    @Substitute
+    @TargetElement(name = "getClassId")
+    public static long getClassId(Class<?> clazz) {
+        return getClassIdNonIntrinsic(clazz);
+    }
+
+    @Substitute
+    @TargetElement(name = "getClassIdNonIntrinsic")
+    public static long getClassIdNonIntrinsic(Class<?> clazz) {
+        return JfrTraceId.load(clazz);
+    }
+
+    @Substitute
+    @TargetElement(name = "getPid")
+    public String getPid() {
+        return String.valueOf(ProcessHandle.current().pid());
+    }
+
+    @Substitute
+    @TargetElement(name = "getStackTraceId")
+    public long getStackTraceId(int skipCount) {
+        return 0;
+    }
+
+    @Substitute
+    @TargetElement(name = "getThreadId")
+    public long getThreadId(Thread t) {
+        return t.getId();
+    }
+
+    @Substitute
+    @TargetElement(name = "getTicksFrequency")
+    public long getTicksFrequency() {
+        return 0;
+    }
+
+    @Substitute
+    @TargetElement(name = "log")
+    public static void log(int tagSetId, int level, String message) {
+        JfrLogger.log(tagSetId, level, message);
+    }
+
+    @Substitute
+    @TargetElement(name = "subscribeLogLevel")
+    public static void subscribeLogLevel(LogTag lt, int tagSetId) {
+        // Substitutions for jdk.jfr.internal.JVM mean this code path should not be
+        // reached
+        throw new RuntimeException("Should not reach here");
+    }
+
+    @Substitute
+    @TargetElement(name = "retransformClasses")
+    public synchronized void retransformClasses(Class<?>[] classes) {
+    }
+
+    @Substitute
+    @TargetElement(name = "setEnabled")
+    public void setEnabled(long eventTypeId, boolean enabled) {
+    }
+
+    @Substitute
+    @TargetElement(name = "setFileNotification")
+    public void setFileNotification(long delta) {
+        JfrChunkRotation.setThreshold(delta, FILE_DELTA_CHANGE);
+    }
+
+    @Substitute
+    @TargetElement(name = "setGlobalBufferCount")
+    public void setGlobalBufferCount(long count) throws IllegalArgumentException, IllegalStateException {
+        // Changes to JfrOptions mean this code path should not be reached
+        throw new RuntimeException("Should not reach here");
+    }
+
+    @Substitute
+    @TargetElement(name = "setGlobalBufferSize")
+    public void setGlobalBufferSize(long size) throws IllegalArgumentException {
+        // Changes to JfrOptions mean this code path should not be reached
+        throw new RuntimeException("Should not reach here");
+    }
+
+    @Substitute
+    @TargetElement(name = "setMemorySize")
+    public void setMemorySize(long size) throws IllegalArgumentException {
+        // Changes to JfrOptions mean this code path should not be reached
+        throw new RuntimeException("Should not reach here");
+    }
+
+    @Substitute
+    @TargetElement(name = "setMethodSamplingInterval")
+    public void setMethodSamplingInterval(long type, long intervalMillis) throws IllegalArgumentException {
+    }
+
+    @Substitute
+    @TargetElement(name = "setOutput")
+    public void setOutput(String file) {
+        if (file != null) {
+            JfrRepository.setInstanceChunkPath(Paths.get(file));
+        } else {
+            JfrRepository.setInstanceChunkPath(null);
+        }
+    }
+
+    @Substitute
+    @TargetElement(name = "setForceInstrumentation")
+    public void setForceInstrumentation(boolean force) {
+        // This code path should not be reached
+        throw new RuntimeException("Should not reach here");
+    }
+
+    @Substitute
+    @TargetElement(name = "setSampleThreads")
+    public void setSampleThreads(boolean sampleThreads) throws IllegalStateException {
+        // Changes to JfrOptions mean this code path should not be reached
+        throw new RuntimeException("Should not reach here");
+    }
+
+    @Substitute
+    @TargetElement(name = "setCompressedIntegers")
+    public void setCompressedIntegers(boolean compressed) throws IllegalStateException {
+        // Seems unused in jdk/jdk
+        throw new RuntimeException("Should not reach here");
+    }
+
+    @Substitute
+    @TargetElement(name = "setStackDepth")
+    public void setStackDepth(int depth) throws IllegalArgumentException, IllegalStateException {
+        // Changes to JfrOptions mean this code path should not be reached
+        throw new RuntimeException("Should not reach here");
+    }
+
+    @Substitute
+    @TargetElement(name = "setStackTraceEnabled")
+    public void setStackTraceEnabled(long eventTypeId, boolean enabled) {
+        // JFR.TODO
+    }
+
+    @Substitute
+    @TargetElement(name = "setThreadBufferSize")
+    public void setThreadBufferSize(long size) throws IllegalArgumentException, IllegalStateException {
+        // Changes to JfrOptions mean this code path should not be reached
+        throw new RuntimeException("Should not reach here");
+    }
+
+    @Substitute
+    @TargetElement(name = "setThreshold")
+    public boolean setThreshold(long eventTypeId, long ticks) {
+        return false;
+    }
+
+    @Substitute
+    @TargetElement(name = "storeMetadataDescriptor")
+    public void storeMetadataDescriptor(byte[] bytes) {
+        JfrMetadataEvent.update(bytes);
+    }
+
+    @Substitute
+    @TargetElement(name = "endRecording_")
+    public void endRecording_() {
+        endRecording();
+    }
+
+    @Substitute
+    @TargetElement(name = "beginRecording_")
+    public void beginRecording_() {
+        beginRecording();
+    }
+
+    @Substitute
+    @TargetElement(name = "isRecording")
+    public boolean isRecording() {
+        // JFR.TODO
+        // This currently returns true unconditionally
+        // It should instead return value of this.recording, but substitutions in
+        // jfr java code need to be added to recompute field values so that
+        // the singleton jvm instance is always the same instance
+        return JfrRecorder.isRecording();
+    }
+
+    @Substitute
+    @TargetElement(name = "getAllowedToDoEventRetransforms")
+    public boolean getAllowedToDoEventRetransforms() {
+        return false;
+    }
+
+    @Substitute
+    @TargetElement(name = "createJFR")
+    private boolean createJFR(boolean simulateFailure) throws IllegalStateException {
+        if (JfrRecorder.isCreated()) {
+            return true;
+        }
+        if (!JfrRecorder.create(simulateFailure)) {
+            // if (!thread->has_pending_exception()) {
+            // JfrJavaSupport::throw_illegal_state_exception("Unable to start Jfr", thread);
+            // }
+
+            return false;
+        }
+        return true;
+    }
+
+    @Substitute
+    @TargetElement(name = "destroyJFR")
+    private boolean destroyJFR() {
+        JfrRecorder.destroy();
+        return true;
+    }
+
+    @Substitute
+    @TargetElement(name = "createFailedNativeJFR")
+    public boolean createFailedNativeJFR() throws IllegalStateException {
+        return createJFR(true);
+    }
+
+    @Substitute
+    @TargetElement(name = "createNativeJFR")
+    public void createNativeJFR() {
+        nativeOK = createJFR(false);
+    }
+
+    @Substitute
+    @TargetElement(name = "destroyNativeJFR")
+    public boolean destroyNativeJFR() {
+        boolean result = destroyJFR();
+        nativeOK = !result;
+        return result;
+    }
+
+    @Substitute
+    @TargetElement(name = "hasNativeJFR")
+    public boolean hasNativeJFR() {
+        return nativeOK;
+    }
+
+    @Substitute
+    @TargetElement(name = "isAvailable")
+    public boolean isAvailable() {
+        return !Jfr.isDisabled();
+    }
+
+    @Substitute
+    @TargetElement(name = "getTimeConversionFactor")
+    public double getTimeConversionFactor() {
+        return 0;
+    }
+
+    @Substitute
+    @TargetElement(name = "getTypeId")
+    public long getTypeId(Class<?> clazz) {
+        return JfrTraceId.getTraceId(clazz);
+    }
+
+    @Substitute
+    @TargetElement(name = "getEventWriter")
+    public static Object getEventWriter() {
+        // Substitutions for jdk.jfr.internal.EventWriter mean this code path should not
+        // be reached
+        throw new RuntimeException("Should not reach here");
+    }
+
+    @Substitute
+    @TargetElement(name = "newEventWriter")
+    public static Target_jdk_jfr_internal_EventWriter newEventWriter() {
+        // Substitutions for jdk.jfr.internal.EventWriter mean this code path should not
+        // be reached
+        throw new RuntimeException("Should not reach here");
+    }
+
+    @Substitute
+    @TargetElement(name = "flush")
+    public static boolean flush(Target_jdk_jfr_internal_EventWriter writer, int uncommittedSize, int requestedSize) {
+        // Substitutions for jdk.jfr.internal.EventWriter mean this code path should not
+        // be reached
+        throw new RuntimeException("Should not reach here");
+    }
+
+    @Substitute
+    @TargetElement(name = "setRepositoryLocation")
+    public void setRepositoryLocation(String dirText) {
+        if (dirText != null) {
+            JfrRepository.setInstancePath(Paths.get(dirText));
+        }
+    }
+
+    @Substitute
+    @TargetElement(name = "abort")
+    public void abort(String errorMsg) {
+    }
+
+    @Substitute
+    @TargetElement(name = "addStringConstant")
+    public static boolean addStringConstant(boolean epoch, long id, String s) {
+        boolean r = JfrStringPool.instance().addStringConstant(epoch, id, s);
+        return r;
+    }
+
+    @Substitute
+    @TargetElement(name = "getEpochAddress")
+    public long getEpochAddress() {
+        // Substitutions for jdk.jfr.internal.StringPool mean this code path should not
+        // be reached
+        throw new RuntimeException("Should not reach here");
+    }
+
+    @Substitute
+    @TargetElement(name = "uncaughtException")
+    public void uncaughtException(Thread thread, Throwable t) {
+    }
+
+    @Substitute
+    @TargetElement(name = "setCutoff")
+    public boolean setCutoff(long eventTypeId, long cutoffTicks) {
+        return false;
+    }
+
+    @Substitute
+    @TargetElement(name = "emitOldObjectSamples")
+    public void emitOldObjectSamples(long cutoff, boolean emitAll) {
+    }
+
+    @Substitute
+    @TargetElement(name = "shouldRotateDisk")
+    public boolean shouldRotateDisk() {
+        boolean b = JfrChunkRotation.shouldRotate();
+        return b;
+    }
+}
+
+public final class JfrSubstitutions {
+}

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/jfr/logging/JfrLogger.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/jfr/logging/JfrLogger.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, Red Hat Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package com.oracle.svm.core.jdk.jfr.logging;
+
+import java.util.Arrays;
+
+import com.oracle.svm.core.jdk.jfr.JfrOptions;
+import com.oracle.svm.core.thread.VMOperation;
+
+public class JfrLogger {
+
+    public enum Level {
+        // Numbers assigned to be the same as jdk.jfr.internal.LogLevel
+        TRACE("trace", 1),
+        DEBUG("debug", 2),
+        INFO("info", 3),
+        WARNING("warning", 4),
+        ERROR("error", 5);
+
+        public String lv;
+        public int id;
+
+        Level(String lv, int id) {
+            this.lv = lv;
+            this.id = id;
+        }
+    }
+
+    public static boolean shouldLog(int tagSetId, int level) {
+        return !VMOperation.isInProgressAtSafepoint() && level >= JfrOptions.getLogLevel();
+    }
+
+    public static void log(int tagSetId, JfrLogger.Level level, String message) {
+        if (shouldLog(tagSetId, level.id)) {
+            System.err.println("[" + level.lv + "] " + "[" + tagSetId + "]  " + message);
+        }
+    }
+
+    public static void log(int tagSetId, int level, String message) {
+        if (shouldLog(tagSetId, level)) {
+            if (1 <= level && level <= 5) {
+                // Subtract one when indexing to align to the correct Level in the array
+                System.err.println("[" + Level.values()[level - 1].lv + "] " + "[" + tagSetId + "]  " + message);
+            }
+        }
+    }
+
+    public static void logError(Object... obj) {
+        log(0, JfrLogger.Level.ERROR, buildLogString(obj));
+    }
+
+    public static void logWarning(Object... obj) {
+        log(0, Level.WARNING, buildLogString(obj));
+    }
+
+    public static void logInfo(Object... obj) {
+        log(0, Level.INFO, buildLogString(obj));
+    }
+
+    public static void logDebug(Object... obj) {
+        log(0, Level.DEBUG, buildLogString(obj));
+    }
+
+    public static void logTrace(Object... obj) {
+        log(0, Level.TRACE, buildLogString(obj));
+    }
+
+    private static String buildLogString(Object... obj) {
+        StringBuilder b = new StringBuilder(obj[0] != null ? obj[0].toString() : "null");
+        for (int i = 1; i < obj.length; i++) {
+            b.append(" ");
+            b.append(obj[i] != null ? obj[i].toString() : "null");
+        }
+        b.append(System.lineSeparator());
+
+        return b.toString();
+    }
+
+    public static void logStackTrace(Exception e) {
+        JfrLogger.logError(Arrays.toString(e.getStackTrace()));
+    }
+}

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/jfr/recorder/JfrRecorder.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/jfr/recorder/JfrRecorder.java
@@ -1,0 +1,182 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, Red Hat Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package com.oracle.svm.core.jdk.jfr.recorder;
+
+import com.oracle.svm.core.jdk.jfr.JfrOptions;
+import com.oracle.svm.core.jdk.jfr.recorder.checkpoint.JfrCheckpointManager;
+import com.oracle.svm.core.jdk.jfr.recorder.repository.JfrRepository;
+import com.oracle.svm.core.jdk.jfr.recorder.service.JfrPostBox;
+import com.oracle.svm.core.jdk.jfr.recorder.service.JfrPostBox.JfrMsg;
+import com.oracle.svm.core.jdk.jfr.recorder.service.JfrRecorderService;
+import com.oracle.svm.core.jdk.jfr.recorder.service.JfrRecorderThread;
+import com.oracle.svm.core.jdk.jfr.recorder.storage.JfrStorage;
+import com.oracle.svm.core.jdk.jfr.recorder.stringpool.JfrStringPool;
+
+public final class JfrRecorder {
+    private static JfrPostBox postBox = null;
+    private static JfrRepository repository = null;
+    private static JfrStorage storage = null;
+    private static JfrCheckpointManager checkpointManager = null;
+    private static JfrStringPool stringPool = null;
+
+    private static boolean created = false;
+    private static boolean enabled = false;
+
+    private JfrRecorder() {
+    }
+
+    public static boolean isDisabled() {
+        // JFR.TODO
+        // Return whether or not -XX:-FlightRecorder has been set
+        return false;
+    }
+
+    public static boolean isEnabled() {
+        return enabled;
+    }
+
+    private static boolean enable() {
+        assert (!enabled);
+        // JFR.TODO
+        // if (!FlightRecorder) {
+        // FLAG_SET_MGMT(FlightRecorder, true);
+        // }
+        enabled = true;
+        assert (enabled);
+
+        return enabled;
+    }
+
+    public static boolean isCreated() {
+        return created;
+    }
+
+    public static boolean create(boolean simulateFailure) {
+        assert (!isDisabled());
+        assert (!isCreated());
+
+        if (!isEnabled()) {
+            enable();
+        }
+
+        if (!JfrOptions.initialize()) {
+            return false;
+        }
+
+        if (!createComponents() || simulateFailure) {
+            destroyComponents();
+            return false;
+        }
+
+        if (!createRecorderThread()) {
+            destroyComponents();
+            return false;
+        }
+
+        created = true;
+
+        return true;
+    }
+
+    private static boolean createComponents() {
+        if (!createPostBox()) {
+            return false;
+        }
+        if (!createChunkRepository()) {
+            return false;
+        }
+        if (!createStorage()) {
+            return false;
+        }
+        if (!createCheckpointManager()) {
+            return false;
+        }
+        if (!createStringPool()) {
+            return false;
+        }
+        return true;
+    }
+
+    private static boolean createStringPool() {
+        assert (stringPool == null);
+        assert (repository != null);
+        stringPool = JfrStringPool.create();
+        return stringPool != null && stringPool.initialize();
+    }
+
+    private static boolean createCheckpointManager() {
+        assert (checkpointManager == null);
+        assert (repository != null);
+        checkpointManager = JfrCheckpointManager.create(JfrRepository.getChunkWriter());
+        return checkpointManager != null && checkpointManager.initialize();
+    }
+
+    private static boolean createStorage() {
+        assert (repository != null);
+        assert (postBox != null);
+        storage = JfrStorage.create(JfrRepository.getChunkWriter(), postBox);
+        return storage != null && storage.initialize();
+    }
+
+    private static boolean createChunkRepository() {
+        assert (repository == null);
+        assert (postBox != null);
+        repository = JfrRepository.create(postBox);
+        return repository != null && repository.initialize();
+    }
+
+    private static boolean createPostBox() {
+        assert (postBox == null);
+        postBox = JfrPostBox.create();
+        return postBox != null;
+    }
+
+    private static void destroyComponents() {
+        // JFR.TODO
+    }
+
+    private static boolean createRecorderThread() {
+        return JfrRecorderThread.start(postBox, Thread.currentThread());
+    }
+
+    public static boolean isRecording() {
+        return JfrRecorderService.isRecording();
+    }
+
+    public static void startRecording() {
+        postBox.post(JfrMsg.START);
+    }
+
+    public static void destroy() {
+        assert (isCreated());
+        postBox.post(JfrMsg.SHUTDOWN);
+    }
+
+    public static void stopRecording() {
+        postBox.post(JfrMsg.STOP);
+    }
+}

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/jfr/recorder/checkpoint/JfrCheckpointClient.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/jfr/recorder/checkpoint/JfrCheckpointClient.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, Red Hat Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package com.oracle.svm.core.jdk.jfr.recorder.checkpoint;
+
+import com.oracle.svm.core.jdk.jfr.recorder.storage.JfrBuffer;
+import com.oracle.svm.core.jdk.jfr.recorder.storage.JfrMemorySpace;
+
+public interface JfrCheckpointClient extends JfrMemorySpace.Client {
+    JfrBuffer flush(JfrBuffer buffer, int used, int requested, Thread t);
+    JfrBuffer lease(int size, boolean previousEpoch, Thread t);
+}

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/jfr/recorder/checkpoint/JfrCheckpointManager.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/jfr/recorder/checkpoint/JfrCheckpointManager.java
@@ -100,7 +100,7 @@ public final class JfrCheckpointManager implements JfrCheckpointClient {
         JfrBuffer b = lease(0, true, thread);
         JfrCheckpointWriter writer = new JfrCheckpointWriter(b, thread, this);
         writer.open();
-        JfrTypeSet.serialize(writer, null, false, false);
+        JfrTypeSet.serialize(writer, null, false);
         writer.close();
 
         write();

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/jfr/recorder/checkpoint/JfrCheckpointManager.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/jfr/recorder/checkpoint/JfrCheckpointManager.java
@@ -1,0 +1,264 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, Red Hat Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package com.oracle.svm.core.jdk.jfr.recorder.checkpoint;
+
+import org.graalvm.nativeimage.IsolateThread;
+
+import com.oracle.svm.core.jdk.jfr.logging.JfrLogger;
+import com.oracle.svm.core.jdk.jfr.recorder.JfrRecorder;
+import com.oracle.svm.core.jdk.jfr.recorder.checkpoint.types.JfrTypeManager;
+import com.oracle.svm.core.jdk.jfr.recorder.checkpoint.types.JfrTypeSet;
+import com.oracle.svm.core.jdk.jfr.recorder.checkpoint.types.traceid.JfrTraceIdEpoch;
+import com.oracle.svm.core.jdk.jfr.recorder.checkpoint.types.traceid.JfrTraceIdLoadBarrier;
+import com.oracle.svm.core.jdk.jfr.recorder.repository.JfrChunkWriter;
+import com.oracle.svm.core.jdk.jfr.recorder.storage.JfrBuffer;
+import com.oracle.svm.core.jdk.jfr.recorder.storage.JfrMemorySpace;
+import com.oracle.svm.core.jdk.jfr.recorder.storage.JfrMemorySpaceRetrieval;
+import com.oracle.svm.core.jdk.jfr.recorder.storage.operations.JfrBufferOperations;
+import com.oracle.svm.core.jdk.jfr.support.JfrThreadLocal;
+import com.oracle.svm.core.jdk.jfr.utilities.JfrCheckpointType;
+import com.oracle.svm.core.thread.JavaThreads;
+import com.oracle.svm.core.thread.VMOperation;
+import com.oracle.svm.core.thread.VMThreads;
+
+public final class JfrCheckpointManager implements JfrCheckpointClient {
+    private static final int bufferCount = 2;
+    private static final int bufferSize = 512 * 1024;
+
+    private static JfrCheckpointManager instance;
+
+    private final JfrChunkWriter chunkWriter;
+    private JfrMemorySpace<JfrMemorySpaceRetrieval, JfrCheckpointManager> mspace;
+
+    private JfrCheckpointManager(JfrChunkWriter chunkWriter) {
+        this.chunkWriter = chunkWriter;
+    }
+
+    public static JfrCheckpointManager create(JfrChunkWriter chunkWriter) {
+        assert (instance == null);
+        instance = new JfrCheckpointManager(chunkWriter);
+        return instance;
+    }
+
+    public static JfrCheckpointManager instance() {
+        return instance;
+    }
+
+    public boolean initialize() {
+        this.mspace = new JfrMemorySpace<>(bufferSize, 0, this, true);
+        this.mspace.initialize(false);
+
+        for (int i = 0; i < bufferCount * 2; i++) {
+            JfrBuffer b = new JfrBuffer(bufferSize);
+            b.initialize();
+            this.mspace.live(i % 2 == 0).add(b);
+        }
+        assert (this.mspace.free().isEmpty());
+
+        return JfrTypeManager.initialize() && JfrTraceIdLoadBarrier.initialize();
+    }
+
+    // Do not safepoint here
+    public void writeTypeSet() {
+        // JFR.LEAK.TODO
+        Thread thread = Thread.currentThread();
+        // {
+        // if (LeakProfiler::is_running()) {
+        // JfrCheckpointWriter leakp_writer(true, thread);
+        // JfrCheckpointWriter writer(true, thread);
+        // JfrTypeSet::serialize(&writer, &leakp_writer, false, false);
+        // ObjectSampleCheckpoint::on_type_set(leakp_writer);
+        // }
+
+        // JFR.TDO buffer instance can be changed while writing due to out of space
+        // Should move acquisition into writer by passing Manager instance into
+        // constructor
+        JfrBuffer b = lease(0, true, thread);
+        JfrCheckpointWriter writer = new JfrCheckpointWriter(b, thread, this);
+        writer.open();
+        JfrTypeSet.serialize(writer, null, false, false);
+        writer.close();
+
+        write();
+    }
+
+    public void beginEpochShift() {
+        assert (VMOperation.isInProgressAtSafepoint());
+        JfrTraceIdEpoch.beginEpochShift();
+    }
+
+    public void onRotation() {
+        assert (VMOperation.isInProgressAtSafepoint());
+
+        JfrTypeManager.onRotation();
+        notifyThreads();
+    }
+
+    private void notifyThreads() {
+        assert (VMOperation.isInProgressAtSafepoint());
+        for (IsolateThread thread = VMThreads.firstThread(); thread.isNonNull(); thread = VMThreads.nextThread(thread)) {
+            Thread t = JavaThreads.fromVMThread(thread);
+            JfrThreadLocal jtl = JavaThreads.getThreadLocal(t);
+            if (jtl != null && jtl.hasEventWriter()) {
+                jtl.setNotified(true);
+            }
+        }
+    }
+
+    public void endEpochShift() {
+        assert (VMOperation.isInProgressAtSafepoint());
+        JfrTraceIdEpoch.endEpochShift();
+    }
+
+    private long write() {
+        assert (this.mspace.free().isEmpty());
+
+        JfrBufferOperations.BufferOperation<JfrBuffer> wo = new JfrBufferOperations.CheckpointWrite<>(chunkWriter);
+        JfrBufferOperations.CompositeAnd<JfrBuffer> wro = new JfrBufferOperations.CompositeAnd<>(
+                new JfrBufferOperations.MutexedWrite<>(wo),
+                new JfrBufferOperations.ReleaseExcision<>(this.mspace, this.mspace.live(true)));
+
+        this.mspace.iterateLiveList(wro, true);
+
+        return wo.elements();
+    }
+
+    private long writeStaticTypeSet(Thread thread) {
+        assert thread != null;
+        JfrBuffer b = lease(0, true, thread);
+        JfrCheckpointWriter writer = new JfrCheckpointWriter(b, thread, JfrCheckpointType.STATICS, this);
+        writer.open();
+        JfrTypeManager.writeStaticTypes(writer);
+        writer.close();
+        return writer.usedSize();
+    }
+
+    private long writeThreads(Thread thread) {
+        assert thread != null;
+        // can safepoint here
+        // ThreadInVMfromNative transition((JavaThread*)thread);
+        // ResetNoHandleMark rnhm;
+        // ResourceMark rm(thread);
+        // HandleMark hm(thread);
+        JfrBuffer b = lease(0, true, thread);
+        JfrCheckpointWriter writer = new JfrCheckpointWriter(b, thread, JfrCheckpointType.THREADS, this);
+        writer.open();
+        JfrTypeManager.writeThreads(writer);
+        writer.close();
+        return writer.usedSize();
+    }
+
+    public long writeStaticTypeSetAndThreads() {
+        // JFR.TODO
+        // Surrounding implemetations are in place but actual write of content is empty
+
+        // Thread thread = Thread.currentThread();
+        // writeStaticTypeSet(thread);
+        // writeThreads(thread);
+        // return write();
+
+        return 0;
+    }
+
+    public void clear() {
+        // JFR.TODO
+        JfrTraceIdLoadBarrier.clear();
+        clearTypeSet();
+        // DiscardOperation discard_operation(mutexed); // mutexed discard mode
+        // ReleaseOperation ro(_mspace, _mspace->live_list(true));
+        // DiscardReleaseOperation discard_op(&discard_operation, &ro);
+        // assert(_mspace->free_list_is_empty(), "invariant");
+        // process_live_list(discard_op, _mspace, true); // previous epoch list
+        // return discard_operation.elements();
+    }
+
+    private void clearTypeSet() {
+        assert (!JfrRecorder.isRecording());
+        // MutexLocker cld_lock(ClassLoaderDataGraph_lock);
+        // MutexLocker module_lock(Module_lock);
+
+        JfrTypeSet.clear();
+    }
+
+    @Override
+    public void registerFull(JfrBuffer buffer, Thread thread) {
+        assert (buffer != null);
+        assert (buffer.acquiredBy(thread));
+        assert (buffer.isRetired());
+    }
+
+    @Override
+    public JfrBuffer flush(JfrBuffer oldBuffer, int used, int requested, Thread t) {
+        assert (oldBuffer != null && oldBuffer.isLeased());
+        if (requested == 0) {
+            // indicates a lease is being returned
+            release(oldBuffer);
+        }
+        JfrBuffer newBuffer = lease(used + requested, true, t);
+        try {
+            newBuffer.getGlobalLock().lock();
+            oldBuffer.transferTo(newBuffer, used);
+            release(oldBuffer);
+        } catch (Exception e) {
+            JfrLogger.logError("JfrBuffer transfer failed. Data may be corrupted");
+        } finally {
+            newBuffer.getGlobalLock().unlock();
+        }
+
+        return newBuffer;
+    }
+
+    private void release(JfrBuffer buffer) {
+        buffer.clearLeased();
+        if (buffer.isTransient()) {
+            buffer.setRetired();
+        } else {
+            buffer.release();
+        }
+    }
+
+    @Override
+    public JfrBuffer lease(int size, boolean previousEpoch, Thread t) {
+        return lease(size, 100, previousEpoch, t);
+    }
+
+    private JfrBuffer lease(int size, int retryCount, boolean previousEpoch, Thread t) {
+        int max = this.mspace.minElementSize();
+        JfrBuffer b;
+        if (size <= max) {
+            b = JfrMemorySpace.acquireLiveLeaseWithRetry(size, this.mspace, retryCount, t, previousEpoch);
+            if (b != null) {
+                return b;
+            }
+        }
+
+        b = JfrMemorySpace.acquireTransientLeaseToLive(size, this.mspace, t, previousEpoch);
+
+        return b;
+    }
+
+}

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/jfr/recorder/checkpoint/JfrCheckpointWriter.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/jfr/recorder/checkpoint/JfrCheckpointWriter.java
@@ -1,0 +1,283 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, Red Hat Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package com.oracle.svm.core.jdk.jfr.recorder.checkpoint;
+
+import java.io.IOException;
+
+import com.oracle.svm.core.jdk.jfr.JfrOptions;
+import com.oracle.svm.core.jdk.jfr.recorder.storage.JfrBuffer;
+import com.oracle.svm.core.jdk.jfr.utilities.JfrCheckpointType;
+import com.oracle.svm.core.jdk.jfr.utilities.JfrTicks;
+import com.oracle.svm.core.jdk.jfr.writers.JfrEncodingWriter;
+import com.oracle.svm.core.jdk.jfr.writers.JfrEncodingWriter.Encoder;
+import com.oracle.svm.core.jdk.jfr.writers.JfrWriter;
+
+public class JfrCheckpointWriter {
+    public static final int jfrCheckpointEntrySize = 32; // 3 longs and 2 ints
+    private static final int sizeSafetyCushion = 1;
+
+    private final JfrCheckpointType type;
+    private final long startTime;
+    private final JfrCheckpointClient callback;
+    private final Thread thread;
+
+    private JfrBuffer buffer;
+    private int count;
+    private int startPosition;
+
+    public JfrCheckpointWriter(JfrBuffer b, Thread thread, JfrCheckpointClient callback) {
+        this(b, thread, JfrCheckpointType.GENERIC, callback);
+    }
+
+    public JfrCheckpointWriter(JfrBuffer b, Thread thread, JfrCheckpointType type, JfrCheckpointClient callback) {
+        this.buffer = b;
+        this.thread = thread;
+        this.startTime = JfrTicks.now();
+        this.type = type;
+        this.callback = callback;
+    }
+
+    public void open() {
+        try {
+            this.startPosition = getCurrentOffset();
+            reserve(jfrCheckpointEntrySize);
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    public void close() {
+        if (count() == 0) {
+            assert (usedSize() == jfrCheckpointEntrySize);
+            this.buffer.getBuffer().position(startPosition);
+            this.buffer.release();
+            return;
+        }
+
+        assert (usedSize() > jfrCheckpointEntrySize);
+        try {
+            writeCheckpointHeader();
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+        this.buffer.setCommittedPosition(getCurrentOffset());
+        this.buffer.release();
+    }
+
+    private void writeCheckpointHeader() throws IOException {
+        long size = usedSize();
+        int oldPos = getCurrentOffset();
+
+        this.buffer.getBuffer().position(startPosition);
+        this.buffer.getBuffer().putLong(size);
+        this.buffer.getBuffer().putLong(startTime);
+        this.buffer.getBuffer().putLong(JfrTicks.now() - startTime);
+        this.buffer.getBuffer().putInt(type.id);
+        this.buffer.getBuffer().putInt(count());
+
+        this.buffer.getBuffer().position(oldPos);
+    }
+
+    public int usedSize() {
+        // JFR.TODO
+        return this.buffer.getBuffer().position() - this.buffer.getCommittedPosition();
+    }
+
+    int ensureSize(int requested) {
+        if (this.buffer.getBuffer().remaining() < requested + sizeSafetyCushion) {
+            this.buffer = callback.flush(this.buffer, this.usedSize(), requested, this.thread);
+        }
+        assert requested + sizeSafetyCushion <= this.buffer.getBuffer().remaining();
+        return this.buffer.getBuffer().position();
+    }
+
+    public int getCurrentOffset() {
+        return this.buffer.getBuffer().position();
+    }
+
+    public int count() {
+        return this.count;
+    }
+
+    public int reserve(int size) throws IOException {
+        if (ensureSize(size) >= 0) {
+            int pos = getCurrentOffset();
+            this.buffer.getBuffer().position(getCurrentOffset() + size);
+            return pos;
+        }
+        // cancel();
+        return 0;
+    }
+
+    // JFR.TODO : Need not throw Exception, but interface is used elsewhere where it
+    // does
+    class EncodingWriter implements JfrWriter {
+        private final Encoder encoder;
+
+        EncodingWriter(Encoder encoder) {
+            this.encoder = encoder;
+        }
+
+        @Override
+        public int writeByte(byte value) throws IOException {
+            if (ensureSize(Byte.BYTES) >= 0) {
+                return this.encoder.encode(buffer.getBuffer(), Byte.BYTES, value);
+            } else {
+                return 0;
+            }
+        }
+
+        @Override
+        public int writeShort(short value) throws IOException {
+            if (ensureSize(Short.BYTES) >= 0) {
+                return this.encoder.encode(buffer.getBuffer(), Short.BYTES, value);
+            } else {
+                return 0;
+            }
+        }
+
+        @Override
+        public int writeInt(int value) throws IOException {
+            if (ensureSize(Integer.BYTES) >= 0) {
+                return this.encoder.encode(buffer.getBuffer(), Integer.BYTES, value);
+            } else {
+                return 0;
+            }
+        }
+
+        @Override
+        public int writeLong(long value) throws IOException {
+            if (ensureSize(Long.BYTES) >= 0) {
+                return this.encoder.encode(buffer.getBuffer(), Long.BYTES, value);
+            } else {
+                return 0;
+            }
+        }
+
+        @Override
+        public int writeByte(byte value, long offset) throws IOException {
+            if (offset < buffer.getBuffer().limit()) {
+                int old = buffer.getBuffer().position();
+                buffer.getBuffer().position((int) offset);
+                int amount = writeByte(value);
+                buffer.getBuffer().position(old);
+                return amount;
+            }
+
+            return 0;
+        }
+
+        @Override
+        public int writeShort(short value, long offset) throws IOException {
+            if (offset < buffer.getBuffer().limit()) {
+                int old = buffer.getBuffer().position();
+                buffer.getBuffer().position((int) offset);
+                int amount = writeShort(value);
+                buffer.getBuffer().position(old);
+                return amount;
+            }
+
+            return 0;
+        }
+
+        @Override
+        public int writeInt(int value, long offset) throws IOException {
+            if (offset < buffer.getBuffer().limit()) {
+                int old = buffer.getBuffer().position();
+                buffer.getBuffer().position((int) offset);
+                int amount = writeInt(value);
+                buffer.getBuffer().position(old);
+                return amount;
+            }
+
+            return 0;
+        }
+
+        @Override
+        public int writeLong(long value, long offset) throws IOException {
+            if (offset < buffer.getBuffer().limit()) {
+                int old = buffer.getBuffer().position();
+                buffer.getBuffer().position((int) offset);
+                int amount = writeLong(value);
+                buffer.getBuffer().position(old);
+                return amount;
+            }
+
+            return 0;
+        }
+    }
+
+    private final JfrWriter beWriter = new EncodingWriter(JfrEncodingWriter::writeBE);
+
+    public JfrWriter be() {
+        return this.beWriter;
+    }
+
+    private final JfrWriter compressedWriter = new EncodingWriter(JfrEncodingWriter::writeCompressed);
+
+    public JfrWriter encoded() {
+        if (JfrOptions.compressedIntegers()) {
+            return this.compressedWriter;
+        } else {
+            return this.beWriter;
+        }
+    }
+
+    private final JfrWriter paddedCompressedWriter = new EncodingWriter(JfrEncodingWriter::writePaddedCompressed);
+
+    public JfrWriter padded() {
+        if (JfrOptions.compressedIntegers()) {
+            return this.paddedCompressedWriter;
+        } else {
+            return this.beWriter;
+        }
+    }
+
+    public void setContext(int offset, int count) {
+        this.buffer.getBuffer().position(offset);
+        this.count = count;
+    }
+
+    public void increment() {
+        this.count++;
+    }
+
+    public void writeString(String s) throws IOException {
+        if (s == null) {
+            encoded().writeInt(0);
+        } else if (s.length() == 0) {
+            encoded().writeInt(1);
+        } else {
+            byte UTF16 = 4;
+            encoded().writeByte(UTF16);
+            encoded().writeInt(s.length());
+            for (byte b : s.getBytes()) {
+                encoded().writeByte(b);
+            }
+        }
+    }
+}

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/jfr/recorder/checkpoint/JfrMetadataEvent.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/jfr/recorder/checkpoint/JfrMetadataEvent.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, Red Hat Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package com.oracle.svm.core.jdk.jfr.recorder.checkpoint;
+
+import java.io.IOException;
+
+import com.oracle.svm.core.jdk.jfr.recorder.repository.JfrChunkWriter;
+import com.oracle.svm.core.jdk.jfr.utilities.JfrTicks;
+import com.oracle.svm.core.jdk.jfr.utilities.JfrTypes;
+
+public class JfrMetadataEvent {
+    private static long metadataId = 0;
+    private static long lastMetadataId = 0;
+    private static byte[] metadata;
+
+    public static void write(JfrChunkWriter writer) {
+        assert (writer.isValid());
+
+        if (JfrMetadataEvent.lastMetadataId == JfrMetadataEvent.metadataId && writer.hasMetadata()) {
+            return;
+        }
+
+        try {
+            long metadataOffset = writer.reserve(Integer.BYTES);
+            writer.encoded().writeLong(JfrTypes.ReservedEvent.EVENT_METADATA.id);
+            writer.encoded().writeLong(JfrTicks.now());
+            // Duration, always 0
+            writer.encoded().writeLong(0);
+            writer.encoded().writeLong(metadataId);
+
+            writeMetadata(writer, Thread.currentThread());
+
+            int sizeWritten = (int) (writer.getCurrentOffset() - metadataOffset);
+            writer.padded().writeInt(sizeWritten, metadataOffset);
+
+            writer.setLastMetadataOffset(metadataOffset);
+            lastMetadataId = metadataId;
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    private static void writeMetadata(JfrChunkWriter writer, Thread thread) {
+        assert (writer.isValid());
+        assert (thread != null);
+        assert (metadata != null);
+        try {
+            writer.writeUnbuffered(metadata, metadata.length);
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    // Called from JFR Java code
+    public static void update(byte[] metadata) {
+        JfrMetadataEvent.metadata = metadata;
+        metadataId++;
+    }
+}

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/jfr/recorder/checkpoint/types/JfrArtifactSet.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/jfr/recorder/checkpoint/types/JfrArtifactSet.java
@@ -48,11 +48,11 @@ public class JfrArtifactSet {
 
     private static final AtomicLong symbolCounter = new AtomicLong(1);
 
-    public JfrArtifactSet(boolean classUnload) {
-        initialize(classUnload, false);
+    public JfrArtifactSet() {
+        initialize(false);
     }
 
-    public void initialize(boolean classUnload, boolean clearArtifacts) {
+    public void initialize(boolean clearArtifacts) {
         this.klassList.clear();
         if (clearArtifacts) {
             this.symbolMap.clear();

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/jfr/recorder/checkpoint/types/JfrArtifactSet.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/jfr/recorder/checkpoint/types/JfrArtifactSet.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, Red Hat Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package com.oracle.svm.core.jdk.jfr.recorder.checkpoint.types;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Consumer;
+
+public class JfrArtifactSet {
+
+    private final Set<Class<?>> klassList = new HashSet<>();
+    // Go by package name as java.lang.Package has default equals
+    // and package instances are not equal in graal
+    // https://github.com/oracle/graal/issues/2989
+    private final Set<Package> packageList = new HashSet<>();
+    private final Set<Module> moduleList = new HashSet<>();
+    private final Set<ClassLoader> classLoaderList = new HashSet<>();
+
+    private final Map<String, Long> symbolMap = new HashMap<>();
+    private int totalCount;
+
+    private static final AtomicLong symbolCounter = new AtomicLong(1);
+
+    public JfrArtifactSet(boolean classUnload) {
+        initialize(classUnload, false);
+    }
+
+    public void initialize(boolean classUnload, boolean clearArtifacts) {
+        this.klassList.clear();
+        if (clearArtifacts) {
+            this.symbolMap.clear();
+            symbolCounter.set(1);
+        }
+        this.totalCount = 0;
+    }
+
+    public boolean hasKlassEntries() {
+        return !this.klassList.isEmpty();
+    }
+
+    public void registerKlass(Class<?> c) {
+        assert (c != null);
+        this.klassList.add(c);
+        // Don't include the package that represents no package
+        if (c.getPackage() != null && c.getPackage().hashCode() != 0) {
+            this.packageList.add(c.getPackage());
+        }
+        if (c.getModule() != null) {
+            this.moduleList.add(c.getModule());
+        }
+        if (c.getClassLoader() != null) {
+            this.classLoaderList.add(c.getClassLoader());
+        }
+    }
+
+    public long mark(Class<?> c, boolean leak) {
+        assert (c != null);
+        // JFR.TODO
+        // if (is_hidden_or_anon_klass(k)) {
+        // assert(k->is_instance_klass(), "invariant");
+        // symbol_id = mark_hidden_or_anon_klass_name((const InstanceKlass*)k, leakp);
+        // }
+        long id = mark(c.getName(), leak);
+        assert (id > 0);
+        return id;
+    }
+
+    public void iterateKlasses(Consumer<Class<?>> consumer) {
+        iterateSet(consumer, klassList);
+    }
+
+    public void iteratePackages(Consumer<Package> consumer) {
+        iterateSet(consumer, packageList);
+    }
+
+    public void iterateModules(Consumer<Module> consumer) {
+        iterateSet(consumer, moduleList);
+    }
+
+    public void iterateClassLoaders(Consumer<ClassLoader> consumer) {
+        iterateSet(consumer, classLoaderList);
+    }
+
+    private <T> void iterateSet(Consumer<T> c, Set<T> set) {
+        for (T item : set) {
+            c.accept(item);
+        }
+    }
+
+    public long mark(String name, boolean leak) {
+        if (this.symbolMap.containsKey(name)) {
+            return this.symbolMap.get(name);
+        } else if (name.trim().length() > 0) {
+            long nextId = symbolCounter.getAndIncrement();
+            this.symbolMap.put(name, nextId);
+            return nextId;
+        } else {
+            return 0;
+        }
+    }
+
+    public Map<String, Long> getSymbolMap() {
+        return this.symbolMap;
+    }
+
+    public void tally(int count) {
+        this.totalCount += count;
+    }
+
+    public int getTotalCount() {
+        return this.totalCount;
+    }
+
+}

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/jfr/recorder/checkpoint/types/JfrSerializer.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/jfr/recorder/checkpoint/types/JfrSerializer.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, Red Hat Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package com.oracle.svm.core.jdk.jfr.recorder.checkpoint.types;
+
+public class JfrSerializer {
+    // JFR.TODO
+    public void onRotation() {
+    }
+}

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/jfr/recorder/checkpoint/types/JfrSerializerRegistration.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/jfr/recorder/checkpoint/types/JfrSerializerRegistration.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, Red Hat Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package com.oracle.svm.core.jdk.jfr.recorder.checkpoint.types;
+
+public class JfrSerializerRegistration {
+    // JFR.TODO
+    private final JfrSerializer serializer = new JfrSerializer();
+
+    public void onRotation() {
+        this.serializer.onRotation();
+    }
+}

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/jfr/recorder/checkpoint/types/JfrTypeManager.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/jfr/recorder/checkpoint/types/JfrTypeManager.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, Red Hat Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package com.oracle.svm.core.jdk.jfr.recorder.checkpoint.types;
+
+import java.util.LinkedList;
+import java.util.List;
+
+import com.oracle.svm.core.jdk.jfr.recorder.checkpoint.JfrCheckpointWriter;
+
+public class JfrTypeManager {
+
+    private static final List<JfrSerializerRegistration> registrationList = new LinkedList<>();
+
+    public static void onRotation() {
+        for (JfrSerializerRegistration registration : registrationList) {
+            registration.onRotation();
+        }
+    }
+
+    public static void writeStaticTypes(JfrCheckpointWriter writer) {
+        // JFR.TODO
+    }
+
+    public static void writeThreads(JfrCheckpointWriter writer) {
+        // JFR.TODO
+    }
+
+    public static boolean initialize() {
+        return true;
+    }
+}

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/jfr/recorder/checkpoint/types/JfrTypeSet.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/jfr/recorder/checkpoint/types/JfrTypeSet.java
@@ -1,0 +1,547 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, Red Hat Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package com.oracle.svm.core.jdk.jfr.recorder.checkpoint.types;
+
+import java.io.IOException;
+import java.util.Set;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+
+import org.graalvm.nativeimage.ImageSingletons;
+
+import com.oracle.svm.core.jdk.jfr.JfrRuntimeAccess;
+import com.oracle.svm.core.jdk.jfr.recorder.checkpoint.JfrCheckpointWriter;
+import com.oracle.svm.core.jdk.jfr.recorder.checkpoint.types.traceid.JfrTraceId;
+import com.oracle.svm.core.jdk.jfr.recorder.checkpoint.types.traceid.JfrTraceIdLoadBarrier;
+import com.oracle.svm.core.jdk.jfr.utilities.JfrTypes;
+
+public class JfrTypeSet {
+
+    private static JfrCheckpointWriter checkpointWriter;
+    private static JfrCheckpointWriter leakWriter;
+
+    // JFR.TODO
+    // Will we ever need to handle class unloading?
+    private static boolean classUnload;
+    private static boolean flushpoint;
+
+    private static JfrArtifactSet artifactSet;
+    private static boolean clearArtifacts;
+
+    private static long checkpointId = 1;
+
+    /**
+     * Write all "tagged" (in-use) constant artifacts and their dependencies.
+     */
+    public static int serialize(JfrCheckpointWriter writer, JfrCheckpointWriter leakWriter, boolean classUnload,
+            boolean flushpoint) {
+        setup(writer, leakWriter, classUnload, flushpoint);
+
+        if (!writeKlasses()) {
+            return 0;
+        }
+
+        writePackages();
+        writeModules();
+        writeClassloaders();
+        // JFR.TODO
+        // writeMethods();
+        writeSymbols();
+        return teardown();
+    }
+
+    private static int teardown() {
+        int totalCount = artifactSet.getTotalCount();
+        if (previousEpoch()) {
+            clearArtifacts();
+            clearArtifacts = true;
+            ++checkpointId;
+        }
+
+        return totalCount;
+    }
+
+    private static void writeSymbols() {
+        assert (checkpointWriter != null);
+
+        JfrTypeWriter symbolWriter = new JfrTypeWriter(JfrTypes.JfrTypeId.TYPE_SYMBOL.id, checkpointWriter);
+
+        if (leakWriter == null) {
+            try {
+                symbolWriter.begin();
+                BiConsumer<String, Long> sc = (s, l) -> symbolWriter.incrementCount(writeSymbol(checkpointWriter, s, l));
+                artifactSet.getSymbolMap().forEach(sc);
+
+                symbolWriter.end();
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        } else {
+            throw new RuntimeException("Leak Profiler not yet implemented");
+        }
+        artifactSet.tally(symbolWriter.count());
+    }
+
+    private static int writeSymbol(JfrCheckpointWriter writer, String s, Long id) {
+        try {
+            writer.encoded().writeLong(getSymbolId(id));
+            byte UTF8 = 3;
+            writer.encoded().writeByte(UTF8);
+            writer.encoded().writeInt(s.length());
+            for (byte b : s.getBytes()) {
+                writer.encoded().writeByte(b);
+            }
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+        return 1;
+    }
+
+    private static void writeMethods() {
+        // JFR.TODO
+        // Write out methods
+    }
+
+    private static void writeClassloaders() {
+        assert (checkpointWriter != null);
+
+        JfrTypeWriter classloaderWriter = new JfrTypeWriter(JfrTypes.JfrTypeId.TYPE_CLASSLOADER.id, checkpointWriter);
+        try {
+            classloaderWriter.begin();
+            Consumer<Class<?>> km = c -> {
+                ClassLoader cld = c.getClassLoader();
+                if (cld != null && !JfrTraceId.isSerialized(cld)) {
+                    classloaderWriter.incrementCount(writeClassloader(checkpointWriter, cld));
+                }
+            };
+            if (currentEpoch()) {
+                artifactSet.iterateKlasses(km);
+                for (ClassLoader cl : getReachableClassloaders()) {
+                    if (!JfrTraceId.isSerialized(cl)) {
+                        classloaderWriter.incrementCount(writeClassloader(checkpointWriter, cl));
+                    }
+                }
+                artifactSet.tally(classloaderWriter.count());
+                classloaderWriter.end();
+                return;
+            }
+            if (leakWriter == null) {
+                // JFR.TODO
+                artifactSet.iterateKlasses(km);
+                for (ClassLoader cl : getReachableClassloaders()) {
+                    if (!JfrTraceId.isSerialized(cl)) {
+                        classloaderWriter.incrementCount(writeClassloader(checkpointWriter, cl));
+                    }
+                }
+                // This iterates the CLDG and writes then clears the classloaders
+            } else {
+                throw new RuntimeException("Leak Profiler not yet implemented");
+            }
+
+            artifactSet.tally(classloaderWriter.count());
+            classloaderWriter.end();
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+
+    }
+
+    private static int writeClassloader(JfrCheckpointWriter writer, ClassLoader cld) {
+        assert (cld != null);
+        JfrTraceId.setSerialized(cld);
+        return writeClassloader(writer, cld, false);
+    }
+
+    private static int writeClassloader(JfrCheckpointWriter writer, ClassLoader cld, boolean leak) {
+        assert (cld != null);
+        assert (artifactSet != null);
+        try {
+            writer.encoded().writeLong(cldId(cld, leak));
+            long cid = cld.getClass() != null ? JfrTraceId.getTraceId(cld.getClass()) : 0;
+            writer.encoded().writeLong(cid);
+            String name = cld.getName() == null ? "bootstrap" : cld.getName();
+            writer.encoded().writeLong(markSymbol(name, leak));
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+        return 1;
+    }
+
+    private static void writeModules() {
+        assert (checkpointWriter != null);
+
+        JfrTypeWriter moduleWriter = new JfrTypeWriter(JfrTypes.JfrTypeId.TYPE_MODULE.id, checkpointWriter);
+        try {
+            moduleWriter.begin();
+            Consumer<Class<?>> km = c -> {
+                Module m = c.getModule();
+                if (m != null && !JfrTraceId.isSerialized(m)) {
+                    moduleWriter.incrementCount(writeModule(checkpointWriter, m));
+                }
+            };
+            if (currentEpoch()) {
+                artifactSet.iterateKlasses(km);
+                artifactSet.tally(moduleWriter.count());
+                moduleWriter.end();
+                return;
+            }
+            if (leakWriter == null) {
+                artifactSet.iterateKlasses(km);
+                // JFR.TODO
+                // This iterates the CLDG and writes then clears their modules
+            } else {
+                throw new RuntimeException("Leak profiler paths are not yet implemented");
+            }
+
+            artifactSet.tally(moduleWriter.count());
+            moduleWriter.end();
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    private static int writeModule(JfrCheckpointWriter writer, Module m) {
+        assert (m != null);
+        JfrTraceId.setSerialized(m);
+        return writeModule(writer, m, false);
+    }
+
+    private static int writeModule(JfrCheckpointWriter writer, Module m, boolean leak) {
+        assert (m != null);
+        assert (artifactSet != null);
+        try {
+            writer.encoded().writeLong(moduleId(m, leak));
+            writer.encoded().writeLong(markSymbol(m.getName(), leak));
+            String version;
+            if (m.getDescriptor() == null) {
+                version = "";
+            } else {
+                version = m.getDescriptor().version().isPresent() ? m.getDescriptor().version().get().toString() : "";
+            }
+            if (version.equals("")) {
+                writer.encoded().writeLong(0);
+            } else {
+                writer.encoded().writeLong(markSymbol(version, leak));
+            }
+            // writer->write(mark_symbol(mod->location(), leakp)
+            writer.encoded().writeLong(0);
+            writer.encoded().writeLong(m.getClassLoader() != null ? cldId(m.getClassLoader(), leak) : 0);
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+        return 1;
+    }
+
+    private static long cldId(ClassLoader classLoader, boolean leak) {
+        assert (classLoader != null);
+        if (leak) {
+            // JFR.TODO.LEAK
+        } else {
+            JfrTraceId.setTransient(classLoader);
+        }
+        return JfrTraceId.getTraceId(classLoader);
+    }
+
+    private static long moduleId(Module m, boolean leak) {
+        assert (m != null);
+        if (leak) {
+            // JFR.TODO.LEAK
+        } else {
+            JfrTraceId.setTransient(m);
+        }
+        return JfrTraceId.getTraceId(m);
+    }
+
+    private static void writePackages() {
+        assert (checkpointWriter != null);
+
+        JfrTypeWriter packageWriter = new JfrTypeWriter(JfrTypes.JfrTypeId.TYPE_PACKAGE.id, checkpointWriter);
+        try {
+            packageWriter.begin();
+
+            Consumer<Class<?>> kp = c -> {
+                Package p = c.getPackage();
+                if (p != null && p.hashCode() != 0 && !JfrTraceId.isSerialized(p)) {
+                    packageWriter.incrementCount(writePackage(checkpointWriter, c));
+                }
+            };
+
+            if (currentEpoch()) {
+                artifactSet.iterateKlasses(kp);
+                artifactSet.tally(packageWriter.count());
+                packageWriter.end();
+                return;
+            }
+
+            if (leakWriter == null) {
+                artifactSet.iterateKlasses(kp);
+                // JFR.TODO
+                // This iterates the CLDG and writes then clears their packages
+
+            } else {
+                throw new RuntimeException("Leak profiler paths are not yet implemented");
+            }
+
+            artifactSet.tally(packageWriter.count());
+
+            packageWriter.end();
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+        assert (previousEpoch());
+    }
+
+    private static int writePackage(JfrCheckpointWriter writer, Class<?> c) {
+        JfrTraceId.setSerialized(c.getPackage());
+        return writePackage(writer, c, false);
+    }
+
+    private static int writePackage(JfrCheckpointWriter writer, Class<?> c, boolean leak) {
+        assert (writer != null);
+        assert (artifactSet != null);
+
+        Package p = c.getPackage();
+
+        assert (p != null);
+
+        try {
+            long traceid = JfrTraceId.getTraceId(p);
+            assert (traceid != -1);
+            writer.encoded().writeLong(JfrTraceId.getTraceId(p));
+            writer.encoded().writeLong(markSymbol(p.getName(), leak));
+            writer.encoded().writeLong(moduleId(c, leak));
+            // JFR.TODO
+            // writer->write((bool)pkg->is_exported());
+            writer.encoded().writeInt(0);
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+
+        return 1;
+    }
+
+    private static long moduleId(Class<?> c, boolean leak) {
+        assert (c != null);
+        Module m = c.getModule();
+        if (!m.isNamed()) {
+            return 0;
+        }
+
+        if (leak) {
+            // JFR.TODO.LEAK
+        } else {
+            JfrTraceId.setTransient(m);
+        }
+
+        return JfrTraceId.getTraceId(m);
+    }
+
+    private static long packageId(Class<?> c) {
+        Package p = c.getPackage();
+        if (p.hashCode() == 0) {
+            return 0;
+        }
+        if (JfrTraceId.getTraceId(p) != -1) {
+            return JfrTraceId.getTraceId(p);
+        }
+
+        return JfrTraceId.assign(p);
+    }
+
+    private static boolean writeKlasses() {
+        assert (!artifactSet.hasKlassEntries());
+        assert (checkpointWriter != null);
+
+        JfrTypeWriter klassWriter = new JfrTypeWriter(JfrTypes.JfrTypeId.TYPE_CLASS.id, checkpointWriter);
+
+        if (leakWriter == null && !classUnload) {
+            try {
+                klassWriter.begin();
+                Consumer<Class<?>> kc = c -> {
+                    if (!JfrTraceId.isSerialized(c)) {
+                        klassWriter.incrementCount(writeKlass(checkpointWriter, c));
+                    }
+                    artifactSet.registerKlass(c);
+                };
+
+                JfrTraceIdLoadBarrier.doKlasses(kc, previousEpoch());
+                doClassloaders(klassWriter);
+                doObject();
+
+                klassWriter.end();
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        } else {
+            throw new RuntimeException("Leak profiler not yet implemented");
+        }
+        if (isComplete()) {
+            return false;
+        }
+
+        artifactSet.tally(klassWriter.count());
+        return true;
+    }
+
+    private static boolean isComplete() {
+        return !artifactSet.hasKlassEntries() && currentEpoch();
+    }
+
+    private static int writeKlass(JfrCheckpointWriter writer, Class<?> c) {
+        JfrTraceId.setSerialized(c);
+        return writeKlass(writer, c, false);
+    }
+
+    private static int writeKlass(JfrCheckpointWriter writer, Class<?> c, boolean leak) {
+        assert (writer != null);
+        assert (artifactSet != null);
+        assert (c != null);
+        try {
+            long cid = JfrTraceId.getTraceId(c);
+            writer.encoded().writeLong(cid);
+            ClassLoader cld = c.getClassLoader();
+            long cldid = cld != null ? cldId(cld, leak) : 0;
+            writer.encoded().writeLong(cldid);
+            long symid = markSymbol(c, leak);
+            writer.encoded().writeLong(symid);
+            long pid = c.getPackage() != null ? packageId(c) : 0;
+            writer.encoded().writeLong(pid);
+            // JFR.TODO
+            // writer->write(get_flags(klass));
+            writer.encoded().writeInt(0);
+            // JFR.TODO: This is added to metadata for JDK 15+
+            // writer->write<bool>(klass->is_hidden());
+            // writer.encoded().writeInt(0);
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+
+        return 1;
+    }
+
+    private static long markSymbol(Class<?> c, boolean leak) {
+        return c != null ? getSymbolId(artifactSet.mark(c, leak)) : 0;
+    }
+
+    private static long markSymbol(String name, boolean leak) {
+        return name != null ? getSymbolId(artifactSet.mark(name, leak)) : 0;
+    }
+
+    private static long getSymbolId(long artifactId) {
+        return artifactId != 0 ? checkpointId << 24 | artifactId : 0;
+    }
+
+    private static void doObject() {
+        // JFR.TODO
+        // Write java.lang.Object
+    }
+
+    private static void doClassloaders(JfrTypeWriter klassWriter) {
+        assert (checkpointWriter != null);
+        for (ClassLoader cl : getReachableClassloaders()) {
+            Class<?> c = cl.getClass();
+            if (!JfrTraceId.isSerialized(c)) {
+                klassWriter.incrementCount(writeKlass(checkpointWriter, c));
+            }
+            artifactSet.registerKlass(c);
+        }
+    }
+
+    private static boolean currentEpoch() {
+        return classUnload || flushpoint;
+    }
+
+    private static boolean previousEpoch() {
+        return !currentEpoch();
+    }
+
+    private static void setup(JfrCheckpointWriter writer, JfrCheckpointWriter leakWriter, boolean classUnload,
+            boolean flushpoint) {
+        checkpointWriter = writer;
+        JfrTypeSet.leakWriter = leakWriter;
+        JfrTypeSet.classUnload = classUnload;
+        JfrTypeSet.flushpoint = flushpoint;
+
+        if (artifactSet == null) {
+            artifactSet = new JfrArtifactSet(JfrTypeSet.classUnload);
+        } else {
+            artifactSet.initialize(JfrTypeSet.classUnload, clearArtifacts);
+        }
+
+        // if (!_class_unload) {
+        // JfrKlassUnloading::sort(previous_epoch());
+        // }
+        clearArtifacts = false;
+        assert (artifactSet != null);
+        assert (!artifactSet.hasKlassEntries());
+
+    }
+
+    private static Set<ClassLoader> getReachableClassloaders() {
+        return ImageSingletons.lookup(JfrRuntimeAccess.class).getReachableClassloaders();
+    }
+
+    public static void clear() {
+        clearArtifacts();
+        clearArtifacts = true;
+        setup(null, null, false, false);
+    }
+
+    private static void clearArtifacts() {
+        if (artifactSet == null) {
+            return;
+        }
+        clearPackages();
+        clearModules();
+        clearClassloaders();
+        clearKlassesAndMethods();
+    }
+
+    private static void clearPackages() {
+        Consumer<Package> consumer = JfrTraceId::clearSerialized;
+        artifactSet.iteratePackages(consumer);
+    }
+
+    private static void clearModules() {
+        Consumer<Module> consumer = JfrTraceId::clearSerialized;
+        artifactSet.iterateModules(consumer);
+    }
+
+    private static void clearClassloaders() {
+        Consumer<ClassLoader> consumer = JfrTraceId::clearSerialized;
+        artifactSet.iterateClassLoaders(consumer);
+        for (ClassLoader cl : getReachableClassloaders()) {
+            JfrTraceId.clearSerialized(cl);
+        }
+    }
+
+    private static void clearKlassesAndMethods() {
+        Consumer<Class<?>> consumer = JfrTraceId::clearSerialized;
+        artifactSet.iterateKlasses(consumer);
+
+    }
+}

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/jfr/recorder/checkpoint/types/JfrTypeWriter.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/jfr/recorder/checkpoint/types/JfrTypeWriter.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, Red Hat Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package com.oracle.svm.core.jdk.jfr.recorder.checkpoint.types;
+
+import java.io.IOException;
+
+import com.oracle.svm.core.jdk.jfr.recorder.checkpoint.JfrCheckpointWriter;
+
+public class JfrTypeWriter {
+
+    private static class JfrTypeWriterContext {
+        final int offset;
+        final int count;
+
+        JfrTypeWriterContext(int offset, int count) {
+            this.offset = offset;
+            this.count = count;
+        }
+    }
+
+    private final JfrCheckpointWriter writer;
+    private final long typeId;
+    private final boolean skipHeader;
+
+    private JfrTypeWriterContext context;
+    private int countOffset;
+    private int count;
+
+    public JfrTypeWriter(long typeId, JfrCheckpointWriter writer) {
+        this(typeId, writer, false);
+    }
+
+    public JfrTypeWriter(long typeId, JfrCheckpointWriter writer, boolean skipHeader) {
+        this.typeId = typeId;
+        this.writer = writer;
+        this.skipHeader = skipHeader;
+    }
+
+    public void begin() throws IOException {
+        assert (writer != null);
+        this.context = new JfrTypeWriterContext(this.writer.getCurrentOffset(), this.writer.count());
+
+        if (!skipHeader) {
+            this.writer.increment();
+            this.writer.encoded().writeLong(typeId);
+            this.countOffset = this.writer.reserve(Integer.BYTES);
+        }
+    }
+
+    public void end() throws IOException {
+        if (this.count == 0) {
+            this.writer.setContext(this.context.offset, this.context.count);
+            return;
+        }
+        assert (this.count > 0);
+        if (!skipHeader) {
+            this.writer.padded().writeInt(this.count, this.countOffset);
+        }
+    }
+
+    public int count() {
+        return this.count;
+    }
+
+    public void incrementCount(int count) {
+        this.count += count;
+    }
+}

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/jfr/recorder/checkpoint/types/traceid/JfrTraceId.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/jfr/recorder/checkpoint/types/traceid/JfrTraceId.java
@@ -29,6 +29,7 @@ package com.oracle.svm.core.jdk.jfr.recorder.checkpoint.types.traceid;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicLong;
 
+import jdk.jfr.internal.JVM;
 import org.graalvm.nativeimage.ImageSingletons;
 
 import com.oracle.svm.core.jdk.jfr.JfrAvailability;
@@ -58,7 +59,6 @@ public class JfrTraceId {
     private static final long JDK_JFR_EVENT_KLASS = 32;
     private static final long EVENT_HOST_KLASS = 64;
 
-    private static final AtomicLong classCounter = new AtomicLong(MaxJfrEventId + 100);
     private static final AtomicLong classLoaderCounter = new AtomicLong(1);
     private static final AtomicLong packageCounter = new AtomicLong(1);
     private static final AtomicLong moduleCounter = new AtomicLong(1);
@@ -158,8 +158,8 @@ public class JfrTraceId {
     public static long assign(Class<?> clazz) {
         assert clazz != null;
         assert getTraceIdMap().getId(clazz) == -1;
-        long nextId = classCounter.getAndIncrement();
-        getTraceIdMap().setId(clazz, nextId << TRACE_ID_SHIFT);
+        long typeId = JVM.getJVM().getTypeId(clazz);
+        getTraceIdMap().setId(clazz, typeId << TRACE_ID_SHIFT);
         if (!setSystemEventClass(clazz)) {
             Class<?> superClazz = clazz.getSuperclass();
             if (superClazz != null) {
@@ -172,7 +172,7 @@ public class JfrTraceId {
             }
         }
 
-        return nextId;
+        return typeId;
     }
 
     public static long assign(ClassLoader classLoader) {

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/jfr/recorder/checkpoint/types/traceid/JfrTraceId.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/jfr/recorder/checkpoint/types/traceid/JfrTraceId.java
@@ -1,0 +1,277 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, Red Hat Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package com.oracle.svm.core.jdk.jfr.recorder.checkpoint.types.traceid;
+
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.graalvm.nativeimage.ImageSingletons;
+
+import com.oracle.svm.core.jdk.jfr.JfrAvailability;
+import com.oracle.svm.core.jdk.jfr.JfrRuntimeAccess;
+
+public class JfrTraceId {
+
+    private static final long MaxJfrEventId = 403;
+
+    public static final long BIT = 1;
+    public static final long META_SHIFT = 8;
+    public static final long TRANSIENT_META_BIT = (BIT << 3);
+    public static final long TRANSIENT_BIT = (TRANSIENT_META_BIT << META_SHIFT);
+    public static final long SERIALIZED_META_BIT = (BIT << 4);
+    public static final long SERIALIZED_BIT = (SERIALIZED_META_BIT << META_SHIFT);
+
+    private static final int TRACE_ID_SHIFT = 16;
+
+    // Epoch stuff
+    private static final long USED_BIT = 1;
+    private static final int EPOCH_1_SHIFT = 0;
+    private static final int EPOCH_2_SHIFT = 1;
+    private static final long USED_EPOCH_1_BIT = USED_BIT << EPOCH_1_SHIFT;
+    private static final long USED_EPOCH_2_BIT = USED_BIT << EPOCH_2_SHIFT;
+
+    private static final long JDK_JFR_EVENT_SUBKLASS = 16;
+    private static final long JDK_JFR_EVENT_KLASS = 32;
+    private static final long EVENT_HOST_KLASS = 64;
+
+    private static final AtomicLong classCounter = new AtomicLong(MaxJfrEventId + 100);
+    private static final AtomicLong classLoaderCounter = new AtomicLong(1);
+    private static final AtomicLong packageCounter = new AtomicLong(1);
+    private static final AtomicLong moduleCounter = new AtomicLong(1);
+    private static final AtomicLong threadCounter = new AtomicLong(1);
+
+    private static JfrTraceIdMap getTraceIdMap() {
+        return ImageSingletons.lookup(JfrRuntimeAccess.class).getTraceIdMap();
+    }
+
+    public static void tag(Object obj, long bits) {
+        JfrTraceIdMap map = getTraceIdMap();
+        long id = map.getId(obj);
+        assert id != -1;
+        map.setId(obj, (id & ~0xff) | (bits & 0xff));
+    }
+
+    public static boolean predicate(Object obj, long bits) {
+        JfrTraceIdMap map = getTraceIdMap();
+        long id = map.getId(obj);
+        assert id != -1;
+        return (id & bits) != 0;
+    }
+
+    public static boolean predicate(Package p, long bits) {
+        Map<String, Long> map = getTraceIdMap().getPackageMap();
+        long id = map.get(p.getName());
+        assert id != -1;
+        return (id & bits) != 0;
+    }
+
+    public static void setUsedThisEpoch(Object obj) {
+        tag(obj, JfrTraceIdEpoch.thisEpochBit());
+    }
+
+    public static boolean isUsedThisEpoch(Object obj) {
+        return predicate(obj, TRANSIENT_BIT | JfrTraceIdEpoch.thisEpochBit());
+    }
+
+    public static long getTraceIdRaw(Object obj) {
+        return getTraceIdMap().getId(obj);
+    }
+
+    public static long getTraceId(Package p) {
+        Long traceid = getTraceIdMap().getPackageMap().get(p.getName());
+        if (traceid != null) {
+            return traceid >> TRACE_ID_SHIFT;
+        } else {
+            return -1;
+        }
+    }
+
+    public static long getTraceId(Object obj) {
+        return getTraceIdMap().getId(obj) >> TRACE_ID_SHIFT;
+    }
+
+    public static long load(Class<?> clazz) {
+        return JfrTraceIdLoadBarrier.load(clazz);
+    }
+
+    private static void tagAsJdkJfrEvent(Class<?> clazz) {
+        JfrTraceIdMap map = getTraceIdMap();
+        long id = map.getId(clazz);
+        assert id != -1;
+        map.setId(clazz, id | JDK_JFR_EVENT_KLASS);
+    }
+
+    private static void tagAsJdkJfrEventSub(Class<?> clazz) {
+        JfrTraceIdMap map = getTraceIdMap();
+        long id = map.getId(clazz);
+        assert id != -1;
+        map.setId(clazz, id | JDK_JFR_EVENT_SUBKLASS);
+    }
+
+    private static boolean isEventClass(Class<?> clazz) {
+        JfrTraceIdMap map = getTraceIdMap();
+        long id = map.getId(clazz);
+        assert id != -1;
+        return (id & (JDK_JFR_EVENT_KLASS | JDK_JFR_EVENT_SUBKLASS)) != 0;
+    }
+
+    private static boolean setSystemEventClass(Class<?> clazz) {
+        String className = clazz.getCanonicalName();
+        if (className != null && className.equals("jdk.internal.event.Event")
+                && clazz.getClassLoader() == null || clazz.getClassLoader() == ClassLoader.getSystemClassLoader()) {
+            tagAsJdkJfrEvent(clazz);
+            return true;
+        }
+
+        if (className != null && className.equals("jdk.jfr.Event")
+                && clazz.getClassLoader() == null || clazz.getClassLoader() == ClassLoader.getSystemClassLoader()) {
+            tagAsJdkJfrEvent(clazz);
+            return true;
+        }
+        return false;
+    }
+
+    public static long assign(Class<?> clazz) {
+        assert clazz != null;
+        assert getTraceIdMap().getId(clazz) == -1;
+        long nextId = classCounter.getAndIncrement();
+        getTraceIdMap().setId(clazz, nextId << TRACE_ID_SHIFT);
+        if (!setSystemEventClass(clazz)) {
+            Class<?> superClazz = clazz.getSuperclass();
+            if (superClazz != null) {
+                if (getTraceIdMap().getId(superClazz) == -1) {
+                    assign(superClazz);
+                }
+                if (isEventClass(superClazz)) {
+                    tagAsJdkJfrEventSub(clazz);
+                }
+            }
+        }
+
+        return nextId;
+    }
+
+    public static long assign(ClassLoader classLoader) {
+        assert classLoader != null;
+        long nextId = classLoaderCounter.getAndIncrement();
+        getTraceIdMap().setId(classLoader, nextId << TRACE_ID_SHIFT);
+        return nextId;
+    }
+
+    public static long assign(Package pkg) {
+        assert pkg != null;
+        long nextId = packageCounter.getAndIncrement();
+        getTraceIdMap().getPackageMap().put(pkg.getName(), nextId << TRACE_ID_SHIFT);
+        assert (getTraceId(pkg) == nextId);
+        return nextId;
+    }
+
+    public static long assign(Module module) {
+        assert module != null;
+        long nextId = moduleCounter.getAndIncrement();
+        getTraceIdMap().setId(module, nextId << TRACE_ID_SHIFT);
+        return nextId;
+    }
+
+    public static void assign(Thread thread) {
+        if (!JfrAvailability.withJfr) {
+            return;
+        }
+        assert thread != null;
+        long nextId = threadCounter.incrementAndGet();
+        getTraceIdMap().setId(thread, nextId << TRACE_ID_SHIFT);
+    }
+
+    public static void unassign(Thread thread) {
+        if (!JfrAvailability.withJfr) {
+            return;
+        }
+        assert thread != null;
+        getTraceIdMap().clearId(thread);
+    }
+
+    public static long load(ClassLoader classLoader) {
+        return JfrTraceIdLoadBarrier.load(classLoader);
+    }
+
+    public static long load(Package pkg) {
+        return JfrTraceIdLoadBarrier.load(pkg);
+    }
+
+    public static long load(Module module) {
+        return JfrTraceIdLoadBarrier.load(module);
+    }
+
+    public static void setTransient(ClassLoader classLoader) {
+        long id = getTraceIdMap().getId(classLoader);
+        getTraceIdMap().setId(classLoader, id | TRANSIENT_BIT);
+    }
+
+    public static void setTransient(Module m) {
+        long id = getTraceIdMap().getId(m);
+        getTraceIdMap().setId(m, id | TRANSIENT_BIT);
+    }
+
+    public static boolean isSerialized(Object obj) {
+        return predicate(obj, SERIALIZED_BIT);
+    }
+
+    public static void setSerialized(Object obj) {
+        long id = getTraceIdMap().getId(obj);
+        assert (id != -1);
+        getTraceIdMap().setId(obj, id | SERIALIZED_BIT);
+    }
+
+    public static boolean isSerialized(Package p) {
+        return predicate(p, SERIALIZED_BIT);
+    }
+
+    public static void setSerialized(Package p) {
+        long id = getTraceIdMap().getPackageMap().get(p.getName());
+        assert (id != -1);
+        getTraceIdMap().getPackageMap().put(p.getName(), id | SERIALIZED_BIT);
+    }
+
+    public static void clearSerialized(Object obj) {
+        long id = getTraceIdMap().getId(obj);
+        assert (id != -1);
+        if (isSerialized(obj)) {
+            getTraceIdMap().setId(obj, id ^ SERIALIZED_BIT);
+        }
+        assert (!isSerialized(obj));
+    }
+
+    public static void clearSerialized(Package p) {
+        long id = getTraceIdMap().getPackageMap().get(p.getName());
+        assert (id != -1);
+        if (isSerialized(p)) {
+            getTraceIdMap().getPackageMap().put(p.getName(), id ^ SERIALIZED_BIT);
+        }
+        assert (!isSerialized(p));
+    }
+
+}

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/jfr/recorder/checkpoint/types/traceid/JfrTraceIdEpoch.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/jfr/recorder/checkpoint/types/traceid/JfrTraceIdEpoch.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2020, 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package com.oracle.svm.core.jdk.jfr.recorder.checkpoint.types.traceid;
+
+public class JfrTraceIdEpoch {
+    public static final long BIT = 1;
+    public static final long METHOD_BIT = (BIT << 2);
+    public static final long EPOCH_0_SHIFT = 0;
+    public static final long EPOCH_1_SHIFT = 1;
+    public static final long EPOCH_0_BIT = (BIT << EPOCH_0_SHIFT);
+    public static final long EPOCH_1_BIT = (BIT << EPOCH_1_SHIFT);
+    public static final long EPOCH_0_METHOD_BIT = (METHOD_BIT << EPOCH_0_SHIFT);
+    public static final long EPOCH_1_METHOD_BIT = (METHOD_BIT << EPOCH_1_SHIFT);
+    public static final long METHOD_AND_CLASS_BITS = (METHOD_BIT | BIT);
+    public static final long EPOCH_0_METHOD_AND_CLASS_BITS = (METHOD_AND_CLASS_BITS << EPOCH_0_SHIFT);
+    public static final long EPOCH_1_METHOD_AND_CLASS_BITS = (METHOD_AND_CLASS_BITS << EPOCH_1_SHIFT);
+
+    private static boolean epoch;
+    private static boolean synchronizing;
+    private static volatile boolean changedTag;
+
+    public static void beginEpochShift() {
+        synchronizing = true;
+    }
+
+    public static void endEpochShift() {
+        epoch = !epoch;
+        synchronizing = false;
+    }
+
+    public static boolean isChangedTag() {
+        return changedTag;
+    }
+
+    public static void setChangedTag(boolean changedTag) {
+        JfrTraceIdEpoch.changedTag = changedTag;
+    }
+
+    public static boolean hasChangedTag() {
+        if (isChangedTag()) {
+            setChangedTag(false);
+            return true;
+        }
+        return false;
+    }
+
+    public static void setChangedTag() {
+        if (!isChangedTag()) {
+            setChangedTag(true);
+        }
+    }
+
+    public static boolean getEpoch() {
+        return epoch;
+    }
+
+    static long thisEpochBit() {
+        return epoch ? EPOCH_1_BIT : EPOCH_0_BIT;
+    }
+
+    public static boolean currentEpoch() {
+        return epoch;
+    }
+
+    public static boolean previousEpoch() {
+        return !epoch;
+    }
+}

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/jfr/recorder/checkpoint/types/traceid/JfrTraceIdLoadBarrier.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/jfr/recorder/checkpoint/types/traceid/JfrTraceIdLoadBarrier.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2020, 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package com.oracle.svm.core.jdk.jfr.recorder.checkpoint.types.traceid;
+
+import java.util.LinkedList;
+import java.util.Queue;
+import java.util.function.Consumer;
+
+public class JfrTraceIdLoadBarrier {
+    private static Queue<Class<?>> klassQueueOne = null;
+    private static Queue<Class<?>> klassQueueTwo = null;
+
+    private static boolean isNotTagged(long value) {
+        long thisEpochBit = JfrTraceIdEpoch.thisEpochBit();
+        return ((value & ((thisEpochBit << JfrTraceId.META_SHIFT) | thisEpochBit)) != thisEpochBit);
+    }
+
+    private static boolean shouldTag(Object obj) {
+        assert obj != null;
+        return isNotTagged(JfrTraceId.getTraceIdRaw(obj));
+    }
+
+    private static void enqueue(Class<?> clazz) {
+        assert (JfrTraceId.isUsedThisEpoch(clazz));
+        klassQueue().add(clazz);
+    }
+
+    private static long setUsedAndGet(Object obj) {
+        assert obj != null;
+        if (shouldTag(obj)) {
+            JfrTraceId.setUsedThisEpoch(obj);
+            JfrTraceIdEpoch.setChangedTag();
+        }
+        assert JfrTraceId.isUsedThisEpoch(obj);
+        return JfrTraceId.getTraceId(obj);
+    }
+
+    public static void clear() {
+        getKlassQueue(JfrTraceIdEpoch.previousEpoch()).clear();
+    }
+
+    public static long load(Class<?> clazz) {
+        assert clazz != null;
+        if (shouldTag(clazz)) {
+            JfrTraceId.setUsedThisEpoch(clazz);
+            enqueue(clazz);
+            JfrTraceIdEpoch.setChangedTag();
+        }
+        assert JfrTraceId.isUsedThisEpoch(clazz);
+        return JfrTraceId.getTraceId(clazz);
+    }
+
+    public static long load(ClassLoader classLoader) {
+        assert classLoader != null;
+        return setUsedAndGet(classLoader);
+    }
+
+    public static long load(Package pkg) {
+        assert pkg != null;
+        return setUsedAndGet(pkg);
+    }
+
+    public static long load(Module module) {
+        assert module != null;
+        return setUsedAndGet(module);
+    }
+
+    public static boolean initialize() {
+        klassQueueOne = new LinkedList<>();
+        klassQueueTwo = new LinkedList<>();
+        return true;
+    }
+
+    private static Queue<Class<?>> klassQueue() {
+        return klassQueue(false);
+    }
+
+    private static Queue<Class<?>> klassQueue(boolean previousEpoch) {
+        if (previousEpoch) {
+            return getKlassQueue(JfrTraceIdEpoch.previousEpoch());
+        }
+        return getKlassQueue(JfrTraceIdEpoch.currentEpoch());
+    }
+
+    private static Queue<Class<?>> getKlassQueue(boolean epoch) {
+        if (epoch) {
+            return klassQueueOne;
+        } else {
+            return klassQueueTwo;
+        }
+    }
+
+    public static void doKlasses(Consumer<Class<?>> kc, boolean previousEpoch) {
+        for (Class<?> c : klassQueue(previousEpoch)) {
+            kc.accept(c);
+        }
+    }
+}

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/jfr/recorder/checkpoint/types/traceid/JfrTraceIdMap.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/jfr/recorder/checkpoint/types/traceid/JfrTraceIdMap.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, Red Hat Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package com.oracle.svm.core.jdk.jfr.recorder.checkpoint.types.traceid;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class JfrTraceIdMap {
+    private final HashMap<Object, Long> map = new HashMap<>();
+    private final HashMap<String, Long> packageMap = new HashMap<>();
+
+    synchronized long getId(Object key) {
+        Long id = map.get(key);
+        if (id != null) {
+            return id;
+        } else {
+            return -1;
+        }
+    }
+
+    synchronized void setId(Object key, long id) {
+        this.map.put(key, id);
+    }
+
+    synchronized void clearId(Object key) {
+        this.map.remove(key);
+    }
+
+    synchronized Map<String, Long> getPackageMap() {
+        return this.packageMap;
+    }
+}

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/jfr/recorder/repository/JfrChunk.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/jfr/recorder/repository/JfrChunk.java
@@ -1,0 +1,240 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, Red Hat Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package com.oracle.svm.core.jdk.jfr.recorder.repository;
+
+import static com.oracle.svm.core.jdk.jfr.utilities.JfrTime.invalidTime;
+
+import java.nio.file.Path;
+
+import com.oracle.svm.core.jdk.jfr.JfrOptions;
+import com.oracle.svm.core.jdk.jfr.utilities.JfrTicks;
+import com.oracle.svm.core.jdk.jfr.utilities.JfrTime;
+import com.oracle.svm.core.jdk.jfr.utilities.JfrTimeConverter;
+
+public class JfrChunk {
+    private Path path;
+    private long startTicks;
+    private long previousStartTicks;
+    private long startNanos;
+    private long previousStartNanos;
+    private long lastUpdateNanos;
+    private long lastCheckpointOffset;
+    private long lastMetadataOffset;
+    private int generation;
+
+    boolean isFinal;
+
+    private static final String MAGIC = "FLR\0";
+    private static final short JFR_VERSION_MAJOR = 2;
+    private static final short JFR_VERSION_MINOR = 1;
+
+    static final byte COMPLETE = 0;
+    static final int GUARD = 0xff;
+    static final byte PAD = 0;
+
+    // strictly monotone
+    static long last = 0;
+    static long getNanosNow() {
+        // We use javaTimeMillis so this can be correlated with
+        // external timestamps.
+        long now = System.currentTimeMillis() * JfrTimeConverter.NANOS_PER_MILLISEC;
+        if (now > last) {
+            last = now;
+        } else {
+            ++last;
+        }
+        return last;
+    }
+
+    static long getTicksNow() {
+        // TODO JFR Figure out what to use here
+        return JfrTicks.now();
+    }
+
+    public JfrChunk() {
+        previousStartTicks = invalidTime;
+        previousStartNanos = invalidTime;
+        generation = 1;
+
+        startTicks = startNanos = lastUpdateNanos = lastCheckpointOffset = lastMetadataOffset = 0;
+        isFinal = false;
+    }
+
+    void reset() {
+        path = null;
+        lastCheckpointOffset = 0;
+        lastMetadataOffset = 0;
+        generation = 1;
+    }
+
+    String getMagic() {
+        return MAGIC;
+    }
+
+    short getMajorVersion() {
+        return JFR_VERSION_MAJOR;
+    }
+
+    short getMinorVersion() {
+        return JFR_VERSION_MINOR;
+    }
+
+    void markFinal() {
+        isFinal = true;
+    }
+
+    short getFlags() {
+        // chunk capabilities, CompressedIntegers etc
+        short flags = 0;
+       if (JfrOptions.compressedIntegers()) {
+           flags |= 1;
+       }
+        if (isFinal) {
+            flags |= 1 << 1;
+        }
+        return flags;
+    }
+
+    private static final long frequency =  JfrTime.getFrequency();
+    long getCpuFrequency() {
+        return frequency;
+    }
+
+    void setLastCheckpointOffset(long offset) {
+        lastCheckpointOffset = offset;
+    }
+
+    long getLastCheckpointOffset() {
+        return lastCheckpointOffset;
+    }
+
+    long getStartTicks() {
+        assert startTicks != 0;
+        return startTicks;
+    }
+
+    long getStartNanos() {
+        assert startNanos != 0;
+        return startNanos;
+    }
+
+    long getPreviousStartTicks() {
+        assert previousStartTicks != invalidTime;
+        return previousStartTicks;
+    }
+
+    long getPreviousStartNanos() {
+        assert previousStartNanos != invalidTime;
+        return previousStartNanos;
+    }
+
+    void updateStartTicks() {
+        startTicks = getTicksNow();
+    }
+
+    void updateStartNanos() {
+        long now = getNanosNow();
+        assert now > startNanos;
+        assert now > lastUpdateNanos;
+        startNanos = lastUpdateNanos = now;
+    }
+
+    void updateCurrentNanos() {
+        long now = getNanosNow();
+        assert now > lastUpdateNanos;
+        lastUpdateNanos = now;
+    }
+
+    void saveCurrentAndUpdateStartTicks() {
+        previousStartTicks = startTicks;
+        updateStartTicks();
+    }
+
+    void saveCurrentAndUpdateStartNanos() {
+        previousStartNanos = startNanos;
+        updateStartNanos();
+    }
+
+    void setTimeStamp() {
+        saveCurrentAndUpdateStartNanos();
+        saveCurrentAndUpdateStartTicks();
+    }
+
+    long getLastChunkDuration() {
+        assert previousStartNanos != invalidTime;
+        return startNanos - previousStartNanos;
+    }
+
+    Path getPath() {
+        return path;
+    }
+
+    void setPath(Path path) {
+        this.path = path;
+    }
+
+    boolean isStarted() {
+        return startNanos != 0;
+    }
+
+    boolean isFinished() {
+        return 0 == generation;
+    }
+
+    long getDuration() {
+        assert lastUpdateNanos >= startNanos;
+        return lastUpdateNanos - startNanos;
+    }
+
+    long getLastMetadataOffset() {
+        return lastMetadataOffset;
+    }
+
+    void setLastMetadataOffset(long offset) {
+        assert offset > lastMetadataOffset;
+        lastMetadataOffset = offset;
+    }
+
+    boolean hasMetadata() {
+        return 0 != lastMetadataOffset;
+    }
+
+    int getGeneration() {
+        assert generation > 0;
+        int thisGeneration = generation++;
+        if (GUARD == generation) {
+            generation = 1;
+        }
+        return thisGeneration;
+    }
+
+    int getNextGeneration() {
+        assert generation > 0;
+        int nextGen = generation;
+        return GUARD == nextGen ? 1 : nextGen;
+    }
+}

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/jfr/recorder/repository/JfrChunkHeadWriter.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/jfr/recorder/repository/JfrChunkHeadWriter.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, Red Hat Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package com.oracle.svm.core.jdk.jfr.recorder.repository;
+
+import static com.oracle.svm.core.jdk.jfr.recorder.repository.JfrChunk.COMPLETE;
+import static com.oracle.svm.core.jdk.jfr.recorder.repository.JfrChunk.GUARD;
+import static com.oracle.svm.core.jdk.jfr.recorder.repository.JfrChunk.PAD;
+import static com.oracle.svm.core.jdk.jfr.recorder.repository.JfrChunkWriter.GENERATION_OFFSET;
+import static com.oracle.svm.core.jdk.jfr.recorder.repository.JfrChunkWriter.HEADER_SIZE;
+
+import java.io.IOException;
+
+public class JfrChunkHeadWriter {
+    private final JfrChunkWriter writer;
+    private final JfrChunk chunk;
+
+    public JfrChunkHeadWriter(JfrChunkWriter writer, long offset) throws IOException {
+        this(writer, offset, true);
+    }
+
+    public JfrChunkHeadWriter(JfrChunkWriter writer, long offset, boolean guard) throws IOException {
+        assert writer != null;
+        assert writer.isValid();
+        assert writer.chunk != null;
+        this.writer = writer;
+        this.chunk = writer.chunk;
+        if (0 == writer.getCurrentOffset()) {
+            assert HEADER_SIZE == offset;
+            initialize();
+        } else {
+            if (guard) {
+                writer.seek(GENERATION_OFFSET);
+                writeGuard();
+                writer.seek(offset);
+            } else {
+                chunk.updateCurrentNanos();
+            }
+        }
+//        DEBUG_ONLY(assert_writer_position(_writer, offset);)
+    }
+
+    void initialize() throws IOException {
+        assert writer.isValid();
+        assert chunk != null;
+//        DEBUG_ONLY(assert_writer_position(_writer, 0);)
+        writeMagic();
+        writeVersion();
+        writeSizeToGeneration(HEADER_SIZE, false);
+        writeFlags();
+//        DEBUG_ONLY(assert_writer_position(_writer, HEADER_SIZE);)
+        writer.flush();
+    }
+
+    public void writeMagic() throws IOException {
+        writer.writeBytes(chunk.getMagic().getBytes());
+    }
+
+    public void writeVersion() throws IOException {
+        writer.be().writeShort(chunk.getMajorVersion());
+        writer.be().writeShort(chunk.getMinorVersion());
+    }
+
+    public void writeSize(long size) throws IOException {
+        writer.be().writeLong(size);
+    }
+
+    public void writeCheckpoint() throws IOException {
+        writer.be().writeLong(chunk.getLastCheckpointOffset());
+    }
+
+    public void writeMetadata() throws IOException {
+        writer.be().writeLong(chunk.getLastMetadataOffset());
+    }
+
+    public void writeTime(boolean finalize) throws IOException {
+        if (finalize) {
+            writer.be().writeLong(chunk.getPreviousStartNanos());
+            writer.be().writeLong(chunk.getLastChunkDuration());
+            writer.be().writeLong(chunk.getPreviousStartTicks());
+            return;
+        }
+        writer.be().writeLong(chunk.getStartNanos());
+        writer.be().writeLong(chunk.getDuration());
+        writer.be().writeLong(chunk.getStartTicks());
+    }
+
+    public void writeCpuFrequency() throws IOException {
+        writer.be().writeLong(chunk.getCpuFrequency());
+    }
+
+    public void writeGeneration(boolean finalize) throws IOException {
+        writer.be().writeByte(finalize ? COMPLETE : (byte) chunk.getGeneration());
+        writer.be().writeByte(PAD);
+    }
+
+    public void writeNextGeneration() throws IOException {
+        writer.be().writeByte((byte) chunk.getNextGeneration());
+        writer.be().writeByte(PAD);
+    }
+
+    public void writeGuard() throws IOException {
+        writer.be().writeByte((byte) GUARD);
+        writer.be().writeByte(PAD);
+    }
+
+    public void writeFlags() throws IOException {
+        writer.be().writeShort(chunk.getFlags());
+    }
+
+    public void writeSizeToGeneration(long size, boolean finalize) throws IOException {
+        writeSize(size);
+        writeCheckpoint();
+        writeMetadata();
+        writeTime(finalize);
+        writeCpuFrequency();
+        writeGeneration(finalize);
+    }
+
+    void flush(long size, boolean finalize) throws IOException {
+        assert writer.isValid();
+        assert chunk != null;
+//        DEBUG_ONLY(assert_writer_position(_writer, SIZE_OFFSET);)
+        writeSizeToGeneration(size, finalize);
+        writeFlags();
+        writer.seek(size); // implicit flush
+    }
+}

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/jfr/recorder/repository/JfrChunkRotation.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/jfr/recorder/repository/JfrChunkRotation.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, Red Hat Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package com.oracle.svm.core.jdk.jfr.recorder.repository;
+
+public class JfrChunkRotation {
+    private static boolean rotate = false;
+    private static long threshold = 0;
+
+    private static Object changeNotifier;
+
+    public static boolean shouldRotate() {
+        return rotate;
+    }
+
+    public static void onRotation() {
+        rotate = false;
+    }
+
+    public static void setThreshold(long delta, Object notifier) {
+        threshold = delta;
+        changeNotifier = notifier;
+    }
+
+    public static void evaluate(JfrChunkWriter chunkWriter) {
+        assert (threshold > 0);
+        if (rotate) {
+            return;
+        }
+        if (chunkWriter.getSizeWritten() > threshold) {
+            rotate = true;
+            notifyChange();
+        }
+    }
+
+    private static void notifyChange() {
+        // JFR.TODO
+        // Need to verify if the object that is substituted via JfrSubstitutions
+        // actually causes notifications to the Java layer
+        if (changeNotifier != null) {
+            synchronized (changeNotifier) {
+                changeNotifier.notifyAll();
+            }
+        }
+    }
+
+}

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/jfr/recorder/repository/JfrChunkWriter.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/jfr/recorder/repository/JfrChunkWriter.java
@@ -1,0 +1,477 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, Red Hat Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package com.oracle.svm.core.jdk.jfr.recorder.repository;
+
+import static com.oracle.svm.core.jdk.jfr.utilities.JfrCheckpointType.FLUSH;
+import static com.oracle.svm.core.jdk.jfr.utilities.JfrCheckpointType.HEADER;
+import static com.oracle.svm.core.jdk.jfr.utilities.JfrTime.invalidTime;
+import static com.oracle.svm.core.jdk.jfr.utilities.JfrTypes.ReservedEvent.EVENT_CHECKPOINT;
+
+import java.io.IOException;
+import java.io.RandomAccessFile;
+import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
+import java.nio.file.Path;
+
+import com.oracle.svm.core.jdk.jfr.JfrOptions;
+import com.oracle.svm.core.jdk.jfr.utilities.JfrTicks;
+import com.oracle.svm.core.jdk.jfr.writers.JfrEncodingWriter;
+import com.oracle.svm.core.jdk.jfr.writers.JfrEncodingWriter.Encoder;
+import com.oracle.svm.core.jdk.jfr.writers.JfrWriter;
+import com.oracle.svm.core.thread.VMOperation;
+
+public class JfrChunkWriter {
+    final JfrChunk chunk;
+
+    private final ByteBuffer data;
+    private RandomAccessFile file;
+    private long streamPos;
+
+    static final long MAGIC_OFFSET = 0;
+    static final long MAGIC_LEN = 4;
+    static final long VERSION_OFFSET = MAGIC_LEN;
+    static final long SIZE_OFFSET = 8;
+    static final long SLOT_SIZE = 8;
+    static final long CHECKPOINT_OFFSET = SIZE_OFFSET + SLOT_SIZE;
+    static final long METADATA_OFFSET = CHECKPOINT_OFFSET + SLOT_SIZE;
+    static final long START_NANOS_OFFSET = METADATA_OFFSET + SLOT_SIZE;
+    static final long DURATION_NANOS_OFFSET = START_NANOS_OFFSET + SLOT_SIZE;
+    static final long START_TICKS_OFFSET = DURATION_NANOS_OFFSET + SLOT_SIZE;
+    static final long CPU_FREQUENCY_OFFSET = START_TICKS_OFFSET + SLOT_SIZE;
+    static final long GENERATION_OFFSET = CPU_FREQUENCY_OFFSET + SLOT_SIZE;
+    static final long FLAG_OFFSET = GENERATION_OFFSET + 2;
+    static final long HEADER_SIZE = FLAG_OFFSET + 2;
+
+    public static final int sizeSafetyCushion = 1;
+
+    public JfrChunkWriter() {
+        chunk = new JfrChunk();
+        data = ByteBuffer.allocate(1024 * 1024);
+    }
+
+    public void setTimeStamp() {
+        assert chunk != null;
+        chunk.setTimeStamp();
+    }
+
+    public long getSizeWritten() {
+        return isValid() ? getCurrentOffset() : 0;
+    }
+
+    public long getLastCheckpointOffset() {
+        assert chunk != null;
+        return chunk.getLastCheckpointOffset();
+    }
+
+    public void setLastCheckpointOffset(long offset) {
+        assert chunk != null;
+        chunk.setLastCheckpointOffset(offset);
+    }
+
+    public void setLastMetadataOffset(long offset) {
+        assert chunk != null;
+        chunk.setLastMetadataOffset(offset);
+    }
+
+    public boolean hasMetadata() {
+        assert chunk != null;
+        return chunk.hasMetadata();
+    }
+
+    public boolean isValid() {
+        return file != null;
+    }
+
+    long getCurrentChunkStartNanos() {
+        assert chunk != null;
+        return isValid() ? chunk.getStartNanos() : invalidTime;
+    }
+
+    void setPath(Path path) {
+        chunk.setPath(path);
+    }
+
+    void markChunkFinal() {
+        assert chunk != null;
+        chunk.markFinal();
+    }
+
+    long flushChunk(boolean flushpoint) throws IOException {
+        assert chunk != null;
+        long szWritten = writeChunkHeaderCheckpoint(flushpoint);
+        assert getSizeWritten() == szWritten;
+        JfrChunkHeadWriter head = new JfrChunkHeadWriter(this, SIZE_OFFSET);
+        head.flush(szWritten, !flushpoint);
+        return szWritten;
+    }
+
+    boolean open() throws IOException {
+        assert chunk != null;
+        reset(openChunk(chunk.getPath()));
+        boolean isOpen = isValid();
+        if (isOpen) {
+            assert 0 == getCurrentOffset();
+            chunk.reset();
+            // Constructor side effects are important here
+            JfrChunkHeadWriter head = new JfrChunkHeadWriter(this, HEADER_SIZE);
+        }
+        return isOpen;
+    }
+
+    static RandomAccessFile openChunk(Path path) throws IOException {
+        return path != null ? new RandomAccessFile(path.toFile(), "rw") : null;
+    }
+
+    void seek(long offset) throws IOException {
+        flush();
+        assert 0 == getUsedSize() : "can only seek from beginning";
+        file.seek(offset);
+        streamPos = offset;
+    }
+
+    public void reset(RandomAccessFile file) {
+        assert !isValid();
+        this.file = file;
+        streamPos = 0;
+        // hardReset();
+    }
+
+    public void flush() throws IOException {
+        if (isValid()) {
+            int used = getUsedSize();
+            if (used > 0) {
+                flush(used);
+            }
+        }
+    }
+
+    protected void flush(int size) throws IOException {
+        assert size > 0;
+        assert isValid();
+        data.flip();
+
+        while (data.hasRemaining()) {
+            file.write(data.get());
+            streamPos++;
+        }
+        data.clear();
+        assert 0 == getUsedSize();
+    }
+
+    long close() throws IOException {
+        assert isValid();
+        long sizeWritten = flushChunk(false);
+        file.close();
+        file = null;
+        assert !isValid();
+        return sizeWritten;
+    }
+
+    long prepareChunkHeaderConstantPool(long eventOffset, boolean flushpoint) throws IOException {
+        long delta = getLastCheckpointOffset() == 0 ? 0 : getLastCheckpointOffset() - eventOffset;
+        int checkpointType = flushpoint ? FLUSH.id | HEADER.id : HEADER.id;
+        reserve(Integer.BYTES);
+        JfrWriter w = encoded();
+        w.writeLong(EVENT_CHECKPOINT.id);
+        w.writeLong(JfrTicks.now());
+        w.writeLong(0L); // duration
+        w.writeLong(delta); // to previous checkpoint
+        w.writeInt(checkpointType);
+        w.writeInt(0); // pool count
+        // w.writeLong(TYPE_CHUNKHEADER.id);
+        // w.writeInt(1); // count
+        // w.writeLong(1L); // key
+        // w.writeInt((int) HEADER_SIZE); // length of byte array
+        return getCurrentOffset();
+    }
+
+    long writeChunkHeaderCheckpoint(boolean flushpoint) throws IOException {
+        assert isValid();
+        long eventSizeOffset = getCurrentOffset();
+        long headerContentPos = prepareChunkHeaderConstantPool(eventSizeOffset, flushpoint);
+        // JfrChunkHeadWriter head = new JfrChunkHeadWriter(this, headerContentPos, false);
+        // head.writeMagic();
+        // head.writeVersion();
+        // long chunkSizeOffset = reserve(Long.BYTES); // size to be decided when we are done
+        // be().writeLong(eventSizeOffset); // last checkpoint offset will be this checkpoint
+        // head.writeMetadata();
+        // head.writeTime(false);
+        // head.writeCpuFrequency();
+        // head.writeNextGeneration();
+        // head.writeFlags();
+        // assert getCurrentOffset() - headerContentPos == HEADER_SIZE;
+        int checkpointSize = (int) (getCurrentOffset() - eventSizeOffset);
+        padded().writeInt(checkpointSize, eventSizeOffset);
+        setLastCheckpointOffset(eventSizeOffset);
+        long szWritten = getSizeWritten();
+        // be().writeLong(szWritten, chunkSizeOffset);
+        return szWritten;
+    }
+
+    public long reserve(int size) throws IOException {
+        if (ensureSize(size) >= 0) {
+            long pos = this.getCurrentOffset();
+            data.position(data.position() + size);
+            return pos;
+        }
+        // cancel();
+        return 0;
+    }
+
+    int ensureSize(int requested) throws IOException {
+        if (!isValid()) {
+            // cancelled
+            return -1;
+        }
+        if (data.remaining() < requested + sizeSafetyCushion) {
+            flush();
+            // if (!accommodate(getUsedSize(), requested + sizeSafetyCushion)) {
+            // assert !isValid();
+            // return -1;
+            // }
+        }
+        assert requested + sizeSafetyCushion <= data.remaining();
+        return data.position();
+    }
+
+    public long getCurrentOffset() {
+        return getUsedSize() + streamPos;
+    }
+
+    public int getUsedSize() {
+        return data.position();
+    }
+
+    public int getAvailableSize() {
+        return data.remaining();
+    }
+
+    public void writeBytes(byte[] buf) throws IOException {
+        writeBytes(buf, buf.length);
+    }
+
+    public void writeBytes(byte[] buf, int len) throws IOException {
+        if (len > getAvailableSize()) {
+            writeUnbuffered(buf, len);
+        } else {
+            data.put(buf, 0, len);
+        }
+    }
+
+    public int writeUnbuffered(byte[] src, int len) throws IOException {
+        flush();
+        assert 0 == getUsedSize() : "can only seek from beginning";
+        file.write(src, 0, len);
+        streamPos += len;
+        return len;
+    }
+
+    public int writeUnbuffered(ByteBuffer buf) throws IOException {
+        flush();
+        assert 0 == getUsedSize() : "can only seek from beginning";
+        int written = 0;
+        if (VMOperation.isInProgressAtSafepoint()) {
+            byte[] b = new byte[buf.remaining()];
+            buf.get(b);
+            file.write(b);
+            written += b.length;
+        } else {
+            FileChannel fc = file.getChannel();
+            written += fc.write(buf);
+        }
+
+        streamPos += written;
+        return written;
+    }
+
+    class EncodingWriter implements JfrWriter {
+        private final Encoder encoder;
+
+        private final ByteBuffer buf;
+
+        EncodingWriter(Encoder encoder) {
+            this.encoder = encoder;
+            buf = ByteBuffer.allocate(9);
+        }
+
+        @Override
+        public int writeByte(byte value) throws IOException {
+            if (ensureSize(Byte.BYTES) >= 0) {
+                return encoder.encode(data, Byte.BYTES, value);
+            } else {
+                return 0;
+            }
+        }
+
+        @Override
+        public int writeShort(short value) throws IOException {
+            if (ensureSize(Short.BYTES) >= 0) {
+                return encoder.encode(data, Short.BYTES, value);
+            } else {
+                return 0;
+            }
+        }
+
+        @Override
+        public int writeInt(int value) throws IOException {
+            if (ensureSize(Integer.BYTES) >= 0) {
+                return encoder.encode(data, Integer.BYTES, value);
+            } else {
+                return 0;
+            }
+        }
+
+        @Override
+        public int writeLong(long value) throws IOException {
+            if (ensureSize(Long.BYTES) >= 0) {
+                return encoder.encode(data, Long.BYTES, value);
+            } else {
+                return 0;
+            }
+        }
+
+        @Override
+        public int writeByte(byte value, long offset) throws IOException {
+            int res;
+            if (offset < file.length()) {
+                buf.clear();
+                res = encoder.encode(buf, Byte.BYTES, value);
+                buf.flip();
+
+                long oldPos = file.getFilePointer();
+                file.seek(offset);
+                while (buf.hasRemaining()) {
+                    file.write(buf.get());
+                }
+                file.seek(oldPos);
+            } else {
+                int p = data.position();
+                data.position((int) (offset - file.length()));
+                res = encoder.encode(data, Byte.BYTES, value);
+                data.position(p);
+            }
+            return res;
+        }
+
+        @Override
+        public int writeShort(short value, long offset) throws IOException {
+            int res;
+            if (offset < file.length()) {
+                buf.clear();
+                res = encoder.encode(buf, Short.BYTES, value);
+                buf.flip();
+
+                long oldPos = file.getFilePointer();
+                file.seek(offset);
+                while (buf.hasRemaining()) {
+                    file.write(buf.get());
+                }
+                file.seek(oldPos);
+            } else {
+                int p = data.position();
+                data.position((int) (offset - file.length()));
+                res = encoder.encode(data, Short.BYTES, value);
+                data.position(p);
+            }
+            return res;
+        }
+
+        @Override
+        public int writeInt(int value, long offset) throws IOException {
+            int res;
+            if (offset < file.length()) {
+                buf.clear();
+                res = encoder.encode(buf, Integer.BYTES, value);
+                buf.flip();
+
+                long oldPos = file.getFilePointer();
+                file.seek(offset);
+                while (buf.hasRemaining()) {
+                    file.write(buf.get());
+                }
+                file.seek(oldPos);
+            } else {
+                int p = data.position();
+                data.position((int) (offset - file.length()));
+                res = encoder.encode(data, Integer.BYTES, value);
+                data.position(p);
+            }
+            return res;
+        }
+
+        @Override
+        public int writeLong(long value, long offset) throws IOException {
+            int res;
+            if (offset < file.length()) {
+                buf.clear();
+                res = encoder.encode(buf, Long.BYTES, value);
+                buf.flip();
+
+                long oldPos = file.getFilePointer();
+                file.seek(offset);
+                while (buf.hasRemaining()) {
+                    file.write(buf.get());
+                }
+                file.seek(oldPos);
+            } else {
+                int p = data.position();
+                data.position((int) (offset - file.length()));
+                res = encoder.encode(data, Long.BYTES, value);
+                data.position(p);
+            }
+            return res;
+        }
+    }
+
+    private final JfrWriter beWriter = new EncodingWriter(JfrEncodingWriter::writeBE);
+
+    public JfrWriter be() {
+        return beWriter;
+    }
+
+    private final JfrWriter compressedWriter = new EncodingWriter(JfrEncodingWriter::writeCompressed);
+
+    public JfrWriter encoded() {
+        if (JfrOptions.compressedIntegers()) {
+            return compressedWriter;
+        } else {
+            return beWriter;
+        }
+    }
+
+    private final JfrWriter paddedCompressedWriter = new EncodingWriter(JfrEncodingWriter::writePaddedCompressed);
+
+    public JfrWriter padded() {
+        if (JfrOptions.compressedIntegers()) {
+            return paddedCompressedWriter;
+        } else {
+            return beWriter;
+        }
+    }
+
+
+}

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/jfr/recorder/repository/JfrRepository.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/jfr/recorder/repository/JfrRepository.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, Red Hat Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package com.oracle.svm.core.jdk.jfr.recorder.repository;
+
+import java.io.IOException;
+import java.nio.file.Path;
+
+import com.oracle.svm.core.jdk.jfr.Jfr;
+import com.oracle.svm.core.jdk.jfr.recorder.service.JfrPostBox;
+import com.oracle.svm.core.jdk.jfr.recorder.service.JfrPostBox.JfrMsg;
+
+public final class JfrRepository {
+    private Path path;
+    private final JfrPostBox postBox;
+
+    private static JfrRepository instance;
+    private static JfrChunkWriter chunkWriter;
+
+    private JfrRepository(JfrPostBox postBox) {
+        this.path = null;
+        this.postBox = postBox;
+    }
+
+    public boolean initialize() {
+        assert (chunkWriter == null);
+        chunkWriter = new JfrChunkWriter();
+        return chunkWriter != null;
+    }
+
+    private void setPath(Path path) {
+        this.path = path;
+    }
+
+    private void setChunkPath(Path path) {
+        getChunkWriter().setPath(path);
+    }
+
+    public boolean openChunk(boolean vmError) throws IOException {
+        if (vmError) {
+            // JFR.TODO Implement JfrEmergencyDump
+            // getChunkWriter().setPath(JfrEmergencyDump::build_dump_path(_path));
+        }
+        return getChunkWriter().open();
+    }
+
+    public long closeChunk() throws IOException {
+        return getChunkWriter().close();
+    }
+
+    private void flushChunk() throws IOException {
+        getChunkWriter().flush();
+    }
+
+    private void onVmError() {
+        if (path == null) {
+            // completed already
+            return;
+        }
+        // TODO Implement JfrEmergencyDump
+        // JfrEmergencyDump.onVmError(path);
+    }
+
+    public static JfrRepository create(JfrPostBox postBox) {
+        assert (instance == null);
+        instance = new JfrRepository(postBox);
+        return instance;
+    }
+
+    public static JfrRepository getInstance() {
+        return instance;
+    }
+
+    public static void destroy() {
+        assert (chunkWriter != null);
+        chunkWriter = null;
+    }
+
+    public static JfrChunkWriter getChunkWriter() {
+        return chunkWriter;
+    }
+
+    public static void notifyOnNewChunkPath() {
+        if (Jfr.isRecording()) {
+            // rotations are synchronous, block until rotation completes
+            getInstance().postBox.post(JfrMsg.ROTATE);
+        }
+    }
+
+    public static void setInstancePath(Path path) {
+        if (path != null) {
+            getInstance().setPath(path);
+        }
+    }
+
+    /**
+     * Sets the file where data should be written.
+     *
+     * Recording  Previous  Current  Action
+     * ==============================================
+     *   true     null      null     Ignore, keep recording in-memory
+     *   true     null      file1    Start disk recording
+     *   true     file      null     Copy out metadata to disk and continue in-memory recording
+     *   true     file1     file2    Copy out metadata and start with new File (file2)
+     *   false     *        null     Ignore, but start recording to memory
+     *   false     *        file     Ignore, but start recording to disk
+     */
+    public static void setInstanceChunkPath(Path path) {
+        if (path == null && !getChunkWriter().isValid()) {
+            // new output is NULL and current output is NULL
+            return;
+        }
+        getInstance().setChunkPath(path);
+        notifyOnNewChunkPath();
+    }
+
+    public static void markChunkFinal() {
+        getChunkWriter().markChunkFinal();
+    }
+
+    public static void flush(Thread jt) {
+        if (!Jfr.isRecording()) {
+            return;
+        }
+        if (!getChunkWriter().isValid()) {
+            return;
+        }
+        getInstance().postBox.post(JfrMsg.FLUSHPOINT);
+    }
+
+    public static long getCurrentChunkStartNanos() {
+        return getChunkWriter().getCurrentChunkStartNanos();
+    }
+
+}

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/jfr/recorder/service/JfrPostBox.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/jfr/recorder/service/JfrPostBox.java
@@ -1,0 +1,232 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, Red Hat Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package com.oracle.svm.core.jdk.jfr.recorder.service;
+
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.locks.Condition;
+import java.util.concurrent.locks.ReentrantLock;
+
+public final class JfrPostBox {
+
+    /**
+     * Jfr messaging.
+     *
+     * Synchronous messages (posting thread waits for message completion):
+     *
+     * MSG_CLONE_IN_MEMORY (0) ; MSGBIT(MSG_CLONE_IN_MEMORY) == (1 << 0) == 0x1
+     * MSG_START(1) ; MSGBIT(MSG_START) == (1 << 0x1) == 0x2 MSG_STOP (2) ;
+     * MSGBIT(MSG_STOP) == (1 << 0x2) == 0x4 MSG_ROTATE (3) ; MSGBIT(MSG_ROTATE) ==
+     * (1 << 0x3) == 0x8 MSG_VM_ERROR (8) ; MSGBIT(MSG_VM_ERROR) == (1 << 0x8) ==
+     * 0x100 MSG_FLUSHPOINT (10) ; MSGBIT(MSG_FLUSHPOINT) == (1 << 0xa) == 0x400
+     *
+     * Asynchronous messages (posting thread returns immediately upon deposit):
+     *
+     * MSG_FULLBUFFER (4) ; MSGBIT(MSG_FULLBUFFER) == (1 << 0x4) == 0x10
+     * MSG_CHECKPOINT (5) ; MSGBIT(CHECKPOINT) == (1 << 0x5) == 0x20 MSG_WAKEUP (6)
+     * ; MSGBIT(WAKEUP) == (1 << 0x6) == 0x40 MSG_SHUTDOWN (7) ;
+     * MSGBIT(MSG_SHUTDOWN) == (1 << 0x7) == 0x80 MSG_DEADBUFFER (9) ;
+     * MSGBIT(MSG_DEADBUFFER) == (1 << 0x9) == 0x200
+     */
+
+    public enum JfrMsg {
+        // Synchronous: posting thread waits for message completion
+        CLONE_IN_MEMORY(0),
+        START(1),
+        STOP(2),
+        ROTATE(3),
+        VM_ERROR(8),
+        FLUSHPOINT(10),
+        // Asynchronous: posting thread returns after depositing message
+        FULLBUFFER(4),
+        CHECKPOINT(5),
+        WAKEUP(6),
+        SHUTDOWN(7),
+        DEADBUFFER(9);
+
+        public final int msg;
+        public final int bit;
+
+        JfrMsg(int msg) {
+            this.msg = msg;
+            this.bit = 1 << msg;
+        }
+
+        private static final int synchronousMsgs = CLONE_IN_MEMORY.bit | START.bit | STOP.bit
+                | ROTATE.bit | VM_ERROR.bit | FLUSHPOINT.bit;
+
+        public boolean isSynchronous() {
+            return (bit & synchronousMsgs) != 0;
+        }
+
+        public boolean in(int messages) {
+            return (messages & bit) == bit;
+        }
+    }
+
+    private static JfrPostBox instance;
+    // Must read/write in thread-safe manner
+    protected final ReentrantLock lock = new ReentrantLock();
+    protected final Condition processing = lock.newCondition();
+    private final AtomicInteger messages = new AtomicInteger(0);
+    private final AtomicInteger messagesRead = new AtomicInteger(0);
+    private final AtomicInteger messagesHandled = new AtomicInteger(0);
+    private volatile boolean hasWaiters = false;
+
+    private JfrPostBox() {
+    }
+
+    public static JfrPostBox create() {
+        assert instance == null : "invariant";
+        instance = new JfrPostBox();
+        return instance;
+    }
+
+    protected boolean isThreadLockAversive() {
+        // JFR.TODO: Figure out if this is something we have to deal with on SVM
+        // Thread* const thread = Thread::current();
+        // return (thread->is_Java_thread() && ((JavaThread*)thread)->thread_state() !=
+        // _thread_in_vm) || thread->is_VM_thread();
+        return false;
+    }
+
+    private boolean isSynchronous(int msg) {
+        return (msg & JfrMsg.synchronousMsgs) != 0;
+    }
+
+    public void post(JfrMsg msg) {
+        if (isThreadLockAversive()) {
+            deposit(msg);
+        } else if (!msg.isSynchronous()) {
+            asyncPost(msg);
+        } else {
+            syncPost(msg);
+        }
+    }
+
+    private void deposit(JfrMsg msg) {
+        while (true) {
+            int currentMsgs = messages.get();
+            int newValue = currentMsgs | msg.bit;
+
+            assert (msg.in(newValue));
+
+            int result = messages.compareAndExchange(currentMsgs, newValue);
+            if (result == currentMsgs) {
+                return;
+            }
+            /* Some other thread just set exactly what this thread wanted */
+            if ((result & newValue) == newValue) {
+                return;
+            }
+        }
+    }
+
+    private void asyncPost(JfrMsg msg) {
+        assert !msg.isSynchronous() : "invariant";
+        deposit(msg);
+        if (lock.tryLock()) {
+            try {
+                processing.signalAll();
+            } finally {
+                lock.unlock();
+            }
+        }
+    }
+
+    private void syncPost(JfrMsg msg) {
+        assert msg.isSynchronous() : "invariant";
+        assert !lock.isHeldByCurrentThread() : "should not hold postboxLock here!";
+        lock.lock();
+        try {
+            deposit(msg);
+            // serialId is used to check when what we send in has been processed.
+            // messagesRead is read under postboxLock protection.
+            int serialId = messagesRead.get() + 1;
+            processing.signalAll();
+            while (!isMessageProcessed(serialId)) {
+                try {
+                    processing.await();
+                } catch (InterruptedException e) {
+                    break;
+                }
+            }
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    /**
+     * Check if a synchronous message has been processed.
+     * We avoid racing on _msg_handled_serial by ensuring
+     * that we are holding the JfrMsg_lock when checking
+     * completion status.
+     */
+    private boolean isMessageProcessed(int serial) {
+        assert lock.isHeldByCurrentThread() : "messagesHandled must be read under postboxLock protection";
+        return serial <= messagesHandled.get();
+    }
+
+    protected boolean isEmpty() {
+        assert lock.isHeldByCurrentThread() : "not holding postboxLock!";
+        return messages.get() == 0;
+    }
+
+    protected int collect() {
+        // get pending and reset to 0
+        int currentMsgs = messages.getAndSet(0);
+        if (checkWaiters(currentMsgs)) {
+            hasWaiters = true;
+            assert lock.isHeldByCurrentThread() : "incrementing _msg_read_serial is protected by JfrMsg_lock";
+            messagesRead.incrementAndGet();
+        }
+        return currentMsgs;
+    }
+
+    protected boolean checkWaiters(int messages) {
+        assert lock.isHeldByCurrentThread() : "not holding postboxLock!";
+        assert !hasWaiters : "invariant";
+        return isSynchronous(messages);
+    }
+
+    protected void notifyWaiters() {
+        if (hasWaiters) {
+            hasWaiters = false;
+            assert lock.isHeldByCurrentThread() : "incrementing messagesHandled must be protected by postboxLock.";
+            messagesHandled.incrementAndGet();
+            processing.signal();
+        }
+    }
+
+    protected void notifyCollectionStop() {
+        lock.lock();
+        try {
+            processing.signalAll();
+        } finally {
+            lock.unlock();
+        }
+    }
+}

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/jfr/recorder/service/JfrRecorderService.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/jfr/recorder/service/JfrRecorderService.java
@@ -1,0 +1,239 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, Red Hat Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package com.oracle.svm.core.jdk.jfr.recorder.service;
+
+import java.io.IOException;
+import java.util.concurrent.locks.ReentrantLock;
+
+import com.oracle.svm.core.jdk.jfr.recorder.checkpoint.JfrCheckpointManager;
+import com.oracle.svm.core.jdk.jfr.recorder.repository.JfrChunkRotation;
+import com.oracle.svm.core.jdk.jfr.recorder.repository.JfrChunkWriter;
+import com.oracle.svm.core.jdk.jfr.recorder.repository.JfrRepository;
+import com.oracle.svm.core.jdk.jfr.recorder.service.JfrPostBox.JfrMsg;
+import com.oracle.svm.core.jdk.jfr.recorder.storage.JfrStorage;
+import com.oracle.svm.core.jdk.jfr.recorder.storage.operations.JfrContentOperations;
+import com.oracle.svm.core.jdk.jfr.recorder.stringpool.JfrStringPool;
+import com.oracle.svm.core.thread.JavaVMOperation;
+
+public class JfrRecorderService {
+    enum RecorderState {
+        STOPPED, RUNNING
+    }
+
+    // JFR.TODO
+    // Needs to be replaced with lock that supports identifying (and stopping)
+    // recursive lock attempts with proper guarding of critical section.
+    // Current usage is not safe
+    private static final ReentrantLock rotationlock = new ReentrantLock();
+
+    static volatile RecorderState recorderState = RecorderState.STOPPED;
+
+    public static boolean isRecording() {
+        return recorderState == RecorderState.RUNNING;
+    }
+
+    public static void start() {
+        rotationlock.lock();
+
+        try {
+            assert (!isRecording());
+            clear();
+            openNewChunk(false);
+            startRecorder();
+            assert (isRecording());
+        } finally {
+            rotationlock.unlock();
+        }
+    }
+
+    static void startRecorder() {
+        assert (rotationlock.isHeldByCurrentThread());
+        setRecorderState(RecorderState.STOPPED, RecorderState.RUNNING);
+    }
+
+    static void stop() {
+        assert (rotationlock.isHeldByCurrentThread());
+        setRecorderState(RecorderState.RUNNING, RecorderState.STOPPED);
+    }
+
+    private static void setRecorderState(RecorderState from, RecorderState to) {
+        assert (from == recorderState);
+        // OrderAccess::storestore();
+        recorderState = to;
+        assert (recorderState == to);
+    }
+
+    public static void rotate(int message) {
+        if (rotationlock.isHeldByCurrentThread()) {
+            // recursive call
+            return;
+        }
+        rotationlock.lock();
+        try {
+            // JFR.TODO
+            // vm error rotation
+            if (JfrStorage.instance().getStorageControl().toDisk()) {
+                chunkRotation();
+            } else {
+                inMemoryRotation();
+            }
+
+            if (JfrMsg.STOP.in(message)) {
+                stop();
+            }
+        } finally {
+            rotationlock.unlock();
+        }
+    }
+
+    private static void openNewChunk(boolean vmError) {
+        assert (rotationlock.isHeldByCurrentThread());
+        JfrChunkRotation.onRotation();
+        try {
+            boolean validChunk = JfrRepository.getInstance().openChunk(vmError);
+            JfrStorage.instance().getStorageControl().setToDisk(validChunk);
+            if (validChunk) {
+                JfrCheckpointManager.instance().writeStaticTypeSetAndThreads();
+            }
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    private static void clear() {
+        assert (rotationlock.isHeldByCurrentThread());
+        preSafepointClear();
+        invokeSafepointClear();
+        postSafepointClear();
+    }
+
+    private static void preSafepointClear() {
+        JfrStorage.instance().clear();
+        // JFR.TODO
+        // _stack_trace_repository.clear();
+    }
+
+    private static void invokeSafepointClear() {
+        JavaVMOperation.enqueueBlockingSafepoint("ClearJFR", () -> {
+            JfrCheckpointManager.instance().beginEpochShift();
+            JfrStorage.instance().clear();
+            JfrRepository.getChunkWriter().setTimeStamp();
+            // JFR.TODO
+            // _stack_trace_repository.clear();
+            JfrCheckpointManager.instance().endEpochShift();
+        });
+    }
+
+    private static void postSafepointClear() {
+        JfrStringPool.instance().clear();
+        JfrCheckpointManager.instance().clear();
+    }
+
+    private static void inMemoryRotation() {
+        assert (rotationlock.isHeldByCurrentThread());
+        // currently running an in-memory recording
+        assert (!JfrStorage.instance().getStorageControl().toDisk());
+        openNewChunk(false);
+        if (JfrRepository.getChunkWriter().isValid()) {
+            JfrStorage.instance().write();
+        }
+    }
+
+    private static void chunkRotation() {
+        assert (rotationlock.isHeldByCurrentThread());
+        finalizeCurrentChunk();
+        openNewChunk(false);
+    }
+
+    private static void finalizeCurrentChunk() {
+        assert (JfrRepository.getChunkWriter().isValid());
+        write();
+    }
+
+    private static void write() {
+        preSafepointWrite();
+        invokeSafepointWrite();
+        postSafepointWrite();
+    }
+
+    private static void preSafepointWrite() {
+        JfrStorage.instance().write();
+
+    }
+
+    private static void invokeSafepointWrite() {
+        JavaVMOperation.enqueueBlockingSafepoint("WriteJFR", () -> {
+            JfrCheckpointManager.instance().beginEpochShift();
+            JfrCheckpointManager.instance().onRotation();
+            JfrStorage.instance().writeAtSafepoint();
+            JfrRepository.getChunkWriter().setTimeStamp();
+            JfrCheckpointManager.instance().endEpochShift();
+        });
+    }
+
+    private static void postSafepointWrite() {
+        assert (JfrRepository.getChunkWriter().isValid());
+        if (JfrStringPool.instance().isModified()) {
+            writeStringPool(JfrStringPool.instance(), JfrRepository.getChunkWriter());
+        }
+        JfrCheckpointManager.instance().writeTypeSet();
+        writeMetadata(JfrRepository.getChunkWriter());
+        try {
+            JfrRepository.getInstance().closeChunk();
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    private static int writeMetadata(JfrChunkWriter chunkWriter) {
+        assert (chunkWriter.isValid());
+        JfrContentOperations.MetadataEventContent me = new JfrContentOperations.MetadataEventContent(chunkWriter);
+        JfrContentOperations.Write wm = new JfrContentOperations.Write(chunkWriter, me);
+        wm.process();
+        return wm.elements();
+    }
+
+    private static void writeStringPool(JfrStringPool stringPool, JfrChunkWriter chunkWriter) {
+        stringPool.write(chunkWriter);
+    }
+
+    public static void processFullBuffers() {
+        rotationlock.lock();
+        try {
+            if (JfrRepository.getChunkWriter().isValid()) {
+                JfrStorage.instance().writeFull(JfrRepository.getChunkWriter());
+            }
+        } finally {
+            rotationlock.unlock();
+        }
+    }
+
+    public static void evaluateChunkSizeForRotation() {
+        JfrChunkRotation.evaluate(JfrRepository.getChunkWriter());
+    }
+
+}

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/jfr/recorder/service/JfrRecorderThread.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/jfr/recorder/service/JfrRecorderThread.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, Red Hat Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package com.oracle.svm.core.jdk.jfr.recorder.service;
+
+import com.oracle.svm.core.jdk.jfr.Jfr;
+import com.oracle.svm.core.jdk.jfr.logging.JfrLogger;
+import com.oracle.svm.core.jdk.jfr.recorder.service.JfrPostBox.JfrMsg;
+
+public class JfrRecorderThread {
+
+    private static JfrPostBox postBox;
+
+    public static boolean start(JfrPostBox postBox, Thread currentThread) {
+
+        assert (postBox != null);
+
+        JfrRecorderThread.postBox = postBox;
+
+        /*
+         * Create recorder thread running JfrRecorderThreadLoop.recorderThreadEntry()
+         * under the system thread group with the system loader
+         */
+        ThreadGroup group = Thread.currentThread().getThreadGroup().getParent();
+        if (!(group.getName().equals("system"))) {
+            group = new ThreadGroup("jfr");
+        }
+        Thread t = new Thread(group, JfrRecorderThreadLoop::recorderThreadEntry);
+        // JFR.WORKAROUND: Set to daemon thread so JVM doesn't hang waiting for this thread
+        // to shutdown. This should be checked again when the overall system lifecycle
+        // is complete as it should shutdown cleanly as well
+        t.setDaemon(true);
+        t.start();
+        Jfr.excludeThread(t);
+        return true;
+    }
+
+    public static JfrPostBox getPostBox() {
+        return JfrRecorderThread.postBox;
+    }
+}
+
+class JfrRecorderThreadLoop {
+
+    static void recorderThreadEntry() {
+        // JFR.TODO
+        // Handle all messages appropriately
+        JfrPostBox postBox = JfrRecorderThread.getPostBox();
+
+        postBox.lock.lock();
+        boolean done = false;
+        while (!done) {
+            if (postBox.isEmpty()) {
+                try {
+                    postBox.processing.await();
+                } catch (InterruptedException e) {
+                    // JFR.TODO
+                    // What should we do here?
+                    break;
+                }
+            }
+            int messages = postBox.collect();
+            postBox.lock.unlock();
+
+            if (JfrMsg.FULLBUFFER.in(messages) || JfrMsg.ROTATE.in(messages) || JfrMsg.STOP.in(messages)) {
+                JfrRecorderService.processFullBuffers();
+            }
+
+            JfrRecorderService.evaluateChunkSizeForRotation();
+
+            if (JfrMsg.DEADBUFFER.in(messages)) {
+                // JFR.TODO
+            }
+
+            if (JfrMsg.START.in(messages)) {
+                JfrRecorderService.start();
+            } else if (JfrMsg.ROTATE.in(messages) || JfrMsg.STOP.in(messages)) {
+                JfrRecorderService.rotate(messages);
+            } else if (JfrMsg.FLUSHPOINT.in(messages)) {
+                JfrLogger.logTrace("JfrPostBox FLUSHPOINT");
+            }
+
+            postBox.lock.lock();
+            postBox.notifyWaiters();
+
+            if (JfrMsg.SHUTDOWN.in(messages)) {
+                done = true;
+            }
+        }
+
+        // assert (!JfrLocks.messageLock.ownedBySelf());
+
+        postBox.notifyCollectionStop();
+        // JfrRecorderThread.onRecorderThreadExit();
+        postBox.lock.unlock();
+    }
+}

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/jfr/recorder/storage/JfrBuffer.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/jfr/recorder/storage/JfrBuffer.java
@@ -1,0 +1,375 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, Red Hat Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package com.oracle.svm.core.jdk.jfr.recorder.storage;
+
+import java.nio.ByteBuffer;
+import java.util.EnumSet;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.locks.ReentrantLock;
+
+import com.oracle.svm.core.jdk.jfr.logging.JfrLogger;
+
+/**
+ * Follows src/hotspot/share/jfr/recorder/storage/jfrBuffer.hpp but backed by a
+ * direct ByteBuffer 'b', rather than memory allocated via malloc.
+ * 
+ * Matches JDK 14+ : concurrency related code was altered (for the better I
+ * assume) compared to JDK 11
+ * 
+ * Initially for ByteBuffer 'b': b.position == b.committedPosition ==
+ * flushedPosition = 0 b.limit == b.capacity = size
+ * 
+ * At all times: flushedPosition <= committedPosition <= b.position <= b.limit
+ * == b.capacity == size
+ * 
+ * During event write, b.position updates for each put operation On successful
+ * write end, committedPosition is set to b.position Otherwise b.position is
+ * reset to committedPosition
+ * 
+ * The only accessor of b.position should be the EventWriter. Readers should use
+ * flushed and committed positions
+ * 
+ * During read, data between flushedPosition and committedPosition is accessed
+ * After read, flushedPosition is updated to committedPosition
+ * 
+ * committedPosition (_pos): used by readers and changed by writers
+ * flushedPosition (_top): used by writers, changed by writers identity:
+ * manipulated by storage system when assigning buffers
+ *
+ * 
+ */
+
+public class JfrBuffer {
+
+    private ByteBuffer buffer;
+    private final int size;
+
+    private enum Flags {
+        RETIRED, TRANSIENT, LEASE, EXCLUDED
+    }
+
+    private final EnumSet<Flags> flags = EnumSet.noneOf(Flags.class);
+
+    // JFR.TODO critical section performance can probably be improved here
+    // Used when transferring data into the buffer where flushed, committed
+    // and buffer data will all change
+    private final ReentrantLock globalLock = new ReentrantLock();
+
+    // _pos
+    private final AtomicInteger committedPosition = new AtomicInteger(0);
+
+    // _top
+    private final AtomicInteger flushedPosition = new AtomicInteger(0);
+    // flushedPosition is a critical section modified by thread local on promote as well as recorder service when
+    // writing data to disk
+    private final ReentrantLock flushedLock = new ReentrantLock();
+
+    private final AtomicLong identity = new AtomicLong(-1);
+
+    public JfrBuffer(int size) {
+        this.size = size;
+        this.buffer = ByteBuffer.allocateDirect(this.size);
+        assert (this.buffer.limit() == this.buffer.capacity() && this.buffer.limit() == this.size);
+    }
+
+    public void initialize() {
+        assert (this.identity.get() == -1);
+        setCommittedPosition(start());
+        setFlushedPosition(start());
+
+        // ByteBuffer specific
+        this.buffer.clear();
+
+        assert (this.getFreeSize() == this.size);
+        assert (this.buffer.limit() == this.buffer.capacity() && this.buffer.limit() == this.size);
+
+        assert (!this.isTransient());
+        assert (!this.isLeased());
+        assert (!this.isRetired());
+    }
+
+    public void reinitialize() {
+        this.reinitialize(false);
+    }
+
+    public void reinitialize(boolean excluded) {
+        this.flushedLock.lock();
+        try {
+            assert (!this.isLeased());
+
+            if (this.isExcluded() != excluded) {
+                if (excluded) {
+                    setExcluded();
+                } else {
+                    clearExcluded();
+                }
+            }
+
+            this.setCommittedPosition(start());
+            this.setFlushedPosition(start());
+            this.clearRetired();
+
+            // ByteBuffer specific
+            this.buffer.clear();
+            assert (this.buffer.limit() == this.buffer.capacity() && this.buffer.limit() == this.size);
+        } finally {
+            this.flushedLock.unlock();
+        }
+    }
+
+    public int start() {
+        return 0;
+    }
+
+    public int end() {
+        return this.buffer.limit();
+    }
+
+    public int getCommittedPosition() {
+        return this.committedPosition.get();
+    }
+
+    public void setCommittedPosition(int position) {
+        assert (position <= end());
+        this.committedPosition.set(position);
+    }
+
+    public int getFlushedPosition() {
+        return this.flushedPosition.get();
+    }
+
+    public void setFlushedPosition(int position) {
+        assert (position <= end());
+        assert (start() <= position);
+        this.flushedPosition.set(position);
+    }
+
+    public boolean isEmpty() {
+        return this.committedPosition.get() == 0;
+    }
+
+    public ReentrantLock getGlobalLock() {
+        return this.globalLock;
+    }
+
+    public ReentrantLock getFlushLock() {
+        return this.flushedLock;
+    }
+
+    public void reset() {
+        this.buffer.clear();
+        this.flushedPosition.set(0);
+        this.committedPosition.set(0);
+    }
+
+    public boolean acquiredBy(Thread thread) {
+        return this.identity.get() == thread.getId();
+    }
+
+    public boolean acquiredBySelf() {
+        return this.identity.get() == Thread.currentThread().getId();
+    }
+
+    public void acquire(Thread thread) {
+        if (acquiredBy(thread)) {
+            return;
+        }
+        long newId = thread.getId();
+        long currentId;
+
+        do {
+            currentId = this.identity.get();
+        } while (currentId != -1 || !this.identity.compareAndSet(currentId, newId));
+    }
+
+    public boolean tryAcquire(Thread thread) {
+        long newId = thread.getId();
+        long currentId = this.identity.get();
+
+        return (currentId == -1 && this.identity.compareAndSet(currentId, newId));
+    }
+
+    public long identity() {
+        return this.identity.get();
+    }
+
+    public void release() {
+        assert (this.identity.get() != -1);
+        this.identity.set(-1);
+        if (this.isLeased()) {
+            this.clearLeased();
+        }
+    }
+
+    // Moves data between flushed and committed position to promotion buffer
+    // Sets flushed/committed to 0, buffer is empty after
+    public void promoteTo(JfrBuffer promotionBuffer, int size) {
+        this.flushedLock.lock();
+        try {
+            assert (this.buffer != null);
+            assert (promotionBuffer.buffer != null);
+            assert (promotionBuffer.acquiredBySelf());
+
+            int start = this.getFlushedPosition();
+            int end = this.getCommittedPosition();
+
+            int actualSize = end - start;
+            assert (actualSize <= size);
+
+            if (actualSize > 0) {
+                int limit = this.buffer.limit();
+                int pos = this.buffer.position();
+                try {
+                    promotionBuffer.getGlobalLock().lock();
+                    this.buffer.position(start);
+                    this.buffer.limit(end);
+                    promotionBuffer.put(this.buffer);
+                    promotionBuffer.setCommittedPosition(promotionBuffer.buffer.position());
+                    promotionBuffer.release();
+
+                    this.buffer.limit(limit);
+                    this.buffer.position(pos);
+                } catch (Exception e) {
+                    JfrLogger.logError("JfrBuffer move failed. Data may be corrupted");
+                    JfrLogger.logStackTrace(e);
+                } finally {
+                    promotionBuffer.getGlobalLock().unlock();
+                }
+            }
+            this.setCommittedPosition(start());
+            this.setFlushedPosition(start());
+        } finally {
+            this.flushedLock.unlock();
+        }
+    }
+
+    // Transfers data from [committed position, committed position + size] to the
+    // new buffer. Does not commit data in the new buffer
+    public void transferTo(JfrBuffer newBuffer, int size) {
+        int oldLimit = this.buffer.limit();
+        int oldPosition = this.buffer.position();
+
+        this.buffer.limit(this.getCommittedPosition() + size);
+        this.buffer.position(this.getCommittedPosition());
+        newBuffer.put(this.buffer);
+
+        this.buffer.limit(oldLimit);
+        this.buffer.position(oldPosition);
+    }
+
+    public void put(ByteBuffer buffer) {
+        assert (this.acquiredBySelf());
+        assert (this.getGlobalLock().isHeldByCurrentThread());
+        this.buffer.put(buffer);
+    }
+
+    public int discard() {
+        int pos = this.committedPosition.get();
+        int top = this.getFlushedPosition();
+        setFlushedPosition(top);
+        return pos - top;
+    }
+
+    public int getUnflushedSize() {
+        return this.committedPosition.get() - this.flushedPosition.get();
+    }
+
+    public boolean isTransient() {
+        return this.flags.contains(Flags.TRANSIENT);
+    }
+
+    public void setTransient() {
+        this.flags.add(Flags.TRANSIENT);
+        assert (this.isTransient());
+    }
+
+    public boolean isLeased() {
+        return this.flags.contains(Flags.LEASE);
+    }
+
+    public void setLeased() {
+        this.flags.add(Flags.LEASE);
+        assert (this.isLeased());
+    }
+
+    public void clearLeased() {
+        this.flags.remove(Flags.LEASE);
+        assert (!this.isLeased());
+    }
+
+    public boolean isExcluded() {
+        return this.flags.contains(Flags.EXCLUDED);
+    }
+
+    public void setExcluded() {
+        assert (acquiredBySelf());
+        this.flags.add(Flags.EXCLUDED);
+        assert (this.isExcluded());
+    }
+
+    public void clearExcluded() {
+        if (this.isExcluded()) {
+            assert (this.identity() != -1);
+            this.flags.remove(Flags.EXCLUDED);
+        }
+        assert (!this.isExcluded());
+    }
+
+    public void setRetired() {
+        this.flags.add(Flags.RETIRED);
+    }
+
+    public void clearRetired() {
+        this.flags.remove(Flags.RETIRED);
+        assert (!this.isRetired());
+    }
+
+    public boolean isRetired() {
+        return this.flags.contains(Flags.RETIRED);
+    }
+
+    public int getFreeSize() {
+        return end() - this.committedPosition.get();
+    }
+
+    /**
+     * SubstrateVM specific below.
+     */
+
+    public ByteBuffer getBuffer() {
+        return this.buffer;
+    }
+
+    public void deallocateBuffer() {
+        this.buffer = null;
+    }
+
+    public int getSize() {
+        return this.buffer.capacity();
+    }
+}

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/jfr/recorder/storage/JfrMemorySpace.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/jfr/recorder/storage/JfrMemorySpace.java
@@ -1,0 +1,255 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, Red Hat Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package com.oracle.svm.core.jdk.jfr.recorder.storage;
+
+import java.util.Deque;
+import java.util.LinkedList;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
+
+import com.oracle.svm.core.jdk.jfr.logging.JfrLogger;
+import com.oracle.svm.core.jdk.jfr.recorder.checkpoint.types.traceid.JfrTraceIdEpoch;
+import com.oracle.svm.core.jdk.jfr.recorder.storage.operations.JfrBufferOperations.BufferOperation;
+
+public class JfrMemorySpace<U extends JfrMemorySpaceRetrieval, V extends JfrMemorySpace.Client> {
+
+    public interface Client {
+        void registerFull(JfrBuffer buffer, Thread thread);
+    }
+
+    private final boolean epochAware;
+
+    private final Queue<JfrBuffer> free = new ConcurrentLinkedQueue<>();
+    private final Deque<JfrBuffer> liveOne = new LinkedList<>();
+    private final Deque<JfrBuffer> liveTwo = new LinkedList<>();
+
+    private final int minElementSize;
+    private final int cacheCount;
+
+    private final V callback;
+
+    public JfrMemorySpace(int minElementSize, int cacheCount, V callback) {
+        this(minElementSize, cacheCount, callback, false);
+    }
+
+    public JfrMemorySpace(int minElementSize, int cacheCount, V callback, boolean epochAware) {
+        this.minElementSize = minElementSize;
+        this.cacheCount = cacheCount;
+        this.callback = callback;
+
+        this.epochAware = epochAware;
+    }
+
+    public boolean initialize(boolean initializeFree) {
+        for (int i = 0; i < this.cacheCount; i++) {
+            if (initializeFree) {
+                this.allocateFree(this.minElementSize);
+            } else {
+                this.allocateLive(this.minElementSize);
+            }
+        }
+
+        if (initializeFree) {
+            assert (free.size() == this.cacheCount);
+        } else {
+            assert (live().size() == this.cacheCount);
+        }
+        return true;
+    }
+
+    public int minElementSize() {
+        return this.minElementSize;
+    }
+
+    public Queue<JfrBuffer> free() {
+        return free;
+    }
+
+    public Deque<JfrBuffer> live() {
+        return live(false);
+    }
+
+    public Deque<JfrBuffer> live(boolean previousEpoch) {
+        if (this.epochAware) {
+            return previousEpoch ? previousEpochList() : currentEpochList();
+        }
+        return liveOne;
+    }
+
+    private Deque<JfrBuffer> previousEpochList() {
+        return epochList(JfrTraceIdEpoch.previousEpoch());
+    }
+
+    private Deque<JfrBuffer> currentEpochList() {
+        return epochList(JfrTraceIdEpoch.currentEpoch());
+    }
+
+    private Deque<JfrBuffer> epochList(boolean epoch) {
+        if (epoch) {
+            return liveOne;
+        }
+        return liveTwo;
+    }
+
+    public JfrBuffer get(int size, Thread thread) {
+        return U.get(size, this, thread);
+    }
+
+    public void registerFull(JfrBuffer buffer, Thread thread) {
+        callback.registerFull(buffer, thread);
+    }
+
+    private JfrBuffer allocateFree(int size) {
+        JfrBuffer b = new JfrBuffer(size);
+        b.initialize();
+        this.free().add(b);
+        return b;
+    }
+
+    private JfrBuffer allocateLive(int size) {
+        return allocateLive(size, false);
+    }
+
+    private JfrBuffer allocateLive(int size, boolean previousEpoch) {
+        JfrBuffer b = new JfrBuffer(size);
+        b.initialize();
+        this.live(previousEpoch).add(b);
+        return b;
+    }
+
+    // Acquire buffer, otherwise return null
+    private JfrBuffer acquireFree(int size, Thread t) {
+        return U.get(size, this, free().iterator(), t);
+    }
+
+    private JfrBuffer acquireLive(int size, Thread t) {
+        return acquireLive(size, t, false);
+    }
+
+    // Acquire buffer, otherwise return null
+    private JfrBuffer acquireLive(int size, Thread t, boolean previousEpoch) {
+        return U.get(size, this, live(previousEpoch).iterator(), t);
+    }
+
+    public void releaseLive(JfrBuffer buffer) {
+        assert (buffer != null);
+        assert (this.live().contains(buffer));
+        this.live().remove(buffer);
+        assert (!this.live().contains(buffer));
+        if (buffer.isTransient()) {
+            this.deallocate(buffer);
+            return;
+        }
+        assert (buffer.isEmpty());
+        assert (!buffer.isRetired());
+        assert (buffer.identity() == -1);
+        if (this.shouldPopulateCache()) {
+            assert (!free.contains(buffer));
+            this.free().add(buffer);
+        } else {
+            this.deallocate(buffer);
+        }
+    }
+
+    private boolean shouldPopulateCache() {
+        return this.free.size() < this.cacheCount;
+    }
+
+    private void deallocate(JfrBuffer buffer) {
+        assert (buffer != null);
+        assert (!this.free.contains(buffer));
+        assert (!this.live().contains(buffer));
+        buffer.deallocateBuffer();
+        JfrLogger.logError("deallocate buffer");
+    }
+
+    public void iterateLiveList(BufferOperation<JfrBuffer> op) {
+        iterateLiveList(op, false);
+    }
+
+    public void iterateLiveList(BufferOperation<JfrBuffer> op, boolean previousEpoch) {
+        for (JfrBuffer b : live(previousEpoch)) {
+            if (!op.process(b)) {
+                return;
+            }
+        }
+    }
+
+    // Attempt retry count times to acquire buffer from live, lease it, and return
+    // it, null otherwise
+    public static JfrBuffer acquireLiveLeaseWithRetry(int size, JfrMemorySpace<?, ?> mspace, int retryCount, Thread t,
+            boolean previousEpoch) {
+
+        JfrBuffer b = acquireLiveWithRetry(size, mspace, retryCount, t, previousEpoch);
+        if (b != null) {
+            b.setLeased();
+            return b;
+        }
+        return null;
+    }
+
+    public static JfrBuffer acquireLiveWithRetry(int size, JfrMemorySpace<?, ?> mspace, int retryCount, Thread t) {
+        return acquireLiveWithRetry(size, mspace, retryCount, t, false);
+    }
+
+    // Attempt retry count times to acquire buffer from live, and return it, null
+    // otherwise
+    public static JfrBuffer acquireLiveWithRetry(int size, JfrMemorySpace<?, ?> mspace, int retryCount, Thread t,
+            boolean previousEpoch) {
+        JfrBuffer b;
+        for (int i = 0; i < retryCount; i++) {
+            b = mspace.acquireLive(size, t, previousEpoch);
+            if (b != null) {
+                return b;
+            }
+        }
+        return null;
+    }
+
+    // Allocate to live, set acquire, lease, transient, and return it
+    public static JfrBuffer acquireTransientLeaseToLive(int size, JfrMemorySpace<?, ?> mspace, Thread t,
+            boolean previousEpoch) {
+        JfrBuffer b = mspace.allocateLive(size, previousEpoch);
+        b.acquire(t);
+        b.setLeased();
+        b.setTransient();
+
+        return b;
+    }
+
+    // Acquire or allocate to live, return it
+    public static JfrBuffer mspaceGetLive(int size, JfrMemorySpace<?, ?> mspace, Thread t) {
+        JfrBuffer b = mspace.acquireFree(size, t);
+        if (b != null) {
+            mspace.live().add(b);
+            return b;
+        }
+
+        return mspace.allocateLive(size);
+    }
+
+}

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/jfr/recorder/storage/JfrMemorySpaceRetrieval.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/jfr/recorder/storage/JfrMemorySpaceRetrieval.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, Red Hat Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package com.oracle.svm.core.jdk.jfr.recorder.storage;
+
+import java.util.Iterator;
+
+public class JfrMemorySpaceRetrieval {
+    public static JfrBuffer get(int size, JfrMemorySpace<?, ?> space, Thread thread) {
+        Iterator<JfrBuffer> iterator = space.free().iterator();
+        return get(size, space, iterator, thread);
+    }
+
+    // Returns buffer from list that is acquired, otherwise null
+    public static JfrBuffer get(int size, JfrMemorySpace<?, ?> space, Iterator<JfrBuffer> iterator,
+            Thread thread) {
+        while (iterator.hasNext()) {
+            JfrBuffer item = iterator.next();
+            if (item.isRetired()) {
+                continue;
+            }
+            if (item.tryAcquire(thread)) {
+                assert (!item.isRetired());
+                if (item.getFreeSize() >= size) {
+                    return item;
+                }
+                item.setRetired();
+                space.registerFull(item, thread);
+            }
+        }
+        return null;
+    }
+}

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/jfr/recorder/storage/JfrRetrieval.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/jfr/recorder/storage/JfrRetrieval.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, Red Hat Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package com.oracle.svm.core.jdk.jfr.recorder.storage;
+
+import java.util.Iterator;
+
+public class JfrRetrieval extends JfrMemorySpaceRetrieval {
+    public static JfrBuffer get(int size, JfrMemorySpace<?, ?> space, Thread thread) {
+        Iterator<JfrBuffer> iterator = space.free().iterator();
+        return JfrMemorySpaceRetrieval.get(size, space, iterator, thread);
+    }
+}

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/jfr/recorder/storage/JfrSequentialRetrieval.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/jfr/recorder/storage/JfrSequentialRetrieval.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, Red Hat Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package com.oracle.svm.core.jdk.jfr.recorder.storage;
+
+public class JfrSequentialRetrieval extends JfrMemorySpaceRetrieval {
+    public static JfrBuffer get(int size, JfrMemorySpace<?, ?> space, Thread thread) {
+        return JfrMemorySpaceRetrieval.get(size, space, space.free().iterator(), thread);
+    }
+
+}

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/jfr/recorder/storage/JfrStorage.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/jfr/recorder/storage/JfrStorage.java
@@ -1,0 +1,442 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, Red Hat Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package com.oracle.svm.core.jdk.jfr.recorder.storage;
+
+import java.nio.ByteBuffer;
+import java.util.concurrent.locks.ReentrantLock;
+
+import com.oracle.svm.core.jdk.jfr.JfrOptions;
+import com.oracle.svm.core.jdk.jfr.logging.JfrLogger;
+import com.oracle.svm.core.jdk.jfr.recorder.repository.JfrChunkWriter;
+import com.oracle.svm.core.jdk.jfr.recorder.service.JfrPostBox;
+import com.oracle.svm.core.jdk.jfr.recorder.service.JfrPostBox.JfrMsg;
+import com.oracle.svm.core.jdk.jfr.recorder.storage.operations.JfrBufferOperations;
+import com.oracle.svm.core.thread.JavaThreads;
+import com.oracle.svm.core.thread.VMOperation;
+
+public final class JfrStorage implements JfrMemorySpace.Client {
+
+    // JFR.TODO
+    // Verify BigInteger? int? long? for the various fields, especially for
+    // mspace and size related ones
+    private static final int inMemoryDiscardThreshholdDelta = 2;
+    private static final int threadLocalCacheCount = 8;
+    private static final int threadLocalScavengeThreshhold = threadLocalCacheCount / 2;
+
+    private static final int promotionRetry = 100;
+
+    private static JfrStorage instance;
+
+    private final JfrChunkWriter chunkWriter;
+    private final JfrPostBox postBox;
+    private JfrStorageControl control;
+
+    private final ReentrantLock bufferLock = new ReentrantLock();
+
+    JfrMemorySpace<JfrRetrieval, JfrStorage> globalMSpace;
+    JfrMemorySpace<JfrThreadLocalRetrieval, JfrStorage> threadLocalMSpace;
+
+    // Slight adjustment from jdk/jdk using a MemorySpace for the FullList that uses
+    // the free() list
+    JfrMemorySpace<JfrSequentialRetrieval, JfrStorage> fullSpace;
+
+    private JfrStorage(JfrChunkWriter chunkWriter, JfrPostBox postBox) {
+        this.chunkWriter = chunkWriter;
+        this.postBox = postBox;
+    }
+
+    public static JfrStorage create(JfrChunkWriter chunkWriter, JfrPostBox postBox) {
+        assert (instance == null);
+        instance = new JfrStorage(chunkWriter, postBox);
+        return instance;
+    }
+
+    public boolean initialize() {
+        // JFR.TODO
+        // Get options from JfrOptionSet
+
+        int numGlobalBuffers = JfrOptions.getGlobalBufferCount();
+        assert (numGlobalBuffers >= inMemoryDiscardThreshholdDelta);
+
+        int globalBufferSize = JfrOptions.getGlobalBufferSize();
+        int threadBufferSize = JfrOptions.getThreadBufferSize();
+
+        this.globalMSpace = new JfrMemorySpace<>(globalBufferSize, numGlobalBuffers, this);
+        this.globalMSpace.initialize(false);
+
+        this.threadLocalMSpace = new JfrMemorySpace<>(threadBufferSize, threadLocalCacheCount, this);
+        this.threadLocalMSpace.initialize(true);
+
+        this.fullSpace = new JfrMemorySpace<>(0, numGlobalBuffers, this);
+        this.fullSpace.initialize(true);
+
+        this.control = new JfrStorageControl(numGlobalBuffers - inMemoryDiscardThreshholdDelta, bufferLock);
+        control.setScavengeThreshhold(threadLocalScavengeThreshhold);
+
+        return true;
+    }
+
+    public JfrStorageControl getStorageControl() {
+        return this.control;
+    }
+
+    private JfrPostBox getPostBox() {
+        return this.postBox;
+    }
+
+    public void registerFull(JfrBuffer buffer, Thread thread) {
+        assert (buffer != null);
+        assert (buffer.isRetired());
+        assert (buffer.acquiredBy(thread));
+        assert (fullSpace != null);
+        assert (fullSpace.live().isEmpty());
+
+        boolean notify;
+
+        this.bufferLock.lock();
+        try {
+            notify = this.control.incrementFull();
+            fullSpace.free().add(buffer);
+        } finally {
+            this.bufferLock.unlock();
+        }
+
+        if (notify) {
+            postBox.post(JfrMsg.FULLBUFFER);
+        }
+    }
+
+    private void release(JfrBuffer buffer, Thread t) {
+        assert (buffer != null);
+        assert (!buffer.isLeased());
+        assert (!buffer.isTransient());
+        assert (!buffer.isRetired());
+
+        if (!buffer.isEmpty()) {
+            if (!flushRegularBuffer(buffer, t)) {
+                buffer.reinitialize();
+            }
+        }
+
+        assert (buffer.isEmpty());
+        assert (buffer.identity() != -1);
+
+        this.control.incrementDead();
+        buffer.setRetired();
+    }
+
+    public JfrBuffer flush(JfrBuffer cur, int used, int requested, Thread t) {
+        int curPos = cur.getCommittedPosition();
+        requested += used;
+        if (!cur.isLeased()) {
+            flushRegular(cur, curPos, used, requested, t);
+        } else {
+            throw new UnsupportedOperationException();
+        }
+        return cur;
+    }
+
+    private JfrBuffer flushRegular(JfrBuffer buffer, int dataStart, int used, int requested, Thread t) {
+        flushRegularBuffer(buffer, t);
+
+        if (buffer.isExcluded()) {
+            return buffer;
+        }
+
+        if (buffer.getFreeSize() >= requested) {
+            if (used > 0) {
+                ByteBuffer tmp = buffer.getBuffer().duplicate();
+                assert (dataStart + used <= buffer.end());
+
+                tmp.position(dataStart);
+                tmp.limit(dataStart + used);
+
+                buffer.getBuffer().position(buffer.getCommittedPosition());
+                buffer.getBuffer().put(tmp);
+            }
+            return buffer;
+        } else {
+            // JFR.TODO
+            // Large buffer required and is not currently supported
+            JfrLogger.logWarning("JFR: Large buffer required but not supported. Event data will be lost: ", buffer.getFreeSize(), requested);
+        }
+
+        return buffer;
+    }
+
+    private boolean flushRegularBuffer(JfrBuffer buffer, Thread t) {
+        assert (buffer != null);
+        assert (!buffer.isLeased());
+        assert (!buffer.isTransient());
+
+        int unflushedSize = buffer.getUnflushedSize();
+        if (unflushedSize == 0) {
+            buffer.reinitialize();
+            assert (buffer.isEmpty());
+            return true;
+        }
+
+        if (buffer.isExcluded()) {
+            boolean threadExcluded = JavaThreads.getThreadLocal(t).isExcluded();
+            buffer.reinitialize(threadExcluded);
+            assert (buffer.isEmpty());
+            if (!threadExcluded) {
+                // JFR.TODO
+                // state change from exclusion to inclusion requires a thread checkpoint
+                // JfrCheckpointManager::write_thread_checkpoint(thread);
+            }
+            return true;
+        }
+
+        JfrBuffer promotionBuffer = acquirePromotionBuffer(unflushedSize, globalMSpace, promotionRetry, t);
+        if (promotionBuffer == null) {
+            writeDataLoss(buffer, t);
+            return false;
+        }
+        assert (promotionBuffer.acquiredBySelf());
+        assert (promotionBuffer.getFreeSize() >= unflushedSize);
+
+        buffer.promoteTo(promotionBuffer, unflushedSize);
+        assert (buffer.isEmpty());
+
+        return true;
+    }
+
+    private void writeDataLoss(JfrBuffer buffer, Thread t) {
+        int unflushedSize = buffer.getUnflushedSize();
+        buffer.reinitialize();
+        if (unflushedSize == 0) {
+            return;
+        }
+        writeDataLossEvent(buffer, unflushedSize, t);
+    }
+
+    private void writeDataLossEvent(JfrBuffer buffer, int unflushedSize, Thread t) {
+        assert (buffer != null);
+        assert (buffer.isEmpty());
+        int totalDataLost = JavaThreads.getThreadLocal(t).addDataLost(unflushedSize);
+        JfrLogger.logInfo("JFR: Data loss event:", totalDataLost);
+        // JFR.TODO
+        // if (EventDataLoss::is_enabled()) {
+        // JfrNativeEventWriter writer(buffer, thread);
+        // writer.write<u8>(EventDataLoss::eventId);
+        // writer.write(JfrTicks::now());
+        // writer.write(unflushed_size);
+        // writer.write(total_data_loss);
+        // }
+    }
+
+    private JfrBuffer acquirePromotionBuffer(int size, JfrMemorySpace<?, ?> mspace, int retryCount, Thread t) {
+        assert (size <= mspace.minElementSize());
+        while (true) {
+            JfrBuffer b = JfrMemorySpace.acquireLiveWithRetry(size, mspace, retryCount, t);
+            if (b == null && this.control.shouldDiscard()) {
+                this.discardOldest(t);
+                continue;
+            }
+            return b;
+        }
+    }
+
+    private void discardOldest(Thread t) {
+        if (this.bufferLock.tryLock()) {
+            int fullPreDiscard = control.fullCount();
+            int fullPostDiscard = 0;
+            int discardSize = 0;
+            try {
+                if (!this.control.shouldDiscard()) {
+                    // Another thread handled it
+                    return;
+                }
+
+                while (true) {
+                    JfrBuffer oldestNode = this.fullSpace.free().remove();
+                    if (oldestNode == null) {
+                        break;
+                    }
+                    assert (oldestNode.isRetired());
+                    assert (oldestNode.identity() != -1);
+                    discardSize += oldestNode.discard();
+                    assert (oldestNode.getUnflushedSize() == 0);
+                    fullPostDiscard = this.control.decrementFull();
+                    if (oldestNode.isTransient()) {
+                        // JFR.TODO Verify the node is in threadLocalMSpace
+                        JfrLogger.logError("Releasing a transient node");
+                        threadLocalMSpace.releaseLive(oldestNode);
+                        continue;
+                    }
+                    oldestNode.reinitialize();
+                    oldestNode.release();
+                    break;
+                }
+            } finally {
+                this.bufferLock.unlock();
+            }
+            int discards = fullPreDiscard - fullPostDiscard;
+            if (discards > 0) {
+                JfrLogger.logDebug("Cleared", discards, "full buffer(s) of", discardSize, "bytes");
+                JfrLogger.logDebug("Current number of full buffers:", fullPostDiscard);
+            }
+        }
+    }
+
+    public boolean bufferIsLocked() {
+        return this.bufferLock.isHeldByCurrentThread();
+    }
+
+    public static JfrStorage instance() {
+        return instance;
+    }
+
+    public static JfrBuffer acquireThreadLocalBuffer(Thread thread) {
+        JfrBuffer b = JfrMemorySpace.mspaceGetLive(0, instance().threadLocalMSpace, thread);
+        if (b == null) {
+            JfrLogger.logWarning("Unable to allocate thread local buffer");
+            return null;
+        }
+        assert (b.acquiredBySelf());
+        return b;
+    }
+
+    public static void releaseThreadLocal(JfrBuffer buffer, Thread t) {
+        assert (buffer != null);
+        instance().release(buffer, t);
+
+        if (instance().getStorageControl().shouldScavenge()) {
+            instance().getPostBox().post(JfrMsg.DEADBUFFER);
+        }
+    }
+
+    public int clear() {
+        int fullElements = clearFull();
+
+        JfrBufferOperations.ConcurrentDiscard<JfrBuffer> discardOp = new JfrBufferOperations.ConcurrentDiscard<>(
+                new JfrBufferOperations.DefaultDiscarder<>());
+        JfrBufferOperations.ScavengingRelease<JfrBuffer> rtlo = new JfrBufferOperations.ScavengingRelease<>(
+                threadLocalMSpace, threadLocalMSpace.live());
+
+        JfrBufferOperations.CompositeAnd<JfrBuffer> tldo = new JfrBufferOperations.CompositeAnd<>(discardOp, rtlo);
+
+        threadLocalMSpace.iterateLiveList(tldo);
+
+        assert (globalMSpace.free().isEmpty());
+        assert (!globalMSpace.live().isEmpty());
+
+        globalMSpace.iterateLiveList(tldo);
+
+        return fullElements + discardOp.elements();
+    }
+
+    private int clearFull() {
+        if (fullSpace.free().isEmpty()) {
+            return 0;
+        }
+
+        JfrBufferOperations.Discard<JfrBuffer> discardOp = new JfrBufferOperations.Discard<>(
+                new JfrBufferOperations.DefaultDiscarder<>());
+        int count = processFull(discardOp);
+
+        if (count != 0) {
+            logWrite(count, discardOp.size());
+        }
+
+        return count;
+
+    }
+
+    public int write() {
+        assert (chunkWriter.isValid());
+        int fullElements = writeFull(chunkWriter);
+
+        assert (globalMSpace.free().isEmpty());
+        assert (!globalMSpace.live().isEmpty());
+
+        JfrBufferOperations.UnbufferedWriteToChunk<JfrBuffer> wo = new JfrBufferOperations.UnbufferedWriteToChunk<>(
+                chunkWriter);
+        JfrBufferOperations.PredicatedConcurrentWrite<JfrBuffer> cnewo = new JfrBufferOperations.PredicatedConcurrentWrite<>(
+                wo, new JfrBufferOperations.Excluded<>(true));
+
+        JfrBufferOperations.ScavengingRelease<JfrBuffer> rtlo = new JfrBufferOperations.ScavengingRelease<>(
+                threadLocalMSpace, threadLocalMSpace.live());
+
+        JfrBufferOperations.CompositeAnd<JfrBuffer> tlop = new JfrBufferOperations.CompositeAnd<>(cnewo, rtlo);
+
+        threadLocalMSpace.iterateLiveList(tlop);
+
+        return fullElements + wo.elements();
+    }
+
+    public int writeFull(JfrChunkWriter writer) {
+        assert (writer.isValid());
+        if (fullSpace.free().isEmpty()) {
+            return 0;
+        }
+
+        JfrBufferOperations.BufferOperation<JfrBuffer> wo = new JfrBufferOperations.UnbufferedWriteToChunk<>(writer);
+
+        JfrBufferOperations.CompositeAnd<JfrBuffer> writeOp = new JfrBufferOperations.CompositeAnd<>(
+                new JfrBufferOperations.MutexedWrite<>(wo), new JfrBufferOperations.Release<>(threadLocalMSpace));
+
+        int count = processFull(writeOp);
+        if (count != 0) {
+            logWrite(count, writeOp.size());
+        }
+        return count;
+    }
+
+    private int processFull(JfrBufferOperations.BufferOperation<JfrBuffer> operation) {
+        int count = 0;
+        while (!fullSpace.free().isEmpty()) {
+            JfrBuffer n = fullSpace.free().remove();
+            operation.process(n);
+            count++;
+        }
+        return count;
+    }
+
+    public int writeAtSafepoint() {
+        assert (VMOperation.isInProgressAtSafepoint());
+        int fullElements = writeFull(chunkWriter);
+
+        JfrBufferOperations.UnbufferedWriteToChunk<JfrBuffer> wo = new JfrBufferOperations.UnbufferedWriteToChunk<>(
+                chunkWriter);
+        JfrBufferOperations.PredicatedSafepointWrite<JfrBuffer> cnewo = new JfrBufferOperations.PredicatedSafepointWrite<>(
+                wo, new JfrBufferOperations.Excluded<>(true));
+
+        threadLocalMSpace.iterateLiveList(cnewo);
+
+        assert (globalMSpace.free().isEmpty());
+        assert (!globalMSpace.live().isEmpty());
+        globalMSpace.iterateLiveList(cnewo);
+
+        return fullElements + wo.elements();
+    }
+
+    private void logWrite(int count, int amount) {
+        JfrLogger.log(0, JfrLogger.Level.DEBUG, "Processed: " + count + " full buffers and " + amount + " bytes");
+    }
+}

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/jfr/recorder/storage/JfrStorageControl.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/jfr/recorder/storage/JfrStorageControl.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, Red Hat Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package com.oracle.svm.core.jdk.jfr.recorder.storage;
+
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.locks.ReentrantLock;
+
+public class JfrStorageControl {
+
+    private final int memoryDiscardThreshhold;
+    private final ReentrantLock bufferLock;
+
+    private final int toDiskThreshhold = 0;
+    private int scavengeThreshhold = 0;
+    private boolean toDisk = false;
+
+    private int fullCount = 0;
+    private final AtomicInteger deadCount = new AtomicInteger(0);
+
+    public JfrStorageControl(int memoryDiscardThreshhold, ReentrantLock bufferLock) {
+        this.memoryDiscardThreshhold = memoryDiscardThreshhold;
+        this.bufferLock = bufferLock;
+    }
+
+    public boolean shouldScavenge() {
+        return deadCount() >= this.scavengeThreshhold;
+    }
+
+    private int deadCount() {
+        return this.deadCount.get();
+    }
+
+    public void setScavengeThreshhold(int scavengeThreshhold) {
+        this.scavengeThreshhold = scavengeThreshhold;
+    }
+
+    public boolean incrementFull() {
+        assert (bufferLock.isHeldByCurrentThread());
+        fullCount++;
+
+        return toDisk() && this.fullCount > this.toDiskThreshhold;
+    }
+
+    public int decrementFull() {
+        assert (bufferLock.isHeldByCurrentThread());
+        return --fullCount;
+    }
+
+    public int incrementDead() {
+        return deadCount.incrementAndGet();
+    }
+
+    public boolean shouldDiscard() {
+        return !toDisk() && fullCount() >= this.memoryDiscardThreshhold;
+    }
+
+    public int fullCount() {
+        return this.fullCount;
+    }
+
+    public boolean toDisk() {
+        return this.toDisk;
+    }
+
+    public void setToDisk(boolean toDisk) {
+        this.toDisk = toDisk;
+    }
+}

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/jfr/recorder/storage/JfrThreadLocalRetrieval.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/jfr/recorder/storage/JfrThreadLocalRetrieval.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, Red Hat Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package com.oracle.svm.core.jdk.jfr.recorder.storage;
+
+import java.util.Iterator;
+
+// Do not use retrieval for memory spaces that are not the thread local memory space
+public class JfrThreadLocalRetrieval extends JfrMemorySpaceRetrieval {
+    public static JfrBuffer get(int size, JfrMemorySpace<?, ?> space, Thread thread) {
+        Iterator<JfrBuffer> iter = space.free().iterator();
+        if (iter.hasNext()) {
+            JfrBuffer item = iter.next();
+            // Assumptions made against thread local memory space implementation details
+            assert (!item.isRetired());
+            assert (item.identity() == -1);
+            assert (item.getFreeSize() >= size);
+
+            item.acquire(thread);
+            space.free().remove(item);
+            return item;
+        }
+        return null;
+    }
+}

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/jfr/recorder/storage/operations/JfrBufferOperations.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/jfr/recorder/storage/operations/JfrBufferOperations.java
@@ -1,0 +1,601 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, Red Hat Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package com.oracle.svm.core.jdk.jfr.recorder.storage.operations;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+
+import com.oracle.svm.core.jdk.jfr.logging.JfrLogger;
+import com.oracle.svm.core.jdk.jfr.recorder.checkpoint.JfrCheckpointWriter;
+import com.oracle.svm.core.jdk.jfr.recorder.repository.JfrChunkWriter;
+import com.oracle.svm.core.jdk.jfr.recorder.storage.JfrBuffer;
+import com.oracle.svm.core.jdk.jfr.recorder.storage.JfrMemorySpace;
+import com.oracle.svm.core.jdk.jfr.utilities.JfrTypes;
+
+public class JfrBufferOperations {
+
+    public interface BufferOperation<T extends JfrBuffer> {
+        default boolean process(T node) {
+            return false;
+        }
+
+        default int elements() {
+            return 0;
+        }
+
+        default boolean write(ByteBuffer data, int size) {
+            return false;
+        }
+
+        default int size() {
+            return 0;
+        }
+
+        default boolean discard(T node, int top, int unflushedSize) {
+            return false;
+        }
+    }
+
+    public static class Release<T extends JfrBuffer> implements BufferOperation<T> {
+        private final JfrMemorySpace<?, ?> space;
+
+        public Release(JfrMemorySpace<?, ?> space) {
+            this.space = space;
+        }
+
+        @Override
+        public boolean process(T node) {
+            if (node.isTransient()) {
+                // JFR.TODO
+                // Support transient buffers by releasing them from this.space
+                JfrLogger.logError("Releasing transient node");
+            }
+
+            node.reinitialize();
+            if (node.identity() != -1) {
+                assert (node.isEmpty());
+                assert (!node.isRetired());
+                node.release();
+            }
+
+            return true;
+        }
+
+        @Override
+        public int elements() {
+            return 0;
+        }
+
+        @Override
+        public int size() {
+            return 0;
+        }
+    }
+
+    public static class ReleaseExcision<T extends JfrBuffer> implements BufferOperation<T> {
+        private final JfrMemorySpace<?, ?> space;
+
+        public ReleaseExcision(JfrMemorySpace<?, ?> space, Collection<T> list) {
+            this.space = space;
+        }
+
+        @Override
+        public boolean process(T node) {
+            assert (node != null);
+            if (node.isTransient()) {
+                // JFR.TODO excise transient nodes
+            }
+
+            node.reinitialize();
+            if (node.identity() != -1) {
+                assert (node.isEmpty());
+                assert (!node.isRetired());
+                node.release();
+            }
+
+            return true;
+        }
+
+        @Override
+        public int elements() {
+            return 0;
+        }
+
+        @Override
+        public int size() {
+            return 0;
+        }
+    }
+
+    public static class UnbufferedWriteToChunk<T extends JfrBuffer> implements BufferOperation<T> {
+        private final JfrChunkWriter writer;
+        private int elements = 0;
+        private int size = 0;
+
+        public UnbufferedWriteToChunk(JfrChunkWriter writer) {
+            this.writer = writer;
+        }
+
+        public boolean write(ByteBuffer data, int size) {
+            try {
+                writer.writeUnbuffered(data);
+                this.elements++;
+                this.size += size;
+                return true;
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+
+            return false;
+        }
+
+        public int elements() {
+            return this.elements;
+        }
+
+        public int size() {
+            return this.size;
+        }
+    }
+
+    public static class MutexedWrite<T extends JfrBuffer> implements BufferOperation<T> {
+        private final BufferOperation<T> write;
+
+        public MutexedWrite(BufferOperation<T> writeOp) {
+            this.write = writeOp;
+        }
+
+        @Override
+        public boolean process(T node) {
+            assert (node != null);
+            int flushed = node.getFlushedPosition();
+            int committed = node.getCommittedPosition();
+
+            int unflushedSize = committed - flushed;
+            assert (unflushedSize >= 0);
+
+            if (unflushedSize == 0) {
+                return true;
+            }
+
+            ByteBuffer toWrite = node.getBuffer().duplicate();
+            toWrite.position(flushed);
+            toWrite.limit(committed);
+
+            boolean result = write.write(toWrite, unflushedSize);
+            if (result) {
+                node.setFlushedPosition(committed);
+            }
+
+            return result;
+        }
+
+        @Override
+        public int elements() {
+            return write.elements();
+        }
+
+        @Override
+        public int size() {
+            return write.size();
+        }
+    }
+
+    public static class CompositeAnd<T extends JfrBuffer> implements BufferOperation<T> {
+
+        private final List<BufferOperation<T>> operations;
+
+        public CompositeAnd(BufferOperation<T>... ops) {
+            operations = Arrays.asList(ops);
+        }
+
+        @Override
+        public boolean process(T node) {
+            for (BufferOperation<T> op : operations) {
+                if (!op.process(node)) {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        @Override
+        public int elements() {
+            int elements = 0;
+            for (BufferOperation<T> op : operations) {
+                elements += op.elements();
+            }
+
+            return elements;
+        }
+
+        @Override
+        public int size() {
+            int size = 0;
+            for (BufferOperation<T> op : operations) {
+                size += op.size();
+            }
+
+            return size;
+        }
+    }
+
+    public static class Excluded<T extends JfrBuffer> implements BufferOperation<T> {
+        private final boolean negation;
+
+        public Excluded(boolean negation) {
+            this.negation = negation;
+        }
+
+        @Override
+        public boolean process(T node) {
+            return negation != node.isExcluded();
+        }
+
+        @Override
+        public int elements() {
+            return 0;
+        }
+
+        @Override
+        public int size() {
+            return 0;
+        }
+    }
+
+    public static class SafepointWrite<T extends JfrBuffer> implements BufferOperation<T> {
+        private final BufferOperation<T> operation;
+
+        public SafepointWrite(BufferOperation<T> operation) {
+            this.operation = operation;
+        }
+
+        @Override
+        public boolean process(T node) {
+            if (node.getFlushLock().tryLock()) {
+                try {
+                    int flushed = node.getFlushedPosition();
+                    int unflushedSize = node.getCommittedPosition() - flushed;
+                    if (unflushedSize == 0) {
+                        node.setFlushedPosition(flushed);
+                        return true;
+                    }
+
+                    ByteBuffer toWrite = node.getBuffer().duplicate();
+                    toWrite.position(flushed);
+                    toWrite.limit(flushed + unflushedSize);
+                    boolean result = operation.write(toWrite, unflushedSize);
+
+                    node.setFlushedPosition(flushed + unflushedSize);
+                    return result;
+                } finally {
+                    node.getFlushLock().unlock();
+                }
+            } else {
+                // Skip the buffer as it is in the process of moving to the global ring buffer
+                // It will be written out later
+                return true;
+            }
+        }
+
+        @Override
+        public int elements() {
+            return operation.elements();
+        }
+
+        @Override
+        public int size() {
+            return operation.size();
+        }
+    }
+
+    public static class ConcurrentWrite<T extends JfrBuffer> implements BufferOperation<T> {
+        private final BufferOperation<T> operation;
+
+        public ConcurrentWrite(BufferOperation<T> operation) {
+            this.operation = operation;
+        }
+
+        @Override
+        public boolean process(T node) {
+            if (node.isRetired()) {
+                return write(node);
+            } else {
+                node.getFlushLock().lock();
+                try {
+                    return write(node);
+                } finally {
+                    node.getFlushLock().unlock();
+                }
+            }
+
+        }
+
+        private boolean write(T node) {
+                int flushed = node.getFlushedPosition();
+                int unflushedSize = node.getCommittedPosition() - flushed;
+                if (unflushedSize == 0) {
+                    node.setFlushedPosition(flushed);
+                    return true;
+                }
+
+                ByteBuffer toWrite = node.getBuffer().duplicate();
+                toWrite.position(flushed);
+                toWrite.limit(flushed + unflushedSize);
+                boolean result = operation.write(toWrite, unflushedSize);
+
+                node.setFlushedPosition(flushed + unflushedSize);
+                return result;
+        }
+
+        @Override
+        public int elements() {
+            return operation.elements();
+        }
+
+        @Override
+        public int size() {
+            return operation.size();
+        }
+    }
+
+    public static class PredicatedSafepointWrite<T extends JfrBuffer> implements BufferOperation<T> {
+        private final BufferOperation<T> operation;
+        private final BufferOperation<T> predicate;
+
+        public PredicatedSafepointWrite(BufferOperation<T> operation, BufferOperation<T> predicate) {
+            this.operation = new SafepointWrite<>(operation);
+            this.predicate = predicate;
+        }
+
+        @Override
+        public boolean process(T node) {
+            return predicate.process(node) && operation.process(node);
+        }
+    }
+
+    public static class PredicatedConcurrentWrite<T extends JfrBuffer> implements BufferOperation<T> {
+        private final BufferOperation<T> operation;
+        private final BufferOperation<T> predicate;
+
+        public PredicatedConcurrentWrite(BufferOperation<T> operation, BufferOperation<T> predicate) {
+            this.operation = new ConcurrentWrite<>(operation);
+            this.predicate = predicate;
+        }
+
+        @Override
+        public boolean process(T node) {
+            return predicate.process(node) && operation.process(node);
+        }
+    }
+
+    public static class ScavengingRelease<T extends JfrBuffer> implements BufferOperation<T> {
+        private final JfrMemorySpace<?, ?> mspace;
+        private final Collection<T> list;
+
+        private int count = 0;
+        private int amount = 0;
+
+        public ScavengingRelease(JfrMemorySpace<?, ?> mspace, Collection<T> list) {
+            this.mspace = mspace;
+            this.list = list;
+        }
+
+        @Override
+        public boolean process(T node) {
+            assert (node != null);
+            assert (!node.isTransient());
+
+            if (node.isRetired()) {
+                return exciseWithRelease(node);
+            }
+
+            return true;
+        }
+
+        private boolean exciseWithRelease(T node) {
+            assert (node != null);
+            assert (node.isRetired());
+            assert (node.identity() != -1);
+            assert (node.isEmpty());
+            assert (!node.isLeased());
+            assert (!node.isExcluded());
+
+            count++;
+            amount += node.getSize();
+            node.clearRetired();
+            node.release();
+            mspace.releaseLive(node);
+
+            return true;
+        }
+
+        @Override
+        public int elements() {
+            return count;
+        }
+
+        @Override
+        public int size() {
+            return amount;
+        }
+    }
+
+    public static class DefaultDiscarder<T extends JfrBuffer> implements BufferOperation<T> {
+        private int elements = 0;
+        private int size = 0;
+
+        @Override
+        public int elements() {
+            return this.elements;
+        }
+
+        @Override
+        public boolean discard(T node, int top, int unflushedSize) {
+            elements++;
+            size += unflushedSize;
+            return true;
+        }
+
+        @Override
+        public int size() {
+            return this.size;
+        }
+    }
+
+    public static class ConcurrentDiscard<T extends JfrBuffer> extends Discard<T> {
+        public ConcurrentDiscard(BufferOperation<T> op) {
+            super(op);
+        }
+
+        @Override
+        public boolean process(T node) {
+            boolean result;
+            node.getFlushLock().lock();
+            try {
+                result = super.process(node);
+            } finally {
+                node.getFlushLock().unlock();
+            }
+
+            return result;
+        }
+    }
+
+    public static class Discard<T extends JfrBuffer> implements BufferOperation<T> {
+
+        private final BufferOperation<T> op;
+
+        public Discard(BufferOperation<T> op) {
+            this.op = op;
+        }
+
+        @Override
+        public boolean process(T node) {
+
+            int top = node.getFlushedPosition();
+            int unflushedSize = node.getCommittedPosition() - top;
+            if (unflushedSize == 0) {
+                return true;
+            }
+
+            boolean result = op.discard(node, top, unflushedSize);
+                node.setFlushedPosition(top + unflushedSize);
+
+            return result;
+        }
+
+        @Override
+        public int elements() {
+            return op.elements();
+        }
+
+        @Override
+        public int size() {
+            return op.size();
+        }
+    }
+
+    public static class CheckpointWrite<T extends JfrBuffer> implements BufferOperation<T> {
+        private final JfrChunkWriter writer;
+        int processed = 0;
+
+        public CheckpointWrite(JfrChunkWriter writer) {
+            this.writer = writer;
+        }
+
+        @Override
+        public boolean write(ByteBuffer data, int size) {
+            processed += writeCheckpoints(data, size);
+            return true;
+        }
+
+        private int writeCheckpoints(ByteBuffer data, int size) {
+            int processed = 0;
+            assert (writer.isValid());
+            assert (data != null);
+            assert (data.limit() == data.position() + size);
+
+            while (data.hasRemaining()) {
+                processed += writeCheckpointEvent(data);
+            }
+
+            return processed;
+        }
+
+        private int writeCheckpointEvent(ByteBuffer data) {
+            assert (data != null);
+            try {
+                long eventBegin = writer.reserve(Integer.BYTES);
+                long lastOffset = writer.getLastCheckpointOffset();
+                long delta = lastOffset == 0 ? 0 : lastOffset - eventBegin;
+                int checkpointSize = (int) data.getLong();
+                assert (checkpointSize > JfrCheckpointWriter.jfrCheckpointEntrySize);
+
+                writeCheckpointHeader(data, delta);
+                writeCheckpointData(data, checkpointSize);
+
+                long eventSize = writer.getCurrentOffset() - eventBegin;
+                writer.padded().writeInt((int) eventSize, eventBegin);
+                writer.setLastCheckpointOffset(eventBegin);
+
+                return checkpointSize;
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+
+            return 0;
+        }
+
+        private void writeCheckpointData(ByteBuffer data, int checkpointSize) throws IOException {
+            assert ((data.position() + checkpointSize - JfrCheckpointWriter.jfrCheckpointEntrySize) == data.limit());
+
+            int startPos = data.position();
+            int written = writer.writeUnbuffered(data);
+            int endPos = data.position();
+            assert (endPos - startPos == written);
+        }
+
+        private void writeCheckpointHeader(ByteBuffer data, long delta) throws IOException {
+            writer.encoded().writeLong(JfrTypes.ReservedEvent.EVENT_CHECKPOINT.id);
+            writer.encoded().writeLong(data.getLong()); // startTime
+            writer.encoded().writeLong(data.getLong()); // duration
+            writer.encoded().writeLong(delta);
+            writer.encoded().writeInt(data.getInt()); // type
+            writer.encoded().writeInt(data.getInt()); // count
+        }
+
+        @Override
+        public int elements() {
+            return processed;
+        }
+
+    }
+}

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/jfr/recorder/storage/operations/JfrContentOperations.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/jfr/recorder/storage/operations/JfrContentOperations.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, Red Hat Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package com.oracle.svm.core.jdk.jfr.recorder.storage.operations;
+
+import com.oracle.svm.core.jdk.jfr.recorder.checkpoint.JfrMetadataEvent;
+import com.oracle.svm.core.jdk.jfr.recorder.repository.JfrChunkWriter;
+
+public class JfrContentOperations {
+
+    public interface Content {
+        boolean process();
+
+        int elements();
+    }
+
+    public static class MetadataEventContent implements Content {
+        private final JfrChunkWriter writer;
+
+        public MetadataEventContent(JfrChunkWriter writer) {
+            this.writer = writer;
+        }
+
+        public boolean process() {
+            JfrMetadataEvent.write(writer);
+            return true;
+        }
+
+        public int elements() {
+            return 1;
+        }
+    }
+
+    public static class Write implements Content {
+        private final long startTime;
+        private long endTime;
+        private final JfrChunkWriter writer;
+        private final Content content;
+        private final long startOffset;
+
+        public Write(JfrChunkWriter writer, Content content) {
+            this.startTime = System.currentTimeMillis();
+            this.endTime = -1;
+            this.writer = writer;
+            this.content = content;
+            this.startOffset = writer.getCurrentOffset();
+            assert (writer.isValid());
+        }
+
+        public boolean process() {
+            content.process();
+            this.endTime = System.currentTimeMillis();
+            return 0 != content.elements();
+        }
+
+        public int elements() {
+            return content.elements();
+        }
+    }
+}

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/jfr/recorder/stringpool/JfrStringPool.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/jfr/recorder/stringpool/JfrStringPool.java
@@ -1,0 +1,222 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, Red Hat Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package com.oracle.svm.core.jdk.jfr.recorder.stringpool;
+
+import java.io.IOException;
+import java.util.LinkedList;
+import java.util.Queue;
+
+import com.oracle.svm.core.jdk.UninterruptibleUtils.AtomicInteger;
+import com.oracle.svm.core.jdk.jfr.recorder.checkpoint.JfrCheckpointClient;
+import com.oracle.svm.core.jdk.jfr.recorder.checkpoint.JfrCheckpointWriter;
+import com.oracle.svm.core.jdk.jfr.recorder.checkpoint.types.JfrTypeWriter;
+import com.oracle.svm.core.jdk.jfr.recorder.checkpoint.types.traceid.JfrTraceIdEpoch;
+import com.oracle.svm.core.jdk.jfr.recorder.repository.JfrChunkWriter;
+import com.oracle.svm.core.jdk.jfr.recorder.storage.JfrBuffer;
+import com.oracle.svm.core.jdk.jfr.recorder.storage.JfrMemorySpace;
+import com.oracle.svm.core.jdk.jfr.recorder.storage.JfrMemorySpaceRetrieval;
+import com.oracle.svm.core.jdk.jfr.recorder.storage.operations.JfrBufferOperations;
+import com.oracle.svm.core.jdk.jfr.utilities.JfrTypes;
+
+public final class JfrStringPool implements JfrCheckpointClient {
+    private static class JfrString {
+        long id;
+        String str;
+
+        JfrString(long id, String str) {
+            this.id = id;
+            this.str = str;
+        }
+
+    }
+
+    private static final int bufferCount = 2;
+    private static final int bufferSize = 512 * 1024;
+
+
+    private static JfrStringPool instance;
+    private JfrMemorySpace<JfrMemorySpaceRetrieval, JfrStringPool> mspace;
+
+    private final Queue<JfrString> stringsZero = new LinkedList<>();
+    private final Queue<JfrString> stringsOne = new LinkedList<>();
+
+    private int sizeZero = 0;
+    private int sizeOne = 0;
+
+    private final AtomicInteger currentGeneration = new AtomicInteger(0);
+    private final AtomicInteger lastGeneration = new AtomicInteger(0);
+
+    private JfrStringPool() {
+    }
+
+    public static JfrStringPool create() {
+        assert (instance == null);
+        instance = new JfrStringPool();
+        return instance;
+    }
+
+    public static JfrStringPool instance() {
+        return instance;
+    }
+
+    public boolean initialize() {
+        this.mspace = new JfrMemorySpace<>(bufferSize, bufferCount, this);
+        this.mspace.initialize(false);
+        assert (this.mspace.free().isEmpty());
+        assert (!this.mspace.live().isEmpty());
+
+        return true;
+    }
+
+    public boolean isModified() {
+        int last = this.lastGeneration.get();
+        int current = this.currentGeneration.get();
+        if (last != current) {
+            this.lastGeneration.compareAndSet(last, this.currentGeneration.get());
+            return true;
+        }
+        return false;
+    }
+
+    private Queue<JfrString> queue(boolean epoch) {
+        return epoch ? stringsZero : stringsOne;
+    }
+
+    private void increment(boolean epoch, int size) {
+        if (epoch) {
+            sizeZero += size;
+        } else {
+            sizeOne += size;
+        }
+    }
+
+    public boolean addStringConstant(boolean epoch, long id, String s) {
+        if (JfrTraceIdEpoch.currentEpoch() != epoch) {
+            return !epoch;
+        }
+        queue(epoch).add(new JfrString(id, s));
+        increment(epoch, s.length() + 4);
+        this.currentGeneration.incrementAndGet();
+
+        return epoch;
+    }
+
+    public void write(JfrChunkWriter chunkWriter) {
+        boolean epoch = JfrTraceIdEpoch.previousEpoch();
+
+        int size = epoch ? sizeZero : sizeOne;
+        if (queue(epoch).size() > 0) {
+            // JFR.TODO optimize StringPool to write directly to buffer instead of storing
+            // in queue
+            JfrBuffer b = lease(size, true, Thread.currentThread());
+            b.acquire(Thread.currentThread());
+            JfrCheckpointWriter writer = new JfrCheckpointWriter(b, Thread.currentThread(), this);
+            writer.open();
+            JfrTypeWriter stringWriter = new JfrTypeWriter(JfrTypes.JfrTypeId.TYPE_STRING.id, writer);
+            try {
+                stringWriter.begin();
+                for (JfrString s : queue(epoch)) {
+                    stringWriter.incrementCount(writeString(writer, s));
+                }
+                stringWriter.end();
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+            writer.close();
+
+            JfrBufferOperations.BufferOperation<JfrBuffer> wo = new JfrBufferOperations.CheckpointWrite<>(chunkWriter);
+            JfrBufferOperations.CompositeAnd<JfrBuffer> wro = new JfrBufferOperations.CompositeAnd<>(
+                    new JfrBufferOperations.MutexedWrite<>(wo),
+                    new JfrBufferOperations.ReleaseExcision<>(mspace, mspace.live(true)));
+
+            mspace.iterateLiveList(wro, true);
+        }
+    }
+
+    private int writeString(JfrCheckpointWriter writer, JfrString s) throws IOException {
+        writer.encoded().writeLong(s.id);
+        writer.writeString(s.str);
+        return 1;
+    }
+
+    public void clear() {
+        boolean epoch = JfrTraceIdEpoch.previousEpoch();
+        queue(epoch).clear();
+    }
+
+    @Override
+    public void registerFull(JfrBuffer buffer, Thread thread) {
+        assert (buffer != null);
+        assert (buffer.acquiredBy(thread));
+        assert (buffer.isRetired());
+    }
+
+    @Override
+    public JfrBuffer flush(JfrBuffer oldBuffer, int used, int requested, Thread t) {
+        assert (oldBuffer != null && oldBuffer.isLeased());
+        if (requested == 0) {
+            // indicates a lease is being returned
+            release(oldBuffer);
+            // JFR.TODO
+            // setConstantPending()
+        }
+        JfrBuffer newBuffer = lease(used + requested, true, t);
+        oldBuffer.transferTo(newBuffer, used);
+
+        release(oldBuffer);
+        return newBuffer;
+    }
+
+    private void release(JfrBuffer buffer) {
+        buffer.clearLeased();
+        if (buffer.isTransient()) {
+            buffer.setRetired();
+        } else {
+            buffer.release();
+        }
+    }
+    @Override
+    public JfrBuffer lease(int size, boolean previousEpoch, Thread t) {
+        return lease(size, 100, previousEpoch, t);
+    }
+
+    private JfrBuffer lease(int size, int retryCount, boolean previousEpoch, Thread t) {
+        int max = mspace.minElementSize();
+        JfrBuffer b;
+        if (size <= max) {
+            b = JfrMemorySpace.acquireLiveLeaseWithRetry(size, mspace, retryCount, t, previousEpoch);
+            if (b != null) {
+                return b;
+            }
+        }
+
+        b = JfrMemorySpace.acquireTransientLeaseToLive(size, mspace, t, previousEpoch);
+
+        return b;
+    }
+
+}

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/jfr/remote/JfrAutoSessionManager.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/jfr/remote/JfrAutoSessionManager.java
@@ -1,0 +1,194 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, Red Hat Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package com.oracle.svm.core.jdk.jfr.remote;
+
+import com.oracle.svm.core.SubstrateOptions;
+import com.oracle.svm.core.jdk.jfr.JfrOptions;
+import com.oracle.svm.core.jdk.jfr.logging.JfrLogger;
+
+import jdk.jfr.Configuration;
+import jdk.jfr.Recording;
+
+import java.io.IOException;
+import java.nio.file.Paths;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.time.Instant;
+import java.util.Date;
+
+/*
+ * Handlers the startup and teardown of JFR when run from either the command line or remote interface.
+ * Implemented by standard JFR calls as user code might do.
+ */
+
+public class JfrAutoSessionManager {
+
+    private static final SimpleDateFormat fmt = new SimpleDateFormat("yyyy_MM_DD_HH_mm_ss");
+    private static final String DEFAULT_JFR_CONFIG = "default";
+
+    private final Configuration jfrConfiguration;
+    private String filename;
+    private Recording recording;
+    private static JfrAutoSessionManager instance;
+
+    static void out(String msg) {
+        JfrLogger.logInfo("JFR.AutoStart " + msg);
+    }
+
+    JfrAutoSessionManager() throws IOException, ParseException {
+        this(DEFAULT_JFR_CONFIG);
+    }
+
+    JfrAutoSessionManager(String configName) throws IOException, ParseException {
+        out("JfrAutoSessionManager(" + configName + ")");
+        jfrConfiguration = Configuration.getConfiguration(configName);
+    }
+
+    /*
+     *   JFR-TODO if these timers expire after the main program has ended, the process hangs.
+     */
+    void startSession(String fn, long delayMilliseconds, long durationMilliseconds) {
+        if (delayMilliseconds > 0) {
+            out("scheduling JFR start in " + delayMilliseconds + "ms.");
+            new java.util.Timer().schedule(
+                    new java.util.TimerTask() {
+                        @Override
+                        public void run() {
+                            startSession(fn, 0, durationMilliseconds);
+                        }
+                    },
+                    delayMilliseconds
+            );
+        } else {
+            out("starting JFR session(" + fn + ")");
+            filename = fn;
+            recording = new Recording(jfrConfiguration);
+            recording.start();
+            try {
+                recording.setDestination(Paths.get(filename));
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+            if (durationMilliseconds > 0) {
+                out("scheduling JFR stop in " + durationMilliseconds + "ms.");
+                new java.util.Timer().schedule(
+                        new java.util.TimerTask() {
+                            @Override
+                            public void run() {
+                                stopSession(true, false);
+                            }
+                        },
+                        durationMilliseconds
+                );
+            }
+        }
+    }
+
+    void stopSession(boolean write, boolean clear) {
+        out("stopSession(" + write + ", " + clear + ") start");
+        try {
+            if (recording != null) {
+                recording.close();
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        out("stopSession(" + write + ", " + clear + ") stop");
+    }
+
+    public static void startupHook() {
+        out("Jfr startupHook() - start");
+        out(dumpJfrOptions(", "));
+        assert instance == null;
+        if (JfrOptions.getStartRecordingAutomatically()) {
+            try {
+                // JFR-TODO fix JfrOptions to parse configuration name instead of using default "default"
+                instance = new JfrAutoSessionManager();
+                String fn = (JfrOptions.getRecordingFileName() != null && JfrOptions.getRecordingFileName().length() > 0) ? JfrOptions.getRecordingFileName() : getDefaultJfrFilename();
+                instance.startSession(fn, JfrOptions.getRecordingDelay(), JfrOptions.getDuration());
+            } catch (IOException | ParseException e) {
+                e.printStackTrace();
+            }
+        } else {
+            out("Jfr startupHook() - no auto start");
+        }
+        out("Jfr startupHook() - end");
+    }
+
+    public static void shutdownHook() {
+        out("Jfr shutdownHook() - start instance is " + (instance == null ? "(null)" : instance.filename));
+        if (instance != null) {
+            instance.stopSession(true, true);
+        }
+        out("Jfr shutdownHook() - end");
+    }
+
+    @SuppressWarnings("unused")
+    private static String asString(Configuration cfg, String sep) {
+        return "name=\"" + cfg.getName() + "\"" + sep +
+                "label=\"" + cfg.getLabel() + "\"" + sep +
+                "description=\"" + cfg.getDescription() + "\"" + sep +
+                "settings=\"" + cfg.getSettings() + "\"";
+    }
+
+    public static String dumpJfrOptions(String sep) {
+        return "filename=\"" + JfrOptions.getRecordingFileName() + "\"" + sep +
+                "recordingName=\"" + JfrOptions.getRecordingName() + "\"" + sep +
+                "recordingSettingsFile=\"" + JfrOptions.getRecordingSettingsFile() + "\"" + sep +
+                "repositoryLocation=\"" + JfrOptions.getRepositoryLocation() + "\"" + sep +
+                "dumpOnExit=\"" + JfrOptions.getDumpOnExit() + "\"" + sep +
+                "persistToDisk=\"" + JfrOptions.isPersistedToDisk() + sep +
+                "pathToGcRoots=\"" + JfrOptions.trackPathToGcRoots() + "\"" + sep +
+                "sampleThreads=\"" + JfrOptions.isSampleThreadsEnabled() + "\"" + sep +
+                "retransform=\"" + JfrOptions.isRetransformEnabled() + "\"" + sep +
+                "sampleProtection=\"" + JfrOptions.isSampleProtectionEnabled() + "\"" + sep +
+                "delay=\"" + JfrOptions.getRecordingDelay() + "\"" + sep +
+                "duration=\"" + JfrOptions.getDuration() + "\"" + sep +
+                "maxAge=\"" + JfrOptions.getMaxAge() + "\"" + sep +
+                "maxChunkSize=\"" + JfrOptions.getMaxChunkSize() + "\"" + sep +
+                "globalBufferSize=\"" + JfrOptions.getGlobalBufferSize() + "\"" + sep +
+                "memorySize=\"" + JfrOptions.getMemorySize() + "\"" + sep +
+                "threadBufferSize=\"" + JfrOptions.getThreadBufferSize() + "\"" + sep +
+                "globalBufferCount=\"" + JfrOptions.getGlobalBufferCount() + "\"" + sep +
+                "oldObjectQueueSize=\"" + JfrOptions.getObjectQueueSize() + "\"" + sep +
+                "maxRecordingSize=\"" + JfrOptions.getMaxRecordingSize() + "\"" + sep +
+                "stackDepth=\"" + JfrOptions.getStackDepth() + "\"" + sep +
+                "logLevel=\"" + JfrOptions.getLogLevel() + "\"";
+    }
+
+    /* NOTE: this changes every time it is called */
+    /* JFR-TODO - should this be the time of the start recording command? */
+    public static String getDefaultJfrFilename() {
+        String program = SubstrateOptions.Name.getValue().replaceAll("[:/\\\\]", "_");
+        if (program.isEmpty()) {
+            program = SubstrateOptions.Class.getValue().replaceAll("[$/]", "_");
+        }
+        long pid = ProcessHandle.current().pid();
+        int id = 1; /* JFR-TODO: don't know how to calculate id; maybe go to filesystem? */
+        return String.format("%s-pid-%d-id-%d-%s.jfr", program, pid, id, fmt.format(Date.from(Instant.now())));
+    }
+}

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/jfr/support/JfrThreadLocal.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/jfr/support/JfrThreadLocal.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, Red Hat Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package com.oracle.svm.core.jdk.jfr.support;
+
+import com.oracle.svm.core.jdk.jfr.recorder.storage.JfrBuffer;
+import com.oracle.svm.core.jdk.jfr.recorder.storage.JfrStorage;
+import com.oracle.svm.core.thread.JavaThreads;
+
+public class JfrThreadLocal {
+
+    private JfrBuffer buffer;
+    private Object eventWriter = null;
+    private boolean excluded = false;
+    private boolean notified = false;
+
+    private int dataLost = 0;
+
+    void release(Thread t) {
+        if (hasBuffer()) {
+            JfrStorage.releaseThreadLocal(buffer(), t);
+            this.buffer = null;
+        }
+
+        // JFR.TODO
+        // Release stack frames
+        if (this.eventWriter != null) {
+            this.eventWriter = null;
+        }
+
+    }
+
+    public static void excludeThread(Thread t) {
+        assert (t != null);
+        JfrThreadLocal jtl = JavaThreads.getThreadLocal(t);
+        jtl.excluded = true;
+        jtl.release(t);
+    }
+
+    private JfrBuffer acquireBuffer(boolean excluded) {
+        JfrBuffer b = JfrStorage.acquireThreadLocalBuffer(Thread.currentThread());
+        if (b != null && excluded) {
+            b.setExcluded();
+        }
+        this.buffer = b;
+        return this.buffer;
+    }
+
+    public JfrBuffer buffer() {
+        return this.buffer != null ? this.buffer : acquireBuffer(this.excluded);
+    }
+
+    public boolean hasBuffer() {
+        return this.buffer != null;
+    }
+
+    public void setBuffer(JfrBuffer buffer) {
+        this.buffer = buffer;
+    }
+
+    public boolean isExcluded() {
+        return this.excluded;
+    }
+
+    public int addDataLost(int value) {
+        this.dataLost += value;
+        return this.dataLost;
+    }
+
+    // JFR.TODO support for large buffers will need this
+    public JfrBuffer shelvedBuffer() {
+        return null;
+    }
+
+    public Object getEventWriter() {
+        return this.eventWriter;
+    }
+
+    public void setEventWriter(Object ew) {
+        this.eventWriter = ew;
+    }
+
+    public boolean hasEventWriter() {
+        return this.eventWriter != null;
+    }
+
+    public void setNotified(boolean notified) {
+        this.notified = notified;
+    }
+
+    public boolean isNotified() {
+        return this.notified;
+    }
+
+}

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/jfr/utilities/JfrCheckpointType.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/jfr/utilities/JfrCheckpointType.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, Red Hat Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package com.oracle.svm.core.jdk.jfr.utilities;
+
+public enum JfrCheckpointType {
+    GENERIC(0),
+    FLUSH(1),
+    HEADER(2),
+    STATICS(4),
+    THREADS(8);
+
+    public final int id;
+
+    JfrCheckpointType(int id) {
+        this.id = id;
+    }
+}

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/jfr/utilities/JfrTicks.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/jfr/utilities/JfrTicks.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, Red Hat Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package com.oracle.svm.core.jdk.jfr.utilities;
+
+public class JfrTicks {
+    // JFR.TODO
+    public static long now() {
+        return System.currentTimeMillis();
+    }
+}

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/jfr/utilities/JfrTime.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/jfr/utilities/JfrTime.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, Red Hat Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package com.oracle.svm.core.jdk.jfr.utilities;
+
+public class JfrTime {
+    public static final long invalidTime = -1;
+
+    public static long getFrequency() {
+        // JFR.TODO fake value
+        return 1000000000;
+    }
+}

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/jfr/utilities/JfrTimeConverter.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/jfr/utilities/JfrTimeConverter.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, Red Hat Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package com.oracle.svm.core.jdk.jfr.utilities;
+
+public class JfrTimeConverter {
+    public static final long NANOS_PER_SEC      = 1000000000;
+    public static final long NANOS_PER_MILLISEC = 1000000;
+    public static final long NANOS_PER_MICROSEC = 1000;
+}

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/jfr/utilities/JfrTypes.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/jfr/utilities/JfrTypes.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, Red Hat Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package com.oracle.svm.core.jdk.jfr.utilities;
+
+public class JfrTypes {
+
+    public enum JfrTypeId {
+
+        TYPE_CLASS(20),
+        TYPE_STRING(21),
+        TYPE_CLASSLOADER(38),
+        TYPE_METHOD(39),
+        TYPE_SYMBOL(40),
+        TYPE_MODULE(57),
+        TYPE_PACKAGE(58),
+        TYPE_CHUNKHEADER(71);
+
+        public final long id;
+
+        JfrTypeId(long id) {
+            this.id = id;
+        }
+    }
+
+    public enum ReservedEvent {
+        EVENT_METADATA(0),
+        EVENT_CHECKPOINT(1),
+        EVENT_BUFFERLOST(2);
+
+        public final long id;
+
+        ReservedEvent(long id) {
+            this.id = id;
+        }
+    }
+}

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/jfr/writers/JfrEncodingWriter.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/jfr/writers/JfrEncodingWriter.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, Red Hat Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package com.oracle.svm.core.jdk.jfr.writers;
+
+import java.nio.ByteBuffer;
+
+public class JfrEncodingWriter {
+    public interface Encoder {
+        int encode(ByteBuffer buf, int size, long value);
+    }
+
+    public static int writeBE(ByteBuffer buf, int size, long value) {
+        switch (size) {
+            case Byte.BYTES:
+                buf.put((byte) value);
+                break;
+            case Short.BYTES:
+                buf.putShort((short) value);
+                break;
+            case Integer.BYTES:
+                buf.putInt((int) value);
+                break;
+            case Long.BYTES:
+                buf.putLong(value);
+                break;
+            default:
+                // We should never get here
+                throw new IllegalArgumentException("Invalid size");
+        }
+        return size;
+    }
+
+    public static int writeCompressed(ByteBuffer buf, int size, long value) {
+        for (int i = 1; i <= 8; i++) {
+            if ((value & ~0x7FL) == 0L) {
+                buf.put((byte) (value & 0x7fL));
+                return i;
+            } else {
+                buf.put((byte) (value & 0x7fL | 0x80L));
+            }
+            value >>>= 7;
+        }
+        buf.put((byte) value);
+        return 9;
+    }
+
+    public static int writePaddedCompressed(ByteBuffer buf, int size, long value) {
+        switch (size) {
+            case Byte.BYTES:
+                buf.put((byte) value);
+                break;
+            case Short.BYTES:
+                buf.put((byte) (value | 0x80));
+                buf.put((byte) (value >>> 7));
+                break;
+            case Integer.BYTES:
+                buf.put((byte) (value | 0x80));
+                buf.put((byte) (value >>> 7 | 0x80));
+                buf.put((byte) (value >>> 14 | 0x80));
+                buf.put((byte) (value >>> 21));
+                break;
+            case Long.BYTES:
+                buf.put((byte) (value | 0x80));
+                buf.put((byte) (value >>> 7 | 0x80));
+                buf.put((byte) (value >>> 14 | 0x80));
+                buf.put((byte) (value >>> 21 | 0x80));
+                buf.put((byte) (value >>> 28 | 0x80));
+                buf.put((byte) (value >>> 35 | 0x80));
+                buf.put((byte) (value >>> 42 | 0x80));
+                buf.put((byte) (value >>> 49));
+                break;
+            default:
+                // We should never get here
+                throw new IllegalArgumentException("Invalid size");
+        }
+        return size;
+    }
+}

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/jfr/writers/JfrStringEncoding.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/jfr/writers/JfrStringEncoding.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, Red Hat Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package com.oracle.svm.core.jdk.jfr.writers;
+
+enum JfrStringEncoding {
+    NULL_STRING(0),
+    EMPTY_STRING(1),
+    STRING_CONSTANT(2),
+    UTF8(3),
+    UTF16(4),
+    LATIN1(5),
+    NOF_STRING_ENCODINGS(6);
+
+    public final int id;
+
+    JfrStringEncoding(int id) {
+        this.id = id;
+    }
+}

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/jfr/writers/JfrWriter.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/jfr/writers/JfrWriter.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, Red Hat Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package com.oracle.svm.core.jdk.jfr.writers;
+
+import java.io.IOException;
+
+public interface JfrWriter {
+    // Writes byte and updates position
+    int writeByte(byte value) throws IOException;
+
+    // Writes short and updates position
+    int writeShort(short value) throws IOException;
+
+    // Writes int and updates position
+    int writeInt(int value) throws IOException;
+
+    // Writes long and updates position
+    int writeLong(long value) throws IOException;
+
+    // Writes byte at offset, then returns to previous position
+    int writeByte(byte value, long offset) throws IOException;
+
+    // Writes short at offset, then returns to previous position
+    int writeShort(short value, long offset) throws IOException;
+
+    // Writes int at offset, then returns to previous position
+    int writeInt(int value, long offset) throws IOException;
+
+    // Writes long at offset, then returns to previous position
+    int writeLong(long value, long offset) throws IOException;
+}

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/thread/Target_java_lang_Thread.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/thread/Target_java_lang_Thread.java
@@ -42,6 +42,7 @@ import com.oracle.svm.core.jdk.JDK11OrLater;
 import com.oracle.svm.core.jdk.JDK14OrLater;
 import com.oracle.svm.core.jdk.JDK8OrEarlier;
 import com.oracle.svm.core.jdk.UninterruptibleUtils.AtomicReference;
+import com.oracle.svm.core.jdk.jfr.support.JfrThreadLocal;
 import com.oracle.svm.core.monitor.MonitorSupport;
 import com.oracle.svm.core.option.XOptions;
 import com.oracle.svm.core.stack.StackOverflowCheck;
@@ -58,6 +59,9 @@ final class Target_java_lang_Thread {
 
     @Inject @RecomputeFieldValue(kind = RecomputeFieldValue.Kind.Reset)//
     boolean wasStartedByCurrentIsolate;
+
+    @Inject @RecomputeFieldValue(kind = RecomputeFieldValue.Kind.NewInstance, declClass = JfrThreadLocal.class)//
+    JfrThreadLocal jfrThreadLocal;
 
     /**
      * Every thread has a {@link ParkEvent} for {@link sun.misc.Unsafe#park} and
@@ -158,6 +162,7 @@ final class Target_java_lang_Thread {
 
         this.unsafeParkEvent = new AtomicReference<>();
         this.sleepParkEvent = new AtomicReference<>();
+        this.jfrThreadLocal = new JfrThreadLocal();
 
         tid = nextThreadID();
         threadStatus = ThreadStatus.RUNNABLE;
@@ -181,6 +186,7 @@ final class Target_java_lang_Thread {
         /* Injected Target_java_lang_Thread instance field initialization. */
         this.unsafeParkEvent = new AtomicReference<>();
         this.sleepParkEvent = new AtomicReference<>();
+        this.jfrThreadLocal = new JfrThreadLocal();
         /* Initialize the rest of the Thread object. */
         JavaThreads.initializeNewThread(this, groupArg, targetArg, nameArg, stackSizeArg);
     }
@@ -200,6 +206,7 @@ final class Target_java_lang_Thread {
         /* Injected Target_java_lang_Thread instance field initialization. */
         this.unsafeParkEvent = new AtomicReference<>();
         this.sleepParkEvent = new AtomicReference<>();
+        this.jfrThreadLocal = new JfrThreadLocal();
         /* Initialize the rest of the Thread object, ignoring `acc` and `inheritThreadLocals`. */
         JavaThreads.initializeNewThread(this, g, target, name, stackSize);
     }

--- a/substratevm/src/com.oracle.svm.driver/src/com/oracle/svm/driver/DefaultOptionHandler.java
+++ b/substratevm/src/com.oracle.svm.driver/src/com/oracle/svm/driver/DefaultOptionHandler.java
@@ -179,6 +179,9 @@ class DefaultOptionHandler extends NativeImage.OptionHandler<NativeImage> {
             return true;
         }
         if (headArg.startsWith(NativeImage.oH) || headArg.startsWith(NativeImage.oR)) {
+            if (headArg.equals("-H:+FlightRecorder")) {
+                nativeImage.addCustomJavaArgs("-XX:FlightRecorderOptions=retransform=false");
+            }
             args.poll();
             nativeImage.addCustomImageBuilderArgs(headArg);
             return true;
@@ -224,6 +227,7 @@ class DefaultOptionHandler extends NativeImage.OptionHandler<NativeImage> {
             NativeImage.showWarning("Ignoring server-mode native-image argument " + headArg + ".");
             return true;
         }
+
         return false;
     }
 

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/NativeImageOptions.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/NativeImageOptions.java
@@ -38,6 +38,7 @@ import org.graalvm.compiler.serviceprovider.JavaVersionUtil;
 
 import com.oracle.graal.pointsto.api.PointstoOptions;
 import com.oracle.graal.pointsto.util.CompletionExecutor;
+import com.oracle.svm.core.jdk.jfr.JfrAvailability;
 import com.oracle.svm.core.option.APIOption;
 import com.oracle.svm.core.option.HostedOptionKey;
 import com.oracle.svm.core.util.UserError;
@@ -106,6 +107,17 @@ public class NativeImageOptions {
         @Override
         protected void onValueUpdate(EconomicMap<OptionKey<?>, Object> values, Boolean oldValue, Boolean newValue) {
             PointstoOptions.UnresolvedIsError.update(values, !newValue);
+        }
+    };
+
+    @Option(help = "Enable flight recorder system")
+    public static final HostedOptionKey<Boolean> FlightRecorder = new HostedOptionKey<Boolean>(false) {
+        @Override
+        protected void onValueUpdate(EconomicMap<OptionKey<?>, Object> values, Boolean oldValue, Boolean newValue) {
+            if (newValue) {
+                AllowIncompleteClasspath.update(values, true);
+                JfrAvailability.withJfr = true;
+            }
         }
     };
 

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/classinitialization/ConfigurableClassInitialization.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/classinitialization/ConfigurableClassInitialization.java
@@ -39,6 +39,7 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
+import com.oracle.svm.core.jdk.jfr.JavaJfrUtils;
 import org.graalvm.compiler.serviceprovider.GraalUnsafeAccess;
 
 import com.oracle.graal.pointsto.constraints.UnsupportedFeatures;
@@ -654,6 +655,8 @@ public class ConfigurableClassInitialization implements ClassInitializationSuppo
             return InitKind.BUILD_TIME;
         } else if (specifiedInitKindFor(clazz) != null) {
             return specifiedInitKindFor(clazz);
+        } else if (JavaJfrUtils.isJFRClass(clazz)) {
+            return InitKind.BUILD_TIME;
         } else {
             /* The default value. */
             return InitKind.RUN_TIME;


### PR DESCRIPTION
This PR adds infrastructure to SubstrateVM supporting JDK Flight Recorder for Java native images (https://github.com/oracle/graal/issues/3018). This is a work in progress and the intention is to welcome feedback from Oracle’s GraalVM team and the GraalVM community during the development process leading up to initial integration.

## Completed Features
* Provide compile-time configuration to include or exclude the JFR infrastructure (`-H:+FlightRecorder`)
* Support existing OpenJDK API to start, stop and dump JFR v2.1 compliant recording files (`.jfr`) during native image run (`jdk.jfr.Recording` and related classes)
* Support build-time inclusion of application-defined events derived from `jdk.jfr.Event` and related classes

## In Progress Features
* Emit OpenJDK Java specific events (Socket/File read/write, ExceptionThrown, etc.)
* Allow command-line options to configure recordings on start-up, similar to the options in OpenJDK

## Other Issues in progress

Along with the major features above, many minor issues that will be addressed are tracked here: https://github.com/rh-jmc-team/graal/issues Issues labelled “jfr-initial-release” are targeted for eventual completion in this PR. This issue tracker is temporary and used to cleanly separate work items for this integration in a publicly accessible location. Note, as this is WIP, new issues will surely appear and be tracked there as well. Once this PR is accepted, we will follow upstream practices for all future work. As well, more long-term additions are described in the original issue: https://github.com/oracle/graal/issues/3018

## Testing

This implementation has been tested against native images produced from sources in this repository: https://github.com/rh-jmc-team/jfr-tests At this time, tests are manually run. We intend to add automated test infrastructure to compile test sources into native images, run them, and verify the resulting JFR file. Tests against other applications have been and will continue to be run as well.

As an example from the jfr-tests repository, TestConcurrentEvents starts a recording to disk, creates 8 threads that emit 1024*1024 events each, stops the recording and prints the location of the produced .jfr file. See `substratevm/JFR.md` in this branch for instructions on building with FlightRecorder enabled.

## Contributors:

Andrew Dinn <adinn@redhat.com>
Jie Kang <jkang@redhat.com>
Roman Kennke <rkennke@redhat.com>
Josh Matsuoka <jmatsuok@redhat.com>
Tako Schotanus <tschotan@redhat.com>
Simon Tooke <stooke@redhat.com>
