### PR TITLE
Make sure that access filter applies to SerializationProcessor

### DIFF
--- a/substratevm/src/com.oracle.svm.configure/src/com/oracle/svm/configure/trace/SerializationProcessor.java
+++ b/substratevm/src/com.oracle.svm.configure/src/com/oracle/svm/configure/trace/SerializationProcessor.java
@@ -31,9 +31,11 @@ import java.util.Map;
 import com.oracle.svm.configure.config.SerializationConfiguration;
 
 public class SerializationProcessor extends AbstractProcessor {
+    private final AccessAdvisor advisor;
     private final SerializationConfiguration serializationConfiguration;
 
-    public SerializationProcessor(SerializationConfiguration serializationConfiguration) {
+    public SerializationProcessor(AccessAdvisor advisor, SerializationConfiguration serializationConfiguration) {
+        this.advisor = advisor;
         this.serializationConfiguration = serializationConfiguration;
     }
 
@@ -51,6 +53,11 @@ public class SerializationProcessor extends AbstractProcessor {
         List<?> args = (List<?>) entry.get("args");
         if ("ObjectStreamClass.<init>".equals(function)) {
             expectSize(args, 2);
+
+            if (advisor.shouldIgnore(LazyValueUtils.lazyValue((String) args.get(0)), LazyValueUtils.lazyValue(null))) {
+                return;
+            }
+
             serializationConfiguration.add((String) args.get(0), (String) args.get(1));
         }
     }

--- a/substratevm/src/com.oracle.svm.configure/src/com/oracle/svm/configure/trace/TraceProcessor.java
+++ b/substratevm/src/com.oracle.svm.configure/src/com/oracle/svm/configure/trace/TraceProcessor.java
@@ -46,7 +46,7 @@ public class TraceProcessor extends AbstractProcessor {
         advisor = accessAdvisor;
         jniProcessor = new JniProcessor(this.advisor, jniConfiguration, reflectionConfiguration);
         reflectionProcessor = new ReflectionProcessor(this.advisor, reflectionConfiguration, proxyConfiguration, resourceConfiguration);
-        serializationProcessor = new SerializationProcessor(serializationConfiguration);
+        serializationProcessor = new SerializationProcessor(this.advisor, serializationConfiguration);
     }
 
     public TypeConfiguration getJniConfiguration() {
@@ -113,7 +113,9 @@ public class TraceProcessor extends AbstractProcessor {
                     break;
             }
         } catch (Exception e) {
-            logWarning("Error processing trace entry: " + e.toString() + ": " + entry.toString());
+            StackTraceElement stackTraceElement = e.getStackTrace()[0];
+            logWarning("Error processing trace entry: " + e.toString() +
+                            " (at " + stackTraceElement.getClassName() + ":" + stackTraceElement.getLineNumber() + ") : " + entry.toString());
         }
     }
 


### PR DESCRIPTION
Adds `advisor.shouldIgnore` to `SerializationProcessor` class (in line with other `native-image-agent` processors).