### PR TITLE
Debug info: Remove methods from class entry

### DIFF
--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/ClassEntry.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/ClassEntry.java
@@ -296,15 +296,4 @@ public class ClassEntry extends StructureTypeEntry {
     public ClassEntry getSuperClass() {
         return superClass;
     }
-
-    public Range makePrimaryRange(String methodName, String symbolName, String paramSignature, String returnTypeName, StringTable stringTable, FileEntry primaryFileEntry, int lo,
-                    int hi, int primaryLine,
-                    int modifiers, boolean isDeoptTarget) {
-        FileEntry fileEntryToUse = primaryFileEntry;
-        if (fileEntryToUse == null) {
-            /* Last chance is the class's file entry. */
-            fileEntryToUse = this.fileEntry;
-        }
-        return new Range(this.typeName, methodName, symbolName, paramSignature, returnTypeName, stringTable, fileEntryToUse, lo, hi, primaryLine, modifiers, isDeoptTarget);
-    }
 }

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/DebugInfoBase.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/DebugInfoBase.java
@@ -251,7 +251,10 @@ public abstract class DebugInfoBase {
             /* Search for a method defining this primary range. */
             ClassEntry classEntry = ensureClassEntry(className);
             FileEntry fileEntry = ensureFileEntry(fileName, filePath, cachePath);
-            Range primaryRange = classEntry.makePrimaryRange(methodName, symbolName, paramSignature, returnTypeName, stringTable, fileEntry, lo, hi, primaryLine, modifiers, isDeoptTarget);
+            if (fileEntry == null) {
+                fileEntry = classEntry.getFileEntry();
+            }
+            Range primaryRange = new Range(classEntry.getTypeName(), methodName, symbolName, paramSignature, returnTypeName, stringTable, fileEntry, lo, hi, primaryLine, modifiers, isDeoptTarget);
             debugContext.log(DebugContext.INFO_LEVEL, "PrimaryRange %s.%s %s %s:%d [0x%x, 0x%x]", className, methodName, filePath, fileName, primaryLine, lo, hi);
             classEntry.indexPrimary(primaryRange, debugCodeInfo.getFrameSizeChanges(), debugCodeInfo.getFrameSize());
             debugCodeInfo.lineInfoProvider().forEach(debugLineInfo -> {

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debuginfo/DebugInfoProvider.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debuginfo/DebugInfoProvider.java
@@ -134,8 +134,6 @@ public interface DebugInfoProvider {
 
         Stream<DebugFieldInfo> fieldInfoProvider();
 
-        Stream<DebugMethodInfo> methodInfoProvider();
-
         String superName();
 
         Stream<String> interfaces();

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/image/NativeImageDebugInfoProvider.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/image/NativeImageDebugInfoProvider.java
@@ -551,11 +551,6 @@ class NativeImageDebugInfoProvider implements DebugInfoProvider {
         }
 
         @Override
-        public Stream<DebugMethodInfo> methodInfoProvider() {
-            return Arrays.stream(hostedType.getAllDeclaredMethods()).map(this::createDebugMethodInfo);
-        }
-
-        @Override
         public String superName() {
             HostedClass superClass = hostedType.getSuperclass();
             /*


### PR DESCRIPTION
The current implementation goes through all the declared methods of reachable classes and adds them to a list called `methods`  in the corresponding `ClassEntry` instance. This list is only used in  https://github.com/oracle/graal/blob/b60963190a30c870877138e985c4fc70daece031/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/ClassEntry.java#L343-L353 which I think is redundant given that [the `FileEntry` created in `processMethod`](https://github.com/oracle/graal/blob/b60963190a30c870877138e985c4fc70daece031/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/ClassEntry.java#L296) should be essentially the same with the corresponding [`FileEntry` created in `installDebugInfo`](https://github.com/oracle/graal/blob/b60963190a30c870877138e985c4fc70daece031/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/DebugInfoBase.java#L253), so if the latter returns `null` I would expect the former to do the same.