### PR TITLE
Native image bash launcher version and vm config

### DIFF
--- a/substratevm/src/com.oracle.svm.driver/src/com/oracle/svm/driver/DefaultOptionHandler.java
+++ b/substratevm/src/com.oracle.svm.driver/src/com/oracle/svm/driver/DefaultOptionHandler.java
@@ -85,7 +85,7 @@ class DefaultOptionHandler extends NativeImage.OptionHandler<NativeImage> {
                 if (NativeImage.IS_AOT) {
                     message = System.getProperty("java.vm.version");
                 } else {
-                    message = NativeImage.graalvmVersion;
+                    message = "native-image " + NativeImage.graalvmVersion + " " + NativeImage.graalvmConfig;
                 }
                 message += " (Java Version " + javaRuntimeVersion + ")";
                 nativeImage.showMessage(message);

--- a/substratevm/src/com.oracle.svm.driver/src/com/oracle/svm/driver/DefaultOptionHandler.java
+++ b/substratevm/src/com.oracle.svm.driver/src/com/oracle/svm/driver/DefaultOptionHandler.java
@@ -81,7 +81,12 @@ class DefaultOptionHandler extends NativeImage.OptionHandler<NativeImage> {
             case "--version":
                 args.poll();
                 singleArgumentCheck(args, headArg);
-                String message = System.getProperty("java.vm.version");
+                String message;
+                if (NativeImage.IS_AOT) {
+                    message = System.getProperty("java.vm.version");
+                } else {
+                    message = NativeImage.graalvmVersion;
+                }
                 message += " (Java Version " + javaRuntimeVersion + ")";
                 nativeImage.showMessage(message);
                 System.exit(0);

--- a/substratevm/src/com.oracle.svm.driver/src/com/oracle/svm/driver/NativeImage.java
+++ b/substratevm/src/com.oracle.svm.driver/src/com/oracle/svm/driver/NativeImage.java
@@ -112,6 +112,7 @@ public class NativeImage {
     }
 
     static final String graalvmVersion = System.getProperty("org.graalvm.version", "dev");
+    static final String graalvmConfig = System.getProperty("org.graalvm.config", "CE");
 
     private static Map<String, String[]> getCompilerFlags() {
         Map<String, String[]> result = new HashMap<>();
@@ -813,6 +814,7 @@ public class NativeImage {
             addImageBuilderJavaArgs("-Djava.awt.headless=true");
         }
         addImageBuilderJavaArgs("-Dorg.graalvm.version=" + graalvmVersion);
+        addImageBuilderJavaArgs("-Dorg.graalvm.config=" + graalvmConfig);
         addImageBuilderJavaArgs("-Dcom.oracle.graalvm.isaot=true");
         addImageBuilderJavaArgs("-Djava.system.class.loader=" + CUSTOM_SYSTEM_CLASS_LOADER);
 

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/VMFeature.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/VMFeature.java
@@ -58,7 +58,8 @@ public class VMFeature implements Feature {
     }
 
     protected VM createVMSingletonValue() {
-        return new VM("CE");
+        String config = System.getProperty("org.graalvm.config", "CE");
+        return new VM(config);
     }
 
     @Override


### PR DESCRIPTION
As discussed in https://github.com/graalvm/mandrel/issues/230 and https://github.com/oracle/graal/issues/3313 in 21.1-dev the `native-image` bash-launcher no longer prints a meaningful version.

This PR makes the bash launcher print:

```
native-image 21.1.0 Java 11 CE (Java Version 11.0.11+5-jvmci-21.1-b02)
```

for GraalVM CE and

```
native-image 21.1.0.0 Java 11 Mandrel Distribution (Java Version 11.0.10+9)
```

for Mandrel.

The corresponding **native** `native-image` binaries print:

```
GraalVM 21.1.0 Java 11 CE (Java Version 11.0.11+5-jvmci-21.1-b02)
```

for GraalVM CE and

```
GraalVM 21.1.0.0 Java 11 Mandrel Distribution (Java Version 11.0.10+9)
```

for Mandrel.