### PR TITLE
Native-image: Add support of iOS simulator (IOS_AMD64)

### DIFF
--- a/sdk/src/org.graalvm.nativeimage/snapshot.sigtest
+++ b/sdk/src/org.graalvm.nativeimage/snapshot.sigtest
@@ -219,6 +219,7 @@ innr public final static DARWIN_AARCH64
 innr public final static DARWIN_AMD64
 innr public final static HOSTED_ONLY
 innr public final static IOS_AARCH64
+innr public final static IOS_AMD64
 innr public final static LINUX_AARCH64
 innr public final static WINDOWS_AMD64
 innr public static LINUX_AMD64
@@ -281,6 +282,13 @@ CLSS public final static org.graalvm.nativeimage.Platform$IOS_AARCH64
  outer org.graalvm.nativeimage.Platform
 cons public init()
 intf org.graalvm.nativeimage.Platform$AARCH64
+intf org.graalvm.nativeimage.Platform$IOS
+supr java.lang.Object
+
+CLSS public final static org.graalvm.nativeimage.Platform$IOS_AMD64
+ outer org.graalvm.nativeimage.Platform
+cons public init()
+intf org.graalvm.nativeimage.Platform$AMD64
 intf org.graalvm.nativeimage.Platform$IOS
 supr java.lang.Object
 

--- a/sdk/src/org.graalvm.nativeimage/src/META-INF/services/org.graalvm.nativeimage.Platform
+++ b/sdk/src/org.graalvm.nativeimage/src/META-INF/services/org.graalvm.nativeimage.Platform
@@ -3,5 +3,6 @@ org.graalvm.nativeimage.Platform$LINUX_AARCH64
 org.graalvm.nativeimage.Platform$ANDROID_AARCH64
 org.graalvm.nativeimage.Platform$DARWIN_AMD64
 org.graalvm.nativeimage.Platform$DARWIN_AARCH64
+org.graalvm.nativeimage.Platform$IOS_AMD64
 org.graalvm.nativeimage.Platform$IOS_AARCH64
 org.graalvm.nativeimage.Platform$WINDOWS_AMD64

--- a/sdk/src/org.graalvm.nativeimage/src/org/graalvm/nativeimage/Platform.java
+++ b/sdk/src/org.graalvm.nativeimage/src/org/graalvm/nativeimage/Platform.java
@@ -337,6 +337,22 @@ public interface Platform {
     }
 
     /**
+     * Supported leaf platform: iOS on x86 64-bit.
+     *
+     * @since 21.1
+     */
+    final class IOS_AMD64 implements IOS, AMD64 {
+
+        /**
+         * Instantiates a marker instance of this platform.
+         *
+         * @since 21.1
+         */
+        public IOS_AMD64() {
+        }
+    }
+
+    /**
      * Supported leaf platform: Windows on x86 64-bit.
      *
      * @since 19.0

--- a/sdk/src/org.graalvm.nativeimage/src/org/graalvm/nativeimage/Platform.java
+++ b/sdk/src/org.graalvm.nativeimage/src/org/graalvm/nativeimage/Platform.java
@@ -339,14 +339,14 @@ public interface Platform {
     /**
      * Supported leaf platform: iOS on x86 64-bit.
      *
-     * @since 21.1
+     * @since 21.3
      */
     final class IOS_AMD64 implements IOS, AMD64 {
 
         /**
          * Instantiates a marker instance of this platform.
          *
-         * @since 21.1
+         * @since 21.3
          */
         public IOS_AMD64() {
         }

--- a/substratevm/src/com.oracle.svm.core.graal.llvm/src/com/oracle/svm/core/graal/llvm/util/LLVMTargetSpecific.java
+++ b/substratevm/src/com.oracle.svm.core.graal.llvm/src/com/oracle/svm/core/graal/llvm/util/LLVMTargetSpecific.java
@@ -158,7 +158,12 @@ class LLVMAMD64TargetSpecificFeature implements Feature {
 
             @Override
             public List<String> getLLCAdditionalOptions() {
-                return Collections.singletonList("-no-x86-call-frame-opt");
+                List<String> list = new ArrayList<>();
+                list.add("-no-x86-call-frame-opt");
+                if (Platform.includedIn(Platform.IOS.class)) {
+                    list.add("-mtriple=x86_64-ios");
+                }
+                return list;
             }
         });
     }


### PR DESCRIPTION
This change is pretty self-explanatory: adds the IOS_AMD64 platform to native-image.
I currently have a working hello world running in ios simulator, the idea is same as https://github.com/gluonhq/substrate, with static libs build for ios simulator.