### PR TITLE
Child context creation from an internal language

### DIFF
--- a/truffle/src/com.oracle.truffle.api.test/src/com/oracle/truffle/api/test/polyglot/ChildContextTest.java
+++ b/truffle/src/com.oracle.truffle.api.test/src/com/oracle/truffle/api/test/polyglot/ChildContextTest.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or
+ * data (collectively the "Software"), free of charge and under any and all
+ * copyright rights in the Software, and any and all patent rights owned or
+ * freely licensable by each licensor hereunder covering either (i) the
+ * unmodified Software as contributed to or provided by such licensor, or (ii)
+ * the Larger Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ *
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ *
+ * The above copyright notice and either this complete permission notice or at a
+ * minimum a reference to the UPL must be included in all copies or substantial
+ * portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.oracle.truffle.api.test.polyglot;
+
+import com.oracle.truffle.api.CallTarget;
+import com.oracle.truffle.api.Truffle;
+import com.oracle.truffle.api.TruffleLanguage;
+import com.oracle.truffle.api.nodes.RootNode;
+import com.oracle.truffle.api.source.Source;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class ChildContextTest extends AbstractPolyglotTest {
+    @Test
+    public void testChildContextCreationInInternalLanguage() {
+        setupEnv();
+        context.initialize(PublicLang.ID);
+        Assert.assertEquals("foo", context.eval(PublicLang.ID, "").toString());
+    }
+
+    public static class LanguageContext {
+        public TruffleLanguage.Env env = null;
+    }
+
+    @TruffleLanguage.Registration(name = PublicLang.NAME, id = PublicLang.ID, dependentLanguages = {InternalLang.ID})
+    public static class PublicLang extends TruffleLanguage<LanguageContext> {
+        public static final String ID = "pl";
+        public static final String NAME = "public-lang";
+
+        @Override
+        protected LanguageContext createContext(Env env) {
+            LanguageContext context = new LanguageContext();
+            context.env = env;
+            return context;
+        }
+
+        @Override
+        protected CallTarget parse(ParsingRequest request) throws Exception {
+            return getCurrentContext(PublicLang.class).env.parseInternal(Source.newBuilder(InternalLang.ID, "", "").build());
+        }
+    }
+
+    @TruffleLanguage.Registration(name = InternalLang.NAME, id = InternalLang.ID, internal = true)
+    public static class InternalLang extends TruffleLanguage<LanguageContext> {
+        public static final String ID = "il";
+        public static final String NAME = "internal-lang";
+
+        @Override
+        protected LanguageContext createContext(Env env) {
+            LanguageContext context = new LanguageContext();
+            context.env = env;
+            return context;
+        }
+
+        @Override
+        protected CallTarget parse(ParsingRequest request) throws Exception {
+            getCurrentContext(InternalLang.class).env.newContextBuilder().build();
+            return Truffle.getRuntime().createCallTarget(RootNode.createConstantNode("foo"));
+        }
+    }
+}

--- a/truffle/src/com.oracle.truffle.api.test/src/com/oracle/truffle/api/test/polyglot/ChildContextTest.java
+++ b/truffle/src/com.oracle.truffle.api.test/src/com/oracle/truffle/api/test/polyglot/ChildContextTest.java
@@ -74,7 +74,8 @@ public class ChildContextTest extends AbstractPolyglotTest {
 
         @Override
         protected CallTarget parse(ParsingRequest request) throws Exception {
-            return getCurrentContext(PublicLang.class).env.parseInternal(Source.newBuilder(InternalLang.ID, "", "").build());
+            Source source = Source.newBuilder(InternalLang.ID, "", "").build();
+            return getCurrentContext(PublicLang.class).env.parseInternal(source);
         }
     }
 

--- a/truffle/src/com.oracle.truffle.api.test/src/com/oracle/truffle/api/test/polyglot/ChildContextTest.java
+++ b/truffle/src/com.oracle.truffle.api.test/src/com/oracle/truffle/api/test/polyglot/ChildContextTest.java
@@ -62,8 +62,8 @@ public class ChildContextTest extends AbstractPolyglotTest {
 
     @TruffleLanguage.Registration(name = PublicLang.NAME, id = PublicLang.ID, dependentLanguages = {InternalLang.ID})
     public static class PublicLang extends TruffleLanguage<LanguageContext> {
-        public static final String ID = "pl";
-        public static final String NAME = "public-lang";
+        public static final String ID = "ChildContextTest_PublicLang";
+        public static final String NAME = "ChildContextTest_PublicLang";
 
         @Override
         protected LanguageContext createContext(Env env) {
@@ -81,8 +81,8 @@ public class ChildContextTest extends AbstractPolyglotTest {
 
     @TruffleLanguage.Registration(name = InternalLang.NAME, id = InternalLang.ID, internal = true)
     public static class InternalLang extends TruffleLanguage<LanguageContext> {
-        public static final String ID = "il";
-        public static final String NAME = "internal-lang";
+        public static final String ID = "ChildContextTest_InternalLang";
+        public static final String NAME = "ChildContextTest_InternalLang";
 
         @Override
         protected LanguageContext createContext(Env env) {

--- a/truffle/src/com.oracle.truffle.polyglot/src/com/oracle/truffle/polyglot/EngineAccessor.java
+++ b/truffle/src/com.oracle.truffle.polyglot/src/com/oracle/truffle/polyglot/EngineAccessor.java
@@ -793,7 +793,7 @@ final class EngineAccessor extends Accessor {
                 impl.initializeContextLocals();
                 impl.engine.initializeMultiContext(creator.context);
                 impl.notifyContextCreated();
-                impl.initializeLanguage(creator.language.getId());
+                impl.initializeInternalLanguage(creator.language.getId());
             }
             return impl.creatorTruffleContext;
         }

--- a/truffle/src/com.oracle.truffle.polyglot/src/com/oracle/truffle/polyglot/EngineAccessor.java
+++ b/truffle/src/com.oracle.truffle.polyglot/src/com/oracle/truffle/polyglot/EngineAccessor.java
@@ -793,7 +793,7 @@ final class EngineAccessor extends Accessor {
                 impl.initializeContextLocals();
                 impl.engine.initializeMultiContext(creator.context);
                 impl.notifyContextCreated();
-                impl.initializeInternalLanguage(creator.language.getId());
+                impl.initializeInnerContextLanguage(creator.language.getId());
             }
             return impl.creatorTruffleContext;
         }

--- a/truffle/src/com.oracle.truffle.polyglot/src/com/oracle/truffle/polyglot/PolyglotContextImpl.java
+++ b/truffle/src/com.oracle.truffle.polyglot/src/com/oracle/truffle/polyglot/PolyglotContextImpl.java
@@ -913,6 +913,28 @@ final class PolyglotContextImpl extends AbstractContextImpl implements com.oracl
         return context;
     }
 
+    void initializeInternalLanguage(String languageId) {
+        PolyglotLanguage language = engine.idToLanguage.get(languageId);
+        if (language == null) {
+            engine.requirePublicLanguage(languageId);
+            assert false;
+            return;
+        }
+        PolyglotLanguageContext languageContext = getContext(language);
+        assert languageContext != null;
+        Object prev = hostEnter(languageContext);
+        try {
+            languageContext.checkAccess(null);
+            if (!languageContext.isInitialized()) {
+                languageContext.ensureInitialized(null);
+            }
+        } catch (Throwable t) {
+            throw PolyglotImpl.guestToHostException(languageContext, t, true);
+        } finally {
+            hostLeave(languageContext, prev);
+        }
+    }
+
     @Override
     public boolean initializeLanguage(String languageId) {
         PolyglotLanguage language = requirePublicLanguage(languageId);

--- a/truffle/src/com.oracle.truffle.polyglot/src/com/oracle/truffle/polyglot/PolyglotContextImpl.java
+++ b/truffle/src/com.oracle.truffle.polyglot/src/com/oracle/truffle/polyglot/PolyglotContextImpl.java
@@ -920,24 +920,10 @@ final class PolyglotContextImpl extends AbstractContextImpl implements com.oracl
             assert false;
             return;
         }
-        PolyglotLanguageContext languageContext = getContext(language);
-        assert languageContext != null;
-        Object prev = hostEnter(languageContext);
-        try {
-            languageContext.checkAccess(null);
-            if (!languageContext.isInitialized()) {
-                languageContext.ensureInitialized(null);
-            }
-        } catch (Throwable t) {
-            throw PolyglotImpl.guestToHostException(languageContext, t, true);
-        } finally {
-            hostLeave(languageContext, prev);
-        }
+        initializeLanguage(language);
     }
 
-    @Override
-    public boolean initializeLanguage(String languageId) {
-        PolyglotLanguage language = requirePublicLanguage(languageId);
+    private boolean initializeLanguage(PolyglotLanguage language) {
         PolyglotLanguageContext languageContext = getContext(language);
         assert languageContext != null;
         Object prev = hostEnter(languageContext);
@@ -952,6 +938,12 @@ final class PolyglotContextImpl extends AbstractContextImpl implements com.oracl
             hostLeave(languageContext, prev);
         }
         return false;
+    }
+
+    @Override
+    public boolean initializeLanguage(String languageId) {
+        PolyglotLanguage language = requirePublicLanguage(languageId);
+        return initializeLanguage(language);
     }
 
     @Override


### PR DESCRIPTION
Fixes a bug in a child `TruffleContext` builder, where it required the instantiating language to be public. 
See the newly added test case, which fails with `language il is not installed` without the fixes implemented.