### PR TITLE
Add exclude-config option

### DIFF
--- a/substratevm/src/com.oracle.svm.driver/src/com/oracle/svm/driver/DefaultOptionHandler.java
+++ b/substratevm/src/com.oracle.svm.driver/src/com/oracle/svm/driver/DefaultOptionHandler.java
@@ -29,6 +29,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
+import java.util.regex.Pattern;
 
 import org.graalvm.compiler.options.OptionType;
 
@@ -150,6 +151,18 @@ class DefaultOptionHandler extends NativeImage.OptionHandler<NativeImage> {
             case verboseServerOption:
                 args.poll();
                 NativeImage.showWarning("Ignoring server-mode native-image argument " + headArg + ".");
+                return true;
+            case "--exclude-config":
+                args.poll();
+                String excludeJar = args.poll();
+                if (excludeJar == null) {
+                    NativeImage.showError(headArg + " requires two arguments: a jar regular expression and a resource regular expression");
+                }
+                String excludeConfig = args.poll();
+                if (excludeConfig == null) {
+                    NativeImage.showError(headArg + " requires resource regular expression");
+                }
+                nativeImage.addExcludeConfig(Pattern.compile(excludeJar), Pattern.compile(excludeConfig));
                 return true;
         }
 

--- a/substratevm/src/com.oracle.svm.driver/src/com/oracle/svm/driver/NativeImage.java
+++ b/substratevm/src/com.oracle.svm.driver/src/com/oracle/svm/driver/NativeImage.java
@@ -263,6 +263,8 @@ public class NativeImage {
     final Registry optionRegistry;
     private LinkedHashSet<EnabledOption> enabledLanguages;
 
+    private final List<ExcludeConfig> excludedConfigs = new ArrayList<>();
+
     public static final String nativeImagePropertiesFilename = "native-image.properties";
     public static final String nativeImageMetaInf = "META-INF/native-image";
 
@@ -978,6 +980,11 @@ public class NativeImage {
                                 .filter(p -> p.endsWith(fileType.fileName))
                                 .collect(Collectors.toList());
                 for (Path nativeImageMetaInfFile : nativeImageMetaInfFiles) {
+                    boolean excluded = isExcluded(nativeImageMetaInfFile, classpathEntry);
+                    if (excluded) {
+                        continue;
+                    }
+
                     Path resourceRoot = nativeImageMetaInfBase.getParent().getParent();
                     Function<String, String> resolver = str -> {
                         Path componentDirectory = resourceRoot.relativize(nativeImageMetaInfFile).getParent();
@@ -998,6 +1005,16 @@ public class NativeImage {
                 }
             }
         }
+    }
+
+    public void addExcludeConfig(Pattern jarPattern, Pattern resourcePattern) {
+        excludedConfigs.add(new ExcludeConfig(jarPattern, resourcePattern));
+    }
+
+    private boolean isExcluded(Path resourcePath, Path classpathEntry) {
+        return excludedConfigs.stream()
+                        .filter(e -> e.jarPattern.matcher(classpathEntry.toString()).find())
+                        .anyMatch(e -> e.resourcePattern.matcher(resourcePath.toString()).find());
     }
 
     static String injectHostedOptionOrigin(String option, String origin) {
@@ -1923,6 +1940,16 @@ public class NativeImage {
                 ModuleSupport.exportAndOpenAllPackagesToUnnamed("java.xml", false);
             }
             NativeImage.main(args);
+        }
+    }
+
+    private static final class ExcludeConfig {
+        final Pattern jarPattern;
+        final Pattern resourcePattern;
+
+        private ExcludeConfig(Pattern jarPattern, Pattern resourcePattern) {
+            this.jarPattern = jarPattern;
+            this.resourcePattern = resourcePattern;
         }
     }
 }


### PR DESCRIPTION
This PR Replaces #3149.

It uses a more fine grained approach to exclude configuration from jars. A new option `--exclude-config` is added that takes as a value a comma separating a jar name and regular expression of resources to exclude from the given jar. Jar names can include path elements for situations where two jar names have the same name but different leading path.


Examples:
```
--exclude-config foo.jar,META-INF\/native-image\/.*.properties
--exclude-config bar.jar,META-INF\/native-image\/.*.json
--exclude-config foo/example.jar,META-INF\/native-image\/.*.json
--exclude-config bar/example.jar,META-INF\/native-image\/.*.json
```

The approach was agreed with @olpaw on [this slack chat](https://graalvm.slack.com/archives/CN9KSFB40/p1611664256033900).

