### PR TITLE
XMLParsersRegistration needs an additional resource bundle

### DIFF
--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/xml/XMLParsersRegistration.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/xml/XMLParsersRegistration.java
@@ -114,6 +114,7 @@ public abstract class XMLParsersRegistration extends JNIRegistrationUtil {
 
             ResourcesRegistry resourcesRegistry = ImageSingletons.lookup(ResourcesRegistry.class);
             resourcesRegistry.addResourceBundles("com.sun.org.apache.xml.internal.serializer.utils.SerializerMessages");
+            resourcesRegistry.addResourceBundles("com.sun.org.apache.xalan.internal.xsltc.compiler.util.ErrorMessages");
             resourcesRegistry.addResources("com.sun.*.properties");
 
             classInitializationSupport.setConfigurationSealed(true);


### PR DESCRIPTION
While testing the use of the JDK's XML parsers to transform JDBC resultsets in native-image, I've got an error about the `com.sun.org.apache.xalan.internal.xsltc.compiler.util.ErrorMessages` resource bundle not having been registered.

I noticed all other resources had been registered automatically by the automatic feature `XMLParsersRegistration`, so I suppose this one had been forgotten?