### PR TITLE
Fix possible "-Xmx0" issue

### DIFF
--- a/substratevm/src/com.oracle.svm.driver/src/com/oracle/svm/driver/NativeImageServer.java
+++ b/substratevm/src/com.oracle.svm.driver/src/com/oracle/svm/driver/NativeImageServer.java
@@ -400,15 +400,16 @@ final class NativeImageServer extends NativeImage {
 
                 /* Maximize reuse by using same VM mem-args for all server-based image builds */
                 String xmxValueStr = getXmxValue(maxServers);
-                replaceArg(javaArgs, oXmx, xmxValueStr);
-                String xmsValueStr = getXmsValue();
-                long xmxValue = SubstrateOptionsParser.parseLong(xmxValueStr);
-                long xmsValue = SubstrateOptionsParser.parseLong(xmsValueStr);
-                if (WordFactory.unsigned(xmsValue).aboveThan(WordFactory.unsigned(xmxValue))) {
-                    xmsValueStr = Long.toUnsignedString(xmxValue);
+                if (!"0".equals(xmxValueStr)) {
+                    replaceArg(javaArgs, oXmx, xmxValueStr);
+                    String xmsValueStr = getXmsValue();
+                    long xmxValue = SubstrateOptionsParser.parseLong(xmxValueStr);
+                    long xmsValue = SubstrateOptionsParser.parseLong(xmsValueStr);
+                    if (WordFactory.unsigned(xmsValue).aboveThan(WordFactory.unsigned(xmxValue))) {
+                        xmsValueStr = Long.toUnsignedString(xmxValue);
+                    }
+                    replaceArg(javaArgs, oXms, xmsValueStr);
                 }
-                replaceArg(javaArgs, oXms, xmsValueStr);
-
                 Path sessionDir = getSessionDir();
                 List<Collection<Path>> builderPaths = new ArrayList<>(Arrays.asList(classpath, bootClasspath));
                 if (config.useJavaModules()) {


### PR DESCRIPTION
`NativeImage` may pass `-Xmx0` and `-Xms0` to start `NativeImageGeneratorRunner` in very rare cases, leading to JVM startup failure. Details are described in this issue: https://github.com/oracle/graal/issues/3255
This PR proposes a fix to avoid the possible failure.