### PR TITLE
Add intrinsics for substring search and SIMD implementation for char search using String.indexOf on AAarch64

### DIFF
--- a/compiler/src/org.graalvm.compiler.asm.aarch64.test/src/org/graalvm/compiler/asm/aarch64/test/AArch64InstructionEncodingTest.java
+++ b/compiler/src/org.graalvm.compiler.asm.aarch64.test/src/org/graalvm/compiler/asm/aarch64/test/AArch64InstructionEncodingTest.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2019, Arm Limited. All rights reserved.
+ * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2021 Arm Limited. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -94,6 +94,20 @@ public class AArch64InstructionEncodingTest extends GraalTest {
         }
     }
 
+    private class LoadvEncodingTestCase extends AArch64InstructionEncodingTestCase {
+        LoadvEncodingTestCase(int expected, ASIMDSize size, Register dst, Register src, Register offset) {
+            super(expected);
+            assembler.neon.loadV1(size, dst, src, offset);
+            closeAssembler();
+        }
+
+        LoadvEncodingTestCase(int expected, ASIMDSize size, Register dst, Register src, boolean postIndexedImm) {
+            super(expected);
+            assembler.neon.loadV1(size, dst, src, postIndexedImm);
+            closeAssembler();
+        }
+    }
+
     private static final int invalidInstructionCode = 0x00000000;
 
     private void assertWrapper(AArch64InstructionEncodingTestCase testCase) {
@@ -146,5 +160,15 @@ public class AArch64InstructionEncodingTest extends GraalTest {
     @SuppressWarnings("unused")
     public void testUmovInvalidSrcIdx() {
         new UmovEncodingTestCase(invalidInstructionCode, ElementSize.DoubleWord, AArch64.r0, 2, AArch64.v0);
+    }
+
+    @Test
+    public void testLoadv() {
+        assertWrapper(new LoadvEncodingTestCase(0x70404c, ASIMDSize.FullReg, AArch64.v0, AArch64.r0, false));
+        assertWrapper(new LoadvEncodingTestCase(0x70df4c, ASIMDSize.FullReg, AArch64.v0, AArch64.r0, true));
+        assertWrapper(new LoadvEncodingTestCase(0x70400c, ASIMDSize.HalfReg, AArch64.v0, AArch64.r0, false));
+        assertWrapper(new LoadvEncodingTestCase(0x70df0c, ASIMDSize.HalfReg, AArch64.v0, AArch64.r0, true));
+        assertWrapper(new LoadvEncodingTestCase(0x70c14c, ASIMDSize.FullReg, AArch64.v0, AArch64.r0, AArch64.r1));
+        assertWrapper(new LoadvEncodingTestCase(0x70c10c, ASIMDSize.HalfReg, AArch64.v0, AArch64.r0, AArch64.r1));
     }
 }

--- a/compiler/src/org.graalvm.compiler.asm.aarch64/src/org/graalvm/compiler/asm/aarch64/AArch64ASIMDAssembler.java
+++ b/compiler/src/org.graalvm.compiler.asm.aarch64/src/org/graalvm/compiler/asm/aarch64/AArch64ASIMDAssembler.java
@@ -518,6 +518,8 @@ public abstract class AArch64ASIMDAssembler {
     private static final int UBit = 0b1 << 29;
 
     public enum ASIMDInstruction {
+        /* Advanced SIMD load/store multiple structures (C4-296). */
+        LD1(0b0111 << 12),
 
         /* Cryptographic AES (C4-341). */
         AESE(0b00100 << 12),
@@ -592,6 +594,7 @@ public abstract class AArch64ASIMDAssembler {
         CMTST(0b10001 << 11),
         MLA(0b10010 << 11),
         MUL(0b10011 << 11),
+        ADDP(0b10111 << 11),
         /* size 0x */
         FMLA(0b11001 << 11),
         FADD(0b11010 << 11),
@@ -729,6 +732,11 @@ public abstract class AArch64ASIMDAssembler {
         emitInt(instr.encoding | baseEncoding | qBit(setQBit) | imm5Encoding | rd(dst) | rs1(src));
     }
 
+    private void loadEncoding(ASIMDInstruction instr, boolean setQBit, Register dst, Register src, int postIndexEncoding) {
+        int baseEncoding = 0b0_0_0011000_1_000000_0010_00_00000_00000;
+        emitInt(instr.encoding | baseEncoding | qBit(setQBit) | rd(dst) | rs1(src) | postIndexEncoding);
+    }
+
     private void twoRegMiscEncoding(ASIMDInstruction instr, ASIMDSize size, int eSizeEncoding, Register dst, Register src) {
         twoRegMiscEncoding(instr, size == ASIMDSize.FullReg, eSizeEncoding, dst, src);
     }
@@ -770,6 +778,14 @@ public abstract class AArch64ASIMDAssembler {
         assert (imm7 & 0b0000_111) != imm7;
         int baseEncoding = 0b0_0_0_011110_0000_000_00000_1_00000_00000;
         emitInt(instr.encoding | baseEncoding | qBit(setQBit) | imm7 << 16 | rd(dst) | rs1(src));
+    }
+
+    private static int getLoadPostIndexEncodingReg(Register offset) {
+        return (0b1 << 23) | rs2(offset);
+    }
+
+    private static int getLoadPostIndexEncodingImm(boolean postIndexed) {
+        return postIndexed ? (0b1 << 23) | (0b11111 << 16) : 0;
     }
 
     /**
@@ -830,6 +846,28 @@ public abstract class AArch64ASIMDAssembler {
         assert src2.getRegisterCategory().equals(SIMD);
 
         threeSameEncoding(ASIMDInstruction.ADD, size, elemSizeXX(eSize), dst, src1, src2);
+    }
+
+    /**
+     * C7.2.5 Add pairwise vector.<br>
+     * <p>
+     * From the manual: "This instruction creates a vector by concatenating the vector elements of
+     * the first source SIMD&FP register after the vector elements of the second source SIMD&FP
+     * register, reads each pair of adjacent vector elements from the concatenated vector, adds each
+     * pair of values together, places the result into a vector, and writes the vector to the
+     * destination SIMD&FP register."
+     *
+     * @param size register size.
+     * @param elementSize width of each addition operand.
+     * @param dst SIMD register.
+     * @param src1 SIMD register.
+     * @param src2 SIMD register.
+     */
+    public void addpVV(ASIMDSize size, ElementSize elementSize, Register dst, Register src1, Register src2) {
+        assert dst.getRegisterCategory().equals(SIMD);
+        assert src1.getRegisterCategory().equals(SIMD);
+        assert src2.getRegisterCategory().equals(SIMD);
+        threeSameEncoding(ASIMDInstruction.ADDP, size, elemSizeXX(elementSize), dst, src1, src2);
     }
 
     /**
@@ -2008,6 +2046,55 @@ public abstract class AArch64ASIMDAssembler {
      */
     public void mvniVI(ASIMDSize size, Register dst, long imm) {
         modifiedImmEncoding(ImmediateOp.MVNI, size, dst, imm);
+    }
+
+    /**
+     * C7.2.178 LD1 (multiple structures) with an optional post-index immediate offset.<br>
+     * This instruction loads multiple single-element structures to one SIMD&FP register and
+     * optionally increments the address by the number of bytes read. Note that LD1 instruction also
+     * supports loading multiple single-element structures to two, three or four registers.
+     * Currently, this method supports loading only one SIMD&FP register.
+     *
+     * <code>for i in 0..n-1<br>
+     * do dst[i] = value_at_address(src + i) endfor<br>
+     * src = src + n</code>
+     *
+     * @param size register size.
+     * @param dst SIMD register.
+     * @param src CPU register.
+     * @param postIndexedImm boolean value signify if the address register should be incremented
+     *            after a load completes.
+     */
+    public void loadV1(ASIMDSize size, Register dst, Register src, boolean postIndexedImm) {
+        // TODO: Add support for loading multiple structures using LD1
+        loadV1(size, dst, src, getLoadPostIndexEncodingImm(postIndexedImm));
+    }
+
+    /**
+     * C7.2.178 LD1 (multiple structures) with post-index register offset.<br>
+     * This instruction loads multiple single-element structures to one SIMD&FP register and later
+     * increments the address by the value specified in offset register. Note that LD1 instruction
+     * also supports loading multiple single-element structures to two, three or four registers.
+     * Currently, this method supports loading only one SIMD&FP register.
+     *
+     * <code>for i in 0..n-1<br>
+     * do dst[i] = value_at_address(src + i) endfor<br>
+     * src = src + offset</code>
+     *
+     * @param size register size.
+     * @param dst SIMD register.
+     * @param src CPU register.
+     * @param offset CPU register with post-index value.
+     */
+    public void loadV1(ASIMDSize size, Register dst, Register src, Register offset) {
+        // TODO: Add support for loading multiple structures using LD1
+        loadV1(size, dst, src, getLoadPostIndexEncodingReg(offset));
+    }
+
+    private void loadV1(ASIMDSize size, Register dst, Register src, int postIndexOffset) {
+        assert dst.getRegisterCategory().equals(SIMD);
+        assert src.getRegisterCategory().equals(CPU);
+        loadEncoding(ASIMDInstruction.LD1, size == ASIMDSize.FullReg, dst, src, postIndexOffset);
     }
 
     /**

--- a/compiler/src/org.graalvm.compiler.asm.aarch64/src/org/graalvm/compiler/asm/aarch64/AArch64MacroAssembler.java
+++ b/compiler/src/org.graalvm.compiler.asm.aarch64/src/org/graalvm/compiler/asm/aarch64/AArch64MacroAssembler.java
@@ -1419,6 +1419,18 @@ public class AArch64MacroAssembler extends AArch64Assembler {
     }
 
     /**
+     * dst = src & (~imm).
+     *
+     * @param size register size. Has to be 32 or 64.
+     * @param dst general purpose register. May not be null or stackpointer.
+     * @param src general purpose register. May not be null or stackpointer.
+     * @param imm immediate to encode.
+     */
+    public void bic(int size, Register dst, Register src, long imm) {
+        super.and(size, dst, src, ~(imm));
+    }
+
+    /**
      * dst = src1 ^ (~src2).
      *
      * @param size register size. Has to be 32 or 64.

--- a/compiler/src/org.graalvm.compiler.core.aarch64/src/org/graalvm/compiler/core/aarch64/AArch64LIRGenerator.java
+++ b/compiler/src/org.graalvm.compiler.core.aarch64/src/org/graalvm/compiler/core/aarch64/AArch64LIRGenerator.java
@@ -531,7 +531,8 @@ public abstract class AArch64LIRGenerator extends LIRGenerator {
     public Variable emitArrayIndexOf(int arrayBaseOffset, JavaKind valueKind, boolean findTwoConsecutive, Value arrayPointer, Value arrayLength, Value fromIndex, Value... searchValues) {
         assert searchValues.length == 1;
         Variable result = newVariable(LIRKind.value(AArch64Kind.DWORD));
-        append(new AArch64ArrayIndexOfOp(arrayBaseOffset, valueKind, this, result, asAllocatable(arrayPointer), asAllocatable(arrayLength), asAllocatable(fromIndex), asAllocatable(searchValues[0])));
+        append(new AArch64ArrayIndexOfOp(arrayBaseOffset, valueKind, findTwoConsecutive, this, result, asAllocatable(arrayPointer), asAllocatable(arrayLength), asAllocatable(fromIndex),
+                        asAllocatable(searchValues[0])));
         return result;
     }
 

--- a/compiler/src/org.graalvm.compiler.hotspot.amd64/src/org/graalvm/compiler/hotspot/amd64/AMD64HotSpotForeignCallsProvider.java
+++ b/compiler/src/org.graalvm.compiler.hotspot.amd64/src/org/graalvm/compiler/hotspot/amd64/AMD64HotSpotForeignCallsProvider.java
@@ -47,14 +47,12 @@ import static org.graalvm.compiler.replacements.nodes.UnaryMathIntrinsicNode.Una
 import static org.graalvm.compiler.replacements.nodes.UnaryMathIntrinsicNode.UnaryOperation.TAN;
 
 import org.graalvm.compiler.core.common.LIRKind;
-import org.graalvm.compiler.hotspot.ArrayIndexOfStub;
 import org.graalvm.compiler.hotspot.GraalHotSpotVMConfig;
 import org.graalvm.compiler.hotspot.HotSpotForeignCallLinkageImpl;
 import org.graalvm.compiler.hotspot.HotSpotGraalRuntimeProvider;
 import org.graalvm.compiler.hotspot.meta.HotSpotHostForeignCallsProvider;
 import org.graalvm.compiler.hotspot.meta.HotSpotProviders;
 import org.graalvm.compiler.options.OptionValues;
-import org.graalvm.compiler.replacements.ArrayIndexOf;
 import org.graalvm.compiler.word.WordTypes;
 
 import jdk.vm.ci.code.CallingConvention;
@@ -98,33 +96,6 @@ public class AMD64HotSpotForeignCallsProvider extends HotSpotHostForeignCallsPro
         if (config.useCRC32CIntrinsics) {
             registerForeignCall(UPDATE_BYTES_CRC32C, config.updateBytesCRC32C, NativeCall);
         }
-
-        link(new ArrayIndexOfStub(options, providers,
-                        registerStubCall(ArrayIndexOf.STUB_INDEX_OF_TWO_CONSECUTIVE_BYTES, LEAF, REEXECUTABLE, COMPUTES_REGISTERS_KILLED, NO_LOCATIONS)));
-        link(new ArrayIndexOfStub(options, providers,
-                        registerStubCall(ArrayIndexOf.STUB_INDEX_OF_TWO_CONSECUTIVE_CHARS, LEAF, REEXECUTABLE, COMPUTES_REGISTERS_KILLED, NO_LOCATIONS)));
-        link(new ArrayIndexOfStub(options, providers,
-                        registerStubCall(ArrayIndexOf.STUB_INDEX_OF_TWO_CONSECUTIVE_CHARS_COMPACT, LEAF, REEXECUTABLE, COMPUTES_REGISTERS_KILLED, NO_LOCATIONS)));
-        link(new ArrayIndexOfStub(options, providers,
-                        registerStubCall(ArrayIndexOf.STUB_INDEX_OF_2_BYTES, LEAF, REEXECUTABLE, COMPUTES_REGISTERS_KILLED, NO_LOCATIONS)));
-        link(new ArrayIndexOfStub(options, providers,
-                        registerStubCall(ArrayIndexOf.STUB_INDEX_OF_3_BYTES, LEAF, REEXECUTABLE, COMPUTES_REGISTERS_KILLED, NO_LOCATIONS)));
-        link(new ArrayIndexOfStub(options, providers,
-                        registerStubCall(ArrayIndexOf.STUB_INDEX_OF_4_BYTES, LEAF, REEXECUTABLE, COMPUTES_REGISTERS_KILLED, NO_LOCATIONS)));
-        link(new ArrayIndexOfStub(options, providers,
-                        registerStubCall(ArrayIndexOf.STUB_INDEX_OF_1_CHAR, LEAF, REEXECUTABLE, COMPUTES_REGISTERS_KILLED, NO_LOCATIONS)));
-        link(new ArrayIndexOfStub(options, providers,
-                        registerStubCall(ArrayIndexOf.STUB_INDEX_OF_2_CHARS, LEAF, REEXECUTABLE, COMPUTES_REGISTERS_KILLED, NO_LOCATIONS)));
-        link(new ArrayIndexOfStub(options, providers,
-                        registerStubCall(ArrayIndexOf.STUB_INDEX_OF_3_CHARS, LEAF, REEXECUTABLE, COMPUTES_REGISTERS_KILLED, NO_LOCATIONS)));
-        link(new ArrayIndexOfStub(options, providers,
-                        registerStubCall(ArrayIndexOf.STUB_INDEX_OF_4_CHARS, LEAF, REEXECUTABLE, COMPUTES_REGISTERS_KILLED, NO_LOCATIONS)));
-        link(new ArrayIndexOfStub(options, providers,
-                        registerStubCall(ArrayIndexOf.STUB_INDEX_OF_2_CHARS_COMPACT, LEAF, REEXECUTABLE, COMPUTES_REGISTERS_KILLED, NO_LOCATIONS)));
-        link(new ArrayIndexOfStub(options, providers,
-                        registerStubCall(ArrayIndexOf.STUB_INDEX_OF_3_CHARS_COMPACT, LEAF, REEXECUTABLE, COMPUTES_REGISTERS_KILLED, NO_LOCATIONS)));
-        link(new ArrayIndexOfStub(options, providers,
-                        registerStubCall(ArrayIndexOf.STUB_INDEX_OF_4_CHARS_COMPACT, LEAF, REEXECUTABLE, COMPUTES_REGISTERS_KILLED, NO_LOCATIONS)));
 
         link(new AMD64ArrayEqualsStub(AMD64ArrayEqualsStub.STUB_BOOLEAN_ARRAY_EQUALS, options, providers,
                         registerStubCall(AMD64ArrayEqualsStub.STUB_BOOLEAN_ARRAY_EQUALS, COMPUTES_REGISTERS_KILLED)));

--- a/compiler/src/org.graalvm.compiler.hotspot/src/org/graalvm/compiler/hotspot/meta/HotSpotHostForeignCallsProvider.java
+++ b/compiler/src/org.graalvm.compiler.hotspot/src/org/graalvm/compiler/hotspot/meta/HotSpotHostForeignCallsProvider.java
@@ -422,6 +422,33 @@ public abstract class HotSpotHostForeignCallsProvider extends HotSpotForeignCall
                         registerStubCall(ArrayIndexOf.STUB_INDEX_OF_1_BYTE, LEAF, REEXECUTABLE, COMPUTES_REGISTERS_KILLED, NO_LOCATIONS)));
         link(new ArrayIndexOfStub(options, providers,
                         registerStubCall(ArrayIndexOf.STUB_INDEX_OF_1_CHAR_COMPACT, LEAF, REEXECUTABLE, COMPUTES_REGISTERS_KILLED, NO_LOCATIONS)));
+        link(new ArrayIndexOfStub(options, providers,
+                        registerStubCall(ArrayIndexOf.STUB_INDEX_OF_TWO_CONSECUTIVE_BYTES, LEAF, REEXECUTABLE, COMPUTES_REGISTERS_KILLED, NO_LOCATIONS)));
+        link(new ArrayIndexOfStub(options, providers,
+                        registerStubCall(ArrayIndexOf.STUB_INDEX_OF_TWO_CONSECUTIVE_CHARS, LEAF, REEXECUTABLE, COMPUTES_REGISTERS_KILLED, NO_LOCATIONS)));
+        link(new ArrayIndexOfStub(options, providers,
+                        registerStubCall(ArrayIndexOf.STUB_INDEX_OF_TWO_CONSECUTIVE_CHARS_COMPACT, LEAF, REEXECUTABLE, COMPUTES_REGISTERS_KILLED, NO_LOCATIONS)));
+        link(new ArrayIndexOfStub(options, providers,
+                        registerStubCall(ArrayIndexOf.STUB_INDEX_OF_2_BYTES, LEAF, REEXECUTABLE, COMPUTES_REGISTERS_KILLED, NO_LOCATIONS)));
+        link(new ArrayIndexOfStub(options, providers,
+                        registerStubCall(ArrayIndexOf.STUB_INDEX_OF_3_BYTES, LEAF, REEXECUTABLE, COMPUTES_REGISTERS_KILLED, NO_LOCATIONS)));
+        link(new ArrayIndexOfStub(options, providers,
+                        registerStubCall(ArrayIndexOf.STUB_INDEX_OF_4_BYTES, LEAF, REEXECUTABLE, COMPUTES_REGISTERS_KILLED, NO_LOCATIONS)));
+        link(new ArrayIndexOfStub(options, providers,
+                        registerStubCall(ArrayIndexOf.STUB_INDEX_OF_1_CHAR, LEAF, REEXECUTABLE, COMPUTES_REGISTERS_KILLED, NO_LOCATIONS)));
+        link(new ArrayIndexOfStub(options, providers,
+                        registerStubCall(ArrayIndexOf.STUB_INDEX_OF_2_CHARS, LEAF, REEXECUTABLE, COMPUTES_REGISTERS_KILLED, NO_LOCATIONS)));
+        link(new ArrayIndexOfStub(options, providers,
+                        registerStubCall(ArrayIndexOf.STUB_INDEX_OF_3_CHARS, LEAF, REEXECUTABLE, COMPUTES_REGISTERS_KILLED, NO_LOCATIONS)));
+        link(new ArrayIndexOfStub(options, providers,
+                        registerStubCall(ArrayIndexOf.STUB_INDEX_OF_4_CHARS, LEAF, REEXECUTABLE, COMPUTES_REGISTERS_KILLED, NO_LOCATIONS)));
+        link(new ArrayIndexOfStub(options, providers,
+                        registerStubCall(ArrayIndexOf.STUB_INDEX_OF_2_CHARS_COMPACT, LEAF, REEXECUTABLE, COMPUTES_REGISTERS_KILLED, NO_LOCATIONS)));
+        link(new ArrayIndexOfStub(options, providers,
+                        registerStubCall(ArrayIndexOf.STUB_INDEX_OF_3_CHARS_COMPACT, LEAF, REEXECUTABLE, COMPUTES_REGISTERS_KILLED, NO_LOCATIONS)));
+        link(new ArrayIndexOfStub(options, providers,
+                        registerStubCall(ArrayIndexOf.STUB_INDEX_OF_4_CHARS_COMPACT, LEAF, REEXECUTABLE, COMPUTES_REGISTERS_KILLED, NO_LOCATIONS)));
+
         link(new ExceptionHandlerStub(options, providers, foreignCalls.get(EXCEPTION_HANDLER.getSignature())));
         link(new UnwindExceptionToCallerStub(options, providers,
                         registerStubCall(UNWIND_EXCEPTION_TO_CALLER, DESTROYS_ALL_CALLER_SAVE_REGISTERS)));

--- a/compiler/src/org.graalvm.compiler.lir.aarch64/src/org/graalvm/compiler/lir/aarch64/AArch64ArrayIndexOfOp.java
+++ b/compiler/src/org.graalvm.compiler.lir.aarch64/src/org/graalvm/compiler/lir/aarch64/AArch64ArrayIndexOfOp.java
@@ -50,6 +50,7 @@ public final class AArch64ArrayIndexOfOp extends AArch64LIRInstruction {
     public static final LIRInstructionClass<AArch64ArrayIndexOfOp> TYPE = LIRInstructionClass.create(AArch64ArrayIndexOfOp.class);
 
     private final boolean isUTF16;
+    private final boolean findTwoConsecutive;
     private final int arrayBaseOffset;
 
     @Def({REG}) protected Value resultValue;
@@ -62,11 +63,13 @@ public final class AArch64ArrayIndexOfOp extends AArch64LIRInstruction {
     @Temp({REG}) protected Value temp3;
     @Temp({REG}) protected Value temp4;
 
-    public AArch64ArrayIndexOfOp(int arrayBaseOffset, JavaKind valueKind, LIRGeneratorTool tool, Value result, Value arrayPtr, Value arrayLength, Value fromIndex, Value searchValue) {
+    public AArch64ArrayIndexOfOp(int arrayBaseOffset, JavaKind valueKind, boolean findTwoConsecutive, LIRGeneratorTool tool, Value result, Value arrayPtr, Value arrayLength, Value fromIndex,
+                    Value searchValue) {
         super(TYPE);
         assert byteMode(valueKind) || charMode(valueKind);
         this.arrayBaseOffset = arrayBaseOffset;
         this.isUTF16 = charMode(valueKind);
+        this.findTwoConsecutive = findTwoConsecutive;
         resultValue = result;
         arrayPtrValue = arrayPtr;
         arrayLengthValue = arrayLength;
@@ -106,6 +109,7 @@ public final class AArch64ArrayIndexOfOp extends AArch64LIRInstruction {
         Label end = new Label();
 
         final int chunkSize = 8;
+        final int charsToRead = findTwoConsecutive ? 2 : 1;
         int charSize;
         int shiftSize;
         long bitMask01;
@@ -124,6 +128,14 @@ public final class AArch64ArrayIndexOfOp extends AArch64LIRInstruction {
             bitMask7f = 0x7fff7fff7fff7fffL;
         }
 
+        /*
+         * @formatter:off
+         * The arguments satisfy the following constraints:
+         *  1. 0 <= fromIndex <= arrayLength - 1 (or 2 when findTwoConsecutive is true)
+         *  2. number of characters in searchChar is 1 (or 2 when findTwoConsecutive is true)
+         *  3. arrayLength - fromIndex >= 2 when findTwoConsecutive is true
+         * @formatter:on
+        */
         // Return for empty strings
         masm.mov(result, -1);
         masm.cbz(64, arrayLength, end);
@@ -136,12 +148,14 @@ public final class AArch64ArrayIndexOfOp extends AArch64LIRInstruction {
          * 4 UTF-16 or 8 Latin1 chars) else search chunk-by-chunk.
          */
         masm.sub(64, curIndex, arrayLength, fromIndex);
-        masm.compare(64, curIndex, chunkSize / charSize);
-        masm.branchConditionally(ConditionFlag.GE, searchByChunk);
-
+        if (!findTwoConsecutive) {
+            masm.compare(64, curIndex, chunkSize / charSize);
+            masm.branchConditionally(ConditionFlag.GE, searchByChunk);
+        }
         /*
-         * Search sequentially for small strings. Note that all indexing is done via a negative
-         * offset from the first position beyond the end of the array.
+         * While searching for one character (not two consecutive), search sequentially if the
+         * target string is small. Note that all indexing is done via a negative offset from the
+         * first position beyond the end of the array.
          */
         masm.mov(64, endIndex, arrayLength);
         // Set the base address to be at the end of the string, after the last char
@@ -150,17 +164,24 @@ public final class AArch64ArrayIndexOfOp extends AArch64LIRInstruction {
         masm.sub(64, curIndex, zr, curIndex, ShiftType.LSL, shiftSize);
         // Loop doing char-by-char search
         masm.bind(searchByCharLoop);
-        int charBitSize = charSize * Byte.SIZE;
+        final int charBitSize = charsToRead * charSize * Byte.SIZE;
         masm.ldr(charBitSize, curChar, AArch64Address.createRegisterOffsetAddress(charBitSize, baseAddress, curIndex, false));
         masm.cmp(32, curChar, searchChar);
         masm.branchConditionally(ConditionFlag.EQ, match);
 
         /*
-         * Add charSize to the curIndex, and retry if the end of the array has not yet been reached
-         * (i.e. the curIndex is still < 0).
+         * Add charSize to the curIndex and retry if the end of the array has not yet been reached,
+         * i.e., the curIndex is still < 0. While searching for two consecutive chars, stop a char
+         * earlier to avoid reading past the array, i.e, retry as long as curIndex < -charSize.
          */
-        masm.adds(64, curIndex, curIndex, charSize);
-        masm.branchConditionally(ConditionFlag.MI, searchByCharLoop);
+        if (findTwoConsecutive) {
+            masm.add(64, curIndex, curIndex, charSize);
+            masm.compare(64, curIndex, -charSize);
+            masm.branchConditionally(ConditionFlag.LT, searchByCharLoop);
+        } else {
+            masm.adds(64, curIndex, curIndex, charSize);
+            masm.branchConditionally(ConditionFlag.MI, searchByCharLoop);
+        }
         masm.jmp(end);
 
         // Search chunk-by-chunk for long strings

--- a/compiler/src/org.graalvm.compiler.lir.aarch64/src/org/graalvm/compiler/lir/aarch64/AArch64ArrayIndexOfOp.java
+++ b/compiler/src/org.graalvm.compiler.lir.aarch64/src/org/graalvm/compiler/lir/aarch64/AArch64ArrayIndexOfOp.java
@@ -25,12 +25,16 @@
  */
 package org.graalvm.compiler.lir.aarch64;
 
+import static jdk.vm.ci.aarch64.AArch64.SIMD;
 import static jdk.vm.ci.aarch64.AArch64.zr;
 import static jdk.vm.ci.code.ValueUtil.asRegister;
 import static org.graalvm.compiler.asm.aarch64.AArch64Assembler.ConditionFlag;
 import static org.graalvm.compiler.lir.LIRInstruction.OperandFlag.REG;
 
 import org.graalvm.compiler.asm.Label;
+import org.graalvm.compiler.asm.aarch64.AArch64ASIMDAssembler.ASIMDSize;
+import org.graalvm.compiler.asm.aarch64.AArch64ASIMDAssembler.ElementSize;
+import org.graalvm.compiler.asm.aarch64.AArch64ASIMDMacroAssembler;
 import org.graalvm.compiler.asm.aarch64.AArch64Address;
 import org.graalvm.compiler.asm.aarch64.AArch64Assembler.ShiftType;
 import org.graalvm.compiler.asm.aarch64.AArch64MacroAssembler;
@@ -62,6 +66,14 @@ public final class AArch64ArrayIndexOfOp extends AArch64LIRInstruction {
     @Temp({REG}) protected Value temp2;
     @Temp({REG}) protected Value temp3;
     @Temp({REG}) protected Value temp4;
+    @Temp({REG}) protected Value temp5;
+    @Temp({REG}) protected Value vectorTemp1;
+    @Temp({REG}) protected Value vectorTemp2;
+    @Temp({REG}) protected Value vectorTemp3;
+    @Temp({REG}) protected Value vectorTemp4;
+    @Temp({REG}) protected Value vectorTemp5;
+    @Temp({REG}) protected Value vectorTemp6;
+    @Temp({REG}) protected Value vectorTemp7;
 
     public AArch64ArrayIndexOfOp(int arrayBaseOffset, JavaKind valueKind, boolean findTwoConsecutive, LIRGeneratorTool tool, Value result, Value arrayPtr, Value arrayLength, Value fromIndex,
                     Value searchValue) {
@@ -80,6 +92,16 @@ public final class AArch64ArrayIndexOfOp extends AArch64LIRInstruction {
         temp2 = tool.newVariable(archWordKind);
         temp3 = tool.newVariable(archWordKind);
         temp4 = tool.newVariable(archWordKind);
+        temp5 = tool.newVariable(archWordKind);
+
+        LIRKind vectorKind = LIRKind.value(tool.target().arch.getLargestStorableKind(SIMD));
+        vectorTemp1 = tool.newVariable(vectorKind);
+        vectorTemp2 = tool.newVariable(vectorKind);
+        vectorTemp3 = tool.newVariable(vectorKind);
+        vectorTemp4 = tool.newVariable(vectorKind);
+        vectorTemp5 = tool.newVariable(vectorKind);
+        vectorTemp6 = tool.newVariable(vectorKind);
+        vectorTemp7 = tool.newVariable(vectorKind);
     }
 
     private static boolean byteMode(JavaKind kind) {
@@ -90,79 +112,41 @@ public final class AArch64ArrayIndexOfOp extends AArch64LIRInstruction {
         return kind == JavaKind.Char;
     }
 
-    @Override
-    public void emitCode(CompilationResultBuilder crb, AArch64MacroAssembler masm) {
+    private void emitScalarCode(AArch64MacroAssembler masm, Register curIndex, Register baseAddress) {
         Register result = asRegister(resultValue);
         Register arrayLength = asRegister(arrayLengthValue);
-        Register fromIndex = asRegister(fromIndexValue);
         Register searchChar = asRegister(searchValue);
-        Register curChar = asRegister(temp1);
-        Register endIndex = asRegister(temp2);
-        Register baseAddress = asRegister(temp3);
-        Register curIndex = asRegister(temp4);
+        Register curChar = asRegister(temp3);
+        Register endIndex = asRegister(temp4);
 
         Label match = new Label();
-        Label chunkedReadLoop = new Label();
-        Label charInChunk = new Label();
-        Label searchByChunk = new Label();
         Label searchByCharLoop = new Label();
         Label end = new Label();
 
-        final int chunkSize = 8;
         final int charsToRead = findTwoConsecutive ? 2 : 1;
         int charSize;
         int shiftSize;
-        long bitMask01;
-        long bitMask7f;
         if (!isUTF16) {
-            // 1-byte characters
+            /* 1-byte characters */
             charSize = 1;
             shiftSize = 0;
-            bitMask01 = 0x0101010101010101L;
-            bitMask7f = 0x7f7f7f7f7f7f7f7fL;
         } else {
-            // 2-byte characters
+            /* 2-byte characters */
             charSize = 2;
             shiftSize = 1;
-            bitMask01 = 0x0001000100010001L;
-            bitMask7f = 0x7fff7fff7fff7fffL;
         }
 
-        /*
-         * @formatter:off
-         * The arguments satisfy the following constraints:
-         *  1. 0 <= fromIndex <= arrayLength - 1 (or 2 when findTwoConsecutive is true)
-         *  2. number of characters in searchChar is 1 (or 2 when findTwoConsecutive is true)
-         *  3. arrayLength - fromIndex >= 2 when findTwoConsecutive is true
-         * @formatter:on
-        */
-        // Return for empty strings
-        masm.mov(result, -1);
-        masm.cbz(64, arrayLength, end);
-
-        // Load address of first array element
-        masm.add(64, baseAddress, asRegister(arrayPtrValue), arrayBaseOffset);
-
-        /*
-         * Search char-by-char for small strings (with search space size of less than 64 bits, i.e.,
-         * 4 UTF-16 or 8 Latin1 chars) else search chunk-by-chunk.
-         */
-        masm.sub(64, curIndex, arrayLength, fromIndex);
-        if (!findTwoConsecutive) {
-            masm.compare(64, curIndex, chunkSize / charSize);
-            masm.branchConditionally(ConditionFlag.GE, searchByChunk);
-        }
         /*
          * While searching for one character (not two consecutive), search sequentially if the
          * target string is small. Note that all indexing is done via a negative offset from the
          * first position beyond the end of the array.
          */
         masm.mov(64, endIndex, arrayLength);
-        // Set the base address to be at the end of the string, after the last char
+        /* Set the base address to be at the end of the string, after the last char */
         masm.add(64, baseAddress, baseAddress, arrayLength, ShiftType.LSL, shiftSize);
-        // Initial index is (fromIndex - arrayLength) << shift size
+        /* Initial index is (fromIndex - arrayLength) << shift size */
         masm.sub(64, curIndex, zr, curIndex, ShiftType.LSL, shiftSize);
-        // Loop doing char-by-char search
+        /* Loop doing char-by-char search */
         masm.bind(searchByCharLoop);
         final int charBitSize = charsToRead * charSize * Byte.SIZE;
         masm.ldr(charBitSize, curChar, AArch64Address.createRegisterOffsetAddress(charBitSize, baseAddress, curIndex, false));
@@ -184,104 +168,259 @@ public final class AArch64ArrayIndexOfOp extends AArch64LIRInstruction {
         }
         masm.jmp(end);
 
-        // Search chunk-by-chunk for long strings
-        masm.bind(searchByChunk);
-        /*
-        * @formatter:off
-        *  Chunk-based reading uses the following approach (with example for UTF-16):
-        *  1. Fill 8 byte chunk with search character ('searchChar'): 0x000000000000char -> 0xcharcharcharchar
-        *  2. Read and compare string chunk-by-chunk.
-        *   2.1 Store end index at the beginning of the last chunk ('endIndex'). This ensures that we don't
-        *   read beyond string boundary.
-        *   2.2 Use non-positive index ('curIndex') and add chunk-size (8 bytes) after each read until the count is positive.
-        *  3. Check each read chunk to see if 'searchChar' is found.
-        *   3.1 XOR read chunk with 0xcharcharcharchar. (e.g., 0x----char-------- XOR 0xcharcharcharchar -> 0x----0000--------)
-        *   Any matching bytes are now 0 and can be detected by using the steps from 3.2 to 3.5 (based on [1]). Here, we set
-        *   the MSB of a UTF-16 char in the chunk that matches 'searchChar'.
-        *   3.2 Subtract 1 from all UTF-16 char in 3.1 above (T1). (0x----0000-------- - 0x0001000100010001 -> 0x----FFFF--------)
-        *   3.3 Except MSB, mask all bits of UTF-16 char in 3.1 (T2). (0x----0000-------- OR 0x7FFF7FFF7FFF7FFF -> 0x----7FFF--------)
-        *   3.4 Calculate T3 = T1 & ~(T2)  (0x----FFFF-------- AND (NOT 0x----7FFF--------) -> 0x0000800000000000, sets Z flag to 0).
-        *   3.5 Check if Z flag is zero using NE condition flag.
-        *  4. Repeat the above steps until 'curIndex' is positive. Then reset the positive 'curIndex' to zero so that
-        *   the next read operation would read the last chunk. This avoids reading beyond the string's boundary.
-        *  5. If character is found in a chunk then find its position. Calculate number zero chars after the matching
-        *     char so that we get the position relative to reference position 'endIndex'.
-        *   5.1 Reverse the bitstream in T3 (0x0000800000000000 -> 0x0000000000010000)
-        *   5.2 Calculate leading zeros in 4.1 and get number of bytes from the end of the chunk
-        *       (by dividing the count by 8).
-        *   5.3 Retrieve the position of 'searchChar' by adding offset within chunk to the current index.
-        *
-        *  [1] https://graphics.stanford.edu/~seander/bithacks.html#ZeroInWord
-        * @formatter:on
-        * */
-
-        // 1. Duplicate the searchChar to 64-bits
-        if (!isUTF16) {
-            masm.orr(64, searchChar, searchChar, searchChar, ShiftType.LSL, Byte.SIZE);
-        }
-        masm.orr(64, searchChar, searchChar, searchChar, ShiftType.LSL, Byte.SIZE * 2);
-        masm.orr(64, searchChar, searchChar, searchChar, ShiftType.LSL, Byte.SIZE * 4);
-
-        // 2.1 Set end index at the starting position of the last chunk
-        masm.sub(64, endIndex, arrayLength, chunkSize / charSize);
-        masm.add(64, baseAddress, baseAddress, endIndex, ShiftType.LSL, shiftSize);
-        /*
-         * Set the current index (will be <= 0). Note that curIndex is not aligned to the chunk
-         * size.
-         */
-        masm.sub(64, curIndex, fromIndex, endIndex);
-        if (isUTF16) {
-            masm.lsl(64, curIndex, curIndex, 1);
-        }
-
-        try (ScratchRegister scratchReg1 = masm.getScratchRegister(); ScratchRegister scratchReg2 = masm.getScratchRegister()) {
-            Register bitMask01Reg = scratchReg1.getRegister();
-            Register tmp2 = scratchReg2.getRegister();
-            masm.mov(bitMask01Reg, bitMask01);
-
-            // 3. Find searchChar in the 8-byte chunk
-            masm.bind(chunkedReadLoop);
-            masm.ldr(64, curChar, AArch64Address.createRegisterOffsetAddress(64, baseAddress, curIndex, false));
-            masm.eor(64, curChar, searchChar, curChar);
-            masm.orr(64, tmp2, curChar, bitMask7f);
-            masm.sub(64, curChar, curChar, bitMask01Reg);
-            masm.bics(64, curChar, curChar, tmp2);
-            masm.branchConditionally(ConditionFlag.NE, charInChunk);
-            // move on to next chunk if no match found and new curIndex is < 0
-            masm.adds(64, curIndex, curIndex, chunkSize);
-            masm.branchConditionally(ConditionFlag.MI, chunkedReadLoop);
-
-            /*
-             * 4. Reset the ref chars count to zero to read the last chunk, only if the chunk was
-             * not already read (i.e. the curIndex is not the chunk size). Because curIndex is not
-             * aligned to the chunk size, it likely that some indexes searched again; however, this
-             * is not a correctness problem and will not result in more than one iteration of
-             * chunkedReadLoop being executed.
-             */
-            masm.compare(32, curIndex, chunkSize);
-            masm.branchConditionally(ConditionFlag.EQ, end);
-            masm.mov(curIndex, 0);
-            masm.jmp(chunkedReadLoop);
-
-            /*
-             * 5. The searchChar found in chunk so retrieve its position relative to the current
-             * index.
-             */
-            masm.bind(charInChunk);
-            masm.rev(64, curChar, curChar);
-            masm.clz(64, curChar, curChar);
-            /*
-             * 5.3 Convert number of leading zeros to number of zero bytes and add to current index.
-             */
-            masm.add(64, curIndex, curIndex, curChar, ShiftType.LSR, 3);
-        }
-
         masm.bind(match);
         if (isUTF16) {
-            // Convert byte offset of searchChar to its char index in UTF-16 string
+            /* Convert byte offset of searchChar to its char index in UTF-16 string */
             masm.asr(64, curIndex, curIndex, 1);
         }
         masm.add(64, result, endIndex, curIndex);
+
         masm.bind(end);
+    }
+
+    private void emitSIMDCode(AArch64MacroAssembler masm, Register baseAddress) {
+        /*
+         * @formatter:off
+         *  Chunk-based reading uses the following approach (with example for UTF-16) inspired from [1]. For SIMD implementation, the steps
+         *  represent computation applied to one lane of 8 bytes. SIMD version replicates the following steps to all 4 lanes of 8 bytes each.
+         *  1. Fill 8-byte chunk with search character ('searchChar'): 0x000000000000char -> 0xcharcharcharchar
+         *  2. Read and compare string chunk-by-chunk.
+         *   2.1 Store end index at the beginning of the last chunk ('refAddress'). This ensures that we don't read beyond string boundary.
+         *   2.2 String is processed in chunks: the first unaligned chunk (head) -> all 32-byte aligned chunks -> the last unaligned chunk
+         *   of 32 bytes (tail). Transitions between processing an unaligned and aligned chunk repeats char search on overlapping part.
+         *   However, overhead gets smaller with longer strings and compensated by the gains from using larger (32-byte sized) chunks.
+         *   2.3 After processing each chunk, adjust the address 4-byte aligned to read the next chunk. Repeat this step until the last
+         *   chunk is reached (address of the next chunk >= 'refAddress').
+         *   2.4 On reaching the last chunk, reset the address to read the last chunk.
+         *  3. Check each read chunk to see if 'searchChar' is found.
+         *   3.1 XOR read chunk with 0xcharcharcharchar. (e.g., 0x----char-------- XOR 0xcharcharcharchar -> 0x----0000--------)
+         *   Any matching bytes are now 0 and can be detected by using the steps from 3.2 to 3.5 (based on [2]). Here, we set
+         *   the MSB of a UTF-16 char in the chunk that matches 'searchChar'.
+         *   3.2 Subtract 1 from all UTF-16 char in 3.1 above (T1). (0x----0000-------- - 0x0001000100010001 -> 0x----FFFF--------)
+         *   3.3 Except MSB, mask all bits of UTF-16 char in 3.1 (T2). (0x----0000-------- OR 0x7FFF7FFF7FFF7FFF -> 0x----7FFF--------)
+         *   3.4 Calculate T3 = T1 & ~(T2)  (0x----FFFF-------- AND (NOT 0x----7FFF--------) -> 0x0000800000000000, sets Z flag to 0).
+         *   3.5 Steps 3.1 to 3.4 would detect a match in a SIMD lane (of 8 bytes). All the lanes are OR-ed to detect a match in the chunk
+         *   of 32 bytes.
+         *  4. If character is found in a 32-byte chunk then find its position. Use 2-bit representation for each byte to detect the index
+         *     of matching char. Set those bits to '11' if the match is found. Then calculate number zero chars after the matching char to
+         *     get the position in the chunk.
+         *   4.1 For each lane, set all the bits where the char is found using T4 = cmhi(T3) (0x0000800000000000 -> 0x0000FFFF00000000).
+         *   4.2 AND T4 with magic constant to set 2 bits based on the position of the char in the chunk.
+         *   T5 = T4 & 0xc000_0300_00c0_0003L (0x0000FFFF00000000 -> 0x0000030000000000)
+         *   4.3 Perform pairwise addition on adjecent elements/chars twice to convert 32-byte to 8-byte representation where each pair of
+         *    bits represents its corresponding char in a chunk. Magic constant sets different bits for each position that ensures the
+         *    pairwise addition would not overflow when consecutive chars are matched as well as preserve the position of matching char.
+         *   4.4 Reverse the bitstream in T5 (0x0000030000000000 -> 0x0000000000c00000)
+         *   4.5 Calculate leading zeros in T5 and divide the count by 2 to get the offset of matching char in a chunk
+         *   4.6 Retrieve the position of 'searchChar' by adding offset within chunk to the index of the chunk.
+         *
+         *  [1] https://github.com/ARM-software/optimized-routines/blob/master/string/aarch64/strchr.S
+         *  [2] https://graphics.stanford.edu/~seander/bithacks.html#ZeroInWord
+         * @formatter:on
+         * */
+
+        Register result = asRegister(resultValue);
+        Register arrayLength = asRegister(arrayLengthValue);
+        Register fromIndex = asRegister(fromIndexValue);
+        Register searchChar = asRegister(searchValue);
+        Register currOffset = asRegister(temp2);
+        Register endOfString = asRegister(temp3);
+        Register refAddress = asRegister(temp4);
+        Register chunkToReadAddress = asRegister(temp5);
+        Register bitMask01RegV = asRegister(vectorTemp1);
+        Register bitMask7fRegV = asRegister(vectorTemp2);
+        Register searchCharRegV = asRegister(vectorTemp3);
+        Register chunkPart1RegV = asRegister(vectorTemp4);
+        Register chunkPart2RegV = asRegister(vectorTemp5);
+        Register tmpRegV1 = asRegister(vectorTemp6);
+        Register tmpRegV2 = asRegister(vectorTemp7);
+
+        /* Register aliases */
+        Register magicConstantRegV = tmpRegV1;
+        Register pairwiseSumRegV = tmpRegV1;
+
+        Label matchInChunk = new Label();
+        Label searchByChunkLoopHead = new Label();
+        Label searchByChunkLoopTail = new Label();
+        Label processTail = new Label();
+        Label end = new Label();
+
+        int bitMask01;
+        int bitMask7f;
+        ElementSize elementSize;
+        /*
+         * Magic constant is used to detect position of the search character in the matching chunk
+         */
+        long magicConstant;
+        if (!isUTF16) {
+            /* 1-byte characters */
+            bitMask01 = 0x0101;
+            bitMask7f = 0x7f7f;
+            elementSize = ElementSize.Byte;
+            magicConstant = 0xc030_0c03_c030_0c03L;
+        } else {
+            /* 2-byte characters */
+            bitMask01 = 0x0001;
+            bitMask7f = 0x7fff;
+            elementSize = ElementSize.HalfWord;
+            magicConstant = 0xc000_0300_00c0_0003L;
+        }
+
+        AArch64ASIMDMacroAssembler simdMasm = new AArch64ASIMDMacroAssembler(masm);
+        try (ScratchRegister scratchReg1 = masm.getScratchRegister(); ScratchRegister scratchReg2 = masm.getScratchRegister()) {
+            Register bitMask01Reg = scratchReg1.getRegister();
+            Register bitMask7fReg = scratchReg2.getRegister();
+
+            masm.mov(bitMask01Reg, bitMask01);
+            masm.mov(bitMask7fReg, bitMask7f);
+            simdMasm.dupVG(ASIMDSize.FullReg, elementSize, bitMask01RegV, bitMask01Reg);
+            simdMasm.dupVG(ASIMDSize.FullReg, elementSize, bitMask7fRegV, bitMask7fReg);
+        }
+        /* 1. Duplicate the searchChar to 32-bytes */
+        simdMasm.dupVG(ASIMDSize.FullReg, elementSize, searchCharRegV, searchChar);
+        /*
+         * 2.1 Set endOfString pointing to byte next to the last valid char in the string and
+         * 'refAddress' pointing to the beginning of the last chunk.
+         */
+        masm.add(64, endOfString, baseAddress, arrayLength, ShiftType.LSL, isUTF16 ? 1 : 0);
+        masm.bic(64, refAddress, endOfString, 31L);
+        /* Set 'chunkToReadAddress' pointing to the chunk from where the search begins. */
+        if (isUTF16) {
+            masm.add(64, chunkToReadAddress, baseAddress, fromIndex, ShiftType.LSL, 1);
+        } else {
+            masm.add(64, chunkToReadAddress, baseAddress, fromIndex);
+        }
+
+        masm.bind(searchByChunkLoopHead);
+        masm.cmp(64, refAddress, chunkToReadAddress);
+        masm.branchConditionally(ConditionFlag.LE, processTail);
+        masm.bind(searchByChunkLoopTail);
+        masm.sub(64, currOffset, chunkToReadAddress, baseAddress);
+
+        /*
+         * TODO: Combine the following 4 instructions to load a 32-byte chunk into 1 instruction
+         * equivalent to 'LD1 {chunkPart1RegV.16b, chunkPart2RegV.16b}, [chunkToReadAddress], #32'
+         */
+        simdMasm.loadV1(ASIMDSize.FullReg, chunkPart1RegV, chunkToReadAddress, true);
+        simdMasm.loadV1(ASIMDSize.FullReg, chunkPart2RegV, chunkToReadAddress, true);
+        /* 3. Find searchChar in the 32-byte chunk */
+        simdMasm.eorVVV(ASIMDSize.FullReg, chunkPart1RegV, chunkPart1RegV, searchCharRegV);
+        simdMasm.eorVVV(ASIMDSize.FullReg, chunkPart2RegV, chunkPart2RegV, searchCharRegV);
+        simdMasm.orrVVV(ASIMDSize.FullReg, tmpRegV1, chunkPart1RegV, bitMask7fRegV);
+        simdMasm.orrVVV(ASIMDSize.FullReg, tmpRegV2, chunkPart2RegV, bitMask7fRegV);
+        simdMasm.subVVV(ASIMDSize.FullReg, elementSize, chunkPart1RegV, chunkPart1RegV, bitMask01RegV);
+        simdMasm.subVVV(ASIMDSize.FullReg, elementSize, chunkPart2RegV, chunkPart2RegV, bitMask01RegV);
+        simdMasm.bicVVV(ASIMDSize.FullReg, chunkPart1RegV, chunkPart1RegV, tmpRegV1);
+        simdMasm.bicVVV(ASIMDSize.FullReg, chunkPart2RegV, chunkPart2RegV, tmpRegV2);
+
+        try (ScratchRegister scratchReg1 = masm.getScratchRegister(); ScratchRegister scratchReg2 = masm.getScratchRegister()) {
+            Register pairwiseSumPart1 = scratchReg1.getRegister();
+            Register pairwiseSumPart2 = scratchReg2.getRegister();
+            simdMasm.orrVVV(ASIMDSize.FullReg, pairwiseSumRegV, chunkPart1RegV, chunkPart2RegV);
+            simdMasm.moveFromIndex(ElementSize.DoubleWord, ElementSize.DoubleWord, pairwiseSumPart1, pairwiseSumRegV, 0);
+            simdMasm.moveFromIndex(ElementSize.DoubleWord, ElementSize.DoubleWord, pairwiseSumPart2, pairwiseSumRegV, 1);
+            masm.orr(64, pairwiseSumPart1, pairwiseSumPart1, pairwiseSumPart2);
+            masm.cbnz(64, pairwiseSumPart1, matchInChunk);
+            masm.bic(64, chunkToReadAddress, chunkToReadAddress, 31);
+            masm.jmp(searchByChunkLoopHead);
+        }
+
+        masm.bind(processTail);
+        masm.cmp(64, chunkToReadAddress, endOfString);
+        masm.branchConditionally(ConditionFlag.GE, end);
+        masm.sub(64, chunkToReadAddress, endOfString, 32);
+        /*
+         * Move back the 'endOfString' by 32-bytes because at the end of 'searchByChunkLoopTail',
+         * the 'chunkToRead' would be reset to 32-byte aligned addressed. Thus, the
+         * searchByChunkLoopHead would never using 'chunkToReadAddress' >= 'endOfString' condition.
+         */
+        masm.mov(64, endOfString, chunkToReadAddress);
+        masm.jmp(searchByChunkLoopTail);
+
+        /* 4. If the character is found in a 32-byte chunk then find its position. */
+        masm.bind(matchInChunk);
+        /*
+         * 4.1 Set all the bits for the matching char. Currently, the MSB is set for the matching
+         * positions. Thus, the element at matching position is negative and checking if element < 0
+         * would set all the corresponding bits.
+         */
+        simdMasm.cmltZeroVV(ASIMDSize.FullReg, elementSize, chunkPart1RegV, chunkPart1RegV);
+        simdMasm.cmltZeroVV(ASIMDSize.FullReg, elementSize, chunkPart2RegV, chunkPart2RegV);
+        /*
+         * 4.2 Using the magic constant set 2 bits in the matching byte that represent its position
+         * in the chunk
+         */
+        try (ScratchRegister scratchReg = masm.getScratchRegister()) {
+            Register magicConstantReg = scratchReg.getRegister();
+            masm.mov(magicConstantReg, magicConstant);
+            simdMasm.dupVG(ASIMDSize.FullReg, ElementSize.DoubleWord, magicConstantRegV, magicConstantReg);
+        }
+        simdMasm.andVVV(ASIMDSize.FullReg, chunkPart1RegV, chunkPart1RegV, magicConstantRegV);
+        simdMasm.andVVV(ASIMDSize.FullReg, chunkPart2RegV, chunkPart2RegV, magicConstantRegV);
+        /* 4.3 Convert 32-byte to 8-byte representation, 2 bits per byte. */
+        simdMasm.addpVV(ASIMDSize.FullReg, elementSize, chunkPart1RegV, chunkPart1RegV, chunkPart2RegV);
+        simdMasm.addpVV(ASIMDSize.FullReg, elementSize, chunkPart1RegV, chunkPart1RegV, chunkPart2RegV);
+
+        try (ScratchRegister scratchReg = masm.getScratchRegister()) {
+            Register matchPositionReg = scratchReg.getRegister();
+            /* Detect the position of matching char in the chunk */
+            simdMasm.moveFromIndex(ElementSize.DoubleWord, ElementSize.DoubleWord, matchPositionReg, chunkPart1RegV, 0);
+            masm.rbit(64, matchPositionReg, matchPositionReg);
+            masm.clz(64, matchPositionReg, matchPositionReg);
+            masm.add(64, result, currOffset, matchPositionReg, ShiftType.ASR, 1);
+        }
+        if (isUTF16) {
+            /* Convert byte offset of searchChar to its char index in UTF-16 string */
+            masm.asr(64, result, result, 1);
+        }
+
+        masm.bind(end);
+    }
+
+    @Override
+    public void emitCode(CompilationResultBuilder crb, AArch64MacroAssembler masm) {
+        Register result = asRegister(resultValue);
+        Register arrayLength = asRegister(arrayLengthValue);
+        Register fromIndex = asRegister(fromIndexValue);
+        Register baseAddress = asRegister(temp1);
+        Register curIndex = asRegister(temp2);
+
+        Label searchByChunk = new Label();
+        Label ret = new Label();
+
+        final int chunkSize = 48;
+        int charSize = isUTF16 ? 2 : 1;
+
+        /*
+         * @formatter:off
+         * The arguments satisfy the following constraints:
+         *  1. 0 <= fromIndex <= arrayLength - 1 (or 2 when findTwoConsecutive is true)
+         *  2. number of characters in searchChar is 1 (or 2 when findTwoConsecutive is true)
+         *  3. arrayLength - fromIndex >= 2 when findTwoConsecutive is true
+         * @formatter:on
+        */
+        masm.mov(result, -1);   // Return for empty strings
+        masm.cbz(64, arrayLength, ret);
+
+        /* Load address of first array element */
+        masm.add(64, baseAddress, asRegister(arrayPtrValue), arrayBaseOffset);
+
+        /*
+         * Search char-by-char for small strings (with search space size of less than 64 bits, i.e.,
+         * 4 UTF-16 or 8 Latin1 chars) else search chunk-by-chunk.
+         */
+        masm.sub(64, curIndex, arrayLength, fromIndex);
+        if (!findTwoConsecutive) {
+            masm.compare(64, curIndex, chunkSize / charSize);
+            masm.branchConditionally(ConditionFlag.GE, searchByChunk);
+        }
+        emitScalarCode(masm, curIndex, baseAddress);
+        masm.jmp(ret);
+
+        /* Search chunk-by-chunk for long strings */
+        masm.bind(searchByChunk);
+        emitSIMDCode(masm, baseAddress);
+
+        masm.bind(ret);
     }
 }

--- a/compiler/src/org.graalvm.compiler.replacements/src/org/graalvm/compiler/replacements/StringLatin1Substitutions.java
+++ b/compiler/src/org.graalvm.compiler.replacements/src/org/graalvm/compiler/replacements/StringLatin1Substitutions.java
@@ -78,20 +78,12 @@ public class StringLatin1Substitutions {
     }
 
     @MethodSubstitution
-    public static int indexOf(byte[] source, int sourceCount, byte[] target, int targetCount, int origFromIndex) {
-        int fromIndex = origFromIndex;
-        if (injectBranchProbability(UNLIKELY_PROBABILITY, fromIndex >= sourceCount)) {
-            return (targetCount == 0 ? sourceCount : -1);
-        }
-        if (injectBranchProbability(UNLIKELY_PROBABILITY, fromIndex < 0)) {
-            fromIndex = 0;
-        }
-        if (injectBranchProbability(UNLIKELY_PROBABILITY, targetCount == 0)) {
-            // The empty string is in every string.
-            return fromIndex;
-        }
+    public static int indexOf(byte[] source, int sourceCount, byte[] target, int targetCount, int fromIndex) {
+        ReplacementsUtil.dynamicAssert(fromIndex >= 0, "StringLatin1.indexOf invalid args: fromIndex negative");
+        ReplacementsUtil.dynamicAssert(fromIndex < sourceCount, "StringLatin1.indexOf invalid args: fromIndex >= length(target)");
+        ReplacementsUtil.dynamicAssert(targetCount > 0, "StringLatin1.indexOf invalid args: targetCount <= 0");
+        ReplacementsUtil.dynamicAssert(targetCount <= target.length, "StringLatin1.indexOf invalid args: targetCount > target.length");
         if (injectBranchProbability(UNLIKELY_PROBABILITY, sourceCount - fromIndex < targetCount)) {
-            // The empty string contains nothing except the empty string.
             return -1;
         }
         if (injectBranchProbability(UNLIKELY_PROBABILITY, targetCount == 1)) {

--- a/compiler/src/org.graalvm.compiler.replacements/src/org/graalvm/compiler/replacements/StringUTF16Substitutions.java
+++ b/compiler/src/org.graalvm.compiler.replacements/src/org/graalvm/compiler/replacements/StringUTF16Substitutions.java
@@ -80,10 +80,11 @@ public class StringUTF16Substitutions {
     @MethodSubstitution
     public static int indexOfUnsafe(byte[] source, int sourceCount, byte[] target, int targetCount, int fromIndex) {
         ReplacementsUtil.dynamicAssert(fromIndex >= 0, "StringUTF16.indexOfUnsafe invalid args: fromIndex negative");
+        ReplacementsUtil.dynamicAssert(fromIndex < sourceCount, "StringUTF16.indexOfUnsafe invalid args: fromIndex >= length(target)");
         ReplacementsUtil.dynamicAssert(targetCount > 0, "StringUTF16.indexOfUnsafe invalid args: targetCount <= 0");
         ReplacementsUtil.dynamicAssert(targetCount <= length(target), "StringUTF16.indexOfUnsafe invalid args: targetCount > length(target)");
         ReplacementsUtil.dynamicAssert(sourceCount >= targetCount, "StringUTF16.indexOfUnsafe invalid args: sourceCount < targetCount");
-        if (targetCount == 1) {
+        if (injectBranchProbability(UNLIKELY_PROBABILITY, targetCount == 1)) {
             return ArrayIndexOf.indexOf1CharCompact(source, sourceCount, fromIndex, getChar(target, 0));
         } else {
             int haystackLength = sourceCount - (targetCount - 2);

--- a/substratevm/src/com.oracle.svm.graal/src/com/oracle/svm/graal/AArch64ArrayIndexOfForeignCalls.java
+++ b/substratevm/src/com.oracle.svm.graal/src/com/oracle/svm/graal/AArch64ArrayIndexOfForeignCalls.java
@@ -78,7 +78,9 @@ class AArch64ArrayIndexOfForeignCallsFeature implements GraalFeature {
 class AArch64ArrayIndexOfForeignCalls {
     private static final ForeignCallSignature[] ORIGINAL_FOREIGN_CALLS = {
                     ArrayIndexOf.STUB_INDEX_OF_1_BYTE,
-                    ArrayIndexOf.STUB_INDEX_OF_1_CHAR_COMPACT
+                    ArrayIndexOf.STUB_INDEX_OF_1_CHAR_COMPACT,
+                    ArrayIndexOf.STUB_INDEX_OF_TWO_CONSECUTIVE_BYTES,
+                    ArrayIndexOf.STUB_INDEX_OF_TWO_CONSECUTIVE_CHARS_COMPACT
     };
 
     static final SubstrateForeignCallDescriptor[] FOREIGN_CALLS = Arrays.stream(ORIGINAL_FOREIGN_CALLS)
@@ -95,5 +97,17 @@ class AArch64ArrayIndexOfForeignCalls {
     @SubstrateForeignCallTarget(stubCallingConvention = false, fullyUninterruptible = true)
     private static int indexOf1CharCompact(byte[] array, int arrayLength, int fromIndex, char ch) {
         return ArrayIndexOfNode.optimizedArrayIndexOf(JavaKind.Byte, JavaKind.Char, false, array, arrayLength, fromIndex, ch);
+    }
+
+    @Uninterruptible(reason = "Must not do a safepoint check.")
+    @SubstrateForeignCallTarget(stubCallingConvention = false, fullyUninterruptible = true)
+    private static int indexOfTwoConsecutiveBytes(byte[] array, int arrayLength, int fromIndex, int searchValue) {
+        return ArrayIndexOfNode.optimizedArrayIndexOf(JavaKind.Byte, JavaKind.Byte, true, array, arrayLength, fromIndex, searchValue);
+    }
+
+    @Uninterruptible(reason = "Must not do a safepoint check.")
+    @SubstrateForeignCallTarget(stubCallingConvention = false, fullyUninterruptible = true)
+    private static int indexOfTwoConsecutiveCharsCompact(byte[] array, int arrayLength, int fromIndex, int searchValue) {
+        return ArrayIndexOfNode.optimizedArrayIndexOf(JavaKind.Byte, JavaKind.Char, true, array, arrayLength, fromIndex, searchValue);
     }
 }


### PR DESCRIPTION
This PR contains two patches

i) The first patch intrinsifies three String methods to search a substring in a given target string:
- StringUTF16.indexOf([BI[BII)I  # both search and target string UTF16
- StringUTF16.indexOf([B[B)I     # both search and target string Latin1
- StringLatin1.indexOf([B[B)I    # search string is Latin1 and target string UTF16

This patch adds a boiler-plate structure for intrinsification of substring methods
that the subsequent patches could utilise for performance improvements. The patch
has not shown any noticeable performance regression on any of the benchmarks.

ii) The second patch adds SIMD implementation of String.indexOf char on AArch64
This patch replaces the chunk-based char search algorithm with its SIMD equivalent.
It uses chunks of size 32 bytes instead of 4 bytes. The patch repurposed the char 
search approach of Arm optimised routines [1].

The benefits of using SIMD implementation should increase for longer strings.
For long strings (~750 Latin1 chars), microbenchmarking shows an improvement of
8% (on A72) and 33% (on Neoverse N1).

[1] https://github.com/ARM-software/optimized-routines/blob/master/string/aarch64/strchr.S
