### PR TITLE
Fix for cl.exe check for non-english languages.

### DIFF
--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/c/codegen/CCompilerInvoker.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/c/codegen/CCompilerInvoker.java
@@ -147,7 +147,9 @@ public abstract class CCompilerInvoker {
                     scanner.next();
                     targetArch = scanner.next();
                 }
-                if (scanner.findInLine("Microsoft.*\\(R\\) C/C\\+\\+") == null) {
+                /* Some languages has "… Microsoft (R) C/C++ … ##.##.#####" other has "…C/C++ … Microsoft (R) … ##.##.#####" in cl.exe banner. */
+                if (scanner.findInLine("Microsoft.*\\(R\\) C/C\\+\\+") == null &&
+                        scanner.findInLine("C/C\\+\\+.*Microsoft.*\\(R\\)") == null) {
                     return null;
                 }
                 scanner.useDelimiter("\\D");

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/c/codegen/CCompilerInvoker.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/c/codegen/CCompilerInvoker.java
@@ -147,7 +147,7 @@ public abstract class CCompilerInvoker {
                     scanner.next();
                     targetArch = scanner.next();
                 }
-                /* Some languages has "… Microsoft (R) C/C++ … ##.##.#####" other has "…C/C++ … Microsoft (R) … ##.##.#####" in cl.exe banner. */
+                /* Some languages has "... Microsoft (R) C/C++ ... ##.##.#####" other has "...C/C++ ... Microsoft (R) ... ##.##.#####" in cl.exe banner. */
                 if (scanner.findInLine("Microsoft.*\\(R\\) C/C\\+\\+") == null &&
                         scanner.findInLine("C/C\\+\\+.*Microsoft.*\\(R\\)") == null) {
                     return null;

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/c/codegen/CCompilerInvoker.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/c/codegen/CCompilerInvoker.java
@@ -147,9 +147,12 @@ public abstract class CCompilerInvoker {
                     scanner.next();
                     targetArch = scanner.next();
                 }
-                /* Some languages has "... Microsoft (R) C/C++ ... ##.##.#####" other has "...C/C++ ... Microsoft (R) ... ##.##.#####" in cl.exe banner. */
+                /*
+                 * Some languages has "... Microsoft (R) C/C++ ... ##.##.#####" other has
+                 * "...C/C++ ... Microsoft (R) ... ##.##.#####" in cl.exe banner.
+                 */
                 if (scanner.findInLine("Microsoft.*\\(R\\) C/C\\+\\+") == null &&
-                        scanner.findInLine("C/C\\+\\+.*Microsoft.*\\(R\\)") == null) {
+                                scanner.findInLine("C/C\\+\\+.*Microsoft.*\\(R\\)") == null) {
                     return null;
                 }
                 scanner.useDelimiter("\\D");


### PR DESCRIPTION
cl.exe prints its banner in system default language. In some languages, there is word "Microsoft" before "C/C++", in other languages there is "C/C++" before "Microsoft".

Fixes #3161.