### PR TITLE
Use method entries instead of primary ranges for method DIE generation

### DIFF
--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/BasicProgbitsSectionImpl.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/BasicProgbitsSectionImpl.java
@@ -35,7 +35,6 @@ import com.oracle.objectfile.ObjectFile.Element;
 import com.oracle.objectfile.ObjectFile.ProgbitsSectionImpl;
 import com.oracle.objectfile.ObjectFile.RelocatableSectionImpl;
 import com.oracle.objectfile.ObjectFile.RelocationKind;
-import com.oracle.objectfile.ObjectFile.RelocationRecord;
 import com.oracle.objectfile.ObjectFile.Section;
 
 /**
@@ -114,15 +113,15 @@ public class BasicProgbitsSectionImpl extends BasicElementImpl implements Progbi
     }
 
     @Override
-    public RelocationRecord markRelocationSite(int offset, RelocationKind k, String symbolName, boolean useImplicitAddend, Long explicitAddend) {
-        return ((RelocatableSectionImpl) getElement()).markRelocationSite(offset, ByteBuffer.wrap(getContent()).order(getOwner().getByteOrder()), k, symbolName, useImplicitAddend,
+    public void markRelocationSite(int offset, RelocationKind k, String symbolName, boolean useImplicitAddend, Long explicitAddend) {
+        ((RelocatableSectionImpl) getElement()).markRelocationSite(offset, ByteBuffer.wrap(getContent()).order(getOwner().getByteOrder()), k, symbolName, useImplicitAddend,
                         explicitAddend);
     }
 
     @Override
-    public final RelocationRecord markRelocationSite(int offset, ByteBuffer bb, RelocationKind k, String symbolName, boolean useImplicitAddend, Long explicitAddend) {
+    public final void markRelocationSite(int offset, ByteBuffer bb, RelocationKind k, String symbolName, boolean useImplicitAddend, Long explicitAddend) {
         assert getContent() == null || bb.array() == getContent();
-        return ((RelocatableSectionImpl) getElement()).markRelocationSite(offset, bb, k, symbolName, useImplicitAddend, explicitAddend);
+        ((RelocatableSectionImpl) getElement()).markRelocationSite(offset, bb, k, symbolName, useImplicitAddend, explicitAddend);
     }
 
     @Override

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/ObjectFile.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/ObjectFile.java
@@ -408,9 +408,8 @@ public abstract class ObjectFile {
          *            bytes
          * @param useImplicitAddend whether the current bytes are to be used as an addend
          * @param explicitAddend a full-width addend, or null if useImplicitAddend is true
-         * @return the relocation record created (or found, if it exists already)
          */
-        RelocationRecord markRelocationSite(int offset, ByteBuffer bb, RelocationKind k, String symbolName, boolean useImplicitAddend, Long explicitAddend);
+        void markRelocationSite(int offset, ByteBuffer bb, RelocationKind k, String symbolName, boolean useImplicitAddend, Long explicitAddend);
 
         /**
          * Force the creation of a relocation section/element for this section, and return it. This
@@ -441,7 +440,7 @@ public abstract class ObjectFile {
          * passed a buffer. It uses the byte array accessed by {@link #getContent} and
          * {@link #setContent}.
          */
-        RelocationRecord markRelocationSite(int offset, RelocationKind k, String symbolName, boolean useImplicitAddend, Long explicitAddend);
+        void markRelocationSite(int offset, RelocationKind k, String symbolName, boolean useImplicitAddend, Long explicitAddend);
     }
 
     public interface NobitsSectionImpl extends ElementImpl {

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/StringSectionImpl.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/StringSectionImpl.java
@@ -35,7 +35,6 @@ import java.util.stream.StreamSupport;
 import com.oracle.objectfile.ObjectFile.Element;
 import com.oracle.objectfile.ObjectFile.ProgbitsSectionImpl;
 import com.oracle.objectfile.ObjectFile.RelocationKind;
-import com.oracle.objectfile.ObjectFile.RelocationRecord;
 import com.oracle.objectfile.io.AssemblyBuffer;
 import com.oracle.objectfile.io.OutputAssembler;
 
@@ -125,12 +124,12 @@ public abstract class StringSectionImpl extends BasicElementImpl implements Prog
     }
 
     @Override
-    public RelocationRecord markRelocationSite(int offset, RelocationKind k, String symbolName, boolean useImplicitAddend, Long explicitAddend) {
+    public void markRelocationSite(int offset, RelocationKind k, String symbolName, boolean useImplicitAddend, Long explicitAddend) {
         throw new UnsupportedOperationException("can't mark relocaction sites in string section");
     }
 
     @Override
-    public RelocationRecord markRelocationSite(int offset, ByteBuffer bb, RelocationKind k, String symbolName, boolean useImplicitAddend, Long explicitAddend) {
+    public void markRelocationSite(int offset, ByteBuffer bb, RelocationKind k, String symbolName, boolean useImplicitAddend, Long explicitAddend) {
         throw new UnsupportedOperationException("can't mark relocaction sites in string section");
     }
 

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/ClassEntry.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/ClassEntry.java
@@ -357,7 +357,7 @@ public class ClassEntry extends StructureTypeEntry {
             MethodEntry methodEntry = methodIterator.next();
             int comparisonResult = methodEntry.compareTo(methodName, paramSignature, returnTypeName);
             if (comparisonResult == 0) {
-                methodEntry.setInRange();
+                methodEntry.setInRange(debugInfoBase, debugRangeInfo);
                 return methodEntry;
             } else if (comparisonResult > 0) {
                 methodIterator.previous();

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/ClassEntry.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/ClassEntry.java
@@ -40,6 +40,7 @@ import com.oracle.objectfile.debuginfo.DebugInfoProvider.DebugFieldInfo;
 import com.oracle.objectfile.debuginfo.DebugInfoProvider.DebugFrameSizeChange;
 import com.oracle.objectfile.debuginfo.DebugInfoProvider.DebugInstanceTypeInfo;
 import com.oracle.objectfile.debuginfo.DebugInfoProvider.DebugMethodInfo;
+import com.oracle.objectfile.debuginfo.DebugInfoProvider.DebugRangeInfo;
 import com.oracle.objectfile.debuginfo.DebugInfoProvider.DebugTypeInfo;
 import com.oracle.objectfile.debuginfo.DebugInfoProvider.DebugTypeInfo.DebugTypeKind;
 
@@ -99,7 +100,8 @@ public class ClassEntry extends StructureTypeEntry {
         this.fileEntry = fileEntry;
         // methods is a sorted list and we want to be able to add more elements to it while keeping
         // it sorted,
-        // so a LinkedList seems more appropriate than an ArrayList. (see getMethodEntry)
+        // so a LinkedList seems more appropriate than an ArrayList.
+        // (see ensureMethodEntryForDebugRangeInfo)
         this.methods = new LinkedList<>();
         this.primaryEntries = new ArrayList<>();
         this.primaryIndex = new HashMap<>();
@@ -345,11 +347,11 @@ public class ClassEntry extends StructureTypeEntry {
         return superClass;
     }
 
-    public MethodEntry getMethodEntry(DebugMethodInfo debugMethodInfo, DebugInfoBase debugInfoBase, DebugContext debugContext) {
+    public MethodEntry ensureMethodEntryForDebugRangeInfo(DebugRangeInfo debugRangeInfo, DebugInfoBase debugInfoBase, DebugContext debugContext) {
         assert listIsSorted(methods);
-        String methodName = debugInfoBase.uniqueDebugString(debugMethodInfo.name());
-        String paramSignature = debugMethodInfo.paramSignature();
-        String returnTypeName = debugMethodInfo.valueType();
+        String methodName = debugInfoBase.uniqueDebugString(debugRangeInfo.name());
+        String paramSignature = debugRangeInfo.paramSignature();
+        String returnTypeName = debugRangeInfo.valueType();
         ListIterator<MethodEntry> methodIterator = methods.listIterator();
         while (methodIterator.hasNext()) {
             MethodEntry methodEntry = methodIterator.next();
@@ -362,7 +364,7 @@ public class ClassEntry extends StructureTypeEntry {
                 break;
             }
         }
-        MethodEntry newMethodEntry = processMethod(debugMethodInfo, debugInfoBase, debugContext, true);
+        MethodEntry newMethodEntry = processMethod(debugRangeInfo, debugInfoBase, debugContext, true);
         methodIterator.add(newMethodEntry);
         return newMethodEntry;
     }

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/ClassEntry.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/ClassEntry.java
@@ -297,14 +297,11 @@ public class ClassEntry extends StructureTypeEntry {
             paramTypeArray[idx++] = paramType;
         }
         paramNameArray = paramNames.toArray(paramNameArray);
-        String fileName = debugMethodInfo.fileName();
-        Path filePath = debugMethodInfo.filePath();
-        Path cachePath = debugMethodInfo.cachePath();
         /*
          * n.b. the method file may differ from the owning class file when the method is a
          * substitution
          */
-        FileEntry methodFileEntry = debugInfoBase.ensureFileEntry(fileName, filePath, cachePath);
+        FileEntry methodFileEntry = debugInfoBase.ensureFileEntry(debugMethodInfo);
         return new MethodEntry(methodFileEntry, debugMethodInfo.symbolNameForMethod(), methodName, this, resultType,
                         paramTypeArray, paramNameArray, modifiers, debugMethodInfo.isDeoptTarget(), fromRangeInfo);
     }
@@ -349,10 +346,10 @@ public class ClassEntry extends StructureTypeEntry {
 
     public MethodEntry ensureMethodEntryForDebugRangeInfo(DebugRangeInfo debugRangeInfo, DebugInfoBase debugInfoBase, DebugContext debugContext) {
         assert listIsSorted(methods);
+        ListIterator<MethodEntry> methodIterator = methods.listIterator();
         String methodName = debugInfoBase.uniqueDebugString(debugRangeInfo.name());
         String paramSignature = debugRangeInfo.paramSignature();
         String returnTypeName = debugRangeInfo.valueType();
-        ListIterator<MethodEntry> methodIterator = methods.listIterator();
         while (methodIterator.hasNext()) {
             MethodEntry methodEntry = methodIterator.next();
             int comparisonResult = methodEntry.compareTo(methodName, paramSignature, returnTypeName);

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/ClassEntry.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/ClassEntry.java
@@ -29,7 +29,6 @@ package com.oracle.objectfile.debugentry;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.ListIterator;
 import java.util.Map;
@@ -98,11 +97,7 @@ public class ClassEntry extends StructureTypeEntry {
         super(className, size);
         this.interfaces = new ArrayList<>();
         this.fileEntry = fileEntry;
-        // methods is a sorted list and we want to be able to add more elements to it while keeping
-        // it sorted,
-        // so a LinkedList seems more appropriate than an ArrayList.
-        // (see ensureMethodEntryForDebugRangeInfo)
-        this.methods = new LinkedList<>();
+        this.methods = new ArrayList<>();
         this.primaryEntries = new ArrayList<>();
         this.primaryIndex = new HashMap<>();
         this.localFiles = new ArrayList<>();

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/ClassEntry.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/ClassEntry.java
@@ -354,7 +354,11 @@ public class ClassEntry extends StructureTypeEntry {
             MethodEntry methodEntry = methodIterator.next();
             int comparisonResult = methodEntry.compareTo(methodName, paramSignature, returnTypeName);
             if (comparisonResult == 0) {
-                methodEntry.setInRange(debugInfoBase, debugRangeInfo);
+                methodEntry.setInRangeAndUpdateFileEntry(debugInfoBase, debugRangeInfo);
+                if (methodEntry.fileEntry != null) {
+                    /* Ensure that the methodEntry's fileEntry is present in the localsFileIndex */
+                    indexLocalFileEntry(methodEntry.fileEntry);
+                }
                 return methodEntry;
             } else if (comparisonResult > 0) {
                 methodIterator.previous();

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/ClassEntry.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/ClassEntry.java
@@ -157,8 +157,9 @@ public class ClassEntry extends StructureTypeEntry {
                 assert includesDeoptTarget == false;
             }
             FileEntry primaryFileEntry = primary.getFileEntry();
-            assert primaryFileEntry != null;
-            indexLocalFileEntry(primaryFileEntry);
+            if (primaryFileEntry != null) {
+                indexLocalFileEntry(primaryFileEntry);
+            }
         }
     }
 
@@ -342,15 +343,6 @@ public class ClassEntry extends StructureTypeEntry {
 
     public ClassEntry getSuperClass() {
         return superClass;
-    }
-
-    public Range makePrimaryRange(StringTable stringTable, MethodEntry method, int lo, int hi, int primaryLine) {
-        FileEntry fileEntryToUse = method.fileEntry;
-        if (fileEntryToUse == null) {
-            /* Last chance is the class's file entry. */
-            fileEntryToUse = this.fileEntry;
-        }
-        return new Range(stringTable, method, fileEntryToUse, lo, hi, primaryLine);
     }
 
     public MethodEntry getMethodEntry(DebugMethodInfo debugMethodInfo, DebugInfoBase debugInfoBase, DebugContext debugContext) {

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/DebugInfoBase.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/DebugInfoBase.java
@@ -246,7 +246,7 @@ public abstract class DebugInfoBase {
             /* Search for a method defining this primary range. */
             ClassEntry classEntry = ensureClassEntry(className);
             MethodEntry methodEntry = classEntry.getMethodEntry(debugCodeInfo, this, debugContext);
-            Range primaryRange = classEntry.makePrimaryRange(stringTable, methodEntry, lo, hi, primaryLine);
+            Range primaryRange = new Range(stringTable, methodEntry, lo, hi, primaryLine);
             debugContext.log(DebugContext.INFO_LEVEL, "PrimaryRange %s.%s %s %s:%d [0x%x, 0x%x]", className, methodName, filePath, fileName, primaryLine, lo, hi);
             classEntry.indexPrimary(primaryRange, debugCodeInfo.getFrameSizeChanges(), debugCodeInfo.getFrameSize());
             debugCodeInfo.lineInfoProvider().forEach(debugLineInfo -> {

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/DebugInfoBase.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/DebugInfoBase.java
@@ -34,6 +34,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import com.oracle.objectfile.debuginfo.DebugInfoProvider.DebugFileInfo;
 import org.graalvm.compiler.debug.DebugContext;
 
 import com.oracle.objectfile.debuginfo.DebugInfoProvider;
@@ -388,10 +389,12 @@ public abstract class DebugInfoBase {
         return fileEntry;
     }
 
-    protected FileEntry ensureFileEntry(String fileName, Path filePath, Path cachePath) {
+    protected FileEntry ensureFileEntry(DebugFileInfo debugFileInfo) {
+        String fileName = debugFileInfo.fileName();
         if (fileName == null || fileName.length() == 0) {
             return null;
         }
+        Path filePath = debugFileInfo.filePath();
         Path fileAsPath;
         if (filePath == null) {
             fileAsPath = Paths.get(fileName);
@@ -401,7 +404,7 @@ public abstract class DebugInfoBase {
         /* Reuse any existing entry. */
         FileEntry fileEntry = findFile(fileAsPath);
         if (fileEntry == null) {
-            fileEntry = addFileEntry(fileName, filePath, cachePath);
+            fileEntry = addFileEntry(fileName, filePath, debugFileInfo.cachePath());
         }
         return fileEntry;
     }

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/DebugInfoBase.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/DebugInfoBase.java
@@ -239,7 +239,6 @@ public abstract class DebugInfoBase {
             Path filePath = debugCodeInfo.filePath();
             String className = TypeEntry.canonicalize(debugCodeInfo.ownerType());
             String methodName = debugCodeInfo.name();
-            String symbolName = debugCodeInfo.symbolNameForMethod();
             int lo = debugCodeInfo.addressLo();
             int hi = debugCodeInfo.addressHi();
             int primaryLine = debugCodeInfo.line();
@@ -247,7 +246,7 @@ public abstract class DebugInfoBase {
             /* Search for a method defining this primary range. */
             ClassEntry classEntry = ensureClassEntry(className);
             MethodEntry methodEntry = classEntry.getMethodEntry(debugCodeInfo, this, debugContext);
-            Range primaryRange = classEntry.makePrimaryRange(symbolName, stringTable, methodEntry, lo, hi, primaryLine);
+            Range primaryRange = classEntry.makePrimaryRange(stringTable, methodEntry, lo, hi, primaryLine);
             debugContext.log(DebugContext.INFO_LEVEL, "PrimaryRange %s.%s %s %s:%d [0x%x, 0x%x]", className, methodName, filePath, fileName, primaryLine, lo, hi);
             classEntry.indexPrimary(primaryRange, debugCodeInfo.getFrameSizeChanges(), debugCodeInfo.getFrameSize());
             debugCodeInfo.lineInfoProvider().forEach(debugLineInfo -> {
@@ -255,7 +254,6 @@ public abstract class DebugInfoBase {
                 Path filePathAtLine = debugLineInfo.filePath();
                 String classNameAtLine = TypeEntry.canonicalize(debugLineInfo.ownerType());
                 String methodNameAtLine = debugLineInfo.name();
-                String symbolNameAtLine = debugLineInfo.symbolNameForMethod();
                 int loAtLine = lo + debugLineInfo.addressLo();
                 int hiAtLine = lo + debugLineInfo.addressHi();
                 int line = debugLineInfo.line();
@@ -265,7 +263,7 @@ public abstract class DebugInfoBase {
                  */
                 ClassEntry subClassEntry = ensureClassEntry(classNameAtLine);
                 MethodEntry subMethodEntry = subClassEntry.getMethodEntry(debugLineInfo, this, debugContext);
-                Range subRange = new Range(symbolNameAtLine, stringTable, subMethodEntry, loAtLine, hiAtLine, line, primaryRange);
+                Range subRange = new Range(stringTable, subMethodEntry, loAtLine, hiAtLine, line, primaryRange);
                 classEntry.indexSubRange(subRange);
                 try (DebugContext.Scope s = debugContext.scope("Subranges")) {
                     debugContext.log(DebugContext.VERBOSE_LEVEL, "SubRange %s.%s %s %s:%d 0x%x, 0x%x]", classNameAtLine, methodNameAtLine, filePathAtLine, fileNameAtLine, line, loAtLine, hiAtLine);

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/DebugInfoBase.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/DebugInfoBase.java
@@ -245,7 +245,7 @@ public abstract class DebugInfoBase {
 
             /* Search for a method defining this primary range. */
             ClassEntry classEntry = ensureClassEntry(className);
-            MethodEntry methodEntry = classEntry.getMethodEntry(debugCodeInfo, this, debugContext);
+            MethodEntry methodEntry = classEntry.ensureMethodEntryForDebugRangeInfo(debugCodeInfo, this, debugContext);
             Range primaryRange = new Range(stringTable, methodEntry, lo, hi, primaryLine);
             debugContext.log(DebugContext.INFO_LEVEL, "PrimaryRange %s.%s %s %s:%d [0x%x, 0x%x]", className, methodName, filePath, fileName, primaryLine, lo, hi);
             classEntry.indexPrimary(primaryRange, debugCodeInfo.getFrameSizeChanges(), debugCodeInfo.getFrameSize());
@@ -262,7 +262,7 @@ public abstract class DebugInfoBase {
                  * symbol for them and don't see a break in the address range.
                  */
                 ClassEntry subClassEntry = ensureClassEntry(classNameAtLine);
-                MethodEntry subMethodEntry = subClassEntry.getMethodEntry(debugLineInfo, this, debugContext);
+                MethodEntry subMethodEntry = subClassEntry.ensureMethodEntryForDebugRangeInfo(debugLineInfo, this, debugContext);
                 Range subRange = new Range(stringTable, subMethodEntry, loAtLine, hiAtLine, line, primaryRange);
                 classEntry.indexSubRange(subRange);
                 try (DebugContext.Scope s = debugContext.scope("Subranges")) {

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/MethodEntry.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/MethodEntry.java
@@ -28,8 +28,6 @@ package com.oracle.objectfile.debugentry;
 
 import com.oracle.objectfile.debuginfo.DebugInfoProvider.DebugRangeInfo;
 
-import java.nio.file.Path;
-
 public class MethodEntry extends MemberEntry implements Comparable<MethodEntry> {
     final TypeEntry[] paramTypes;
     final String[] paramNames;
@@ -95,7 +93,7 @@ public class MethodEntry extends MemberEntry implements Comparable<MethodEntry> 
 
     public void setInRange(DebugInfoBase debugInfoBase, DebugRangeInfo debugRangeInfo) {
         if (isInRange) {
-            assert fileEntry == debugInfoBase.ensureFileEntry(debugRangeInfo.fileName(), debugRangeInfo.filePath(), debugRangeInfo.cachePath());
+            assert fileEntry == debugInfoBase.ensureFileEntry(debugRangeInfo);
             return;
         }
         /*
@@ -104,10 +102,7 @@ public class MethodEntry extends MemberEntry implements Comparable<MethodEntry> 
          * a result when setting a MethodEntry as isInRange we also make sure that its fileEntry
          * reflects the file info associated with the corresponding Range.
          */
-        String fileName = debugRangeInfo.fileName();
-        Path filePath = debugRangeInfo.filePath();
-        Path cachePath = debugRangeInfo.cachePath();
-        fileEntry = debugInfoBase.ensureFileEntry(fileName, filePath, cachePath);
+        fileEntry = debugInfoBase.ensureFileEntry(debugRangeInfo);
         isInRange = true;
     }
 

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/MethodEntry.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/MethodEntry.java
@@ -28,6 +28,9 @@ package com.oracle.objectfile.debugentry;
 
 import com.oracle.objectfile.debuginfo.DebugInfoProvider.DebugRangeInfo;
 
+import java.util.Arrays;
+import java.util.stream.Collectors;
+
 public class MethodEntry extends MemberEntry implements Comparable<MethodEntry> {
     final TypeEntry[] paramTypes;
     final String[] paramNames;
@@ -35,6 +38,7 @@ public class MethodEntry extends MemberEntry implements Comparable<MethodEntry> 
     boolean isInRange;
 
     final String symbolName;
+    private String signature;
 
     public MethodEntry(FileEntry fileEntry, String symbolName, String methodName, ClassEntry ownerType,
                     TypeEntry valueType, TypeEntry[] paramTypes, String[] paramNames, int modifiers,
@@ -120,6 +124,13 @@ public class MethodEntry extends MemberEntry implements Comparable<MethodEntry> 
         return symbolName;
     }
 
+    private String getSignature() {
+        if (signature == null) {
+            signature = Arrays.stream(paramTypes).map(TypeEntry::getTypeName).collect(Collectors.joining(", "));
+        }
+        return signature;
+    }
+
     public int compareTo(String methodName, String paramSignature, String returnTypeName) {
         int nameComparison = memberName.compareTo(methodName);
         if (nameComparison != 0) {
@@ -129,24 +140,7 @@ public class MethodEntry extends MemberEntry implements Comparable<MethodEntry> 
         if (typeComparison != 0) {
             return typeComparison;
         }
-        String[] paramTypeNames = paramSignature.split((","));
-        int length;
-        if (paramSignature.trim().length() == 0) {
-            length = 0;
-        } else {
-            length = paramTypeNames.length;
-        }
-        int paramCountComparison = getParamCount() - length;
-        if (paramCountComparison != 0) {
-            return paramCountComparison;
-        }
-        for (int i = 0; i < getParamCount(); i++) {
-            int paraComparison = getParamTypeName(i).compareTo(paramTypeNames[i].trim());
-            if (paraComparison != 0) {
-                return paraComparison;
-            }
-        }
-        return 0;
+        return getSignature().compareTo(paramSignature);
     }
 
     @Override
@@ -160,16 +154,6 @@ public class MethodEntry extends MemberEntry implements Comparable<MethodEntry> 
         if (typeComparison != 0) {
             return typeComparison;
         }
-        int paramCountComparison = getParamCount() - other.getParamCount();
-        if (paramCountComparison != 0) {
-            return paramCountComparison;
-        }
-        for (int i = 0; i < getParamCount(); i++) {
-            int paramComparison = getParamTypeName(i).compareTo(other.getParamTypeName(i));
-            if (paramComparison != 0) {
-                return paramComparison;
-            }
-        }
-        return 0;
+        return getSignature().compareTo(other.getSignature());
     }
 }

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/MethodEntry.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/MethodEntry.java
@@ -26,6 +26,10 @@
 
 package com.oracle.objectfile.debugentry;
 
+import com.oracle.objectfile.debuginfo.DebugInfoProvider.DebugRangeInfo;
+
+import java.nio.file.Path;
+
 public class MethodEntry extends MemberEntry implements Comparable<MethodEntry> {
     final TypeEntry[] paramTypes;
     final String[] paramNames;
@@ -89,7 +93,21 @@ public class MethodEntry extends MemberEntry implements Comparable<MethodEntry> 
         return isInRange;
     }
 
-    public void setInRange() {
+    public void setInRange(DebugInfoBase debugInfoBase, DebugRangeInfo debugRangeInfo) {
+        if (isInRange) {
+            assert fileEntry == debugInfoBase.ensureFileEntry(debugRangeInfo.fileName(), debugRangeInfo.filePath(), debugRangeInfo.cachePath());
+            return;
+        }
+        /*
+         * If the MethodEntry was added by traversing the DeclaredMethods of a Class its fileEntry
+         * will point to the original source file, thus it will be wrong for substituted methods. As
+         * a result when setting a MethodEntry as isInRange we also make sure that its fileEntry
+         * reflects the file info associated with the corresponding Range.
+         */
+        String fileName = debugRangeInfo.fileName();
+        Path filePath = debugRangeInfo.filePath();
+        Path cachePath = debugRangeInfo.cachePath();
+        fileEntry = debugInfoBase.ensureFileEntry(fileName, filePath, cachePath);
         isInRange = true;
     }
 

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/MethodEntry.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/MethodEntry.java
@@ -30,14 +30,21 @@ public class MethodEntry extends MemberEntry implements Comparable<MethodEntry> 
     final TypeEntry[] paramTypes;
     final String[] paramNames;
     final boolean isDeoptTarget;
+    boolean isInRange;
 
-    public MethodEntry(FileEntry fileEntry, String methodName, ClassEntry ownerType, TypeEntry valueType, TypeEntry[] paramTypes, String[] paramNames, int modifiers, boolean isDeoptTarget) {
+    final String symbolName;
+
+    public MethodEntry(FileEntry fileEntry, String symbolName, String methodName, ClassEntry ownerType,
+                    TypeEntry valueType, TypeEntry[] paramTypes, String[] paramNames, int modifiers,
+                    boolean isDeoptTarget, boolean isInRange) {
         super(fileEntry, methodName, ownerType, valueType, modifiers);
         assert ((paramTypes == null && paramNames == null) ||
                         (paramTypes != null && paramNames != null && paramTypes.length == paramNames.length));
         this.paramTypes = paramTypes;
         this.paramNames = paramNames;
         this.isDeoptTarget = isDeoptTarget;
+        this.isInRange = isInRange;
+        this.symbolName = symbolName;
     }
 
     public String methodName() {
@@ -60,6 +67,10 @@ public class MethodEntry extends MemberEntry implements Comparable<MethodEntry> 
         return paramTypes[idx];
     }
 
+    public TypeEntry[] getParamTypes() {
+        return paramTypes;
+    }
+
     public String getParamTypeName(int idx) {
         assert paramTypes != null;
         assert idx < paramTypes.length;
@@ -72,6 +83,18 @@ public class MethodEntry extends MemberEntry implements Comparable<MethodEntry> 
         assert idx < paramNames.length;
         /* N.b. param names may be null. */
         return paramNames[idx];
+    }
+
+    public boolean isInRange() {
+        return isInRange;
+    }
+
+    public void setInRange() {
+        isInRange = true;
+    }
+
+    public String getSymbolName() {
+        return symbolName;
     }
 
     public int compareTo(String methodName, String paramSignature, String returnTypeName) {

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/MethodEntry.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/MethodEntry.java
@@ -91,11 +91,22 @@ public class MethodEntry extends MemberEntry implements Comparable<MethodEntry> 
         return isInRange;
     }
 
-    public void setInRange(DebugInfoBase debugInfoBase, DebugRangeInfo debugRangeInfo) {
+    /**
+     * Sets {@code isInRange} and ensures that the {@code fileEntry} is up to date. If the
+     * MethodEntry was added by traversing the DeclaredMethods of a Class its fileEntry will point
+     * to the original source file, thus it will be wrong for substituted methods. As a result when
+     * setting a MethodEntry as isInRange we also make sure that its fileEntry reflects the file
+     * info associated with the corresponding Range.
+     *
+     * @param debugInfoBase
+     * @param debugRangeInfo
+     */
+    public void setInRangeAndUpdateFileEntry(DebugInfoBase debugInfoBase, DebugRangeInfo debugRangeInfo) {
         if (isInRange) {
             assert fileEntry == debugInfoBase.ensureFileEntry(debugRangeInfo);
             return;
         }
+        isInRange = true;
         /*
          * If the MethodEntry was added by traversing the DeclaredMethods of a Class its fileEntry
          * will point to the original source file, thus it will be wrong for substituted methods. As
@@ -103,7 +114,6 @@ public class MethodEntry extends MemberEntry implements Comparable<MethodEntry> 
          * reflects the file info associated with the corresponding Range.
          */
         fileEntry = debugInfoBase.ensureFileEntry(debugRangeInfo);
-        isInRange = true;
     }
 
     public String getSymbolName() {

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/MethodEntry.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/MethodEntry.java
@@ -31,7 +31,7 @@ import com.oracle.objectfile.debuginfo.DebugInfoProvider.DebugRangeInfo;
 public class MethodEntry extends MemberEntry implements Comparable<MethodEntry> {
     final TypeEntry[] paramTypes;
     final String[] paramNames;
-    final boolean isDeoptTarget;
+    public final boolean isDeoptTarget;
     boolean isInRange;
 
     final String symbolName;
@@ -147,10 +147,6 @@ public class MethodEntry extends MemberEntry implements Comparable<MethodEntry> 
             }
         }
         return 0;
-    }
-
-    public boolean isDeoptTarget() {
-        return isDeoptTarget;
     }
 
     @Override

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/Range.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/Range.java
@@ -35,8 +35,7 @@ package com.oracle.objectfile.debugentry;
 public class Range {
     private static final String CLASS_DELIMITER = ".";
     private final FileEntry fileEntry;
-    private MethodEntry methodEntry;
-    private final String symbolName;
+    private final MethodEntry methodEntry;
     private final String fullMethodNameWithParams;
     private final int lo;
     private final int hi;
@@ -49,21 +48,21 @@ public class Range {
     /*
      * Create a primary range.
      */
-    public Range(String symbolName, StringTable stringTable, MethodEntry methodEntry, FileEntry fileEntry, int lo, int hi, int line) {
-        this(symbolName, stringTable, methodEntry, fileEntry, lo, hi, line, null);
+    public Range(StringTable stringTable, MethodEntry methodEntry, FileEntry fileEntry, int lo, int hi, int line) {
+        this(stringTable, methodEntry, fileEntry, lo, hi, line, null);
     }
 
     /*
      * Create a secondary range.
      */
-    public Range(String symbolName, StringTable stringTable, MethodEntry methodEntry, int lo, int hi, int line, Range primary) {
-        this(symbolName, stringTable, methodEntry, methodEntry.fileEntry, lo, hi, line, primary);
+    public Range(StringTable stringTable, MethodEntry methodEntry, int lo, int hi, int line, Range primary) {
+        this(stringTable, methodEntry, methodEntry.fileEntry, lo, hi, line, primary);
     }
 
     /*
      * Create a primary or secondary range.
      */
-    private Range(String symbolName, StringTable stringTable, MethodEntry methodEntry, FileEntry fileEntry, int lo, int hi, int line,
+    private Range(StringTable stringTable, MethodEntry methodEntry, FileEntry fileEntry, int lo, int hi, int line,
                     Range primary) {
         this.fileEntry = fileEntry;
         if (fileEntry != null) {
@@ -72,7 +71,6 @@ public class Range {
         }
         assert methodEntry != null;
         this.methodEntry = methodEntry;
-        this.symbolName = stringTable.uniqueString(symbolName);
         this.fullMethodNameWithParams = stringTable.uniqueString(constructClassAndMethodNameWithParams());
         this.lo = lo;
         this.hi = hi;
@@ -101,7 +99,7 @@ public class Range {
     }
 
     public String getSymbolName() {
-        return symbolName;
+        return methodEntry.getSymbolName();
     }
 
     public int getHi() {
@@ -159,14 +157,6 @@ public class Range {
         return getExtendedMethodName(true, true, false);
     }
 
-    public String getMethodReturnTypeName() {
-        return methodEntry.valueType.typeName;
-    }
-
-    public TypeEntry[] getParamTypes() {
-        return methodEntry.paramTypes;
-    }
-
     public FileEntry getFileEntry() {
         return fileEntry;
     }
@@ -182,5 +172,9 @@ public class Range {
 
     public String getFileName() {
         return fileEntry.getFileName();
+    }
+
+    public MethodEntry getMethodEntry() {
+        return methodEntry;
     }
 }

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/Range.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/Range.java
@@ -34,7 +34,6 @@ package com.oracle.objectfile.debugentry;
 
 public class Range {
     private static final String CLASS_DELIMITER = ".";
-    private final FileEntry fileEntry;
     private final MethodEntry methodEntry;
     private final String fullMethodNameWithParams;
     private final int lo;
@@ -48,28 +47,19 @@ public class Range {
     /*
      * Create a primary range.
      */
-    public Range(StringTable stringTable, MethodEntry methodEntry, FileEntry fileEntry, int lo, int hi, int line) {
-        this(stringTable, methodEntry, fileEntry, lo, hi, line, null);
-    }
-
-    /*
-     * Create a secondary range.
-     */
-    public Range(StringTable stringTable, MethodEntry methodEntry, int lo, int hi, int line, Range primary) {
-        this(stringTable, methodEntry, methodEntry.fileEntry, lo, hi, line, primary);
+    public Range(StringTable stringTable, MethodEntry methodEntry, int lo, int hi, int line) {
+        this(stringTable, methodEntry, lo, hi, line, null);
     }
 
     /*
      * Create a primary or secondary range.
      */
-    private Range(StringTable stringTable, MethodEntry methodEntry, FileEntry fileEntry, int lo, int hi, int line,
-                    Range primary) {
-        this.fileEntry = fileEntry;
-        if (fileEntry != null) {
-            stringTable.uniqueDebugString(fileEntry.getFileName());
-            stringTable.uniqueDebugString(fileEntry.getPathName());
-        }
+    public Range(StringTable stringTable, MethodEntry methodEntry, int lo, int hi, int line, Range primary) {
         assert methodEntry != null;
+        if (methodEntry.fileEntry != null) {
+            stringTable.uniqueDebugString(methodEntry.fileEntry.getFileName());
+            stringTable.uniqueDebugString(methodEntry.fileEntry.getPathName());
+        }
         this.methodEntry = methodEntry;
         this.fullMethodNameWithParams = stringTable.uniqueString(constructClassAndMethodNameWithParams());
         this.lo = lo;
@@ -158,7 +148,7 @@ public class Range {
     }
 
     public FileEntry getFileEntry() {
-        return fileEntry;
+        return methodEntry.fileEntry;
     }
 
     public int getModifiers() {
@@ -167,11 +157,11 @@ public class Range {
 
     @Override
     public String toString() {
-        return String.format("Range(lo=0x%05x hi=0x%05x %s %s:%d)", lo, hi, constructClassAndMethodNameWithParams(), fileEntry.getFullName(), line);
+        return String.format("Range(lo=0x%05x hi=0x%05x %s %s:%d)", lo, hi, constructClassAndMethodNameWithParams(), methodEntry.getFullFileName(), line);
     }
 
     public String getFileName() {
-        return fileEntry.getFileName();
+        return methodEntry.getFileName();
     }
 
     public MethodEntry getMethodEntry() {

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/StructureTypeEntry.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/StructureTypeEntry.java
@@ -30,7 +30,6 @@ import com.oracle.objectfile.debuginfo.DebugInfoProvider.DebugFieldInfo;
 import org.graalvm.compiler.debug.DebugContext;
 
 import java.lang.reflect.Modifier;
-import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Stream;
@@ -68,14 +67,11 @@ public abstract class StructureTypeEntry extends TypeEntry {
         debugContext.log("typename %s adding %s field %s type %s size %s at offset %d\n",
                         typeName, memberModifiers(fieldModifiers), fieldName, valueTypeName, fieldSize, fieldoffset);
         TypeEntry valueType = debugInfoBase.lookupTypeEntry(valueTypeName);
-        String fileName = debugFieldInfo.fileName();
-        Path filePath = debugFieldInfo.filePath();
-        Path cachePath = debugFieldInfo.cachePath();
         /*
          * n.b. the field file may differ from the owning class file when the field is a
          * substitution
          */
-        FileEntry fileEntry = debugInfoBase.ensureFileEntry(fileName, filePath, cachePath);
+        FileEntry fileEntry = debugInfoBase.ensureFileEntry(debugFieldInfo);
         FieldEntry fieldEntry = new FieldEntry(fileEntry, fieldName, this, valueType, fieldSize, fieldoffset, fieldModifiers);
         fields.add(fieldEntry);
         return fieldEntry;

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debuginfo/DebugInfoProvider.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debuginfo/DebugInfoProvider.java
@@ -228,9 +228,16 @@ public interface DebugInfoProvider {
     }
 
     /**
+     * Access details of a compiled method producing the code in a specific
+     * {@link com.oracle.objectfile.debugentry.Range}.
+     */
+    interface DebugRangeInfo extends DebugMethodInfo {
+    }
+
+    /**
      * Access details of a specific compiled method.
      */
-    interface DebugCodeInfo extends DebugMethodInfo {
+    interface DebugCodeInfo extends DebugRangeInfo {
         void debugContext(Consumer<DebugContext> action);
 
         /**
@@ -291,7 +298,7 @@ public interface DebugInfoProvider {
      * Access details of code generated for a specific outer or inlined method at a given line
      * number.
      */
-    interface DebugLineInfo extends DebugMethodInfo {
+    interface DebugLineInfo extends DebugRangeInfo {
         /**
          * @return the lowest address containing code generated for an outer or inlined code segment
          *         reported at this line represented as an offset into the code segment.

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/ELFProgbitsSection.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/ELFProgbitsSection.java
@@ -69,7 +69,7 @@ public class ELFProgbitsSection extends ELFUserDefinedSection implements Progbit
     }
 
     @Override
-    public ObjectFile.RelocationRecord markRelocationSite(int offset, ObjectFile.RelocationKind k, String symbolName, boolean useImplicitAddend, Long explicitAddend) {
-        return markRelocationSite(offset, ByteBuffer.wrap(getContent()).order(getOwner().getByteOrder()), k, symbolName, useImplicitAddend, explicitAddend);
+    public void markRelocationSite(int offset, ObjectFile.RelocationKind k, String symbolName, boolean useImplicitAddend, Long explicitAddend) {
+        markRelocationSite(offset, ByteBuffer.wrap(getContent()).order(getOwner().getByteOrder()), k, symbolName, useImplicitAddend, explicitAddend);
     }
 }

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/ELFUserDefinedSection.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/ELFUserDefinedSection.java
@@ -34,7 +34,6 @@ import com.oracle.objectfile.ElementImpl;
 import com.oracle.objectfile.LayoutDecisionMap;
 import com.oracle.objectfile.ObjectFile;
 import com.oracle.objectfile.ObjectFile.Element;
-import com.oracle.objectfile.ObjectFile.RelocationRecord;
 import com.oracle.objectfile.elf.ELFObjectFile.ELFSection;
 import com.oracle.objectfile.elf.ELFObjectFile.ELFSectionFlag;
 import com.oracle.objectfile.elf.ELFObjectFile.SectionType;
@@ -148,7 +147,7 @@ public class ELFUserDefinedSection extends ELFSection implements ObjectFile.Relo
     }
 
     @Override
-    public RelocationRecord markRelocationSite(int offset, ByteBuffer bb, ObjectFile.RelocationKind k, String symbolName, boolean useImplicitAddend, Long explicitAddend) {
+    public void markRelocationSite(int offset, ByteBuffer bb, ObjectFile.RelocationKind k, String symbolName, boolean useImplicitAddend, Long explicitAddend) {
         if (useImplicitAddend != (explicitAddend == null)) {
             throw new IllegalArgumentException("must have either an explicit or implicit addend");
         }
@@ -157,6 +156,6 @@ public class ELFUserDefinedSection extends ELFSection implements ObjectFile.Relo
         assert symbolName != null;
         ELFSymtab.Entry ent = syms.getSymbol(symbolName);
         assert ent != null;
-        return rs.addEntry(this, offset, ELFMachine.getRelocation(getOwner().getMachine(), k), ent, explicitAddend);
+        rs.addEntry(this, offset, ELFMachine.getRelocation(getOwner().getMachine(), k), ent, explicitAddend);
     }
 }

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfInfoSectionImpl.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfInfoSectionImpl.java
@@ -31,6 +31,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import com.oracle.objectfile.debugentry.MethodEntry;
 import org.graalvm.compiler.debug.DebugContext;
 
 import com.oracle.objectfile.BuildDependency;
@@ -654,24 +655,24 @@ public class DwarfInfoSectionImpl extends DwarfSectionImpl {
 
     private int writeMethodDeclarations(DebugContext context, ClassEntry classEntry, byte[] buffer, int p) {
         int pos = p;
-        List<PrimaryEntry> classPrimaryEntries = classEntry.getPrimaryEntries();
-        for (PrimaryEntry primaryEntry : classPrimaryEntries) {
-            Range range = primaryEntry.getPrimary();
-            /*
-             * Declare all methods including deopt targets even though they are written in separate
-             * CUs.
-             */
-            pos = writeMethodDeclaration(context, classEntry, range, buffer, pos);
+        for (MethodEntry method : classEntry.getMethods()) {
+            if (method.isInRange()) {
+                /*
+                 * Declare all methods including deopt targets even though they are written in
+                 * separate CUs.
+                 */
+                pos = writeMethodDeclaration(context, classEntry, method, buffer, pos);
+            }
         }
 
         return pos;
     }
 
-    private int writeMethodDeclaration(DebugContext context, ClassEntry classEntry, Range range, byte[] buffer, int p) {
+    private int writeMethodDeclaration(DebugContext context, ClassEntry classEntry, MethodEntry method, byte[] buffer, int p) {
         int pos = p;
-        String methodKey = range.getSymbolName();
+        String methodKey = method.getSymbolName();
         setMethodDeclarationIndex(classEntry, methodKey, pos);
-        int modifiers = range.getModifiers();
+        int modifiers = method.getModifiers();
         boolean isStatic = Modifier.isStatic(modifiers);
         log(context, "  [0x%08x] method declaration %s", pos, methodKey);
         int abbrevCode = (isStatic ? DwarfDebugInfo.DW_ABBREV_CODE_method_declaration2 : DwarfDebugInfo.DW_ABBREV_CODE_method_declaration1);
@@ -679,19 +680,23 @@ public class DwarfInfoSectionImpl extends DwarfSectionImpl {
         pos = writeAbbrevCode(abbrevCode, buffer, pos);
         log(context, "  [0x%08x]     external  true", pos);
         pos = writeFlag((byte) 1, buffer, pos);
-        String name = uniqueDebugString(range.getMethodName());
+        String name = uniqueDebugString(method.methodName());
         log(context, "  [0x%08x]     name 0x%x (%s)", pos, debugStringIndex(name), name);
         pos = writeAttrStrp(name, buffer, pos);
-        FileEntry fileEntry = range.getFileEntry();
-        int fileIdx = (fileEntry != null ? classEntry.localFilesIdx(fileEntry) : classEntry.localFilesIdx());
-        log(context, "  [0x%08x]     file 0x%x (%s)", pos, fileIdx, range.getFileEntry().getFullName());
+        FileEntry fileEntry = method.getFileEntry();
+        if (fileEntry == null) {
+            fileEntry = classEntry.getFileEntry();
+        }
+        assert fileEntry != null;
+        int fileIdx = classEntry.localFilesIdx(fileEntry);
+        log(context, "  [0x%08x]     file 0x%x (%s)", pos, fileIdx, fileEntry.getFullName());
         pos = writeAttrData2((short) fileIdx, buffer, pos);
-        String returnTypeName = range.getMethodReturnTypeName();
+        String returnTypeName = method.getValueType().getTypeName();
         int retTypeIdx = getTypeIndex(returnTypeName);
         log(context, "  [0x%08x]     type 0x%x (%s)", pos, retTypeIdx, returnTypeName);
         pos = writeAttrRefAddr(retTypeIdx, buffer, pos);
-        log(context, "  [0x%08x]     artificial %s", pos, range.isDeoptTarget() ? "true" : "false");
-        pos = writeFlag((range.isDeoptTarget() ? (byte) 1 : (byte) 0), buffer, pos);
+        log(context, "  [0x%08x]     artificial %s", pos, method.isDeoptTarget() ? "true" : "false");
+        pos = writeFlag((method.isDeoptTarget() ? (byte) 1 : (byte) 0), buffer, pos);
         log(context, "  [0x%08x]     accessibility %s", pos, "public");
         pos = writeAttrAccessibility(modifiers, buffer, pos);
         log(context, "  [0x%08x]     declaration true", pos);
@@ -713,22 +718,22 @@ public class DwarfInfoSectionImpl extends DwarfSectionImpl {
             writeAttrRefAddr(pos, buffer, objectPointerIndex);
         }
         /* Write method parameter declarations. */
-        pos = writeMethodParameterDeclarations(context, classEntry, range, true, buffer, pos);
+        pos = writeMethodParameterDeclarations(context, classEntry, method, true, buffer, pos);
         /*
          * Write a terminating null attribute.
          */
         return writeAttrNull(buffer, pos);
     }
 
-    private int writeMethodParameterDeclarations(DebugContext context, ClassEntry classEntry, Range range, boolean isSpecification, byte[] buffer, int p) {
+    private int writeMethodParameterDeclarations(DebugContext context, ClassEntry classEntry, MethodEntry method, boolean isSpecification, byte[] buffer, int p) {
         int pos = p;
-        if (!Modifier.isStatic(range.getModifiers())) {
+        if (!Modifier.isStatic(method.getModifiers())) {
             pos = writeMethodParameterDeclaration(context, "this", classEntry.getTypeName(), true, isSpecification, buffer, pos);
         }
-        for (TypeEntry paramType : range.getParamTypes()) {
+        for (TypeEntry paramType : method.getParamTypes()) {
             String paramTypeName = paramType.getTypeName();
             String paramName = uniqueDebugString("");
-            FileEntry fileEntry = range.getFileEntry();
+            FileEntry fileEntry = method.getFileEntry();
             if (fileEntry != null) {
                 pos = writeMethodParameterDeclaration(context, paramName, paramTypeName, false, isSpecification, buffer, pos);
             } else {
@@ -1237,7 +1242,7 @@ public class DwarfInfoSectionImpl extends DwarfSectionImpl {
         int methodSpecOffset = getMethodDeclarationIndex(classEntry, methodKey);
         log(context, "  [0x%08x]     specification  0x%x (%s)", pos, methodSpecOffset, methodKey);
         pos = writeAttrRefAddr(methodSpecOffset, buffer, pos);
-        pos = writeMethodParameterDeclarations(context, classEntry, range, false, buffer, pos);
+        pos = writeMethodParameterDeclarations(context, classEntry, range.getMethodEntry(), false, buffer, pos);
         /*
          * Write a terminating null attribute.
          */

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfInfoSectionImpl.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfInfoSectionImpl.java
@@ -695,8 +695,8 @@ public class DwarfInfoSectionImpl extends DwarfSectionImpl {
         int retTypeIdx = getTypeIndex(returnTypeName);
         log(context, "  [0x%08x]     type 0x%x (%s)", pos, retTypeIdx, returnTypeName);
         pos = writeAttrRefAddr(retTypeIdx, buffer, pos);
-        log(context, "  [0x%08x]     artificial %s", pos, method.isDeoptTarget() ? "true" : "false");
-        pos = writeFlag((method.isDeoptTarget() ? (byte) 1 : (byte) 0), buffer, pos);
+        log(context, "  [0x%08x]     artificial %s", pos, method.isDeoptTarget ? "true" : "false");
+        pos = writeFlag((method.isDeoptTarget ? (byte) 1 : (byte) 0), buffer, pos);
         log(context, "  [0x%08x]     accessibility %s", pos, "public");
         pos = writeAttrAccessibility(modifiers, buffer, pos);
         log(context, "  [0x%08x]     declaration true", pos);

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/macho/MachORegularSection.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/macho/MachORegularSection.java
@@ -30,7 +30,6 @@ import java.util.EnumSet;
 import com.oracle.objectfile.ObjectFile;
 import com.oracle.objectfile.ObjectFile.ProgbitsSectionImpl;
 import com.oracle.objectfile.ObjectFile.RelocationKind;
-import com.oracle.objectfile.ObjectFile.RelocationRecord;
 import com.oracle.objectfile.macho.MachOObjectFile.SectionFlag;
 import com.oracle.objectfile.macho.MachOObjectFile.Segment64Command;
 
@@ -51,8 +50,8 @@ public class MachORegularSection extends MachOUserDefinedSection implements Obje
     }
 
     @Override
-    public RelocationRecord markRelocationSite(int offset, RelocationKind k, String symbolName, boolean useImplicitAddend, Long explicitAddend) {
-        return markRelocationSite(offset, ByteBuffer.wrap(getContent()).order(getOwner().getByteOrder()), k, symbolName, useImplicitAddend, explicitAddend);
+    public void markRelocationSite(int offset, RelocationKind k, String symbolName, boolean useImplicitAddend, Long explicitAddend) {
+        markRelocationSite(offset, ByteBuffer.wrap(getContent()).order(getOwner().getByteOrder()), k, symbolName, useImplicitAddend, explicitAddend);
     }
 
 }

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/macho/MachOUserDefinedSection.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/macho/MachOUserDefinedSection.java
@@ -36,7 +36,6 @@ import com.oracle.objectfile.LayoutDecisionMap;
 import com.oracle.objectfile.ObjectFile;
 import com.oracle.objectfile.ObjectFile.Element;
 import com.oracle.objectfile.ObjectFile.RelocationKind;
-import com.oracle.objectfile.ObjectFile.RelocationRecord;
 import com.oracle.objectfile.ObjectFile.Segment;
 import com.oracle.objectfile.ObjectFile.Symbol;
 import com.oracle.objectfile.io.AssemblyBuffer;
@@ -160,7 +159,7 @@ public class MachOUserDefinedSection extends MachOSection implements ObjectFile.
     }
 
     @Override
-    public RelocationRecord markRelocationSite(int offset, ByteBuffer bb, RelocationKind k, String symbolName, boolean useImplicitAddend, Long explicitAddend) {
+    public void markRelocationSite(int offset, ByteBuffer bb, RelocationKind k, String symbolName, boolean useImplicitAddend, Long explicitAddend) {
         MachORelocationElement el = getOrCreateRelocationElement(useImplicitAddend);
         AssemblyBuffer sbb = new AssemblyBuffer(bb);
         sbb.setByteOrder(getOwner().getByteOrder());
@@ -215,7 +214,5 @@ public class MachOUserDefinedSection extends MachOSection implements ObjectFile.
         sbb.pop();
         RelocationInfo rec = new RelocationInfo(el, this, offset, length, k, symbolName, createAsLocalReloc);
         el.add(rec);
-
-        return rec;
     }
 }

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/pecoff/PECoffProgbitsSection.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/pecoff/PECoffProgbitsSection.java
@@ -69,7 +69,7 @@ public class PECoffProgbitsSection extends PECoffUserDefinedSection implements P
     }
 
     @Override
-    public ObjectFile.RelocationRecord markRelocationSite(int offset, ObjectFile.RelocationKind k, String symbolName, boolean useImplicitAddend, Long explicitAddend) {
-        return markRelocationSite(offset, ByteBuffer.wrap(getContent()).order(getOwner().getByteOrder()), k, symbolName, useImplicitAddend, explicitAddend);
+    public void markRelocationSite(int offset, ObjectFile.RelocationKind k, String symbolName, boolean useImplicitAddend, Long explicitAddend) {
+        markRelocationSite(offset, ByteBuffer.wrap(getContent()).order(getOwner().getByteOrder()), k, symbolName, useImplicitAddend, explicitAddend);
     }
 }

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/pecoff/PECoffRelocationTable.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/pecoff/PECoffRelocationTable.java
@@ -58,7 +58,7 @@ public class PECoffRelocationTable extends ObjectFile.Element {
         long toLong();
     }
 
-    private static final class Entry implements RelocationRecord {
+    static final class Entry implements RelocationRecord {
         final PECoffSection section;
         final long offset;
         final PECoffRelocationMethod t;

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/pecoff/PECoffUserDefinedSection.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/pecoff/PECoffUserDefinedSection.java
@@ -149,7 +149,11 @@ public class PECoffUserDefinedSection extends PECoffSection implements ObjectFil
         PECoffRelocationTable rs = (PECoffRelocationTable) getOrCreateRelocationElement(useImplicitAddend);
         assert symbolName != null;
         PECoffSymtab.Entry ent = syms.getSymbol(symbolName);
-        assert ent != null;
+        if (ent == null) {
+            warn("attempting to mark relocation site for non-existent symbol " + symbolName);
+            /* Return (but do not add to entry list) dummy relocation entry. It is never used (in GraalVM CE) */
+            return new PECoffRelocationTable.Entry(this, offset, PECoffMachine.getRelocation(getOwner().getMachine(), k), null, 0L);
+        }
 
         AssemblyBuffer sbb = new AssemblyBuffer(bb);
         sbb.setByteOrder(getOwner().getByteOrder());
@@ -195,5 +199,14 @@ public class PECoffUserDefinedSection extends PECoffSection implements ObjectFil
         sbb.pop();
 
         return rs.addEntry(this, offset, PECoffMachine.getRelocation(getOwner().getMachine(), k), ent, explicitAddend);
+    }
+
+    /**
+     * Report a warning message in SVM.
+     *
+     * @param msg warning message that is printed.
+     */
+    private static void warn(String msg) {
+        System.err.println("Warning: " + msg);
     }
 }

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/pecoff/PECoffUserDefinedSection.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/pecoff/PECoffUserDefinedSection.java
@@ -34,7 +34,6 @@ import com.oracle.objectfile.ElementImpl;
 import com.oracle.objectfile.LayoutDecisionMap;
 import com.oracle.objectfile.ObjectFile;
 import com.oracle.objectfile.ObjectFile.Element;
-import com.oracle.objectfile.ObjectFile.RelocationRecord;
 import com.oracle.objectfile.io.AssemblyBuffer;
 import com.oracle.objectfile.pecoff.PECoffObjectFile.PECoffSection;
 import com.oracle.objectfile.pecoff.PECoffObjectFile.PECoffSectionFlag;
@@ -141,7 +140,7 @@ public class PECoffUserDefinedSection extends PECoffSection implements ObjectFil
     }
 
     @Override
-    public RelocationRecord markRelocationSite(int offset, ByteBuffer bb, ObjectFile.RelocationKind k, String symbolName, boolean useImplicitAddend, Long explicitAddend) {
+    public void markRelocationSite(int offset, ByteBuffer bb, ObjectFile.RelocationKind k, String symbolName, boolean useImplicitAddend, Long explicitAddend) {
         if (useImplicitAddend != (explicitAddend == null)) {
             throw new IllegalArgumentException("must have either an explicit or implicit addend");
         }
@@ -151,8 +150,7 @@ public class PECoffUserDefinedSection extends PECoffSection implements ObjectFil
         PECoffSymtab.Entry ent = syms.getSymbol(symbolName);
         if (ent == null) {
             warn("attempting to mark relocation site for non-existent symbol " + symbolName);
-            /* Return (but do not add to entry list) dummy relocation entry. It is never used (in GraalVM CE) */
-            return new PECoffRelocationTable.Entry(this, offset, PECoffMachine.getRelocation(getOwner().getMachine(), k), null, 0L);
+            return;
         }
 
         AssemblyBuffer sbb = new AssemblyBuffer(bb);
@@ -198,7 +196,7 @@ public class PECoffUserDefinedSection extends PECoffSection implements ObjectFil
         // return ByteBuffer cursor to where it was
         sbb.pop();
 
-        return rs.addEntry(this, offset, PECoffMachine.getRelocation(getOwner().getMachine(), k), ent, explicitAddend);
+        rs.addEntry(this, offset, PECoffMachine.getRelocation(getOwner().getMachine(), k), ent, explicitAddend);
     }
 
     /**


### PR DESCRIPTION
As of https://github.com/oracle/graal/pull/3304 we associate every range
with the `MethodEntry` of the method it was compiled from, and as a
result we know that a `MethodEntry` exists for each compiled method in
the image. Actually we create `MethodEntry`s even for methods that are
not compiled but are part of `ClassEntry` that describes a Class
reachable in the image.

For every range we generate a DIE (Debugging Information Entry) which
references another DIE that holds the specification of the method that
this range was generated from. So for every range we need a method DIE
containing information for the corresponding method.

Till now we have been generating these DIEs by traversing the primary
ranges of each ClassEntry. There are, however, subranges that might be
compiled from a method that is not referenced by a primary range, e.g.,
inlined methods.

This patch ensures that every method that is compiled in the native
image (including inlined ones) will get a method DIE.