### PR TITLE
Fix method names in three error messages

### DIFF
--- a/truffle/src/com.oracle.truffle.polyglot/src/com/oracle/truffle/polyglot/PolyglotValue.java
+++ b/truffle/src/com.oracle.truffle.polyglot/src/com/oracle/truffle/polyglot/PolyglotValue.java
@@ -3245,7 +3245,7 @@ abstract class PolyglotValue extends AbstractValueImpl {
                     return toString.asString(objects.getMetaQualifiedName(receiver));
                 } catch (UnsupportedMessageException e) {
                     unsupported.enter();
-                    throw unsupported(context, receiver, "throwException()", "isException()");
+                    throw unsupported(context, receiver, "getMetaQualifiedName()", "isMetaObject()");
                 }
             }
         }
@@ -3275,7 +3275,7 @@ abstract class PolyglotValue extends AbstractValueImpl {
                     return toString.asString(objects.getMetaSimpleName(receiver));
                 } catch (UnsupportedMessageException e) {
                     unsupported.enter();
-                    throw unsupported(context, receiver, "throwException()", "isException()");
+                    throw unsupported(context, receiver, "getMetaSimpleName()", "isMetaObject()");
                 }
             }
         }
@@ -3305,7 +3305,7 @@ abstract class PolyglotValue extends AbstractValueImpl {
                     return objects.isMetaInstance(receiver, toGuest.execute(context, args[ARGUMENT_OFFSET]));
                 } catch (UnsupportedMessageException e) {
                     unsupported.enter();
-                    throw unsupported(context, receiver, "throwException()", "isException()");
+                    throw unsupported(context, receiver, "isMetaInstance()", "isMetaObject()");
                 }
             }
         }


### PR DESCRIPTION
These three error messages were referring to `throwException()` / `isException()`, for no good reason I can discern – I assume they were copy+pasted from `ThrowExceptionNode` and not updated.