### PR TITLE
Add SubstitutionReportFeature

### DIFF
--- a/substratevm/src/com.oracle.graal.pointsto/src/com/oracle/graal/pointsto/reports/ReportUtils.java
+++ b/substratevm/src/com.oracle.graal.pointsto/src/com/oracle/graal/pointsto/reports/ReportUtils.java
@@ -104,7 +104,7 @@ public class ReportUtils {
             try (FileWriter fw = new FileWriter(Files.createFile(file).toFile())) {
                 try (PrintWriter writer = new PrintWriter(fw)) {
                     Path cwd = Paths.get("").toAbsolutePath();
-                    System.out.println("# Printing " + description + " to: " + cwd.relativize(file));
+                    System.out.println("# Printing " + description + " to: " + cwd.relativize(file.toAbsolutePath()));
                     reporter.accept(writer);
                 }
             }

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/SubstitutionReportFeature.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/SubstitutionReportFeature.java
@@ -120,7 +120,7 @@ public class SubstitutionReportFeature implements Feature {
 
     private void reportSubstitutions() {
         ReportUtils.report("substitutions performed by native-image", "reports", "substitutions", "csv", pw -> {
-            pw.println("location , category (type/method/field) , original , annotated");
+            pw.println("location, category (type/method/field), original, annotated");
             for (Map.Entry<String, Substitutions> g : substitutions.entrySet()) {
                 for (Map.Entry<ResolvedJavaType, ResolvedJavaType> e : g.getValue().getSubstitutedTypes().entrySet()) {
                     pw.println(formatSubstitution(g.getKey(), "type", e.getKey(), e.getValue(), t -> t.toJavaName(true)));

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/SubstitutionReportFeature.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/SubstitutionReportFeature.java
@@ -81,7 +81,7 @@ public class SubstitutionReportFeature implements Feature {
                 if (t instanceof SubstitutionType) {
                     SubstitutionType subType = (SubstitutionType) t;
                     if (subType.isUserSubstitution()) {
-                        String jarLocation = getJarLocation(subType.getAnnotated());
+                        String jarLocation = getTypeClassFileLocation(subType.getAnnotated());
                         substitutions.putIfAbsent(jarLocation, new Substitutions());
                         substitutions.get(jarLocation).addType(subType);
                     }
@@ -96,7 +96,7 @@ public class SubstitutionReportFeature implements Feature {
             if (method.wrapped instanceof SubstitutionMethod) {
                 SubstitutionMethod subMethod = (SubstitutionMethod) method.wrapped;
                 if (subMethod.isUserSubstitution()) {
-                    String jarLocation = getJarLocation(subMethod.getAnnotated().getDeclaringClass());
+                    String jarLocation = getTypeClassFileLocation(subMethod.getAnnotated().getDeclaringClass());
                     substitutions.putIfAbsent(jarLocation, new Substitutions());
                     substitutions.get(jarLocation).addMethod(subMethod);
                 }
@@ -110,7 +110,7 @@ public class SubstitutionReportFeature implements Feature {
             if (field.wrapped instanceof SubstitutionField) {
                 SubstitutionField subField = (SubstitutionField) field.wrapped;
                 if (subField.isUserSubstitution()) {
-                    String jarLocation = getJarLocation(subField.getAnnotated().getDeclaringClass());
+                    String jarLocation = getTypeClassFileLocation(subField.getAnnotated().getDeclaringClass());
                     substitutions.putIfAbsent(jarLocation, new Substitutions());
                     substitutions.get(jarLocation).addField(subField);
                 }
@@ -135,12 +135,6 @@ public class SubstitutionReportFeature implements Feature {
         });
     }
 
-    private String getJarLocation(ResolvedJavaType type) {
-        Class<?> annotatedClass = OriginalClassProvider.getJavaClass(GraalAccess.getOriginalSnippetReflection(), type);
-        CodeSource source = annotatedClass.getProtectionDomain().getCodeSource();
-        return source == null ? "unknown" : source.getLocation().toString();
-    }
-
     private String formatMethod(ResolvedJavaMethod method) {
         return method.getDeclaringClass().toJavaName(true) + "#" + method.getName();
     }
@@ -149,7 +143,13 @@ public class SubstitutionReportFeature implements Feature {
         return field.getDeclaringClass().toJavaName(true) + "." + field.getName();
     }
 
-    private <T> String formatSubstitution(String jar, String type, T original, T annotated, Function<T, String> formatter) {
+    private static String getTypeClassFileLocation(ResolvedJavaType type) {
+        Class<?> annotatedClass = OriginalClassProvider.getJavaClass(GraalAccess.getOriginalSnippetReflection(), type);
+        CodeSource source = annotatedClass.getProtectionDomain().getCodeSource();
+        return source == null ? "unknown" : source.getLocation().toString();
+    }
+
+    private static <T> String formatSubstitution(String jar, String type, T original, T annotated, Function<T, String> formatter) {
         return '\'' + jar + "'," + type + ',' + formatter.apply(original) + ',' + formatter.apply(annotated);
     }
 

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/SubstitutionReportFeature.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/SubstitutionReportFeature.java
@@ -1,3 +1,27 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
 package com.oracle.svm.hosted;
 
 import com.oracle.graal.pointsto.infrastructure.OriginalClassProvider;
@@ -32,11 +56,8 @@ public class SubstitutionReportFeature implements Feature {
         public static final HostedOptionKey<Boolean> ReportPerformedSubstitutions = new HostedOptionKey<>(false);
     }
 
-
     private final boolean enabled = Options.ReportPerformedSubstitutions.getValue();
-
     private final Map<String, Substitutions> substitutions = new TreeMap<>();
-
 
     @Override
     public boolean isInConfiguration(IsInConfigurationAccess access) {
@@ -51,7 +72,6 @@ public class SubstitutionReportFeature implements Feature {
         findSubstitutedFields(accessImpl);
         reportSubstitutions();
     }
-
 
     private void findSubstitutedTypes(FeatureImpl.AfterAnalysisAccessImpl access) {
         AnalysisUniverse universe = access.getUniverse();
@@ -99,7 +119,7 @@ public class SubstitutionReportFeature implements Feature {
     }
 
     private void reportSubstitutions() {
-        ReportUtils.report("substitutions performed by native-image","reports", "substitutions", "csv", pw -> {
+        ReportUtils.report("substitutions performed by native-image", "reports", "substitutions", "csv", pw -> {
             pw.println("location , category (type/method/field) , original , annotated");
             for (Map.Entry<String, Substitutions> g : substitutions.entrySet()) {
                 for (Map.Entry<ResolvedJavaType, ResolvedJavaType> e : g.getValue().getSubstitutedTypes().entrySet()) {
@@ -122,11 +142,11 @@ public class SubstitutionReportFeature implements Feature {
     }
 
     private String formatMethod(ResolvedJavaMethod method) {
-        return method.getDeclaringClass().toJavaName(true) + "::" + method.getName();
+        return method.getDeclaringClass().toJavaName(true) + "#" + method.getName();
     }
 
     private String formatField(ResolvedJavaField field) {
-        return field.getDeclaringClass().toJavaName(true) + "#" + field.getName();
+        return field.getDeclaringClass().toJavaName(true) + "." + field.getName();
     }
 
     private <T> String formatSubstitution(String jar, String type, T original, T annotated, Function<T, String> formatter) {

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/SubstitutionReportFeature.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/SubstitutionReportFeature.java
@@ -1,0 +1,188 @@
+package com.oracle.svm.hosted;
+
+import com.oracle.graal.pointsto.infrastructure.OriginalClassProvider;
+import com.oracle.graal.pointsto.meta.AnalysisField;
+import com.oracle.graal.pointsto.meta.AnalysisMethod;
+import com.oracle.graal.pointsto.meta.AnalysisType;
+import com.oracle.graal.pointsto.meta.AnalysisUniverse;
+import com.oracle.graal.pointsto.reports.ReportUtils;
+import com.oracle.svm.core.annotate.AutomaticFeature;
+import com.oracle.svm.core.option.HostedOptionKey;
+import com.oracle.svm.hosted.c.GraalAccess;
+import com.oracle.svm.hosted.substitute.SubstitutionField;
+import com.oracle.svm.hosted.substitute.SubstitutionMethod;
+import com.oracle.svm.hosted.substitute.SubstitutionType;
+import jdk.vm.ci.meta.ResolvedJavaField;
+import jdk.vm.ci.meta.ResolvedJavaMethod;
+import jdk.vm.ci.meta.ResolvedJavaType;
+import org.graalvm.compiler.options.Option;
+import org.graalvm.nativeimage.hosted.Feature;
+
+import java.security.CodeSource;
+import java.util.Comparator;
+import java.util.Map;
+import java.util.TreeMap;
+import java.util.function.Function;
+
+@AutomaticFeature
+public class SubstitutionReportFeature implements Feature {
+
+    static class Options {
+        @Option(help = "Report performed substitutions")//
+        public static final HostedOptionKey<Boolean> ReportPerformedSubstitutions = new HostedOptionKey<>(false);
+    }
+
+
+    private final boolean enabled = Options.ReportPerformedSubstitutions.getValue();
+
+    private final Map<String, Substitutions> substitutions = new TreeMap<>();
+
+
+    @Override
+    public boolean isInConfiguration(IsInConfigurationAccess access) {
+        return enabled;
+    }
+
+    @Override
+    public void afterAnalysis(AfterAnalysisAccess access) {
+        FeatureImpl.AfterAnalysisAccessImpl accessImpl = (FeatureImpl.AfterAnalysisAccessImpl) access;
+        findSubstitutedTypes(accessImpl);
+        findSubstitutedMethods(accessImpl);
+        findSubstitutedFields(accessImpl);
+        reportSubstitutions();
+    }
+
+
+    private void findSubstitutedTypes(FeatureImpl.AfterAnalysisAccessImpl access) {
+        AnalysisUniverse universe = access.getUniverse();
+        for (AnalysisType type : universe.getTypes()) {
+            if (type.isReachable() && !type.isArray()) {
+                ResolvedJavaType t = type.getWrappedWithoutResolve();
+                if (t instanceof SubstitutionType) {
+                    SubstitutionType subType = (SubstitutionType) t;
+                    if (subType.isUserSubstitution()) {
+                        String jarLocation = getJarLocation(subType.getAnnotated());
+                        substitutions.putIfAbsent(jarLocation, new Substitutions());
+                        substitutions.get(jarLocation).addType(subType);
+                    }
+                }
+            }
+        }
+    }
+
+    private void findSubstitutedMethods(FeatureImpl.AfterAnalysisAccessImpl access) {
+        AnalysisUniverse universe = access.getUniverse();
+        for (AnalysisMethod method : universe.getMethods()) {
+            if (method.wrapped instanceof SubstitutionMethod) {
+                SubstitutionMethod subMethod = (SubstitutionMethod) method.wrapped;
+                if (subMethod.isUserSubstitution()) {
+                    String jarLocation = getJarLocation(subMethod.getAnnotated().getDeclaringClass());
+                    substitutions.putIfAbsent(jarLocation, new Substitutions());
+                    substitutions.get(jarLocation).addMethod(subMethod);
+                }
+            }
+        }
+    }
+
+    private void findSubstitutedFields(FeatureImpl.AfterAnalysisAccessImpl access) {
+        AnalysisUniverse universe = access.getUniverse();
+        for (AnalysisField field : universe.getFields()) {
+            if (field.wrapped instanceof SubstitutionField) {
+                SubstitutionField subField = (SubstitutionField) field.wrapped;
+                if (subField.isUserSubstitution()) {
+                    String jarLocation = getJarLocation(subField.getAnnotated().getDeclaringClass());
+                    substitutions.putIfAbsent(jarLocation, new Substitutions());
+                    substitutions.get(jarLocation).addField(subField);
+                }
+            }
+        }
+    }
+
+    private void reportSubstitutions() {
+        ReportUtils.report("substitutions performed by native-image","reports", "substitutions", "csv", pw -> {
+            pw.println("location , category (type/method/field) , original , annotated");
+            for (Map.Entry<String, Substitutions> g : substitutions.entrySet()) {
+                for (Map.Entry<ResolvedJavaType, ResolvedJavaType> e : g.getValue().getSubstitutedTypes().entrySet()) {
+                    pw.println(formatSubstitution(g.getKey(), "type", e.getKey(), e.getValue(), t -> t.toJavaName(true)));
+                }
+                for (Map.Entry<ResolvedJavaMethod, ResolvedJavaMethod> e : g.getValue().getSubstitutedMethods().entrySet()) {
+                    pw.println(formatSubstitution(g.getKey(), "method", e.getKey(), e.getValue(), this::formatMethod));
+                }
+                for (Map.Entry<ResolvedJavaField, ResolvedJavaField> e : g.getValue().getSubstitutedFields().entrySet()) {
+                    pw.println(formatSubstitution(g.getKey(), "field", e.getKey(), e.getValue(), this::formatField));
+                }
+            }
+        });
+    }
+
+    private String getJarLocation(ResolvedJavaType type) {
+        Class<?> annotatedClass = OriginalClassProvider.getJavaClass(GraalAccess.getOriginalSnippetReflection(), type);
+        CodeSource source = annotatedClass.getProtectionDomain().getCodeSource();
+        return source == null ? "unknown" : source.getLocation().toString();
+    }
+
+    private String formatMethod(ResolvedJavaMethod method) {
+        return method.getDeclaringClass().toJavaName(true) + "::" + method.getName();
+    }
+
+    private String formatField(ResolvedJavaField field) {
+        return field.getDeclaringClass().toJavaName(true) + "#" + field.getName();
+    }
+
+    private <T> String formatSubstitution(String jar, String type, T original, T annotated, Function<T, String> formatter) {
+        return '\'' + jar + "'," + type + ',' + formatter.apply(original) + ',' + formatter.apply(annotated);
+    }
+
+    private static class Substitutions {
+        private final Map<ResolvedJavaType, ResolvedJavaType> substitutedTypes = new TreeMap<>(new ResolvedJavaTypeComparator());
+        private final Map<ResolvedJavaMethod, ResolvedJavaMethod> substitutedMethods = new TreeMap<>(new ResolvedJavaMethodComparator());
+        private final Map<ResolvedJavaField, ResolvedJavaField> substitutedFields = new TreeMap<>(new ResolvedJavaFieldComparator());
+
+        public void addType(SubstitutionType type) {
+            substitutedTypes.put(type.getOriginal(), type.getAnnotated());
+        }
+
+        public void addMethod(SubstitutionMethod method) {
+            substitutedMethods.put(method.getOriginal(), method.getAnnotated());
+        }
+
+        public void addField(SubstitutionField field) {
+            substitutedFields.put(field.getOriginal(), field.getAnnotated());
+        }
+
+        public Map<ResolvedJavaType, ResolvedJavaType> getSubstitutedTypes() {
+            return substitutedTypes;
+        }
+
+        public Map<ResolvedJavaMethod, ResolvedJavaMethod> getSubstitutedMethods() {
+            return substitutedMethods;
+        }
+
+        public Map<ResolvedJavaField, ResolvedJavaField> getSubstitutedFields() {
+            return substitutedFields;
+        }
+
+        private static class ResolvedJavaTypeComparator implements Comparator<ResolvedJavaType> {
+            @Override
+            public int compare(ResolvedJavaType t1, ResolvedJavaType t2) {
+                return t1.toJavaName(true).compareTo(t2.toJavaName(true));
+            }
+        }
+
+        private static class ResolvedJavaMethodComparator implements Comparator<ResolvedJavaMethod> {
+            @Override
+            public int compare(ResolvedJavaMethod m1, ResolvedJavaMethod m2) {
+                int cmp = m1.getDeclaringClass().toJavaName(true).compareTo(m2.getDeclaringClass().toJavaName(true));
+                return cmp != 0 ? cmp : m1.getName().compareTo(m2.getName());
+            }
+        }
+
+        private static class ResolvedJavaFieldComparator implements Comparator<ResolvedJavaField> {
+            @Override
+            public int compare(ResolvedJavaField f1, ResolvedJavaField f2) {
+                int cmp = f1.getDeclaringClass().toJavaName(true).compareTo(f2.getDeclaringClass().toJavaName(true));
+                return cmp != 0 ? cmp : f1.getName().compareTo(f2.getName());
+            }
+        }
+    }
+}

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/substitute/AnnotationSubstitutionProcessor.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/substitute/AnnotationSubstitutionProcessor.java
@@ -202,7 +202,7 @@ public class AnnotationSubstitutionProcessor extends SubstitutionProcessor {
                 }
 
                 PolymorphicSignatureWrapperMethod wrapperMethod = new PolymorphicSignatureWrapperMethod(substitutionBaseMethod, method);
-                SubstitutionMethod substitutionMethod = new SubstitutionMethod(method, wrapperMethod);
+                SubstitutionMethod substitutionMethod = new SubstitutionMethod(method, wrapperMethod, false, true);
                 synchronized (methodSubstitutions) {
                     /*
                      * It may happen that, during analysis, two threads are trying to register the
@@ -380,7 +380,7 @@ public class AnnotationSubstitutionProcessor extends SubstitutionProcessor {
             }
             registerAsDeleted(annotated, original, deleteAnnotation);
         } else if (substituteAnnotation != null) {
-            SubstitutionMethod substitution = new SubstitutionMethod(original, annotated);
+            SubstitutionMethod substitution = new SubstitutionMethod(original, annotated, false, true);
             if (substituteAnnotation.polymorphicSignature()) {
                 register(polymorphicMethodSubstitutions, annotated, original, substitution);
             }
@@ -578,7 +578,7 @@ public class AnnotationSubstitutionProcessor extends SubstitutionProcessor {
         ResolvedJavaType annotated = metaAccess.lookupJavaType(annotatedClass);
 
         for (int i = 0; i < ARRAY_DIMENSIONS; i++) {
-            ResolvedJavaType substitution = new SubstitutionType(original, annotated);
+            ResolvedJavaType substitution = new SubstitutionType(original, annotated, true);
             register(typeSubstitutions, annotated, original, substitution);
 
             original = original.getArrayClass();
@@ -640,7 +640,7 @@ public class AnnotationSubstitutionProcessor extends SubstitutionProcessor {
         if (original == null) {
             /* Optional target that is not present, so nothing to do. */
         } else if (substituteAnnotation != null) {
-            SubstitutionMethod substitution = new SubstitutionMethod(original, annotated, true);
+            SubstitutionMethod substitution = new SubstitutionMethod(original, annotated, true, true);
             if (substituteAnnotation.polymorphicSignature()) {
                 register(polymorphicMethodSubstitutions, annotated, original, substitution);
             }
@@ -664,7 +664,7 @@ public class AnnotationSubstitutionProcessor extends SubstitutionProcessor {
         if (original == null) {
             /* Optional target that is not present, so nothing to do. */
         } else {
-            register(fieldSubstitutions, annotated, original, new SubstitutionField(original, annotated));
+            register(fieldSubstitutions, annotated, original, new SubstitutionField(original, annotated, true));
         }
     }
 

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/substitute/SubstitutionField.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/substitute/SubstitutionField.java
@@ -41,9 +41,20 @@ public class SubstitutionField implements ReadableJavaField, OriginalFieldProvid
     private final ResolvedJavaField original;
     private final ResolvedJavaField annotated;
 
+    /**
+     * This field is used in the {@link com.oracle.svm.hosted.SubstitutionReportFeature} class to
+     * determine {@link SubstitutionMethod} objects which correspond to annotated substitutions.
+     */
+    private final boolean isUserSubstitution;
+
     public SubstitutionField(ResolvedJavaField original, ResolvedJavaField annotated) {
+        this(original, annotated, false);
+    }
+
+    public SubstitutionField(ResolvedJavaField original, ResolvedJavaField annotated, boolean isUserSubstitution) {
         this.original = original;
         this.annotated = annotated;
+        this.isUserSubstitution = isUserSubstitution;
     }
 
     @Override
@@ -68,6 +79,10 @@ public class SubstitutionField implements ReadableJavaField, OriginalFieldProvid
             value = ReadableJavaField.readFieldValue(GraalAccess.getOriginalProviders().getConstantReflection(), annotated, receiver);
         }
         return value;
+    }
+
+    public boolean isUserSubstitution() {
+        return isUserSubstitution;
     }
 
     public ResolvedJavaField getOriginal() {

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/substitute/SubstitutionMethod.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/substitute/SubstitutionMethod.java
@@ -58,14 +58,25 @@ public class SubstitutionMethod implements ResolvedJavaMethod, GraphProvider, Or
     private final LocalVariableTable localVariableTable;
     private final boolean inClassSubstitution;
 
+    /**
+     * This field is used in the {@link com.oracle.svm.hosted.SubstitutionReportFeature} class to
+     * determine {@link SubstitutionMethod} objects which correspond to annotated substitutions.
+     */
+    private final boolean isUserSubstitution;
+
     public SubstitutionMethod(ResolvedJavaMethod original, ResolvedJavaMethod annotated) {
-        this(original, annotated, false);
+        this(original, annotated, false, false);
     }
 
     public SubstitutionMethod(ResolvedJavaMethod original, ResolvedJavaMethod annotated, boolean inClassSubstitution) {
+        this(original, annotated, inClassSubstitution, false);
+    }
+
+    public SubstitutionMethod(ResolvedJavaMethod original, ResolvedJavaMethod annotated, boolean inClassSubstitution, boolean isUserSubstitution) {
         this.original = original;
         this.annotated = annotated;
         this.inClassSubstitution = inClassSubstitution;
+        this.isUserSubstitution = isUserSubstitution;
 
         LocalVariableTable newLocalVariableTable = null;
         if (annotated.getLocalVariableTable() != null) {
@@ -84,6 +95,10 @@ public class SubstitutionMethod implements ResolvedJavaMethod, GraphProvider, Or
             newLocalVariableTable = new LocalVariableTable(newLocals);
         }
         localVariableTable = newLocalVariableTable;
+    }
+
+    public boolean isUserSubstitution() {
+        return isUserSubstitution;
     }
 
     public ResolvedJavaMethod getOriginal() {

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/substitute/SubstitutionType.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/substitute/SubstitutionType.java
@@ -43,9 +43,24 @@ public class SubstitutionType implements ResolvedJavaType, OriginalClassProvider
     private final ResolvedJavaType original;
     private final ResolvedJavaType annotated;
 
+    /**
+     * This field is used in the {@link com.oracle.svm.hosted.SubstitutionReportFeature} class to
+     * determine {@link SubstitutionType} objects which correspond to type.
+     */
+    private final boolean isUserSubstitution;
+
     public SubstitutionType(ResolvedJavaType original, ResolvedJavaType annotated) {
+        this(original, annotated, false);
+    }
+
+    public SubstitutionType(ResolvedJavaType original, ResolvedJavaType annotated, boolean isUserSubstitution) {
         this.annotated = annotated;
         this.original = original;
+        this.isUserSubstitution = isUserSubstitution;
+    }
+
+    public boolean isUserSubstitution() {
+        return isUserSubstitution;
     }
 
     public ResolvedJavaType getOriginal() {


### PR DESCRIPTION
This PR implements a new feature which creates a report file containing a list of performed substitutions in CSV format. This report can be created by enabling the `ReportPerformedSubstitutions` option, i.e.  `-H:+ReportPerformedSubstitutions`. 

The output will be written to `reports` directory within the current working directory with name `substitutions_<TIMESTAMP>.csv`. A report consists of the substitution list, with one substitution per line, and a header which preceeds the list and has the following column names:
- `location` (URL of the annotated element location)
- `category` (type/method/field substitution)
- `original` (fully qualified type/method/field name of the original element) 
- `annotated` (fully qualified type/method/field name of the element that substitutes the original)

A sample of the output can be seen below: 
```csv
location , category (type/method/field) , original , annotated
'file:/home/ivan/graal/sdk/mxbuild/linux-amd64/GRAALVM_57F0F1CAF4_JAVA11/graalvm-57f0f1caf4-java11-21.1.0-dev/lib/svm/builder/svm.jar',type,java.lang.Class,com.oracle.svm.core.hub.DynamicHub
'file:/home/ivan/graal/sdk/mxbuild/linux-amd64/GRAALVM_57F0F1CAF4_JAVA11/graalvm-57f0f1caf4-java11-21.1.0-dev/lib/svm/builder/svm.jar',type,java.lang.ref.Reference,com.oracle.svm.core.heap.Target_java_lang_ref_Reference
'file:/home/ivan/graal/sdk/mxbuild/linux-amd64/GRAALVM_57F0F1CAF4_JAVA11/graalvm-57f0f1caf4-java11-21.1.0-dev/lib/svm/builder/svm.jar',type,jdk.internal.util.StaticProperty,com.oracle.svm.core.jdk.Target_jdk_internal_util_StaticProperty
'file:/home/ivan/graal/sdk/mxbuild/linux-amd64/GRAALVM_57F0F1CAF4_JAVA11/graalvm-57f0f1caf4-java11-21.1.0-dev/lib/svm/builder/svm.jar',type,sun.util.locale.provider.LocaleServiceProviderPool,com.oracle.svm.core.jdk.Target_sun_util_locale_provider_LocaleServiceProviderPool
```

The implementation uses `com.oracle.svm.hosted.substitute.SubstitutionType`, `com.oracle.svm.hosted.substitute.SubstitutionMethod` and `com.oracle.svm.hosted.substitute.SubstitutionField` types to determine annotated substitutions. In order to distinguish such substitutions, a new field called `isUserSubstitution` is added to each of the specified classes. Another constructor is added through which the field can be initialized, while the other constructors are kept for compatibility and simplicity in cases where that information does not matter.

**Note:**
This PR also fixes a minor bug in the `com.oracle.graal.pointsto.reports.ReportUtils::reportImpl` method, which throws an exception when the provided folder path is relative on Linux. The exception originates from path relativization: https://github.com/oracle/graal/blob/57c39320c65788fd15636f5e9557b6e8f59e6f38/substratevm/src/com.oracle.graal.pointsto/src/com/oracle/graal/pointsto/reports/ReportUtils.java#L107
This bug can be reproduced on Linux (probably the distro/version does not matter) by attempting to call the `reportImpl` methods through one of it's decorators and providing the path such as:
```java
ReportUtils.report("sample description", "reports", "sampleName", "txt", pw -> pw.println("Sample"));
```
whereas the following invocation will succeed:
```java
ReportUtils.report("sample description", "subdir/reports", "sampleName", "txt", pw -> pw.println("Sample"));
```
