### PR TITLE
Run apt update on github actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -99,13 +99,16 @@ jobs:
       run: |
         mkdir jdk-dl
         ${MX_PATH}/mx fetch-jdk --java-distribution ${JDK} --to jdk-dl --alias ${JAVA_HOME}
+    - name: Update dependency cache
+      if: ${{ contains(matrix.env.GATE, 'debug') || contains(matrix.env.GATE, 'style') }}
+      run: sudo apt update
     - name: Debug dependencies
       if: ${{ contains(matrix.env.GATE, 'debug') }}
       run: sudo apt install gdb
     - name: Style dependencies
       if: ${{ contains(matrix.env.GATE, 'style') }}
       run: |
-        sudo apt install python-pip
+        sudo apt install python-pip python-setuptools 
         sudo pip install astroid==1.1.0
         sudo pip install pylint==1.1.0
     - name: Build GraalVM and run gate


### PR DESCRIPTION
Fixes transient issues that are caused by apt cache being invalid on first run when azure-based ubuntu mirrors are used.