### PR TITLE
Override toString() in HostException

### DIFF
--- a/truffle/src/com.oracle.truffle.host/src/com/oracle/truffle/host/HostException.java
+++ b/truffle/src/com.oracle.truffle.host/src/com/oracle/truffle/host/HostException.java
@@ -62,6 +62,11 @@ final class HostException extends AbstractTruffleException {
     Throwable getOriginal() {
         return original;
     }
+    
+    @Override
+    public String toString() {
+        return getClass().getName() + ": " + getOriginal().toString();
+    }
 
     @Override
     public String getMessage() {


### PR DESCRIPTION
Throwable#toString() displays the class name and optionally the message. While the original message is forwarded, the class name is not. This makes toString() less useful, especially when the message is null. NullPointerExceptions, for example, do not have a message. toString() for an HostException wrapping a NPE returns "com.oracle.truffle.host.HostException".
This commit ensures that the original class name is included in HostException#toString(). For an NPE, that would be "com.oracle.truffle.host.HostException: java.lang.NullPointerException".

Please assign to @chumer

/cc @janehmueller