### PR TITLE
Implement static field base and offset substitutions for Unsafe

### DIFF
--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/SunMiscSubstitutions.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/SunMiscSubstitutions.java
@@ -33,10 +33,7 @@ import java.security.ProtectionDomain;
 import java.util.function.Function;
 
 import com.oracle.svm.core.StaticFieldsSupport;
-import com.oracle.svm.core.config.ObjectLayout;
-import jdk.vm.ci.meta.JavaKind;
 import org.graalvm.compiler.nodes.extended.MembarNode;
-import org.graalvm.compiler.serviceprovider.GraalUnsafeAccess;
 import org.graalvm.compiler.serviceprovider.JavaVersionUtil;
 import org.graalvm.nativeimage.Platform;
 import org.graalvm.nativeimage.Platforms;
@@ -208,14 +205,6 @@ final class Target_Unsafe_Core {
     @Substitute
     public void ensureClassInitialized(Class<?> c) {
         DynamicHub.fromClass(c).ensureInitialized();
-    }
-
-    @Substitute
-    private long staticFieldOffset(Field f) {
-        ObjectLayout layout = ConfigurationValues.getObjectLayout();
-        final int baseOffset = layout.getArrayBaseOffset(JavaKind.fromJavaClass(f.getDeclaringClass()));
-        final long objOffset = GraalUnsafeAccess.getUnsafe().objectFieldOffset(f);
-        return objOffset - baseOffset;
     }
 
     @Substitute

--- a/substratevm/src/com.oracle.svm.reflect/src/com/oracle/svm/reflect/target/Target_jdk_internal_misc_Unsafe_Reflection.java
+++ b/substratevm/src/com.oracle.svm.reflect/src/com/oracle/svm/reflect/target/Target_jdk_internal_misc_Unsafe_Reflection.java
@@ -43,15 +43,7 @@ public final class Target_jdk_internal_misc_Unsafe_Reflection {
 
     @Substitute
     public long objectFieldOffset(Target_java_lang_reflect_Field field) {
-        int offset = field.root == null ? field.offset : field.root.offset;
-        if (offset > 0) {
-            return offset;
-        }
-
-        throw VMError.unsupportedFeature("The offset of " + field + " is accessed without the field being first registered as unsafe accessed. " +
-                        "Please register the field as unsafe accessed. You can do so with a reflection configuration that " +
-                        "contains an entry for the field with the attribute \"allowUnsafeAccess\": true. Such a configuration " +
-                        "file can be generated for you. Read BuildConfiguration.md and Reflection.md for details.");
+        return FieldUtils.getFieldOffset(field);
     }
 
     @Substitute
@@ -70,7 +62,23 @@ public final class Target_jdk_internal_misc_Unsafe_Reflection {
     }
 
     @Substitute
-    private long staticFieldOffset(Target_java_lang_reflect_Field f) {
-        return f.offset;
+    public long staticFieldOffset(Target_java_lang_reflect_Field field) {
+        return FieldUtils.getFieldOffset(field);
+    }
+
+
+    private static class FieldUtils {
+        private static long getFieldOffset(Target_java_lang_reflect_Field field) {
+            int offset = field.root == null ? field.offset : field.root.offset;
+            if (offset > 0) {
+                return offset;
+            }
+            throw VMError.unsupportedFeature(
+            "The offset of " + field + " is accessed without the field being first registered as unsafe accessed. " +
+                  "Please register the field as unsafe accessed. You can do so with a reflection configuration that " +
+                  "contains an entry for the field with the attribute \"allowUnsafeAccess\": true. Such a configuration " +
+                  "file can be generated for you. Read BuildConfiguration.md and Reflection.md for details."
+            );
+        }
     }
 }

--- a/substratevm/src/com.oracle.svm.reflect/src/com/oracle/svm/reflect/target/Target_jdk_internal_misc_Unsafe_Reflection.java
+++ b/substratevm/src/com.oracle.svm.reflect/src/com/oracle/svm/reflect/target/Target_jdk_internal_misc_Unsafe_Reflection.java
@@ -27,13 +27,22 @@ package com.oracle.svm.reflect.target;
 
 // Checkstyle: allow reflection
 
+import com.oracle.svm.core.StaticFieldsSupport;
 import com.oracle.svm.core.SubstrateUtil;
 import com.oracle.svm.core.annotate.Substitute;
 import com.oracle.svm.core.annotate.TargetClass;
 import com.oracle.svm.core.annotate.TargetElement;
+import com.oracle.svm.core.config.ConfigurationValues;
+import com.oracle.svm.core.config.ObjectLayout;
 import com.oracle.svm.core.jdk.JDK11OrLater;
 import com.oracle.svm.core.jdk.Package_jdk_internal_misc;
 import com.oracle.svm.core.util.VMError;
+import com.oracle.svm.hosted.meta.HostedField;
+import com.oracle.svm.reflect.hosted.FieldOffsetComputer;
+import jdk.vm.ci.meta.JavaKind;
+import jdk.vm.ci.meta.MetaAccessProvider;
+import jdk.vm.ci.meta.MetaUtil;
+import org.graalvm.compiler.serviceprovider.GraalUnsafeAccess;
 
 import java.lang.reflect.Field;
 
@@ -47,6 +56,7 @@ public final class Target_jdk_internal_misc_Unsafe_Reflection {
         if (offset > 0) {
             return offset;
         }
+
         throw VMError.unsupportedFeature("The offset of " + field + " is accessed without the field being first registered as unsafe accessed. " +
                         "Please register the field as unsafe accessed. You can do so with a reflection configuration that " +
                         "contains an entry for the field with the attribute \"allowUnsafeAccess\": true. Such a configuration " +
@@ -66,5 +76,10 @@ public final class Target_jdk_internal_misc_Unsafe_Reflection {
         } catch (NoSuchFieldException nse) {
             throw new InternalError();
         }
+    }
+
+    @Substitute
+    private long staticFieldOffset(Target_java_lang_reflect_Field f) {
+        return f.offset;
     }
 }

--- a/substratevm/src/com.oracle.svm.reflect/src/com/oracle/svm/reflect/target/Target_jdk_internal_misc_Unsafe_Reflection.java
+++ b/substratevm/src/com.oracle.svm.reflect/src/com/oracle/svm/reflect/target/Target_jdk_internal_misc_Unsafe_Reflection.java
@@ -63,6 +63,11 @@ public final class Target_jdk_internal_misc_Unsafe_Reflection {
 
     @Substitute
     public long staticFieldOffset(Target_java_lang_reflect_Field field) {
+        /*
+         * Since we store the offset in the `offset` field, which is computed
+         * through `FieldOffsetComputer#compute`, the implementation for
+         * this is the same as `objectFieldOffset` method
+         */
         return FieldUtils.getFieldOffset(field);
     }
 

--- a/substratevm/src/com.oracle.svm.reflect/src/com/oracle/svm/reflect/target/Target_jdk_internal_misc_Unsafe_Reflection.java
+++ b/substratevm/src/com.oracle.svm.reflect/src/com/oracle/svm/reflect/target/Target_jdk_internal_misc_Unsafe_Reflection.java
@@ -27,22 +27,13 @@ package com.oracle.svm.reflect.target;
 
 // Checkstyle: allow reflection
 
-import com.oracle.svm.core.StaticFieldsSupport;
 import com.oracle.svm.core.SubstrateUtil;
 import com.oracle.svm.core.annotate.Substitute;
 import com.oracle.svm.core.annotate.TargetClass;
 import com.oracle.svm.core.annotate.TargetElement;
-import com.oracle.svm.core.config.ConfigurationValues;
-import com.oracle.svm.core.config.ObjectLayout;
 import com.oracle.svm.core.jdk.JDK11OrLater;
 import com.oracle.svm.core.jdk.Package_jdk_internal_misc;
 import com.oracle.svm.core.util.VMError;
-import com.oracle.svm.hosted.meta.HostedField;
-import com.oracle.svm.reflect.hosted.FieldOffsetComputer;
-import jdk.vm.ci.meta.JavaKind;
-import jdk.vm.ci.meta.MetaAccessProvider;
-import jdk.vm.ci.meta.MetaUtil;
-import org.graalvm.compiler.serviceprovider.GraalUnsafeAccess;
 
 import java.lang.reflect.Field;
 

--- a/substratevm/src/com.oracle.svm.reflect/src/com/oracle/svm/reflect/target/Target_jdk_internal_misc_Unsafe_Reflection.java
+++ b/substratevm/src/com.oracle.svm.reflect/src/com/oracle/svm/reflect/target/Target_jdk_internal_misc_Unsafe_Reflection.java
@@ -64,13 +64,12 @@ public final class Target_jdk_internal_misc_Unsafe_Reflection {
     @Substitute
     public long staticFieldOffset(Target_java_lang_reflect_Field field) {
         /*
-         * Since we store the offset in the `offset` field, which is computed
-         * through `FieldOffsetComputer#compute`, the implementation for
-         * this is the same as `objectFieldOffset` method
+         * Since we store the offset in the `offset` field, which is computed through
+         * `FieldOffsetComputer#compute`, the implementation for this is the same as
+         * `objectFieldOffset` method
          */
         return FieldUtils.getFieldOffset(field);
     }
-
 
     private static class FieldUtils {
         private static long getFieldOffset(Target_java_lang_reflect_Field field) {
@@ -78,12 +77,10 @@ public final class Target_jdk_internal_misc_Unsafe_Reflection {
             if (offset > 0) {
                 return offset;
             }
-            throw VMError.unsupportedFeature(
-            "The offset of " + field + " is accessed without the field being first registered as unsafe accessed. " +
-                  "Please register the field as unsafe accessed. You can do so with a reflection configuration that " +
-                  "contains an entry for the field with the attribute \"allowUnsafeAccess\": true. Such a configuration " +
-                  "file can be generated for you. Read BuildConfiguration.md and Reflection.md for details."
-            );
+            throw VMError.unsupportedFeature("The offset of " + field + " is accessed without the field being first registered as unsafe accessed. " +
+                            "Please register the field as unsafe accessed. You can do so with a reflection configuration that " +
+                            "contains an entry for the field with the attribute \"allowUnsafeAccess\": true. Such a configuration " +
+                            "file can be generated for you. Read BuildConfiguration.md and Reflection.md for details.");
         }
     }
 }


### PR DESCRIPTION
This PR implements `staticFieldOffset` and `staticFieldBase` methods in `com.oracle.svm.core.jdk.SunMiscUnsafeSubstitutions`