### PR TITLE
Fix file cache crash.

### DIFF
--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/image/sources/SourceCache.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/image/sources/SourceCache.java
@@ -313,7 +313,7 @@ public class SourceCache {
             moduleName = ModuleSupport.getModuleName(clazz);
         }
 
-        if (moduleName != null) {
+        if (moduleName != null && !specialSrcRoots.isEmpty()) {
             for (String specialRootModule : specialRootModules) {
                 if (moduleName.equals(specialRootModule)) {
                     for (Path srcRoot : specialSrcRoots.get(specialRootModule)) {


### PR DESCRIPTION
As observed in our R3 tests, specialSrcRoots needs to be checked for emptiness, otherwise, an exception will be thrown.