### PR TITLE
fix NPE in DerivedOffsetInductionVariable

### DIFF
--- a/compiler/src/org.graalvm.compiler.nodes/src/org/graalvm/compiler/nodes/loop/DerivedOffsetInductionVariable.java
+++ b/compiler/src/org.graalvm.compiler.nodes/src/org/graalvm/compiler/nodes/loop/DerivedOffsetInductionVariable.java
@@ -54,10 +54,11 @@ public class DerivedOffsetInductionVariable extends DerivedInductionVariable {
 
     @Override
     public Direction direction() {
-        if (value instanceof SubNode && base.valueNode() == value.getY()) {
-            return base.direction().opposite();
+        Direction baseDirection = base.direction();
+        if (baseDirection != null && value instanceof SubNode && base.valueNode() == value.getY()) {
+            return baseDirection.opposite();
         }
-        return base.direction();
+        return baseDirection;
     }
 
     @Override


### PR DESCRIPTION
I ran into this stacktrace when running native-image compiled from master. Issue does not occur on 21.0.

```java
Fatal error:org.graalvm.compiler.debug.GraalError: java.lang.NullPointerException
	at method: void org.bouncycastle.crypto.digests.KeccakDigest.absorb(byte[], int, int)  [Direct call from void KeccakDigest.update(byte[], int, int)]
	at com.oracle.svm.hosted.code.CompileQueue.defaultCompileFunction(CompileQueue.java:1028)
	at com.oracle.svm.hosted.code.CompileQueue.doCompile(CompileQueue.java:959)
	at com.oracle.svm.hosted.code.CompileQueue$CompileTask.run(CompileQueue.java:264)
	at com.oracle.graal.pointsto.util.CompletionExecutor.lambda$execute$0(CompletionExecutor.java:173)
	at java.base/java.util.concurrent.ForkJoinTask$RunnableExecuteAction.exec(ForkJoinTask.java:1426)
	at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:290)
	at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1020)
	at java.base/java.util.concurrent.ForkJoinPool.scan(ForkJoinPool.java:1656)
	at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1594)
	at java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:183)
Caused by: java.lang.NullPointerException
	at jdk.internal.vm.compiler/org.graalvm.compiler.nodes.loop.DerivedOffsetInductionVariable.direction(DerivedOffsetInductionVariable.java:58)
	at jdk.internal.vm.compiler/org.graalvm.compiler.nodes.loop.LoopEx.detectCounted(LoopEx.java:363)
	at jdk.internal.vm.compiler/org.graalvm.compiler.nodes.loop.LoopsData.detectedCountedLoops(LoopsData.java:117)
	at jdk.internal.vm.compiler/org.graalvm.compiler.loop.phases.LoopFullUnrollPhase.run(LoopFullUnrollPhase.java:75)
	at jdk.internal.vm.compiler/org.graalvm.compiler.loop.phases.LoopFullUnrollPhase.run(LoopFullUnrollPhase.java:45)
	at jdk.internal.vm.compiler/org.graalvm.compiler.phases.BasePhase.apply(BasePhase.java:212)
	at jdk.internal.vm.compiler/org.graalvm.compiler.phases.BasePhase.apply(BasePhase.java:147)
	at jdk.internal.vm.compiler/org.graalvm.compiler.phases.PhaseSuite.run(PhaseSuite.java:209)
	at jdk.internal.vm.compiler/org.graalvm.compiler.phases.BasePhase.apply(BasePhase.java:212)
	at jdk.internal.vm.compiler/org.graalvm.compiler.phases.BasePhase.apply(BasePhase.java:147)
	at jdk.internal.vm.compiler/org.graalvm.compiler.core.GraalCompiler.emitFrontEnd(GraalCompiler.java:232)
	at jdk.internal.vm.compiler/org.graalvm.compiler.core.GraalCompiler.compile(GraalCompiler.java:145)
	at jdk.internal.vm.compiler/org.graalvm.compiler.core.GraalCompiler.compileGraph(GraalCompiler.java:130)
	at com.oracle.svm.hosted.code.CompileQueue.defaultCompileFunction(CompileQueue.java:997)
	... 9 more
Error: Image build request failed with exit status 1
com.oracle.svm.driver.NativeImage$NativeImageError: Image build request failed with exit status 1
	at com.oracle.svm.driver.NativeImage.showError(NativeImage.java:1760)
	at com.oracle.svm.driver.NativeImage.build(NativeImage.java:1507)
	at com.oracle.svm.driver.NativeImage.performBuild(NativeImage.java:1468)
	at com.oracle.svm.driver.NativeImage.main(NativeImage.java:1455)
	at com.oracle.svm.driver.NativeImage$JDK9Plus.main(NativeImage.java:1947)
```

The suggested fix is sort-of a quick-fix, as it only checks if the direction returned by `base.direction()` is not null. Looking at other implementations of `InductionVariable` it looks like `null` should be a valid option which needs to be handled correctly.
I am however not at all knowledgeable of compiler code, so this is by no means a well analysed fix.

I also do not have a minimal example where this occurs, and I cannot share my code as it's closed source.