### PR TITLE
Only scan for resources in jar if really a jar #3467

### DIFF
--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/ResourcesFeature.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/ResourcesFeature.java
@@ -50,6 +50,7 @@ import java.util.jar.JarFile;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
+import com.oracle.svm.core.util.ClasspathUtils;
 import org.graalvm.compiler.debug.DebugContext;
 import org.graalvm.compiler.options.Option;
 import org.graalvm.compiler.options.OptionType;
@@ -212,7 +213,7 @@ public final class ResourcesFeature implements Feature {
             try {
                 if (classpathFile.isDirectory()) {
                     scanDirectory(debugContext, classpathFile, includePatterns, excludePatterns);
-                } else {
+                } else if (ClasspathUtils.isJar(classpathFile.toPath())) {
                     scanJar(debugContext, classpathFile, includePatterns, excludePatterns);
                 }
             } catch (IOException ex) {


### PR DESCRIPTION
Fixes #3467 by checking if jar is really a jar before scanning it.