### PR TITLE
Print TraceClassInitialization without error

### DIFF
--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/agent/NativeImageBytecodeInstrumentationAgent.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/agent/NativeImageBytecodeInstrumentationAgent.java
@@ -58,7 +58,7 @@ public class NativeImageBytecodeInstrumentationAgent {
 
     private static byte[] applyInitializationTrackingTransformation(@SuppressWarnings("unused") String moduleName, @SuppressWarnings("unused") ClassLoader loader, String className,
                     byte[] classfileBuffer) {
-        if (advisor.shouldTraceClassInitialization(className)) {
+        if (advisor.shouldTraceClassInitialization(className.replace('/', '.'))) {
             ClassReader reader = new ClassReader(classfileBuffer);
             ClassWriter writer = new ClassWriter(reader, COMPUTE_FRAMES);
             ClinitGenerationVisitor visitor = new ClinitGenerationVisitor(writer);

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/classinitialization/ClassInitializationFeature.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/classinitialization/ClassInitializationFeature.java
@@ -260,6 +260,10 @@ public class ClassInitializationFeature implements GraalFeature {
                 reportSafeTypeInitiazliation(universe, initGraph, path, provenSafe);
                 reportMethodInitializationInfo(path);
             }
+
+            if (SubstrateOptions.TraceClassInitialization.hasBeenSet()) {
+                reportTrackedClassInitializationTraces(path);
+            }
         }
     }
 
@@ -292,6 +296,21 @@ public class ClassInitializationFeature implements GraalFeature {
                                             .map(Class::getTypeName)
                                             .sorted()
                                             .forEach(writer::println));
+        }
+    }
+
+    private static void reportTrackedClassInitializationTraces(String path) {
+        Map<Class<?>, StackTraceElement[]> initializedClasses = ConfigurableClassInitialization.getInitializedClasses();
+        int size = initializedClasses.size();
+        if (size > 0) {
+            ReportUtils.report(size + " classes are tracked for initialization", path, "tracked_class_initialization", "txt", writer -> {
+                initializedClasses.forEach((k, v) -> {
+                    writer.println(k.getName());
+                    writer.println("---------------------------------------------");
+                    writer.println(ConfigurableClassInitialization.getTraceString(v));
+                    writer.println();
+                });
+            });
         }
     }
 

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/classinitialization/ConfigurableClassInitialization.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/classinitialization/ConfigurableClassInitialization.java
@@ -363,7 +363,11 @@ public class ConfigurableClassInitialization implements ClassInitializationSuppo
         return getTraceString(initializedClasses.get(clazz));
     }
 
-    private static String getTraceString(StackTraceElement[] trace) {
+    public static Map<Class<?>, StackTraceElement[]> getInitializedClasses() {
+        return initializedClasses;
+    }
+
+    public static String getTraceString(StackTraceElement[] trace) {
         StringBuilder b = new StringBuilder();
 
         for (int i = 0; i < trace.length; i++) {


### PR DESCRIPTION
`-H:+TraceClassInitialization` can only print out trace information when class initialization error happens, but sometimes we still need to check the reason why a class is initialized without error.
This patch helps to achieve this goal. The specified class' initialization stack trace is printed out when the option is set.