### PR TITLE
Associate debug Ranges with MethodEntries

### DIFF
--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/ClassEntry.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/ClassEntry.java
@@ -53,7 +53,7 @@ public class ClassEntry extends StructureTypeEntry {
     /**
      * Details of this class's interfaces.
      */
-    protected LinkedList<InterfaceClassEntry> interfaces;
+    protected List<InterfaceClassEntry> interfaces;
     /**
      * Details of the associated file.
      */
@@ -66,7 +66,7 @@ public class ClassEntry extends StructureTypeEntry {
      * A list recording details of all primary ranges included in this class sorted by ascending
      * address range.
      */
-    private LinkedList<PrimaryEntry> primaryEntries;
+    private List<PrimaryEntry> primaryEntries;
     /**
      * An index identifying primary ranges which have already been encountered.
      */
@@ -78,7 +78,7 @@ public class ClassEntry extends StructureTypeEntry {
     /**
      * A list of the same files.
      */
-    private LinkedList<FileEntry> localFiles;
+    private List<FileEntry> localFiles;
     /**
      * An index of all primary and secondary dirs referenced from this class's compilation unit.
      */
@@ -86,7 +86,7 @@ public class ClassEntry extends StructureTypeEntry {
     /**
      * A list of the same dirs.
      */
-    private LinkedList<DirEntry> localDirs;
+    private List<DirEntry> localDirs;
     /**
      * This flag is true iff the entry includes methods that are deopt targets.
      */
@@ -94,14 +94,16 @@ public class ClassEntry extends StructureTypeEntry {
 
     public ClassEntry(String className, FileEntry fileEntry, int size) {
         super(className, size);
-        this.interfaces = new LinkedList<>();
+        this.interfaces = new ArrayList<>();
         this.fileEntry = fileEntry;
+        // methods is a sorted list and we want to be able to add more elements to it while keeping it sorted,
+        // so a LinkedList seems more appropriate than an ArrayList. (see getMethodEntry)
         this.methods = new LinkedList<>();
-        this.primaryEntries = new LinkedList<>();
+        this.primaryEntries = new ArrayList<>();
         this.primaryIndex = new HashMap<>();
-        this.localFiles = new LinkedList<>();
+        this.localFiles = new ArrayList<>();
         this.localFilesIndex = new HashMap<>();
-        this.localDirs = new LinkedList<>();
+        this.localDirs = new ArrayList<>();
         this.localDirsIndex = new HashMap<>();
         if (fileEntry != null) {
             localFiles.add(fileEntry);
@@ -231,7 +233,7 @@ public class ClassEntry extends StructureTypeEntry {
         return fileEntry;
     }
 
-    public LinkedList<PrimaryEntry> getPrimaryEntries() {
+    public List<PrimaryEntry> getPrimaryEntries() {
         return primaryEntries;
     }
 
@@ -240,11 +242,11 @@ public class ClassEntry extends StructureTypeEntry {
         return primaryIndex.get(primaryRange);
     }
 
-    public LinkedList<DirEntry> getLocalDirs() {
+    public List<DirEntry> getLocalDirs() {
         return localDirs;
     }
 
-    public LinkedList<FileEntry> getLocalFiles() {
+    public List<FileEntry> getLocalFiles() {
         return localFiles;
     }
 

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/ClassEntry.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/ClassEntry.java
@@ -268,8 +268,8 @@ public class ClassEntry extends StructureTypeEntry {
     }
 
     protected MethodEntry processMethod(DebugMethodInfo debugMethodInfo, DebugInfoBase debugInfoBase, DebugContext debugContext) {
-        String methodName = debugInfoBase.uniqueDebugString(debugMethodInfo.methodName());
-        String resultTypeName = TypeEntry.canonicalize(debugMethodInfo.returnTypeName());
+        String methodName = debugInfoBase.uniqueDebugString(debugMethodInfo.name());
+        String resultTypeName = TypeEntry.canonicalize(debugMethodInfo.valueType());
         int modifiers = debugMethodInfo.modifiers();
         List<String> paramTypes = debugMethodInfo.paramTypes();
         List<String> paramNames = debugMethodInfo.paramNames();

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/ClassEntry.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/ClassEntry.java
@@ -337,25 +337,11 @@ public class ClassEntry extends StructureTypeEntry {
         return superClass;
     }
 
-    public Range makePrimaryRange(String methodName, String symbolName, String paramSignature, String returnTypeName, StringTable stringTable, MethodEntry method, int lo,
-                    int hi, int primaryLine) {
+    public Range makePrimaryRange(String symbolName, StringTable stringTable, MethodEntry method, int lo, int hi, int primaryLine) {
         FileEntry fileEntryToUse = method.fileEntry;
         if (fileEntryToUse == null) {
-            /*
-             * Search for a matching method to supply the file entry or failing that use the one
-             * from this class.
-             */
-            for (MethodEntry methodEntry : methods) {
-                if (methodEntry.match(methodName, paramSignature, returnTypeName)) {
-                    /* maybe the method's file entry */
-                    fileEntryToUse = methodEntry.getFileEntry();
-                    break;
-                }
-            }
-            if (fileEntryToUse == null) {
-                /* Last chance is the class's file entry. */
-                fileEntryToUse = this.fileEntry;
-            }
+            /* Last chance is the class's file entry. */
+            fileEntryToUse = this.fileEntry;
         }
         return new Range(symbolName, stringTable, method, fileEntryToUse, lo, hi, primaryLine);
     }

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/ClassEntry.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/ClassEntry.java
@@ -294,7 +294,7 @@ public class ClassEntry extends StructureTypeEntry {
          * substitution
          */
         FileEntry methodFileEntry = debugInfoBase.ensureFileEntry(fileName, filePath, cachePath);
-        final MethodEntry methodEntry = new MethodEntry(methodFileEntry, methodName, this, resultType, paramTypeArray, paramNameArray, modifiers);
+        final MethodEntry methodEntry = new MethodEntry(methodFileEntry, methodName, this, resultType, paramTypeArray, paramNameArray, modifiers, debugMethodInfo.isDeoptTarget());
         methods.add(methodEntry);
         return methodEntry;
     }
@@ -338,7 +338,7 @@ public class ClassEntry extends StructureTypeEntry {
     }
 
     public Range makePrimaryRange(String methodName, String symbolName, String paramSignature, String returnTypeName, StringTable stringTable, MethodEntry method, int lo,
-                                  int hi, int primaryLine, boolean isDeoptTarget) {
+                    int hi, int primaryLine) {
         FileEntry fileEntryToUse = method.fileEntry;
         if (fileEntryToUse == null) {
             /*
@@ -357,7 +357,7 @@ public class ClassEntry extends StructureTypeEntry {
                 fileEntryToUse = this.fileEntry;
             }
         }
-        return new Range(symbolName, stringTable, method, fileEntryToUse, lo, hi, primaryLine, isDeoptTarget);
+        return new Range(symbolName, stringTable, method, fileEntryToUse, lo, hi, primaryLine);
     }
 
     public MethodEntry ensureMethodEntry(DebugInfoProvider.DebugMethodInfo debugMethodInfo, DebugInfoBase debugInfoBase, DebugContext debugContext) {

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/ClassEntry.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/ClassEntry.java
@@ -267,9 +267,9 @@ public class ClassEntry extends StructureTypeEntry {
         interfaceClassEntry.addImplementor(this, debugContext);
     }
 
-    protected void processMethod(DebugMethodInfo debugMethodInfo, DebugInfoBase debugInfoBase, DebugContext debugContext) {
-        String methodName = debugInfoBase.uniqueDebugString(debugMethodInfo.name());
-        String resultTypeName = TypeEntry.canonicalize(debugMethodInfo.valueType());
+    protected MethodEntry processMethod(DebugMethodInfo debugMethodInfo, DebugInfoBase debugInfoBase, DebugContext debugContext) {
+        String methodName = debugInfoBase.uniqueDebugString(debugMethodInfo.methodName());
+        String resultTypeName = TypeEntry.canonicalize(debugMethodInfo.returnTypeName());
         int modifiers = debugMethodInfo.modifiers();
         List<String> paramTypes = debugMethodInfo.paramTypes();
         List<String> paramNames = debugMethodInfo.paramNames();
@@ -294,7 +294,9 @@ public class ClassEntry extends StructureTypeEntry {
          * substitution
          */
         FileEntry methodFileEntry = debugInfoBase.ensureFileEntry(fileName, filePath, cachePath);
-        methods.add(new MethodEntry(methodFileEntry, methodName, this, resultType, paramTypeArray, paramNameArray, modifiers));
+        final MethodEntry methodEntry = new MethodEntry(methodFileEntry, methodName, this, resultType, paramTypeArray, paramNameArray, modifiers);
+        methods.add(methodEntry);
+        return methodEntry;
     }
 
     @Override

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/ClassEntry.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/ClassEntry.java
@@ -369,7 +369,7 @@ public class ClassEntry extends StructureTypeEntry {
         return newMethodEntry;
     }
 
-    private boolean listIsSorted(List<MethodEntry> list) {
+    private static boolean listIsSorted(List<MethodEntry> list) {
         List<MethodEntry> copy = new ArrayList<>(list);
         copy.sort(MethodEntry::compareTo);
         return list.equals(copy);

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/ClassEntry.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/ClassEntry.java
@@ -26,7 +26,7 @@
 
 package com.oracle.objectfile.debugentry;
 
-import com.oracle.objectfile.debuginfo.DebugInfoProvider;
+import com.oracle.objectfile.debuginfo.DebugInfoProvider.DebugFieldInfo;
 import com.oracle.objectfile.debuginfo.DebugInfoProvider.DebugFrameSizeChange;
 import com.oracle.objectfile.debuginfo.DebugInfoProvider.DebugMethodInfo;
 import com.oracle.objectfile.debuginfo.DebugInfoProvider.DebugTypeInfo;
@@ -300,7 +300,7 @@ public class ClassEntry extends StructureTypeEntry {
     }
 
     @Override
-    protected FieldEntry addField(DebugInfoProvider.DebugFieldInfo debugFieldInfo, DebugInfoBase debugInfoBase, DebugContext debugContext) {
+    protected FieldEntry addField(DebugFieldInfo debugFieldInfo, DebugInfoBase debugInfoBase, DebugContext debugContext) {
         FieldEntry fieldEntry = super.addField(debugFieldInfo, debugInfoBase, debugContext);
         FileEntry fieldFileEntry = fieldEntry.getFileEntry();
         if (fieldFileEntry != null) {
@@ -360,7 +360,7 @@ public class ClassEntry extends StructureTypeEntry {
         return new Range(symbolName, stringTable, method, fileEntryToUse, lo, hi, primaryLine);
     }
 
-    public MethodEntry ensureMethodEntry(DebugInfoProvider.DebugMethodInfo debugMethodInfo, DebugInfoBase debugInfoBase, DebugContext debugContext) {
+    public MethodEntry ensureMethodEntry(DebugMethodInfo debugMethodInfo, DebugInfoBase debugInfoBase, DebugContext debugContext) {
         String methodName = debugInfoBase.uniqueDebugString(debugMethodInfo.name());
         String paramSignature = debugMethodInfo.paramSignature();
         String returnTypeName = debugMethodInfo.valueType();

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/ClassEntry.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/ClassEntry.java
@@ -337,10 +337,9 @@ public class ClassEntry extends StructureTypeEntry {
         return superClass;
     }
 
-    public Range makePrimaryRange(String methodName, String symbolName, String paramSignature, String returnTypeName, StringTable stringTable, FileEntry primaryFileEntry, int lo,
-                    int hi, int primaryLine,
-                    int modifiers, boolean isDeoptTarget) {
-        FileEntry fileEntryToUse = primaryFileEntry;
+    public Range makePrimaryRange(String methodName, String symbolName, String paramSignature, String returnTypeName, StringTable stringTable, MethodEntry method, int lo,
+                                  int hi, int primaryLine, boolean isDeoptTarget) {
+        FileEntry fileEntryToUse = method.fileEntry;
         if (fileEntryToUse == null) {
             /*
              * Search for a matching method to supply the file entry or failing that use the one
@@ -358,6 +357,19 @@ public class ClassEntry extends StructureTypeEntry {
                 fileEntryToUse = this.fileEntry;
             }
         }
-        return new Range(this.typeName, methodName, symbolName, paramSignature, returnTypeName, stringTable, fileEntryToUse, lo, hi, primaryLine, modifiers, isDeoptTarget);
+        return new Range(symbolName, stringTable, method, fileEntryToUse, lo, hi, primaryLine, isDeoptTarget);
+    }
+
+    public MethodEntry ensureMethodEntry(DebugInfoProvider.DebugMethodInfo debugMethodInfo, DebugInfoBase debugInfoBase, DebugContext debugContext) {
+        String methodName = debugInfoBase.uniqueDebugString(debugMethodInfo.name());
+        String paramSignature = debugMethodInfo.paramSignature();
+        String returnTypeName = debugMethodInfo.valueType();
+        // TODO improve data structure to avoid loops...
+        for (MethodEntry methodEntry : methods) {
+            if (methodEntry.match(methodName, paramSignature, returnTypeName)) {
+                return methodEntry;
+            }
+        }
+        return processMethod(debugMethodInfo, debugInfoBase, debugContext);
     }
 }

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/DebugInfoBase.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/DebugInfoBase.java
@@ -239,8 +239,6 @@ public abstract class DebugInfoBase {
             String className = TypeEntry.canonicalize(debugCodeInfo.ownerType());
             String methodName = debugCodeInfo.name();
             String symbolName = debugCodeInfo.symbolNameForMethod();
-            String paramSignature = debugCodeInfo.paramSignature();
-            String returnTypeName = TypeEntry.canonicalize(debugCodeInfo.valueType());
             int lo = debugCodeInfo.addressLo();
             int hi = debugCodeInfo.addressHi();
             int primaryLine = debugCodeInfo.line();
@@ -248,7 +246,7 @@ public abstract class DebugInfoBase {
             /* Search for a method defining this primary range. */
             ClassEntry classEntry = ensureClassEntry(className);
             MethodEntry methodEntry = classEntry.ensureMethodEntry(debugCodeInfo, this, debugContext);
-            Range primaryRange = classEntry.makePrimaryRange(methodName, symbolName, paramSignature, returnTypeName, stringTable, methodEntry, lo, hi, primaryLine);
+            Range primaryRange = classEntry.makePrimaryRange(symbolName, stringTable, methodEntry, lo, hi, primaryLine);
             debugContext.log(DebugContext.INFO_LEVEL, "PrimaryRange %s.%s %s %s:%d [0x%x, 0x%x]", className, methodName, filePath, fileName, primaryLine, lo, hi);
             classEntry.indexPrimary(primaryRange, debugCodeInfo.getFrameSizeChanges(), debugCodeInfo.getFrameSize());
             debugCodeInfo.lineInfoProvider().forEach(debugLineInfo -> {

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/DebugInfoBase.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/DebugInfoBase.java
@@ -244,12 +244,11 @@ public abstract class DebugInfoBase {
             int lo = debugCodeInfo.addressLo();
             int hi = debugCodeInfo.addressHi();
             int primaryLine = debugCodeInfo.line();
-            boolean isDeoptTarget = debugCodeInfo.isDeoptTarget();
 
             /* Search for a method defining this primary range. */
             ClassEntry classEntry = ensureClassEntry(className);
             MethodEntry methodEntry = classEntry.ensureMethodEntry(debugCodeInfo, this, debugContext);
-            Range primaryRange = classEntry.makePrimaryRange(methodName, symbolName, paramSignature, returnTypeName, stringTable, methodEntry, lo, hi, primaryLine, isDeoptTarget);
+            Range primaryRange = classEntry.makePrimaryRange(methodName, symbolName, paramSignature, returnTypeName, stringTable, methodEntry, lo, hi, primaryLine);
             debugContext.log(DebugContext.INFO_LEVEL, "PrimaryRange %s.%s %s %s:%d [0x%x, 0x%x]", className, methodName, filePath, fileName, primaryLine, lo, hi);
             classEntry.indexPrimary(primaryRange, debugCodeInfo.getFrameSizeChanges(), debugCodeInfo.getFrameSize());
             debugCodeInfo.lineInfoProvider().forEach(debugLineInfo -> {

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/DebugInfoBase.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/DebugInfoBase.java
@@ -237,16 +237,16 @@ public abstract class DebugInfoBase {
             String fileName = debugCodeInfo.fileName();
             Path filePath = debugCodeInfo.filePath();
             Path cachePath = debugCodeInfo.cachePath();
-            String className = TypeEntry.canonicalize(debugCodeInfo.className());
-            String methodName = debugCodeInfo.methodName();
+            String className = TypeEntry.canonicalize(debugCodeInfo.ownerType());
+            String methodName = debugCodeInfo.name();
             String symbolName = debugCodeInfo.symbolNameForMethod();
             String paramSignature = debugCodeInfo.paramSignature();
-            String returnTypeName = TypeEntry.canonicalize(debugCodeInfo.returnTypeName());
+            String returnTypeName = TypeEntry.canonicalize(debugCodeInfo.valueType());
             int lo = debugCodeInfo.addressLo();
             int hi = debugCodeInfo.addressHi();
             int primaryLine = debugCodeInfo.line();
             boolean isDeoptTarget = debugCodeInfo.isDeoptTarget();
-            int modifiers = debugCodeInfo.getModifiers();
+            int modifiers = debugCodeInfo.modifiers();
 
             /* Search for a method defining this primary range. */
             ClassEntry classEntry = ensureClassEntry(className);
@@ -257,8 +257,8 @@ public abstract class DebugInfoBase {
             debugCodeInfo.lineInfoProvider().forEach(debugLineInfo -> {
                 String fileNameAtLine = debugLineInfo.fileName();
                 Path filePathAtLine = debugLineInfo.filePath();
-                String classNameAtLine = TypeEntry.canonicalize(debugLineInfo.className());
-                String methodNameAtLine = debugLineInfo.methodName();
+                String classNameAtLine = TypeEntry.canonicalize(debugLineInfo.ownerType());
+                String methodNameAtLine = debugLineInfo.name();
                 String symbolNameAtLine = debugLineInfo.symbolNameForMethod();
                 int loAtLine = lo + debugLineInfo.addressLo();
                 int hiAtLine = lo + debugLineInfo.addressHi();

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/DebugInfoBase.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/DebugInfoBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2020, 2020, Red Hat Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -245,7 +245,7 @@ public abstract class DebugInfoBase {
 
             /* Search for a method defining this primary range. */
             ClassEntry classEntry = ensureClassEntry(className);
-            MethodEntry methodEntry = classEntry.ensureMethodEntry(debugCodeInfo, this, debugContext);
+            MethodEntry methodEntry = classEntry.getMethodEntry(debugCodeInfo, this, debugContext);
             Range primaryRange = classEntry.makePrimaryRange(symbolName, stringTable, methodEntry, lo, hi, primaryLine);
             debugContext.log(DebugContext.INFO_LEVEL, "PrimaryRange %s.%s %s %s:%d [0x%x, 0x%x]", className, methodName, filePath, fileName, primaryLine, lo, hi);
             classEntry.indexPrimary(primaryRange, debugCodeInfo.getFrameSizeChanges(), debugCodeInfo.getFrameSize());
@@ -263,7 +263,7 @@ public abstract class DebugInfoBase {
                  * symbol for them and don't see a break in the address range.
                  */
                 ClassEntry subClassEntry = ensureClassEntry(classNameAtLine);
-                MethodEntry subMethodEntry = subClassEntry.ensureMethodEntry(debugLineInfo, this, debugContext);
+                MethodEntry subMethodEntry = subClassEntry.getMethodEntry(debugLineInfo, this, debugContext);
                 Range subRange = new Range(symbolNameAtLine, stringTable, subMethodEntry, loAtLine, hiAtLine, line, primaryRange);
                 classEntry.indexSubRange(subRange);
                 try (DebugContext.Scope s = debugContext.scope("Subranges")) {

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/DebugInfoBase.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/DebugInfoBase.java
@@ -29,8 +29,9 @@ package com.oracle.objectfile.debugentry;
 import java.nio.ByteOrder;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.LinkedList;
+import java.util.List;
 import java.util.Map;
 
 import org.graalvm.compiler.debug.DebugContext;
@@ -89,7 +90,7 @@ public abstract class DebugInfoBase {
     /**
      * List of class entries detailing class info for primary ranges.
      */
-    private LinkedList<TypeEntry> types = new LinkedList<>();
+    private List<TypeEntry> types = new ArrayList<>();
     /**
      * index of already seen classes.
      */
@@ -97,7 +98,7 @@ public abstract class DebugInfoBase {
     /**
      * List of class entries detailing class info for primary ranges.
      */
-    private LinkedList<ClassEntry> primaryClasses = new LinkedList<>();
+    private List<ClassEntry> primaryClasses = new ArrayList<>();
     /**
      * index of already seen classes.
      */
@@ -109,7 +110,7 @@ public abstract class DebugInfoBase {
     /**
      * List of of files which contain primary or secondary ranges.
      */
-    private LinkedList<FileEntry> files = new LinkedList<>();
+    private List<FileEntry> files = new ArrayList<>();
     /**
      * Flag set to true if heap references are stored as addresses relative to a heap base register
      * otherwise false.
@@ -426,16 +427,16 @@ public abstract class DebugInfoBase {
         return byteOrder;
     }
 
-    public LinkedList<TypeEntry> getTypes() {
+    public List<TypeEntry> getTypes() {
         return types;
     }
 
-    public LinkedList<ClassEntry> getPrimaryClasses() {
+    public List<ClassEntry> getPrimaryClasses() {
         return primaryClasses;
     }
 
     @SuppressWarnings("unused")
-    public LinkedList<FileEntry> getFiles() {
+    public List<FileEntry> getFiles() {
         return files;
     }
 

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/DebugInfoBase.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/DebugInfoBase.java
@@ -236,7 +236,6 @@ public abstract class DebugInfoBase {
              */
             String fileName = debugCodeInfo.fileName();
             Path filePath = debugCodeInfo.filePath();
-            Path cachePath = debugCodeInfo.cachePath();
             String className = TypeEntry.canonicalize(debugCodeInfo.ownerType());
             String methodName = debugCodeInfo.name();
             String symbolName = debugCodeInfo.symbolNameForMethod();
@@ -246,12 +245,11 @@ public abstract class DebugInfoBase {
             int hi = debugCodeInfo.addressHi();
             int primaryLine = debugCodeInfo.line();
             boolean isDeoptTarget = debugCodeInfo.isDeoptTarget();
-            int modifiers = debugCodeInfo.modifiers();
 
             /* Search for a method defining this primary range. */
             ClassEntry classEntry = ensureClassEntry(className);
-            FileEntry fileEntry = ensureFileEntry(fileName, filePath, cachePath);
-            Range primaryRange = classEntry.makePrimaryRange(methodName, symbolName, paramSignature, returnTypeName, stringTable, fileEntry, lo, hi, primaryLine, modifiers, isDeoptTarget);
+            MethodEntry methodEntry = classEntry.ensureMethodEntry(debugCodeInfo, this, debugContext);
+            Range primaryRange = classEntry.makePrimaryRange(methodName, symbolName, paramSignature, returnTypeName, stringTable, methodEntry, lo, hi, primaryLine, isDeoptTarget);
             debugContext.log(DebugContext.INFO_LEVEL, "PrimaryRange %s.%s %s %s:%d [0x%x, 0x%x]", className, methodName, filePath, fileName, primaryLine, lo, hi);
             classEntry.indexPrimary(primaryRange, debugCodeInfo.getFrameSizeChanges(), debugCodeInfo.getFrameSize());
             debugCodeInfo.lineInfoProvider().forEach(debugLineInfo -> {
@@ -263,13 +261,13 @@ public abstract class DebugInfoBase {
                 int loAtLine = lo + debugLineInfo.addressLo();
                 int hiAtLine = lo + debugLineInfo.addressHi();
                 int line = debugLineInfo.line();
-                Path cachePathAtLine = debugLineInfo.cachePath();
                 /*
                  * Record all subranges even if they have no line or file so we at least get a
                  * symbol for them and don't see a break in the address range.
                  */
-                FileEntry subFileEntry = ensureFileEntry(fileNameAtLine, filePathAtLine, cachePathAtLine);
-                Range subRange = new Range(classNameAtLine, methodNameAtLine, symbolNameAtLine, stringTable, subFileEntry, loAtLine, hiAtLine, line, primaryRange);
+                ClassEntry subClassEntry = ensureClassEntry(classNameAtLine);
+                MethodEntry subMethodEntry = subClassEntry.ensureMethodEntry(debugLineInfo, this, debugContext);
+                Range subRange = new Range(symbolNameAtLine, stringTable, subMethodEntry, loAtLine, hiAtLine, line, primaryRange);
                 classEntry.indexSubRange(subRange);
                 try (DebugContext.Scope s = debugContext.scope("Subranges")) {
                     debugContext.log(DebugContext.VERBOSE_LEVEL, "SubRange %s.%s %s %s:%d 0x%x, 0x%x]", classNameAtLine, methodNameAtLine, filePathAtLine, fileNameAtLine, line, loAtLine, hiAtLine);

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/InterfaceClassEntry.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/InterfaceClassEntry.java
@@ -31,7 +31,7 @@ import com.oracle.objectfile.debuginfo.DebugInfoProvider.DebugTypeInfo;
 import com.oracle.objectfile.debuginfo.DebugInfoProvider.DebugTypeInfo.DebugTypeKind;
 import org.graalvm.compiler.debug.DebugContext;
 
-import java.util.LinkedList;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Stream;
 
@@ -40,7 +40,7 @@ public class InterfaceClassEntry extends ClassEntry {
 
     public InterfaceClassEntry(String className, FileEntry fileEntry, int size) {
         super(className, fileEntry, size);
-        implementors = new LinkedList<>();
+        implementors = new ArrayList<>();
     }
 
     @Override

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/MethodEntry.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/MethodEntry.java
@@ -29,13 +29,15 @@ package com.oracle.objectfile.debugentry;
 public class MethodEntry extends MemberEntry {
     TypeEntry[] paramTypes;
     String[] paramNames;
+    final boolean isDeoptTarget;
 
-    public MethodEntry(FileEntry fileEntry, String methodName, ClassEntry ownerType, TypeEntry valueType, TypeEntry[] paramTypes, String[] paramNames, int modifiers) {
+    public MethodEntry(FileEntry fileEntry, String methodName, ClassEntry ownerType, TypeEntry valueType, TypeEntry[] paramTypes, String[] paramNames, int modifiers, boolean isDeoptTarget) {
         super(fileEntry, methodName, ownerType, valueType, modifiers);
         assert ((paramTypes == null && paramNames == null) ||
                         (paramTypes != null && paramNames != null && paramTypes.length == paramNames.length));
         this.paramTypes = paramTypes;
         this.paramNames = paramNames;
+        this.isDeoptTarget = isDeoptTarget;
     }
 
     public String methodName() {
@@ -93,5 +95,9 @@ public class MethodEntry extends MemberEntry {
             }
         }
         return true;
+    }
+
+    public boolean isDeoptTarget() {
+        return isDeoptTarget;
     }
 }

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/MethodEntry.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/MethodEntry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2020, 2020, Red Hat Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -26,7 +26,7 @@
 
 package com.oracle.objectfile.debugentry;
 
-public class MethodEntry extends MemberEntry {
+public class MethodEntry extends MemberEntry implements Comparable<MethodEntry> {
     final TypeEntry[] paramTypes;
     final String[] paramNames;
     final boolean isDeoptTarget;
@@ -74,30 +74,51 @@ public class MethodEntry extends MemberEntry {
         return paramNames[idx];
     }
 
-    public boolean match(String methodName, String paramSignature, String returnTypeName) {
-        if (!methodName.equals(this.memberName)) {
-            return false;
+    public int compareTo(String methodName, String paramSignature, String returnTypeName) {
+        if (!memberName.equals(methodName)) {
+            return memberName.compareTo(methodName);
         }
-        if (!returnTypeName.equals(valueType.getTypeName())) {
-            return false;
+        if (!valueType.getTypeName().equals(returnTypeName)) {
+            return valueType.getTypeName().compareTo(returnTypeName);
         }
         int paramCount = getParamCount();
         if (paramCount == 0) {
-            return paramSignature.trim().length() == 0;
+            return 0 - paramSignature.trim().length();
         }
         String[] paramTypeNames = paramSignature.split((","));
         if (paramCount != paramTypeNames.length) {
-            return false;
+            return paramCount - paramTypeNames.length;
         }
         for (int i = 0; i < paramCount; i++) {
             if (!paramTypeNames[i].trim().equals(getParamTypeName(i))) {
-                return false;
+                return getParamTypeName(i).compareTo(paramTypeNames[i].trim());
             }
         }
-        return true;
+        return 0;
     }
 
     public boolean isDeoptTarget() {
         return isDeoptTarget;
+    }
+
+    @Override
+    public int compareTo(MethodEntry other) {
+        assert other != null;
+        int result = methodName().compareTo(other.methodName());
+        if (result == 0) {
+            result = valueType.getTypeName().compareTo(other.valueType.getTypeName());
+        }
+        if (result == 0) {
+            result = getParamCount() - other.getParamCount();
+        }
+        if (result == 0) {
+            for (int i = 0; i < getParamCount(); i++) {
+                result = getParamTypeName(i).compareTo(other.getParamTypeName(i));
+                if (result != 0) {
+                    break;
+                }
+            }
+        }
+        return result;
     }
 }

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/MethodEntry.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/MethodEntry.java
@@ -75,23 +75,29 @@ public class MethodEntry extends MemberEntry implements Comparable<MethodEntry> 
     }
 
     public int compareTo(String methodName, String paramSignature, String returnTypeName) {
-        if (!memberName.equals(methodName)) {
-            return memberName.compareTo(methodName);
+        int nameComparison = memberName.compareTo(methodName);
+        if (nameComparison != 0) {
+            return nameComparison;
         }
-        if (!valueType.getTypeName().equals(returnTypeName)) {
-            return valueType.getTypeName().compareTo(returnTypeName);
-        }
-        int paramCount = getParamCount();
-        if (paramCount == 0) {
-            return 0 - paramSignature.trim().length();
+        int typeComparison = valueType.getTypeName().compareTo(returnTypeName);
+        if (typeComparison != 0) {
+            return typeComparison;
         }
         String[] paramTypeNames = paramSignature.split((","));
-        if (paramCount != paramTypeNames.length) {
-            return paramCount - paramTypeNames.length;
+        int length;
+        if (paramSignature.trim().length() == 0) {
+            length = 0;
+        } else {
+            length = paramTypeNames.length;
         }
-        for (int i = 0; i < paramCount; i++) {
-            if (!paramTypeNames[i].trim().equals(getParamTypeName(i))) {
-                return getParamTypeName(i).compareTo(paramTypeNames[i].trim());
+        int paramCountComparison = getParamCount() - length;
+        if (paramCountComparison != 0) {
+            return paramCountComparison;
+        }
+        for (int i = 0; i < getParamCount(); i++) {
+            int paraComparison = getParamTypeName(i).compareTo(paramTypeNames[i].trim());
+            if (paraComparison != 0) {
+                return paraComparison;
             }
         }
         return 0;
@@ -104,21 +110,24 @@ public class MethodEntry extends MemberEntry implements Comparable<MethodEntry> 
     @Override
     public int compareTo(MethodEntry other) {
         assert other != null;
-        int result = methodName().compareTo(other.methodName());
-        if (result == 0) {
-            result = valueType.getTypeName().compareTo(other.valueType.getTypeName());
+        int nameComparison = methodName().compareTo(other.methodName());
+        if (nameComparison != 0) {
+            return nameComparison;
         }
-        if (result == 0) {
-            result = getParamCount() - other.getParamCount();
+        int typeComparison = valueType.getTypeName().compareTo(other.valueType.getTypeName());
+        if (typeComparison != 0) {
+            return typeComparison;
         }
-        if (result == 0) {
-            for (int i = 0; i < getParamCount(); i++) {
-                result = getParamTypeName(i).compareTo(other.getParamTypeName(i));
-                if (result != 0) {
-                    break;
-                }
+        int paramCountComparison = getParamCount() - other.getParamCount();
+        if (paramCountComparison != 0) {
+            return paramCountComparison;
+        }
+        for (int i = 0; i < getParamCount(); i++) {
+            int paramComparison = getParamTypeName(i).compareTo(other.getParamTypeName(i));
+            if (paramComparison != 0) {
+                return paramComparison;
             }
         }
-        return result;
+        return 0;
     }
 }

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/MethodEntry.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/MethodEntry.java
@@ -27,8 +27,8 @@
 package com.oracle.objectfile.debugentry;
 
 public class MethodEntry extends MemberEntry {
-    TypeEntry[] paramTypes;
-    String[] paramNames;
+    final TypeEntry[] paramTypes;
+    final String[] paramNames;
     final boolean isDeoptTarget;
 
     public MethodEntry(FileEntry fileEntry, String methodName, ClassEntry ownerType, TypeEntry valueType, TypeEntry[] paramTypes, String[] paramNames, int modifiers, boolean isDeoptTarget) {

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/PrimaryEntry.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/PrimaryEntry.java
@@ -28,7 +28,7 @@ package com.oracle.objectfile.debugentry;
 
 import com.oracle.objectfile.debuginfo.DebugInfoProvider.DebugFrameSizeChange;
 
-import java.util.LinkedList;
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -59,7 +59,7 @@ public class PrimaryEntry {
     public PrimaryEntry(Range primary, List<DebugFrameSizeChange> frameSizeInfos, int frameSize, ClassEntry classEntry) {
         this.primary = primary;
         this.classEntry = classEntry;
-        this.subranges = new LinkedList<>();
+        this.subranges = new ArrayList<>();
         this.frameSizeInfos = frameSizeInfos;
         this.frameSize = frameSize;
     }

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/Range.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/Range.java
@@ -41,7 +41,6 @@ public class Range {
     private final int lo;
     private final int hi;
     private final int line;
-    private final boolean isDeoptTarget;
     /*
      * This is null for a primary range.
      */
@@ -50,23 +49,22 @@ public class Range {
     /*
      * Create a primary range.
      */
-    public Range(String symbolName, StringTable stringTable, MethodEntry methodEntry, FileEntry fileEntry, int lo, int hi, int line,
-                 boolean isDeoptTarget) {
-        this(symbolName, stringTable, methodEntry, fileEntry, lo, hi, line, isDeoptTarget, null);
+    public Range(String symbolName, StringTable stringTable, MethodEntry methodEntry, FileEntry fileEntry, int lo, int hi, int line) {
+        this(symbolName, stringTable, methodEntry, fileEntry, lo, hi, line, null);
     }
 
     /*
      * Create a secondary range.
      */
     public Range(String symbolName, StringTable stringTable, MethodEntry methodEntry, int lo, int hi, int line, Range primary) {
-        this(symbolName, stringTable, methodEntry, methodEntry.fileEntry, lo, hi, line, false, primary);
+        this(symbolName, stringTable, methodEntry, methodEntry.fileEntry, lo, hi, line, primary);
     }
 
     /*
      * Create a primary or secondary range.
      */
     private Range(String symbolName, StringTable stringTable, MethodEntry methodEntry, FileEntry fileEntry, int lo, int hi, int line,
-                    boolean isDeoptTarget, Range primary) {
+                    Range primary) {
         this.fileEntry = fileEntry; // TODO remove and use fileEntry from MethodEntry
         if (fileEntry != null) {
             stringTable.uniqueDebugString(fileEntry.getFileName());
@@ -79,7 +77,6 @@ public class Range {
         this.lo = lo;
         this.hi = hi;
         this.line = line;
-        this.isDeoptTarget = isDeoptTarget;
         this.primary = primary;
     }
 
@@ -128,7 +125,7 @@ public class Range {
     }
 
     public boolean isDeoptTarget() {
-        return isDeoptTarget;
+        return methodEntry.isDeoptTarget;
     }
 
     private String getExtendedMethodName(boolean includeClass, boolean includeParams, boolean includeReturnType) {

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/Range.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/Range.java
@@ -35,22 +35,22 @@ package com.oracle.objectfile.debugentry;
 public class Range {
     private static final String CLASS_DELIMITER = ".";
     private FileEntry fileEntry;
-    private String className;
-    private String methodName;
-    private String symbolName;
-    private String paramSignature;
-    private String returnTypeName;
-    private String fullMethodName;
-    private String fullMethodNameWithParams;
-    private int lo;
-    private int hi;
-    private int line;
-    private boolean isDeoptTarget;
-    private int modifiers;
+    private final String className;
+    private final String methodName;
+    private final String symbolName;
+    private final String paramSignature;
+    private final String returnTypeName;
+    private final String fullMethodName;
+    private final String fullMethodNameWithParams;
+    private final int lo;
+    private final int hi;
+    private final int line;
+    private final boolean isDeoptTarget;
+    private final int modifiers;
     /*
      * This is null for a primary range.
      */
-    private Range primary;
+    private final Range primary;
 
     /*
      * Create a primary range.

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/Range.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/Range.java
@@ -34,7 +34,7 @@ package com.oracle.objectfile.debugentry;
 
 public class Range {
     private static final String CLASS_DELIMITER = ".";
-    private FileEntry fileEntry;
+    private final FileEntry fileEntry;
     private final String className;
     private final String methodName;
     private final String symbolName;
@@ -182,10 +182,6 @@ public class Range {
 
     public FileEntry getFileEntry() {
         return fileEntry;
-    }
-
-    public void setFileEntry(FileEntry fileEntry) {
-        this.fileEntry = fileEntry;
     }
 
     public int getModifiers() {

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/Range.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/Range.java
@@ -65,7 +65,7 @@ public class Range {
      */
     private Range(String symbolName, StringTable stringTable, MethodEntry methodEntry, FileEntry fileEntry, int lo, int hi, int line,
                     Range primary) {
-        this.fileEntry = fileEntry; // TODO remove and use fileEntry from MethodEntry
+        this.fileEntry = fileEntry;
         if (fileEntry != null) {
             stringTable.uniqueDebugString(fileEntry.getFileName());
             stringTable.uniqueDebugString(fileEntry.getPathName());

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/StructureTypeEntry.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/StructureTypeEntry.java
@@ -31,7 +31,7 @@ import org.graalvm.compiler.debug.DebugContext;
 
 import java.lang.reflect.Modifier;
 import java.nio.file.Path;
-import java.util.LinkedList;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Stream;
 
@@ -47,7 +47,7 @@ public abstract class StructureTypeEntry extends TypeEntry {
 
     public StructureTypeEntry(String typeName, int size) {
         super(typeName, size);
-        this.fields = new LinkedList<>();
+        this.fields = new ArrayList<>();
     }
 
     public Stream<FieldEntry> fields() {

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debuginfo/DebugInfoProvider.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debuginfo/DebugInfoProvider.java
@@ -200,7 +200,7 @@ public interface DebugInfoProvider {
         int size();
     }
 
-    interface DebugMethodInfo extends DebugMemberInfo{
+    interface DebugMethodInfo extends DebugMemberInfo {
         /**
          * @return a string identifying the method parameters.
          */
@@ -220,6 +220,11 @@ public interface DebugInfoProvider {
          * @return the symbolNameForMethod string
          */
         String symbolNameForMethod();
+
+        /**
+         * @return true if this method has been compiled in as a deoptimization target
+         */
+        boolean isDeoptTarget();
     }
 
     /**
@@ -261,11 +266,6 @@ public interface DebugInfoProvider {
          *         to an empty frame
          */
         List<DebugFrameSizeChange> getFrameSizeChanges();
-
-        /**
-         * @return true if this method has been compiled in as a deoptimization target
-         */
-        boolean isDeoptTarget();
     }
 
     /**

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debuginfo/DebugInfoProvider.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debuginfo/DebugInfoProvider.java
@@ -200,32 +200,33 @@ public interface DebugInfoProvider {
         int size();
     }
 
-    interface DebugMethodInfo extends DebugMemberInfo {
+    interface DebugMethodInfo extends DebugMemberInfo{
+        /**
+         * @return a string identifying the method parameters.
+         */
+        String paramSignature();
+
+        /**
+         * @return an array of Strings identifying the method parameters.
+         */
         List<String> paramTypes();
 
+        /**
+         * @return an array of Strings with the method parameters' names.
+         */
         List<String> paramNames();
-    }
-
-    /**
-     * Access details of a specific compiled method.
-     */
-    interface DebugCodeInfo extends DebugFileInfo {
-        void debugContext(Consumer<DebugContext> action);
-
-        /**
-         * @return the fully qualified name of the class owning the compiled method.
-         */
-        String className();
-
-        /**
-         * @return the name of the compiled method including signature.
-         */
-        String methodName();
 
         /**
          * @return the symbolNameForMethod string
          */
         String symbolNameForMethod();
+    }
+
+    /**
+     * Access details of a specific compiled method.
+     */
+    interface DebugCodeInfo extends DebugMethodInfo {
+        void debugContext(Consumer<DebugContext> action);
 
         /**
          * @return the lowest address containing code generated for the method represented as an
@@ -251,16 +252,6 @@ public interface DebugInfoProvider {
         Stream<DebugLineInfo> lineInfoProvider();
 
         /**
-         * @return a string identifying the method parameters.
-         */
-        String paramSignature();
-
-        /**
-         * @return a string identifying the method return type.
-         */
-        String returnTypeName();
-
-        /**
          * @return the size of the method frame between prologue and epilogue.
          */
         int getFrameSize();
@@ -275,8 +266,6 @@ public interface DebugInfoProvider {
          * @return true if this method has been compiled in as a deoptimization target
          */
         boolean isDeoptTarget();
-
-        int getModifiers();
     }
 
     /**
@@ -302,22 +291,7 @@ public interface DebugInfoProvider {
      * Access details of code generated for a specific outer or inlined method at a given line
      * number.
      */
-    interface DebugLineInfo extends DebugFileInfo {
-        /**
-         * @return the fully qualified name of the class owning the outer or inlined method.
-         */
-        String className();
-
-        /**
-         * @return the name of the outer or inlined method including signature.
-         */
-        String methodName();
-
-        /**
-         * @return the symbolNameForMethod string
-         */
-        String symbolNameForMethod();
-
+    interface DebugLineInfo extends DebugMethodInfo {
         /**
          * @return the lowest address containing code generated for an outer or inlined code segment
          *         reported at this line represented as an offset into the code segment.

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfARangesSectionImpl.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfARangesSectionImpl.java
@@ -34,7 +34,7 @@ import com.oracle.objectfile.debugentry.PrimaryEntry;
 import com.oracle.objectfile.debugentry.Range;
 import org.graalvm.compiler.debug.DebugContext;
 
-import java.util.LinkedList;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -102,7 +102,7 @@ public class DwarfARangesSectionImpl extends DwarfSectionImpl {
              * Align to 2 * address size.
              */
             pos += DW_AR_HEADER_PAD_SIZE;
-            LinkedList<PrimaryEntry> classPrimaryEntries = classEntry.getPrimaryEntries();
+            List<PrimaryEntry> classPrimaryEntries = classEntry.getPrimaryEntries();
             if (classEntry.includesDeoptTarget()) {
                 /* Deopt targets are in a higher address range so delay emit for them. */
                 for (PrimaryEntry classPrimaryEntry : classPrimaryEntries) {
@@ -123,7 +123,7 @@ public class DwarfARangesSectionImpl extends DwarfSectionImpl {
                  * Align to 2 * address size.
                  */
                 pos += DW_AR_HEADER_PAD_SIZE;
-                LinkedList<PrimaryEntry> classPrimaryEntries = classEntry.getPrimaryEntries();
+                List<PrimaryEntry> classPrimaryEntries = classEntry.getPrimaryEntries();
                 for (PrimaryEntry classPrimaryEntry : classPrimaryEntries) {
                     if (classPrimaryEntry.getPrimary().isDeoptTarget()) {
                         pos += 2 * 8;
@@ -167,7 +167,7 @@ public class DwarfARangesSectionImpl extends DwarfSectionImpl {
             int lastpos = pos;
             int length = DW_AR_HEADER_SIZE + DW_AR_HEADER_PAD_SIZE - 4;
             int cuIndex = getCUIndex(classEntry);
-            LinkedList<PrimaryEntry> classPrimaryEntries = classEntry.getPrimaryEntries();
+            List<PrimaryEntry> classPrimaryEntries = classEntry.getPrimaryEntries();
             /*
              * Count only real methods, omitting deopt targets.
              */
@@ -218,7 +218,7 @@ public class DwarfARangesSectionImpl extends DwarfSectionImpl {
                 int lastpos = pos;
                 int length = DW_AR_HEADER_SIZE + DW_AR_HEADER_PAD_SIZE - 4;
                 int cuIndex = getDeoptCUIndex(classEntry);
-                LinkedList<PrimaryEntry> classPrimaryEntries = classEntry.getPrimaryEntries();
+                List<PrimaryEntry> classPrimaryEntries = classEntry.getPrimaryEntries();
                 /*
                  * Count only linkage stubs.
                  */

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfInfoSectionImpl.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfInfoSectionImpl.java
@@ -27,7 +27,7 @@
 package com.oracle.objectfile.elf.dwarf;
 
 import java.lang.reflect.Modifier;
-import java.util.LinkedList;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -439,7 +439,7 @@ public class DwarfInfoSectionImpl extends DwarfSectionImpl {
         String compilationDirectory = classEntry.getCachePath();
         log(context, "  [0x%08x]     comp_dir  0x%x (%s)", pos, debugStringIndex(compilationDirectory), compilationDirectory);
         pos = writeAttrStrp(compilationDirectory, buffer, pos);
-        LinkedList<PrimaryEntry> classPrimaryEntries = classEntry.getPrimaryEntries();
+        List<PrimaryEntry> classPrimaryEntries = classEntry.getPrimaryEntries();
         /*
          * Specify hi and lo for the compile unit which means we also need to ensure methods within
          * it are listed in ascending address order.
@@ -654,7 +654,7 @@ public class DwarfInfoSectionImpl extends DwarfSectionImpl {
 
     private int writeMethodDeclarations(DebugContext context, ClassEntry classEntry, byte[] buffer, int p) {
         int pos = p;
-        LinkedList<PrimaryEntry> classPrimaryEntries = classEntry.getPrimaryEntries();
+        List<PrimaryEntry> classPrimaryEntries = classEntry.getPrimaryEntries();
         for (PrimaryEntry primaryEntry : classPrimaryEntries) {
             Range range = primaryEntry.getPrimary();
             /*
@@ -913,7 +913,7 @@ public class DwarfInfoSectionImpl extends DwarfSectionImpl {
 
     private int writeMethodLocations(DebugContext context, ClassEntry classEntry, byte[] buffer, int p) {
         int pos = p;
-        LinkedList<PrimaryEntry> classPrimaryEntries = classEntry.getPrimaryEntries();
+        List<PrimaryEntry> classPrimaryEntries = classEntry.getPrimaryEntries();
         for (PrimaryEntry primaryEntry : classPrimaryEntries) {
             Range range = primaryEntry.getPrimary();
             if (!range.isDeoptTarget()) {
@@ -1181,7 +1181,7 @@ public class DwarfInfoSectionImpl extends DwarfSectionImpl {
     private int writeDeoptMethodsCU(DebugContext context, ClassEntry classEntry, byte[] buffer, int p) {
         int pos = p;
         assert classEntry.includesDeoptTarget();
-        LinkedList<PrimaryEntry> classPrimaryEntries = classEntry.getPrimaryEntries();
+        List<PrimaryEntry> classPrimaryEntries = classEntry.getPrimaryEntries();
         String fileName = classEntry.getFileName();
         int lineIndex = getLineIndex(classEntry);
         int abbrevCode = (fileName.length() > 0 ? DwarfDebugInfo.DW_ABBREV_CODE_class_unit1 : DwarfDebugInfo.DW_ABBREV_CODE_class_unit2);
@@ -1266,10 +1266,10 @@ public class DwarfInfoSectionImpl extends DwarfSectionImpl {
         }
     }
 
-    private static int findLo(LinkedList<PrimaryEntry> classPrimaryEntries, boolean isDeoptTargetCU) {
+    private static int findLo(List<PrimaryEntry> classPrimaryEntries, boolean isDeoptTargetCU) {
         if (!isDeoptTargetCU) {
             /* First entry is the one we want. */
-            return classPrimaryEntries.getFirst().getPrimary().getLo();
+            return classPrimaryEntries.get(0).getPrimary().getLo();
         } else {
             /* Need the first entry which is a deopt target. */
             for (PrimaryEntry primaryEntry : classPrimaryEntries) {
@@ -1284,10 +1284,10 @@ public class DwarfInfoSectionImpl extends DwarfSectionImpl {
         return 0;
     }
 
-    private static int findHi(LinkedList<PrimaryEntry> classPrimaryEntries, boolean includesDeoptTarget, boolean isDeoptTargetCU) {
+    private static int findHi(List<PrimaryEntry> classPrimaryEntries, boolean includesDeoptTarget, boolean isDeoptTargetCU) {
         if (isDeoptTargetCU || !includesDeoptTarget) {
             /* Either way the last entry is the one we want. */
-            return classPrimaryEntries.getLast().getPrimary().getHi();
+            return classPrimaryEntries.get(classPrimaryEntries.size() - 1).getPrimary().getHi();
         } else {
             /* Need the last entry which is not a deopt target. */
             int hi = 0;

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfInfoSectionImpl.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfInfoSectionImpl.java
@@ -724,18 +724,14 @@ public class DwarfInfoSectionImpl extends DwarfSectionImpl {
         if (!Modifier.isStatic(range.getModifiers())) {
             pos = writeMethodParameterDeclaration(context, "this", classEntry.getTypeName(), true, isSpecification, buffer, pos);
         }
-        String paramsString = range.getParamSignature();
-        if (!paramsString.isEmpty()) {
-            String[] paramTypes = paramsString.split(",");
-            for (int i = 0; i < paramTypes.length; i++) {
-                String paramName = uniqueDebugString("");
-                String paramTypeName = paramTypes[i].trim();
-                FileEntry fileEntry = range.getFileEntry();
-                if (fileEntry != null) {
-                    pos = writeMethodParameterDeclaration(context, paramName, paramTypeName, false, isSpecification, buffer, pos);
-                } else {
-                    pos = writeMethodParameterDeclaration(context, paramTypeName, paramTypeName, false, isSpecification, buffer, pos);
-                }
+        for (TypeEntry paramType : range.getParamTypes()) {
+            String paramTypeName = paramType.getTypeName();
+            String paramName = uniqueDebugString("");
+            FileEntry fileEntry = range.getFileEntry();
+            if (fileEntry != null) {
+                pos = writeMethodParameterDeclaration(context, paramName, paramTypeName, false, isSpecification, buffer, pos);
+            } else {
+                pos = writeMethodParameterDeclaration(context, paramTypeName, paramTypeName, false, isSpecification, buffer, pos);
             }
         }
         return pos;

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/image/NativeImageDebugInfoProvider.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/image/NativeImageDebugInfoProvider.java
@@ -30,6 +30,7 @@ import static com.oracle.objectfile.debuginfo.DebugInfoProvider.DebugFrameSizeCh
 
 import java.lang.reflect.Modifier;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
@@ -694,9 +695,10 @@ class NativeImageDebugInfoProvider implements DebugInfoProvider {
 
             @Override
             public List<String> paramTypes() {
-                LinkedList<String> paramTypes = new LinkedList<>();
                 Signature signature = hostedMethod.getSignature();
-                for (int i = 0; i < signature.getParameterCount(false); i++) {
+                int parameterCount = signature.getParameterCount(false);
+                List<String> paramTypes = new ArrayList<>(parameterCount);
+                for (int i = 0; i < parameterCount; i++) {
                     paramTypes.add(signature.getParameterType(i, null).toJavaName());
                 }
                 return paramTypes;
@@ -705,9 +707,10 @@ class NativeImageDebugInfoProvider implements DebugInfoProvider {
             @Override
             public List<String> paramNames() {
                 /* Can only provide blank names for now. */
-                LinkedList<String> paramNames = new LinkedList<>();
                 Signature signature = hostedMethod.getSignature();
-                for (int i = 0; i < signature.getParameterCount(false); i++) {
+                int parameterCount = signature.getParameterCount(false);
+                List<String> paramNames = new ArrayList<>(parameterCount);
+                for (int i = 0; i < parameterCount; i++) {
                     paramNames.add("");
                 }
                 return paramNames;
@@ -986,10 +989,11 @@ class NativeImageDebugInfoProvider implements DebugInfoProvider {
 
         @Override
         public List<String> paramTypes() {
-            LinkedList<String> paramTypes = new LinkedList<>();
             Signature signature = hostedMethod.getSignature();
-            for (int i = 0; i < signature.getParameterCount(false); i++) {
-                final JavaType parameterType = signature.getParameterType(i, null);
+            int parameterCount = signature.getParameterCount(false);
+            List<String> paramTypes = new ArrayList<>(parameterCount);
+            for (int i = 0; i < parameterCount; i++) {
+                JavaType parameterType = signature.getParameterType(i, null);
                 paramTypes.add(toJavaName(parameterType));
             }
             return paramTypes;
@@ -998,9 +1002,10 @@ class NativeImageDebugInfoProvider implements DebugInfoProvider {
         @Override
         public List<String> paramNames() {
             /* Can only provide blank names for now. */
-            LinkedList<String> paramNames = new LinkedList<>();
             Signature signature = hostedMethod.getSignature();
-            for (int i = 0; i < signature.getParameterCount(false); i++) {
+            int parameterCount = signature.getParameterCount(false);
+            List<String> paramNames = new ArrayList<>(parameterCount);
+            for (int i = 0; i < parameterCount; i++) {
                 paramNames.add("");
             }
             return paramNames;
@@ -1147,10 +1152,11 @@ class NativeImageDebugInfoProvider implements DebugInfoProvider {
 
         @Override
         public List<String> paramTypes() {
-            LinkedList<String> paramTypes = new LinkedList<>();
             Signature signature = method.getSignature();
-            for (int i = 0; i < signature.getParameterCount(false); i++) {
-                final JavaType parameterType = signature.getParameterType(i, null);
+            int parameterCount = signature.getParameterCount(false);
+            List<String> paramTypes = new ArrayList<>(parameterCount);
+            for (int i = 0; i < parameterCount; i++) {
+                JavaType parameterType = signature.getParameterType(i, null);
                 paramTypes.add(toJavaName(parameterType));
             }
             return paramTypes;
@@ -1159,9 +1165,10 @@ class NativeImageDebugInfoProvider implements DebugInfoProvider {
         @Override
         public List<String> paramNames() {
             /* Can only provide blank names for now. */
-            LinkedList<String> paramNames = new LinkedList<>();
             Signature signature = method.getSignature();
-            for (int i = 0; i < signature.getParameterCount(false); i++) {
+            int parameterCount = signature.getParameterCount(false);
+            List<String> paramNames = new ArrayList<>(parameterCount);
+            for (int i = 0; i < parameterCount; i++) {
                 paramNames.add("");
             }
             return paramNames;

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/image/NativeImageDebugInfoProvider.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/image/NativeImageDebugInfoProvider.java
@@ -1063,7 +1063,11 @@ class NativeImageDebugInfoProvider implements DebugInfoProvider {
 
         @Override
         public String ownerType() {
-            return method.format("%H");
+            if (method instanceof HostedMethod) {
+                return getJavaType((HostedMethod) method, true).toJavaName();
+            } else {
+                return method.getDeclaringClass().toJavaName();
+            }
         }
 
         @Override

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/image/NativeImageDebugInfoProvider.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/image/NativeImageDebugInfoProvider.java
@@ -723,7 +723,7 @@ class NativeImageDebugInfoProvider implements DebugInfoProvider {
 
             @Override
             public boolean isDeoptTarget() {
-                return name().endsWith(HostedMethod.METHOD_NAME_DEOPT_SUFFIX);
+                return hostedMethod.isDeoptTarget();
             }
 
             @Override
@@ -984,7 +984,7 @@ class NativeImageDebugInfoProvider implements DebugInfoProvider {
 
         @Override
         public boolean isDeoptTarget() {
-            return name().endsWith(HostedMethod.METHOD_NAME_DEOPT_SUFFIX);
+            return hostedMethod.isDeoptTarget();
         }
 
         @Override
@@ -1128,6 +1128,9 @@ class NativeImageDebugInfoProvider implements DebugInfoProvider {
 
         @Override
         public boolean isDeoptTarget() {
+            if (method instanceof HostedMethod) {
+                return ((HostedMethod) method).isDeoptTarget();
+            }
             return name().endsWith(HostedMethod.METHOD_NAME_DEOPT_SUFFIX);
         }
 

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/image/NativeImageDebugInfoProvider.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/image/NativeImageDebugInfoProvider.java
@@ -719,6 +719,11 @@ class NativeImageDebugInfoProvider implements DebugInfoProvider {
             }
 
             @Override
+            public boolean isDeoptTarget() {
+                return name().endsWith(HostedMethod.METHOD_NAME_DEOPT_SUFFIX);
+            }
+
+            @Override
             public int modifiers() {
                 return hostedMethod.getModifiers();
             }
@@ -1114,6 +1119,11 @@ class NativeImageDebugInfoProvider implements DebugInfoProvider {
         @Override
         public String symbolNameForMethod() {
             return NativeImage.localSymbolNameForMethod(method);
+        }
+
+        @Override
+        public boolean isDeoptTarget() {
+            return name().endsWith(HostedMethod.METHOD_NAME_DEOPT_SUFFIX);
         }
 
         @Override


### PR DESCRIPTION
As discussed in https://github.com/oracle/graal/pull/3290 this PR ensures that every debug `Range` is associated with a `MethodEntry`. This PR will enable us to continue working on https://github.com/oracle/graal/pull/2880 and associate the debug info for nested inline methods with `MethodEntry` instances.