### PR TITLE
[Espresso] Make CodeAttribute fully immutable

### DIFF
--- a/espresso/src/com.oracle.truffle.espresso/src/com/oracle/truffle/espresso/classfile/ClassfileParser.java
+++ b/espresso/src/com.oracle.truffle.espresso/src/com/oracle/truffle/espresso/classfile/ClassfileParser.java
@@ -204,13 +204,13 @@ public final class ClassfileParser {
 
     void checkInvokeDynamicSupport(Tag tag) {
         if (majorVersion < INVOKEDYNAMIC_MAJOR_VERSION) {
-            stream.classFormatError("Class file version does not support constant tag %d", tag.getValue());
+            throw stream.classFormatError("Class file version does not support constant tag %d", tag.getValue());
         }
     }
 
     void checkDynamicConstantSupport(Tag tag) {
         if (majorVersion < DYNAMICCONSTANT_MAJOR_VERSION) {
-            stream.classFormatError("Class file version does not support constant tag %d", tag.getValue());
+            throw stream.classFormatError("Class file version does not support constant tag %d", tag.getValue());
         }
     }
 

--- a/espresso/src/com.oracle.truffle.espresso/src/com/oracle/truffle/espresso/classfile/attributes/CodeAttribute.java
+++ b/espresso/src/com.oracle.truffle.espresso/src/com/oracle/truffle/espresso/classfile/attributes/CodeAttribute.java
@@ -26,9 +26,7 @@ package com.oracle.truffle.espresso.classfile.attributes;
 import static com.oracle.truffle.espresso.classfile.ClassfileParser.JAVA_6_VERSION;
 
 import java.io.PrintStream;
-import java.util.Arrays;
 
-import com.oracle.truffle.api.CompilerDirectives;
 import com.oracle.truffle.api.CompilerDirectives.CompilationFinal;
 import com.oracle.truffle.espresso.bytecode.BytecodeStream;
 import com.oracle.truffle.espresso.descriptors.Symbol;
@@ -46,9 +44,6 @@ public final class CodeAttribute extends Attribute {
 
     private final int maxStack;
     private final int maxLocals;
-
-    @CompilationFinal(dimensions = 1) //
-    private volatile byte[] code = null;
 
     @CompilationFinal(dimensions = 1) //
     private final byte[] originalCode; // no bytecode patching
@@ -84,18 +79,6 @@ public final class CodeAttribute extends Attribute {
 
     public Attribute[] getAttributes() {
         return attributes;
-    }
-
-    public byte[] getCode() {
-        if (code == null) {
-            CompilerDirectives.transferToInterpreterAndInvalidate();
-            synchronized (this) {
-                if (code == null) {
-                    code = Arrays.copyOf(originalCode, originalCode.length);
-                }
-            }
-        }
-        return code;
     }
 
     public byte[] getOriginalCode() {
@@ -158,11 +141,7 @@ public final class CodeAttribute extends Attribute {
         return majorVersion;
     }
 
-    public CodeAttribute forceSplit() {
-        return new CodeAttribute(getName(), maxStack, maxLocals, code.clone(), exceptionHandlerEntries, attributes, majorVersion);
-    }
-
-    public void print(Klass klass, PrintStream out) {
+    public void print(Klass klass, byte[] code, PrintStream out) {
         try {
             new BytecodeStream(code).printBytecode(klass, out);
         } catch (Throwable e) {

--- a/espresso/src/com.oracle.truffle.espresso/src/com/oracle/truffle/espresso/impl/Method.java
+++ b/espresso/src/com.oracle.truffle.espresso/src/com/oracle/truffle/espresso/impl/Method.java
@@ -299,10 +299,6 @@ public final class Method extends Member<Signature> implements TruffleObject, Co
         return (BootstrapMethodsAttribute) getAttribute(BootstrapMethodsAttribute.NAME);
     }
 
-    public byte[] getCode() {
-        return getCodeAttribute().getCode();
-    }
-
     public byte[] getOriginalCode() {
         return getCodeAttribute().getOriginalCode();
     }
@@ -941,7 +937,7 @@ public final class Method extends Member<Signature> implements TruffleObject, Co
     }
 
     public Method forceSplit() {
-        Method result = new Method(this, getCodeAttribute().forceSplit());
+        Method result = new Method(this, getCodeAttribute());
         FrameDescriptor frameDescriptor = new FrameDescriptor();
         EspressoRootNode root = EspressoRootNode.create(frameDescriptor, new BytecodeNode(result.getMethodVersion(), frameDescriptor));
         result.getMethodVersion().callTarget = Truffle.getRuntime().createCallTarget(root);
@@ -1179,11 +1175,27 @@ public final class Method extends Member<Signature> implements TruffleObject, Co
         private final CodeAttribute codeAttribute;
         @CompilationFinal private CallTarget callTarget;
 
+        @CompilationFinal(dimensions = 1) //
+        private volatile byte[] code = null;
+
         MethodVersion(RuntimeConstantPool pool, LinkedMethod linkedMethod, CodeAttribute codeAttribute) {
             this.assumption = Truffle.getRuntime().createAssumption();
             this.pool = pool;
             this.linkedMethod = linkedMethod;
             this.codeAttribute = codeAttribute;
+        }
+
+        public byte[] getCode() {
+            if (code == null) {
+                CompilerDirectives.transferToInterpreterAndInvalidate();
+                synchronized (this) {
+                    if (code == null) {
+                        byte[] originalCode = getCodeAttribute().getOriginalCode();
+                        code = Arrays.copyOf(originalCode, originalCode.length);
+                    }
+                }
+            }
+            return code;
         }
 
         public Method getMethod() {
@@ -1312,7 +1324,7 @@ public final class Method extends Member<Signature> implements TruffleObject, Co
         }
 
         public int getCodeSize() {
-            return codeAttribute.getCode() != null ? codeAttribute.getCode().length : 0;
+            return getCode() != null ? getCode().length : 0;
         }
 
         public LineNumberTableAttribute getLineNumberTableAttribute() {
@@ -1471,7 +1483,7 @@ public final class Method extends Member<Signature> implements TruffleObject, Co
         @Override
         public long getLastBCI() {
             int bci = 0;
-            BytecodeStream bs = new BytecodeStream(getCodeAttribute().getCode());
+            BytecodeStream bs = new BytecodeStream(getCode());
             int end = bs.endBCI();
 
             while (bci < end) {


### PR DESCRIPTION
This PR makes `com.oracle.truffle.espresso.classfile.attributes.CodeAttribute` class fully immutable by moving mutable `code` field and appropriate methods to `com.oracle.truffle.espresso.impl.MethodVersion`.