### PR TITLE
CI: Test with Quarkus main instead of Quarkus latest release

### DIFF
--- a/.github/workflows/quarkus.yml
+++ b/.github/workflows/quarkus.yml
@@ -41,7 +41,7 @@ jobs:
         path: ${{ env.MX_PATH }}
     - name: Get latest quarkus release
       run: |
-        export QUARKUS_VERSION=$(curl https://repo1.maven.org/maven2/io/quarkus/quarkus-bom/maven-metadata.xml | awk -F"[<>]" '/latest/ {print $3}')
+        export QUARKUS_VERSION=main #$(curl https://repo1.maven.org/maven2/io/quarkus/quarkus-bom/maven-metadata.xml | awk -F"[<>]" '/latest/ {print $3}')
         echo Getting Quarkus $QUARKUS_VERSION
         curl --output quarkus.tgz -sL https://api.github.com/repos/quarkusio/quarkus/tarball/$QUARKUS_VERSION
         mkdir ${QUARKUS_PATH}
@@ -116,7 +116,7 @@ jobs:
         run: tar -xzvf graalvm.tgz -C $(dirname ${GRAALVM_HOME})
       - name: Get latest quarkus release
         run: |
-          export QUARKUS_VERSION=$(curl https://repo1.maven.org/maven2/io/quarkus/quarkus-bom/maven-metadata.xml | awk -F"[<>]" '/latest/ {print $3}')
+          export QUARKUS_VERSION=main #$(curl https://repo1.maven.org/maven2/io/quarkus/quarkus-bom/maven-metadata.xml | awk -F"[<>]" '/latest/ {print $3}')
           echo Getting Quarkus $QUARKUS_VERSION
           curl --output quarkus.tgz -sL https://api.github.com/repos/quarkusio/quarkus/tarball/$QUARKUS_VERSION
           mkdir ${QUARKUS_PATH}


### PR DESCRIPTION
Quarkus current latest release is 1.13.1.Final which does not support the upcoming GraalVM 21.1. As discussed in https://github.com/oracle/graal/issues/3272 GraalVM 21.1 brings some changes that break several Quarkus tests. Quarkus is now preparing its 2.x release which is expected to take a bit longer than its usual releases. This patch makes the CI use Quarkus `main` branch instead of the latest release, as `main` is meant to work with the upcoming GraalVM 21.1 release.