### PR TITLE
Fix: neo4j-analytics benchmark.

### DIFF
--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/snippets/SubstrateGraphBuilderPlugins.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/snippets/SubstrateGraphBuilderPlugins.java
@@ -365,6 +365,16 @@ public class SubstrateGraphBuilderPlugins {
              */
             List<Class<?>> classList = new ArrayList<>();
             FixedNode successor = unwrapNode(newArray.next());
+            /*
+             * In a case when we are creating a proxy, which contains a method with a class as a
+             * parameter, a successor node will not be StoreIndexNode, so we need to skip
+             * initialization nodes.
+             */
+            if (successor instanceof EnsureClassInitializedNode) {
+                AbstractBeginNode classInitializedNode = ((EnsureClassInitializedNode) successor).next();
+                VMError.guarantee(classInitializedNode != null);
+                successor = classInitializedNode.next();
+            }
             while (successor instanceof StoreIndexedNode) {
                 StoreIndexedNode store = (StoreIndexedNode) successor;
                 assert getDeoptProxyOriginalValue(store.array()).equals(newArray);

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/snippets/SubstrateGraphBuilderPlugins.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/snippets/SubstrateGraphBuilderPlugins.java
@@ -366,9 +366,9 @@ public class SubstrateGraphBuilderPlugins {
             List<Class<?>> classList = new ArrayList<>();
             FixedNode successor = unwrapNode(newArray.next());
             /*
-             * In a case when we are creating a proxy, which contains a method with a class as a
-             * parameter, a successor node will not be StoreIndexNode, so we need to skip
-             * initialization nodes.
+             * In a case when we are creating a proxy, which contains a method with a class
+             * (initialized at runtime) as a parameter, a successor node will not be StoreIndexNode,
+             * so we need to skip initialization nodes.
              */
             if (successor instanceof EnsureClassInitializedNode) {
                 AbstractBeginNode classInitializedNode = ((EnsureClassInitializedNode) successor).next();

--- a/substratevm/src/com.oracle.svm.test/src/META-INF/native-image/proxy-config.json
+++ b/substratevm/src/com.oracle.svm.test/src/META-INF/native-image/proxy-config.json
@@ -1,0 +1,3 @@
+[
+  ["com.oracle.svm.test.proxy.CustomProxy"]
+]

--- a/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/proxy/CustomInvocationHandler.java
+++ b/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/proxy/CustomInvocationHandler.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2021, 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package com.oracle.svm.test.proxy;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+
+public class CustomInvocationHandler implements InvocationHandler {
+    @Override
+    public Object invoke(Object proxy, Method method, Object[] args) {
+        return null;
+    }
+}

--- a/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/proxy/CustomInvocationHandler.java
+++ b/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/proxy/CustomInvocationHandler.java
@@ -25,8 +25,10 @@
 
 package com.oracle.svm.test.proxy;
 
+// Checkstyle: stop
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Method;
+// Checkstyle: resume
 
 public class CustomInvocationHandler implements InvocationHandler {
     @Override

--- a/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/proxy/CustomProxy.java
+++ b/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/proxy/CustomProxy.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2021, 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package com.oracle.svm.test.proxy;
+
+public interface CustomProxy {
+    void method(DummyClass dummyClass);
+}

--- a/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/proxy/DummyClass.java
+++ b/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/proxy/DummyClass.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2021, 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package com.oracle.svm.test.proxy;
+
+public class DummyClass {
+    public static final String RND_NUMBER;
+
+    static {
+        RND_NUMBER = Long.toString(System.currentTimeMillis());
+    }
+
+}

--- a/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/proxy/ProxyExceptionTest.java
+++ b/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/proxy/ProxyExceptionTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2021, 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package com.oracle.svm.test.proxy;
+
+import org.junit.Test;
+
+import java.lang.reflect.Proxy;
+
+public class ProxyExceptionTest {
+
+    /**
+     * <p>
+     * When we are creating a proxy, which contains a method with a class (<b>initialized at
+     * runtime</b>) as a parameter, will cause exception in runtime. Cause of this issue is that
+     * {@link com.oracle.svm.hosted.snippets.SubstrateGraphBuilderPlugins} didn't manage to make a
+     * constant out of proxies methods (which are accessed reflectively at runtime).
+     * </p>
+     */
+    @Test
+    public void test1() {
+        Proxy.newProxyInstance(ClassLoader.getSystemClassLoader(), new Class<?>[]{CustomProxy.class}, new CustomInvocationHandler());
+    }
+}

--- a/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/proxy/ProxyExceptionTest.java
+++ b/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/proxy/ProxyExceptionTest.java
@@ -27,7 +27,9 @@ package com.oracle.svm.test.proxy;
 
 import org.junit.Test;
 
+// Checkstyle: stop
 import java.lang.reflect.Proxy;
+// Checkstyle: resume
 
 public class ProxyExceptionTest {
 


### PR DESCRIPTION
The **neo4j-analytics** benchmark is not working due to a proxy initialization problem. 

Stacktrace is:

> java.lang.NoSuchMethodError: org.neo4j.kernel.impl.api.index.IndexingService$Monitor.awaitingPopulationOfRecoveredIndex(org.neo4j.storageengine.api.schema.StoreIndexDescriptor)
> 	at com.sun.proxy.$Proxy196.<clinit>(Unknown Source)
> The following benchmarks failed: neo4j-analytics
> 	at com.oracle.svm.core.classinitialization.ClassInitializationInfo.invokeClassInitializer(ClassInitializationInfo.java:375)
> 	at com.oracle.svm.core.classinitialization.ClassInitializationInfo.initialize(ClassInitializationInfo.java:295)
> 	at java.lang.reflect.Constructor.newInstance(Constructor.java:490)
> 	at java.lang.reflect.Proxy.newProxyInstance(Proxy.java:1022)
> 	at java.lang.reflect.Proxy.newProxyInstance(Proxy.java:1008)
>     ....
	
Reason: 
Each Proxy class contains static fields as a reference toward methods, something like `private static Method m1 = Class.getMethod("method1")`. We are replacing these reflective calls with constants inside `ReflectionPlugin`. If`method1` is receiving an object (non-primitive type) we are adding `EnsureInitilizedNode ` (to check if a class is initialized) and in that case, this part of the code is not working:  https://github.com/oracle/graal/blob/1637cd77629fd4ffbb14295fc79b486824307fa8/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/snippets/SubstrateGraphBuilderPlugins.java#L373-L393 .

Command to reproduce:
`mx --env ni-ce benchmark renaissance-native-image:neo4j-analytics -- --jvm=native-image --jvm-config=default-ce`

Link to a simpler version of reproducer:
https://github.com/jovanstevanovic/ProxyException

