### PR TITLE
Omit DebugLineInfo originating from inlined methods for now

### DIFF
--- a/substratevm/mx.substratevm/mx_substratevm.py
+++ b/substratevm/mx.substratevm/mx_substratevm.py
@@ -756,6 +756,7 @@ def _debuginfotest(native_image, path, build_only, args):
                          '-cp', classpath('com.oracle.svm.test'),
                          '-Dgraal.LogFile=graal.log',
                          '-g',
+                         '-H:-OmitInlinedMethodDebugLineInfo',
                          '-H:DebugInfoSourceSearchPath=' + sourcepath,
                          '-H:DebugInfoSourceCacheRoot=' + join(path, 'sources'),
                          'hello.Hello'] + args

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/SubstrateOptions.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/SubstrateOptions.java
@@ -472,6 +472,9 @@ public class SubstrateOptions {
         }
     }
 
+    @Option(help = "Omit generation of DebugLineInfo originating from inlined methods") //
+    public static final HostedOptionKey<Boolean> OmitInlinedMethodDebugLineInfo = new HostedOptionKey<>(true);
+
     /** Command line option to disable image build server. */
     public static final String NO_SERVER = "--no-server";
 

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/image/NativeImageDebugInfoProvider.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/image/NativeImageDebugInfoProvider.java
@@ -922,7 +922,9 @@ class NativeImageDebugInfoProvider implements DebugInfoProvider {
             if (fileName().length() == 0) {
                 return Stream.empty();
             }
-            return compilation.getSourceMappings().stream().map(sourceMapping -> new NativeImageDebugLineInfo(sourceMapping));
+            return compilation.getSourceMappings().stream()
+                            .filter(NativeImageDebugInfoProvider::filterLineInfoSourceMapping)
+                            .map(sourceMapping -> new NativeImageDebugLineInfo(sourceMapping));
         }
 
         @Override
@@ -963,6 +965,13 @@ class NativeImageDebugInfoProvider implements DebugInfoProvider {
         public int getModifiers() {
             return hostedMethod.getModifiers();
         }
+    }
+
+    private static boolean filterLineInfoSourceMapping(SourceMapping sourceMapping) {
+        if (!SubstrateOptions.OmitInlinedMethodDebugLineInfo.getValue()) {
+            return true;
+        }
+        return sourceMapping.getSourcePosition().getCaller() == null;
     }
 
     /**


### PR DESCRIPTION
To improve the debugging experience with CE debuginfo we should not emit lineinfo for non-root SourceMappings (i.e. inlined code) for now. Only when we later add debuginfo that species PC ranges for inlined methods (with `DW_TAG_inlined_subroutine`) having lineinfo for inlined code will work reasonably well when stepping through code with GDB.

This change will improve the stepping through experience with the CE debuginfo
It gets rid of jumping in-and-out of `GenScavengeAllocationSnippets` while line-stepping through code.