### PR TITLE
Fix updategraalinopenjdk for JDK17

### DIFF
--- a/compiler/mx.compiler/mx_updategraalinopenjdk.py
+++ b/compiler/mx.compiler/mx_updategraalinopenjdk.py
@@ -1,7 +1,7 @@
 #
 # ----------------------------------------------------------------------------------------------------
 #
-# Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -382,13 +382,18 @@ def updategraalinopenjdk(args):
     def do_nothing(line):
         pass
 
-    # Update jdk.internal.vm.compiler.EXCLUDES in make/CompileJavaModules.gmk
-    # to exclude all test, benchmark and annotation processor packages.
-    CompileJavaModules_gmk = join(jdkrepo, 'make', 'CompileJavaModules.gmk') # pylint: disable=invalid-name
+    # Exclude all test, benchmark and annotation processor packages.
+    if args.version >= 17:
+        # See JDK-8258407
+        CompileJavaModules_gmk = join(jdkrepo, 'make', 'modules', 'jdk.internal.vm.compiler', 'Java.gmk') # pylint: disable=invalid-name
+        begin_lines = ['EXCLUDES += \\']
+    else:
+        CompileJavaModules_gmk = join(jdkrepo, 'make', 'CompileJavaModules.gmk') # pylint: disable=invalid-name
+        begin_lines = ['jdk.internal.vm.compiler_EXCLUDES += \\']
+
     new_lines = []
     for pkg in sorted(jdk_internal_vm_compiler_EXCLUDES):
         new_lines.append(pkg + ' \\\n')
-    begin_lines = ['jdk.internal.vm.compiler_EXCLUDES += \\']
     end_line = '#'
     old_line_check = single_column_with_continuation
     replace_lines(CompileJavaModules_gmk, begin_lines, end_line, new_lines, old_line_check, preserve_indent=True)


### PR DESCRIPTION
JDK-8258407 refactored the build scripts.
Fix updategraalinopenjdk to take this into account.