### PR TITLE
Add flat to skip configuration files inside jars

### DIFF
--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/configure/ConfigurationFiles.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/configure/ConfigurationFiles.java
@@ -96,6 +96,9 @@ public final class ConfigurationFiles {
 
         @Option(help = "Comma-separated list of file names with declarative substitutions", type = OptionType.User)//
         public static final HostedOptionKey<String[]> SubstitutionFiles = new HostedOptionKey<>(null);
+
+        @Option(help = "Skip processing configuration files", type = OptionType.Expert)
+        public static final HostedOptionKey<Boolean> SkipConfigurationFiles = new HostedOptionKey<>(false);
     }
 
     public static List<Path> findConfigurationFiles(String fileName) {

--- a/substratevm/src/com.oracle.svm.driver/src/com/oracle/svm/driver/NativeImage.java
+++ b/substratevm/src/com.oracle.svm.driver/src/com/oracle/svm/driver/NativeImage.java
@@ -191,6 +191,7 @@ public class NativeImage {
     final String oHJNIConfigurationFiles = oH(ConfigurationFiles.Options.JNIConfigurationFiles);
     final String oHSerializationConfigurationFiles = oH(ConfigurationFiles.Options.SerializationConfigurationFiles);
     final String oHSerializationDenyConfigurationFiles = oH(ConfigurationFiles.Options.SerializationDenyConfigurationFiles);
+    final String oHSkipConfigurationFilesFlag = oH + "+" + ConfigurationFiles.Options.SkipConfigurationFiles.getName();
 
     final String oHInspectServerContentPath = oH(PointstoOptions.InspectServerContentPath);
     final String oHDeadlockWatchdogInterval = oH(SubstrateOptions.DeadlockWatchdogInterval);
@@ -928,7 +929,8 @@ public class NativeImage {
     }
 
     private void processNativeImageMetaInf(Path classpathEntry, Path nativeImageMetaInfBase, NativeImageMetaInfResourceProcessor metaInfProcessor) throws IOException {
-        if (Files.isDirectory(nativeImageMetaInfBase)) {
+        boolean skipConfigurationFiles = config.getBuildArgs().contains(oHSkipConfigurationFilesFlag);
+        if (!skipConfigurationFiles && Files.isDirectory(nativeImageMetaInfBase)) {
             for (MetaInfFileType fileType : MetaInfFileType.values()) {
                 List<Path> nativeImageMetaInfFiles = Files.walk(nativeImageMetaInfBase)
                                 .filter(p -> p.endsWith(fileType.fileName))


### PR DESCRIPTION
Related to #2535. 

Add a global option, `-H:+SkipConfigurationFiles`, to skip processing of native image metadata inside jar files.