### PR TITLE
allowMapAccess and dot notation for hashmaps feature implementation

### DIFF
--- a/sdk/src/org.graalvm.polyglot/src/org/graalvm/polyglot/Engine.java
+++ b/sdk/src/org.graalvm.polyglot/src/org/graalvm/polyglot/Engine.java
@@ -675,6 +675,11 @@ public final class Engine implements AutoCloseable {
         }
 
         @Override
+        public boolean isMapAccessible(HostAccess access) {
+            return access.allowMapAccess;
+        }
+
+        @Override
         public boolean isBufferAccessible(HostAccess access) {
             return access.allowBufferAccess;
         }

--- a/sdk/src/org.graalvm.polyglot/src/org/graalvm/polyglot/HostAccess.java
+++ b/sdk/src/org.graalvm.polyglot/src/org/graalvm/polyglot/HostAccess.java
@@ -96,12 +96,13 @@ public final class HostAccess {
     private final boolean allowAllClassImplementations;
     final boolean allowArrayAccess;
     final boolean allowListAccess;
+    final boolean allowMapAccess;
     final boolean allowBufferAccess;
     final boolean allowIterableAccess;
     final boolean allowIteratorAccess;
     volatile Object impl;
 
-    private static final HostAccess EMPTY = new HostAccess(null, null, null, null, null, null, null, false, false, false, false, false, false, false, false);
+    private static final HostAccess EMPTY = new HostAccess(null, null, null, null, null, null, null, false, false, false, false, false, false, false, false, false);
 
     /**
      * Predefined host access policy that allows access to public host methods or fields that were
@@ -151,7 +152,7 @@ public final class HostAccess {
                     allowPublicAccess(true).//
                     allowAllImplementations(true).//
                     allowAllClassImplementations(true).//
-                    allowArrayAccess(true).allowListAccess(true).allowBufferAccess(true).//
+                    allowArrayAccess(true).allowListAccess(true).allowBufferAccess(true).allowMapAccess(true).//
                     allowIterableAccess(true).allowIteratorAccess(true).//
                     name("HostAccess.ALL").build();
 
@@ -173,7 +174,7 @@ public final class HostAccess {
                     EconomicSet<Class<?>> implementableTypes, List<Object> targetMappings,
                     String name,
                     boolean allowPublic, boolean allowAllImplementations, boolean allowAllClassImplementations, boolean allowArrayAccess, boolean allowListAccess, boolean allowBufferAccess,
-                    boolean allowIterableAccess, boolean allowIteratorAccess) {
+                    boolean allowIterableAccess, boolean allowIteratorAccess, boolean allowMapAccess) {
         // create defensive copies
         this.accessAnnotations = copySet(annotations, Equivalence.IDENTITY);
         this.excludeTypes = copyMap(excludeTypes, Equivalence.IDENTITY);
@@ -187,6 +188,7 @@ public final class HostAccess {
         this.allowAllClassImplementations = allowAllClassImplementations;
         this.allowArrayAccess = allowArrayAccess;
         this.allowListAccess = allowListAccess;
+        this.allowMapAccess = allowMapAccess;
         this.allowBufferAccess = allowBufferAccess;
         this.allowIterableAccess = allowListAccess || allowIterableAccess;
         this.allowIteratorAccess = allowListAccess || allowIterableAccess || allowIteratorAccess;
@@ -208,6 +210,7 @@ public final class HostAccess {
                         && allowAllClassImplementations == other.allowAllClassImplementations//
                         && allowArrayAccess == other.allowArrayAccess//
                         && allowListAccess == other.allowListAccess//
+                        && allowMapAccess == other.allowMapAccess//
                         && allowIterableAccess == other.allowIterableAccess//
                         && allowIteratorAccess == other.allowIteratorAccess//
                         && equalsMap(excludeTypes, other.excludeTypes)//
@@ -230,6 +233,7 @@ public final class HostAccess {
                         allowAllClassImplementations,
                         allowArrayAccess,
                         allowListAccess,
+                        allowMapAccess,
                         allowIterableAccess,
                         allowIteratorAccess,
                         hashMap(excludeTypes),
@@ -561,6 +565,7 @@ public final class HostAccess {
         private boolean allowPublic;
         private boolean allowArrayAccess;
         private boolean allowListAccess;
+        private boolean allowMapAccess;
         private boolean allowBufferAccess;
         private boolean allowIterableAccess;
         private boolean allowIteratorAccess;
@@ -583,6 +588,7 @@ public final class HostAccess {
             this.targetMappings = access.targetMappings;
             this.allowPublic = access.allowPublic;
             this.allowListAccess = access.allowListAccess;
+            this.allowMapAccess = access.allowMapAccess;
             this.allowArrayAccess = access.allowArrayAccess;
             this.allowIterableAccess = access.allowIterableAccess;
             this.allowIteratorAccess = access.allowIteratorAccess;
@@ -781,6 +787,18 @@ public final class HostAccess {
          */
         public Builder allowListAccess(boolean listAccess) {
             this.allowListAccess = listAccess;
+            return this;
+        }
+
+
+        /**
+         * Allows the guest application to access map element with dot operator.
+         * By default no map access is allowed.
+         *
+         * @since 21.1
+         */
+        public Builder allowMapAccess(boolean mapAccess) {
+            this.allowMapAccess = mapAccess;
             return this;
         }
 
@@ -988,7 +1006,7 @@ public final class HostAccess {
          */
         public HostAccess build() {
             return new HostAccess(accessAnnotations, excludeTypes, members, implementationAnnotations, implementableTypes, targetMappings, name, allowPublic,
-                            allowAllImplementations, allowAllClassImplementations, allowArrayAccess, allowListAccess, allowBufferAccess, allowIterableAccess, allowIteratorAccess);
+                            allowAllImplementations, allowAllClassImplementations, allowArrayAccess, allowListAccess, allowBufferAccess, allowIterableAccess, allowIteratorAccess, allowMapAccess);
         }
     }
 

--- a/sdk/src/org.graalvm.polyglot/src/org/graalvm/polyglot/impl/AbstractPolyglotImpl.java
+++ b/sdk/src/org.graalvm.polyglot/src/org/graalvm/polyglot/impl/AbstractPolyglotImpl.java
@@ -180,6 +180,8 @@ public abstract class AbstractPolyglotImpl {
 
         public abstract boolean isListAccessible(HostAccess access);
 
+        public abstract boolean isMapAccessible(HostAccess access);
+
         public abstract boolean isBufferAccessible(HostAccess access);
 
         public abstract boolean isIterableAccessible(HostAccess access);

--- a/truffle/src/com.oracle.truffle.api.test/src/com/oracle/truffle/api/test/polyglot/HostAccessTest.java
+++ b/truffle/src/com.oracle.truffle.api.test/src/com/oracle/truffle/api/test/polyglot/HostAccessTest.java
@@ -399,6 +399,29 @@ public class HostAccessTest {
     }
 
     @Test
+    public void testMapAccessEnabled() {
+
+        this.setupEnv(HostAccess.newBuilder().allowMapAccess(true));
+        final  Map<String, Integer> map = new HashMap<>();
+        map.put("one", 1);
+
+        final Value value = this.context.asValue(map);
+        final Value one = value.getMember("one");
+        assertEquals(1, one.asInt());
+    }
+
+    @Test
+    public void testMapAccessDisabled() {
+
+        this.setupEnv(HostAccess.newBuilder().allowMapAccess(false));
+        final  Map<String, Integer> map = new HashMap<>();
+        map.put("one", 1);
+
+        final Value value = this.context.asValue(map);
+        assertNull(value.getMember("one"));
+    }
+
+    @Test
     public void testListAccessDisabled() {
         setupEnv(HostAccess.newBuilder().allowListAccess(false));
         assertListAccessDisabled(context, false);

--- a/truffle/src/com.oracle.truffle.polyglot/src/com/oracle/truffle/polyglot/HostClassCache.java
+++ b/truffle/src/com.oracle.truffle.polyglot/src/com/oracle/truffle/polyglot/HostClassCache.java
@@ -65,6 +65,7 @@ final class HostClassCache {
     final HostAccess hostAccess;
     private final boolean arrayAccess;
     private final boolean listAccess;
+    private final boolean mapAccess;
     private final boolean bufferAccess;
     private final boolean iterableAccess;
     private final boolean iteratorAccess;
@@ -75,6 +76,7 @@ final class HostClassCache {
         this.hostAccess = conf;
         this.arrayAccess = apiAccess.isArrayAccessible(hostAccess);
         this.listAccess = apiAccess.isListAccessible(hostAccess);
+        this.mapAccess = apiAccess.isMapAccessible(hostAccess);
         this.bufferAccess = apiAccess.isBufferAccessible(hostAccess);
         this.iterableAccess = apiAccess.isIterableAccessible(hostAccess);
         this.iteratorAccess = apiAccess.isIteratorAccessible(hostAccess);
@@ -227,6 +229,10 @@ final class HostClassCache {
 
     boolean isListAccess() {
         return listAccess;
+    }
+
+    boolean isMapAccess() {
+        return mapAccess;
     }
 
     boolean isBufferAccess() {

--- a/truffle/src/com.oracle.truffle.polyglot/src/com/oracle/truffle/polyglot/HostObject.java
+++ b/truffle/src/com.oracle.truffle.polyglot/src/com/oracle/truffle/polyglot/HostObject.java
@@ -281,7 +281,7 @@ final class HostObject implements TruffleObject {
         if (this.getHostClassCache().isMapAccess() && this.obj instanceof Map) {
             final Map<?, ?> mapObject = (Map<?, ?>) this.obj;
             if (mapObject.containsKey(name)) {
-                return mapObject.get(name);
+                return HostObject.forObject(mapObject.get(name), this.languageContext);
             }
         }
 

--- a/truffle/src/com.oracle.truffle.polyglot/src/com/oracle/truffle/polyglot/HostObject.java
+++ b/truffle/src/com.oracle.truffle.polyglot/src/com/oracle/truffle/polyglot/HostObject.java
@@ -84,6 +84,7 @@ import java.time.ZonedDateTime;
 import java.util.Date;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Objects;
 
@@ -276,6 +277,14 @@ final class HostObject implements TruffleObject {
         }
         boolean isStatic = isStaticClass();
         Class<?> lookupClass = getLookupClass();
+
+        if (this.getHostClassCache().isMapAccess() && this.obj instanceof Map) {
+            final Map<?, ?> mapObject = (Map<?, ?>) this.obj;
+            if (mapObject.containsKey(name)) {
+                return mapObject.get(name);
+            }
+        }
+
         HostFieldDesc foundField = lookupField.execute(this, lookupClass, name, isStatic);
         if (foundField != null) {
             return readField.execute(foundField, this);

--- a/truffle/src/com.oracle.truffle.polyglot/src/com/oracle/truffle/polyglot/HostObject.java
+++ b/truffle/src/com.oracle.truffle.polyglot/src/com/oracle/truffle/polyglot/HostObject.java
@@ -278,8 +278,8 @@ final class HostObject implements TruffleObject {
         }
 
         if (isMapNode.execute(this)) {
-            if (((Map<?, ?>) this.obj).containsKey(name)) {
-                return HostObject.forObject(((Map<?, ?>) this.obj).get(name), this.languageContext);
+            if (IsMapNode.containsKey(this.obj, name)) {
+                return HostObject.forObject(IsMapNode.get(this.obj, name), this.languageContext);
             }
         }
 
@@ -2219,6 +2219,14 @@ final class HostObject implements TruffleObject {
                                  @Cached(value = "receiver.getHostClassCache().isMapAccess()", allowUncached = true) boolean isMapAccess) {
             assert receiver.getHostClassCache().isMapAccess() == isMapAccess;
             return isMapAccess && receiver.obj instanceof Map;
+        }
+
+        public static boolean containsKey(Object map, String key) {
+            return ((Map<?, ?>) map).containsKey(key);
+        }
+
+        public static Object get(Object map, String key) {
+            return ((Map<?, ?>) map).get(key);
         }
 
     }


### PR DESCRIPTION
I have created a basic implementation for https://github.com/oracle/graaljs/issues/143 issue, I am pretty sure lots of things are missing. If you guide me. I can handle it in a short period of time.

I have tested with the following code, after PR merged I can put it into the graaljs repository.

```java
@Test
public void allowMapAccessTest() {

    final HostAccess hostAccess = HostAccess.newBuilder().allowAccessAnnotatedBy(HostAccess.Export.class).allowMapAccess(true).build();

    try (final Context context = newContextBuilder().allowHostAccess(hostAccess).build()) {
        final Value bindings = context.getBindings(JavaScriptLanguage.ID);

        bindings.putMember("map", Map.of("one", 1, "x", Map.of("y", 2)));
        assert Integer.valueOf(1).equals(context.eval(JavaScriptLanguage.ID, "map.one").asInt());
        assert Integer.valueOf(1).equals(context.eval(JavaScriptLanguage.ID, "map['one']").asInt());
        assert Integer.valueOf(2).equals(context.eval(JavaScriptLanguage.ID, "map.x.y").asInt());
        assert Integer.valueOf(2).equals(context.eval(JavaScriptLanguage.ID, "map['x']['y']").asInt());
        assert Integer.valueOf(1).equals(context.eval(JavaScriptLanguage.ID, "map.get('one')").asInt());
        assert Integer.valueOf(1).equals(context.eval(JavaScriptLanguage.ID, "var myGet = map.get; myGet('one')").asInt());
        assert Boolean.TRUE.equals(context.eval(JavaScriptLanguage.ID, "map.one === 1").asBoolean());
    }
}
```