### PR TITLE
AArch64: Changes to combine shift and negate to a single instruction.

### DIFF
--- a/compiler/src/org.graalvm.compiler.asm.aarch64/src/org/graalvm/compiler/asm/aarch64/AArch64MacroAssembler.java
+++ b/compiler/src/org.graalvm.compiler.asm.aarch64/src/org/graalvm/compiler/asm/aarch64/AArch64MacroAssembler.java
@@ -965,7 +965,7 @@ public class AArch64MacroAssembler extends AArch64Assembler {
     }
 
     /**
-     * dst = src1 + shiftType(src2, shiftAmt & (size-1)) and sets condition flags.
+     * dst = src1 - shiftType(src2, shiftAmt & (size-1)) and sets condition flags.
      *
      * @param size register size. Has to be 32 or 64.
      * @param dst general purpose register. May not be null or stackpointer.
@@ -986,7 +986,7 @@ public class AArch64MacroAssembler extends AArch64Assembler {
     }
 
     /**
-     * dst = -src1.
+     * dst = -src.
      *
      * @param size register size. Has to be 32 or 64.
      * @param dst general purpose register. May not be null or stackpointer.
@@ -994,6 +994,19 @@ public class AArch64MacroAssembler extends AArch64Assembler {
      */
     public void neg(int size, Register dst, Register src) {
         sub(size, dst, zr, src);
+    }
+
+    /**
+     * dst = -(shiftType(src, shiftAmt & (size - 1))).
+     *
+     * @param size register size. Has to be 32 or 64.
+     * @param dst general purpose register. May not be null or stackpointer.
+     * @param src general purpose register. May not be null or stackpointer.
+     * @param shiftType right or left shift, arithmetic or logical.
+     * @param shiftAmt number of shift bits. Has to be between 0 and (size - 1).
+     */
+    public void neg(int size, Register dst, Register src, ShiftType shiftType, int shiftAmt) {
+        sub(size, dst, zr, src, shiftType, shiftAmt);
     }
 
     /**

--- a/compiler/src/org.graalvm.compiler.core.aarch64.test/src/org/graalvm/compiler/core/aarch64/test/AArch64BitFieldTest.java
+++ b/compiler/src/org.graalvm.compiler.core.aarch64.test/src/org/graalvm/compiler/core/aarch64/test/AArch64BitFieldTest.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2019, 2020, Arm Limited and affiliates. All rights reserved.
+ * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2021, Arm Limited and affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -207,7 +207,7 @@ public class AArch64BitFieldTest extends AArch64MatchRuleTest {
     // SBFIZ with B2I.
     public int signedB2IInsert(int input) {
         byte b = (byte) input;
-        return b << 31;
+        return b << 30;
     }
 
     @Test

--- a/compiler/src/org.graalvm.compiler.core.aarch64.test/src/org/graalvm/compiler/core/aarch64/test/AArch64NegateShiftTest.java
+++ b/compiler/src/org.graalvm.compiler.core.aarch64.test/src/org/graalvm/compiler/core/aarch64/test/AArch64NegateShiftTest.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, Arm Limited and affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.graalvm.compiler.core.aarch64.test;
+
+import org.graalvm.compiler.lir.LIRInstruction;
+import org.graalvm.compiler.lir.aarch64.AArch64ArithmeticOp;
+import org.junit.Test;
+
+import java.util.function.Predicate;
+
+public class AArch64NegateShiftTest extends AArch64MatchRuleTest {
+    private static final Predicate<LIRInstruction> predicate = op -> (op instanceof AArch64ArithmeticOp.NegShiftOp);
+
+    /**
+     * negateShift match rule tests for shift operations with int type.
+     */
+    public int negShiftLeftLogicInt(int input) {
+        return -(input << 5);
+    }
+
+    @Test
+    public void testNegShiftLeftLogicInt() {
+        test("negShiftLeftLogicInt", 123);
+        checkLIR("negShiftLeftLogicInt", predicate, 1);
+    }
+
+    public int negShiftRightLogicInt(int input) {
+        return -(input >>> 6);
+    }
+
+    @Test
+    public void testNegShiftRightLogicInt() {
+        test("negShiftRightLogicInt", 123);
+        checkLIR("negShiftRightLogicInt", predicate, 1);
+    }
+
+    public int negShiftRightArithInt(int input) {
+        return -(input >> 7);
+    }
+
+    @Test
+    public void testNegShiftRightArithInt() {
+        test("negShiftRightArithInt", 123);
+        checkLIR("negShiftRightArithInt", predicate, 1);
+    }
+
+    /**
+     * negateShift match rule tests for shift operations with long type.
+     */
+    public long negShiftLeftLogicLong(long input) {
+        return -(input << 8);
+    }
+
+    @Test
+    public void testNegShiftLeftLogicLong() {
+        test("negShiftLeftLogicLong", 123L);
+        checkLIR("negShiftLeftLogicLong", predicate, 1);
+    }
+
+    public long negShiftRightLogicLong(long input) {
+        return -(input >>> 9);
+    }
+
+    @Test
+    public void testNegShiftRightLogicLong() {
+        test("negShiftRightLogicLong", 123L);
+        checkLIR("negShiftRightLogicLong", predicate, 1);
+    }
+
+    public long negShiftRightArithLong(long input) {
+        return -(input >> 10);
+    }
+
+    @Test
+    public void testNegShiftRightArithLong() {
+        test("negShiftRightArithLong", 123L);
+        checkLIR("negShiftRightArithLong", predicate, 1);
+    }
+}

--- a/compiler/src/org.graalvm.compiler.lir.aarch64/src/org/graalvm/compiler/lir/aarch64/AArch64ArithmeticOp.java
+++ b/compiler/src/org.graalvm.compiler.lir.aarch64/src/org/graalvm/compiler/lir/aarch64/AArch64ArithmeticOp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -676,6 +676,34 @@ public enum AArch64ArithmeticOp {
                 default:
                     throw GraalError.shouldNotReachHere();
             }
+        }
+    }
+
+    public static class NegShiftOp extends AArch64LIRInstruction {
+        private static final LIRInstructionClass<NegShiftOp> TYPE = LIRInstructionClass.create(NegShiftOp.class);
+        @Def(REG) protected AllocatableValue result;
+        @Use(REG) protected AllocatableValue src;
+        private final AArch64Assembler.ShiftType shiftType;
+        private final int shiftAmt;
+
+        /**
+         * Computes <code>result = - shiftType(src, shiftAmt)</code>.
+         *
+         * @param shiftType defines left shift, right shift, arithmetic, logical.
+         * @param shiftAmt must be in range 0 to 31 for ints (63 for longs).
+         */
+        public NegShiftOp(AllocatableValue result, AllocatableValue src, AArch64Assembler.ShiftType shiftType, int shiftAmt) {
+            super(TYPE);
+            this.result = result;
+            this.src = src;
+            this.shiftType = shiftType;
+            this.shiftAmt = shiftAmt;
+        }
+
+        @Override
+        public void emitCode(CompilationResultBuilder crb, AArch64MacroAssembler masm) {
+            int size = result.getPlatformKind().getSizeInBytes() * Byte.SIZE;
+            masm.neg(size, asRegister(result), asRegister(src), shiftType, shiftAmt);
         }
     }
 


### PR DESCRIPTION
Add three node match rules to handle the three varieties of shift, together with capability to emit a combined negate instruction with shift.
