### PR TITLE
JNIRegistrationAwt::registerFreeType called for sun.font.FontConfigManager too

### DIFF
--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/jdk/JNIRegistrationAwt.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/jdk/JNIRegistrationAwt.java
@@ -64,7 +64,8 @@ public class JNIRegistrationAwt extends JNIRegistrationUtil implements Feature {
             PlatformNativeLibrarySupport.singleton().addBuiltinPkgNativePrefix("sun_java2d");
 
             access.registerReachabilityHandler(JNIRegistrationAwt::registerFreeType,
-                            clazz(access, "sun.font.FontManagerNativeLibrary"));
+                            clazz(access, "sun.font.FontManagerNativeLibrary"),
+                            clazz(access, "sun.font.FontConfigManager"));
             PlatformNativeLibrarySupport.singleton().addBuiltinPkgNativePrefix("sun_font");
 
             access.registerReachabilityHandler(JNIRegistrationAwt::registerLCMS,


### PR DESCRIPTION
Fixes #3416 

With this patch, `registerFreeType` gets properly called and the build works. The resulting binary runs as expected and lists available fonts. Steps to reproduce are described on #3416. Copy-pasting here for clarity:

The following code, Main.java:
```
import java.awt.Font;
import java.awt.GraphicsEnvironment;

public class Main {
    public static void main(String[] args) {
        for (Font font : GraphicsEnvironment.getLocalGraphicsEnvironment().getAllFonts()) {
            System.out.printf("%s, %s\n", font.getFontName(), font.getFamily());
        }
    }
}
```
compiled as:

```
export JAVA_HOME=/home/karm/tmp/graal-labsjava11-build;export GRAALVM_HOME=${JAVA_HOME};export PATH=${JAVA_HOME}/bin:${PATH}
javac Main.java
java -agentlib:native-image-agent=config-output-dir=./META-INF/native-image Main
native-image --no-fallback --initialize-at-build-time= -H:DeadlockWatchdogInterval=2 --native-image-info --verbose Main
```

The occasional deadlock mentioned in the original issue #3416 still occurs, although I am not sure it's not my system's fault so I ll be debugging and pursuing that in a separate issue/PR.

Feedback is welcome, I am definitely not sure I am approaching this the right way. 
