### PR TITLE
Ignore non zip/jar files in classpath

### DIFF
--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/util/ClasspathUtils.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/util/ClasspathUtils.java
@@ -25,6 +25,8 @@
 package com.oracle.svm.core.util;
 
 import java.io.File;
+import java.io.IOException;
+import java.io.RandomAccessFile;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -63,6 +65,15 @@ public final class ClasspathUtils {
     public static boolean isJar(Path p) {
         Path fn = p.getFileName();
         assert fn != null;
-        return fn.toString().toLowerCase().endsWith(".jar") && Files.isRegularFile(p);
+        if (Files.exists(p) && Files.isRegularFile(p) && Files.isReadable(p)) {
+            try (RandomAccessFile file = new RandomAccessFile(p.toFile(), "r")) {
+                final int magic = file.readInt();
+                return magic == 0x504B0304 || magic == 0x504B0506 || magic == 0x504B0708;
+            } catch (IOException e) {
+                return false;
+            }
+        }
+
+        return false;
     }
 }

--- a/substratevm/src/com.oracle.svm.driver/src/com/oracle/svm/driver/NativeImage.java
+++ b/substratevm/src/com.oracle.svm.driver/src/com/oracle/svm/driver/NativeImage.java
@@ -898,7 +898,7 @@ public class NativeImage {
                     } catch (NoSuchFileException e) {
                         /* Fallthrough */
                     }
-                } else if (Files.isReadable(classpathEntry)) {
+                } else if (ClasspathUtils.isJar(classpathEntry)) {
                     jarFileMatches = Collections.singletonList(classpathEntry);
                 }
 
@@ -985,7 +985,7 @@ public class NativeImage {
             } catch (IOException e) {
                 throw NativeImage.showError("Error while expanding wildcard for '" + path + "'", e);
             }
-        } else if (!Files.isDirectory(path)) {
+        } else if (ClasspathUtils.isJar(path)) {
             processJarManifestMainAttributes(path, manifestConsumer);
         }
     }

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/AbstractNativeImageClassLoaderSupport.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/AbstractNativeImageClassLoaderSupport.java
@@ -176,30 +176,28 @@ public abstract class AbstractNativeImageClassLoaderSupport {
         }
 
         private void loadClassesFromPath(Path path) {
-            if (Files.exists(path)) {
-                if (Files.isRegularFile(path)) {
+            if (ClasspathUtils.isJar(path)) {
+                try {
+                    URI jarURI = new URI("jar:" + path.toAbsolutePath().toUri());
+                    FileSystem probeJarFileSystem;
                     try {
-                        URI jarURI = new URI("jar:" + path.toAbsolutePath().toUri());
-                        FileSystem probeJarFileSystem;
-                        try {
-                            probeJarFileSystem = FileSystems.newFileSystem(jarURI, Collections.emptyMap());
-                        } catch (UnsupportedOperationException e) {
-                            /* Silently ignore invalid jar-files on image-classpath */
-                            probeJarFileSystem = null;
-                        }
-                        if (probeJarFileSystem != null) {
-                            try (FileSystem jarFileSystem = probeJarFileSystem) {
-                                loadClassesFromPath(jarFileSystem.getPath("/"), Collections.emptySet());
-                            }
-                        }
-                    } catch (ClosedByInterruptException ignored) {
-                        throw new InterruptImageBuilding();
-                    } catch (IOException | URISyntaxException e) {
-                        throw shouldNotReachHere(e);
+                        probeJarFileSystem = FileSystems.newFileSystem(jarURI, Collections.emptyMap());
+                    } catch (UnsupportedOperationException e) {
+                        /* Silently ignore invalid jar-files on image-classpath */
+                        probeJarFileSystem = null;
                     }
-                } else {
-                    loadClassesFromPath(path, excludeDirectories);
+                    if (probeJarFileSystem != null) {
+                        try (FileSystem jarFileSystem = probeJarFileSystem) {
+                            loadClassesFromPath(jarFileSystem.getPath("/"), Collections.emptySet());
+                        }
+                    }
+                } catch (ClosedByInterruptException ignored) {
+                    throw new InterruptImageBuilding();
+                } catch (IOException | URISyntaxException e) {
+                    throw shouldNotReachHere(e);
                 }
+            } else {
+                loadClassesFromPath(path, excludeDirectories);
             }
         }
 


### PR DESCRIPTION
Closes #3071

* Ignore classpath entries that are not jars.
* A more robust check to see if a file is a zip/jar, is to check whether the magic is the correct one, rather than relying on the file extension.