### PR TITLE
CI: Cancel previous jobs for same PR or pendings ones for branches

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,6 +13,10 @@ on:
       - '**.md'
   workflow_dispatch: []
 
+concurrency:
+  group: "workflow = ${{ github.workflow }}, ref = ${{ github.event.ref }}, pr = ${{ github.event.pull_request.id }}"
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 env:
   LANG: en_US.UTF-8
   MX_GIT_CACHE: refcache

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,6 +13,15 @@ on:
       - '**.md'
   workflow_dispatch: []
 
+# The following aims to reduce CI CPU cycles by:
+# 1. Cancelling any previous builds of this PR when pushing new changes to it
+# 2. Cancelling any previous builds of a branch when pushing new changes to it in a fork
+# 3. Cancelling any pending builds, but not active ones, when pushing to a branch in the main
+#    repository. This prevents us from constantly cancelling CI runs, while being able to skip
+#    intermediate builds. E.g., if we perform two pushes the first one will start a CI job and
+#    the second one will add another one to the queue; if we perform a third push while the
+#    first CI job is still running the previously queued CI job (for the second push) will be
+#    cancelled and a new CI job will be queued for the latest (third) push.
 concurrency:
   group: "workflow = ${{ github.workflow }}, ref = ${{ github.event.ref }}, pr = ${{ github.event.pull_request.id }}"
   cancel-in-progress: ${{ github.event_name == 'pull_request' || github.repository != 'oracle/graal' }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ on:
 
 concurrency:
   group: "workflow = ${{ github.workflow }}, ref = ${{ github.event.ref }}, pr = ${{ github.event.pull_request.id }}"
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.repository != 'oracle/graal' }}
 
 env:
   LANG: en_US.UTF-8


### PR DESCRIPTION
The changes in this patch as well as the following commit message have
been copied from:
https://github.com/quarkusio/quarkus/commit/c97aa9dded0926a642680c27ecf859bf51f2e1e7

> See
> https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#concurrency
> for the documentation of this feature.
> 
> Essentially, this gives the following behavior:
> 
> * For pull requests, only the most recent HEAD gets built. Builds for
>   previous HEADs get cancelled automatically.
> * For branches (main, ...), we can only ever have two concurrent builds:
>   one running, and one (more recent) pending.
>   If a build is running and another one gets requested (because of a
>   push), the second one will be pending and wait for the first one to
>   finish.
>   If a third build gets requested before the first one finishes,
>   the second build gets cancelled and the third build will be pending
>   until the first build finishes.
