### PR TITLE
Avoid implicit allocation in VMOperationControl

### DIFF
--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/thread/VMOperationControl.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/thread/VMOperationControl.java
@@ -864,6 +864,7 @@ public final class VMOperationControl {
      */
     private static class VMOpHistory {
         private final RingBuffer<VMOpStatusChange> history;
+        private static final RingBuffer.Consumer<VMOpStatusChange> PRINT_ENTRY = VMOpHistory::printEntry;
 
         @Platforms(Platform.HOSTED_ONLY.class)
         VMOpHistory() {
@@ -883,7 +884,7 @@ public final class VMOperationControl {
 
         public void print(Log log) {
             log.string("The ").signed(history.size()).string(" most recent VM operation status changes (oldest first):").indent(true);
-            history.foreach(log, VMOpHistory::printEntry);
+            history.foreach(log, PRINT_ENTRY);
             log.indent(false);
         }
 


### PR DESCRIPTION
Fixes https://github.com/graalvm/mandrel/issues/225

https://github.com/oracle/graal/commit/c323ce752d3611c3b39e99e0875849d6d91cb879 results in the following error when building Mandrel:

```
Error: @RestrictHeapAccess warning: Restricted method: 'GCImpl$CollectionVMOperation.operate(NativeVMOperationData)' calls 'VMOperationControl$VMOpHistory$$Lambda$ca91da068fbe395c2178d758d4d0702d388c9790.get$Lambda()' that violates restriction NO_ALLOCATION.
  [Path:
    app//com.oracle.svm.core.genscavenge.GCImpl$CollectionVMOperation.operate(GCImpl.java:1110)
    app//com.oracle.svm.core.genscavenge.GCImpl.access$200(GCImpl.java:97)
    app//com.oracle.svm.core.genscavenge.GCImpl.collectOperation(GCImpl.java:174)
    app//com.oracle.svm.core.genscavenge.ThreadLocalAllocation.disableAndFlushForAllThreads(ThreadLocalAllocation.java:282)
    app//com.oracle.svm.core.thread.VMOperation.guaranteeInProgress(VMOperation.java:133)
    app//com.oracle.svm.core.jdk.Target_com_oracle_svm_core_util_VMError.shouldNotReachHere(VMErrorSubstitutions.java:63)
    app//com.oracle.svm.core.jdk.VMErrorSubstitutions.shouldNotReachHere(VMErrorSubstitutions.java:104)
    app//com.oracle.svm.core.jdk.VMErrorSubstitutions.shutdown(VMErrorSubstitutions.java:111)
    app//com.oracle.svm.core.jdk.VMErrorSubstitutions.doShutdown(VMErrorSubstitutions.java:136)
    app//com.oracle.svm.core.SubstrateUtil.printDiagnostics(SubstrateUtil.java:304)
    app//com.oracle.svm.core.SubstrateUtil.printDiagnostics(SubstrateUtil.java:379)
    app//com.oracle.svm.core.SubstrateUtil.dumpRecentVMOperations(SubstrateUtil.java:563)
    app//com.oracle.svm.core.thread.VMOperationControl.logRecentEvents(VMOperationControl.java:212)
    app//com.oracle.svm.core.thread.VMOperationControl$VMOpHistory.print(VMOperationControl.java:886)
    com.oracle.svm.core.thread.VMOperationControl$VMOpHistory$$Lambda$ca91da068fbe395c2178d758d4d0702d388c9790.get$Lambda()]
com.oracle.svm.core.util.UserError$UserException: @RestrictHeapAccess warning: Restricted method: 'GCImpl$CollectionVMOperation.operate(NativeVMOperationData)' calls 'VMOperationControl$VMOpHistory$$Lambda$ca91da068fbe395c2178d758d4d0702d388c9790.get$Lambda()' that violates restriction NO_ALLOCATION.
  [Path:
    app//com.oracle.svm.core.genscavenge.GCImpl$CollectionVMOperation.operate(GCImpl.java:1110)
    app//com.oracle.svm.core.genscavenge.GCImpl.access$200(GCImpl.java:97)
    app//com.oracle.svm.core.genscavenge.GCImpl.collectOperation(GCImpl.java:174)
    app//com.oracle.svm.core.genscavenge.ThreadLocalAllocation.disableAndFlushForAllThreads(ThreadLocalAllocation.java:282)
    app//com.oracle.svm.core.thread.VMOperation.guaranteeInProgress(VMOperation.java:133)
    app//com.oracle.svm.core.jdk.Target_com_oracle_svm_core_util_VMError.shouldNotReachHere(VMErrorSubstitutions.java:63)
    app//com.oracle.svm.core.jdk.VMErrorSubstitutions.shouldNotReachHere(VMErrorSubstitutions.java:104)
    app//com.oracle.svm.core.jdk.VMErrorSubstitutions.shutdown(VMErrorSubstitutions.java:111)
    app//com.oracle.svm.core.jdk.VMErrorSubstitutions.doShutdown(VMErrorSubstitutions.java:136)
    app//com.oracle.svm.core.SubstrateUtil.printDiagnostics(SubstrateUtil.java:304)
    app//com.oracle.svm.core.SubstrateUtil.printDiagnostics(SubstrateUtil.java:379)
    app//com.oracle.svm.core.SubstrateUtil.dumpRecentVMOperations(SubstrateUtil.java:563)
    app//com.oracle.svm.core.thread.VMOperationControl.logRecentEvents(VMOperationControl.java:212)
    app//com.oracle.svm.core.thread.VMOperationControl$VMOpHistory.print(VMOperationControl.java:886)
    com.oracle.svm.core.thread.VMOperationControl$VMOpHistory$$Lambda$ca91da068fbe395c2178d758d4d0702d388c9790.get$Lambda()]
	at com.oracle.svm.core.util.UserError.abort(UserError.java:68)
	at com.oracle.svm.hosted.code.RestrictHeapAccessAnnotationChecker$RestrictHeapAccessWarningVisitor.postRestrictHeapAccessWarning(RestrictHeapAccessAnnotationChecker.java:201)
	at com.oracle.svm.hosted.code.RestrictHeapAccessAnnotationChecker$RestrictHeapAccessWarningVisitor.visitMethod(RestrictHeapAccessAnnotationChecker.java:144)
	at com.oracle.svm.hosted.code.RestrictHeapAccessAnnotationChecker.check(RestrictHeapAccessAnnotationChecker.java:77)
	at com.oracle.svm.hosted.code.CompileQueue.finish(CompileQueue.java:351)
	at com.oracle.svm.hosted.NativeImageGenerator.doRun(NativeImageGenerator.java:651)
	at com.oracle.svm.hosted.NativeImageGenerator.lambda$run$2(NativeImageGenerator.java:493)
	at java.base/java.util.concurrent.ForkJoinTask$AdaptedRunnableAction.exec(ForkJoinTask.java:1407)
	at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:290)
	at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1020)
	at java.base/java.util.concurrent.ForkJoinPool.scan(ForkJoinPool.java:1656)
	at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1594)
	at java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:183)
Error: Image build request failed with exit status 1
com.oracle.svm.driver.NativeImage$NativeImageError: Image build request failed with exit status 1
	at com.oracle.svm.driver.NativeImage.showError(NativeImage.java:1760)
	at com.oracle.svm.driver.NativeImage.build(NativeImage.java:1507)
	at com.oracle.svm.driver.NativeImage.performBuild(NativeImage.java:1468)
	at com.oracle.svm.driver.NativeImage.main(NativeImage.java:1455)
	at com.oracle.svm.driver.NativeImage$JDK9Plus.main(NativeImage.java:1947)
```

This PR fixes the issue by avoiding the implicit allocation in https://github.com/oracle/graal/blob/870e6fb68767e2d1d3e7561257cd87781d4bfd31/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/thread/VMOperationControl.java#L886