### PR TITLE
[Espresso] Change EspressoLanguage context policy to SHARED

### DIFF
--- a/espresso/src/com.oracle.truffle.espresso/src/com/oracle/truffle/espresso/EspressoLanguage.java
+++ b/espresso/src/com.oracle.truffle.espresso/src/com/oracle/truffle/espresso/EspressoLanguage.java
@@ -65,7 +65,7 @@ import com.oracle.truffle.espresso.substitutions.Substitutions;
                 name = EspressoLanguage.NAME, //
                 implementationName = EspressoLanguage.IMPLEMENTATION_NAME, //
                 version = EspressoLanguage.VERSION, //
-                contextPolicy = TruffleLanguage.ContextPolicy.EXCLUSIVE, //
+                contextPolicy = TruffleLanguage.ContextPolicy.SHARED, //
                 dependentLanguages = {"nfi", "llvm"})
 @ProvidedTags({StandardTags.RootTag.class, StandardTags.RootBodyTag.class, StandardTags.StatementTag.class})
 public final class EspressoLanguage extends TruffleLanguage<EspressoContext> {
@@ -89,8 +89,6 @@ public final class EspressoLanguage extends TruffleLanguage<EspressoContext> {
     private final Names names;
     private final Types types;
     private final Signatures signatures;
-
-    private long startupClockNanos = 0;
 
     private static final StaticProperty ARRAY_PROPERTY = new DefaultStaticProperty("array");
     // This field should be static final, but until we move the static object model we cannot have a
@@ -142,13 +140,12 @@ public final class EspressoLanguage extends TruffleLanguage<EspressoContext> {
 
     @Override
     protected void initializeContext(final EspressoContext context) throws Exception {
-        startupClockNanos = System.nanoTime();
         context.initializeContext();
     }
 
     @Override
     protected void finalizeContext(EspressoContext context) {
-        long elapsedTimeNanos = System.nanoTime() - startupClockNanos;
+        long elapsedTimeNanos = System.nanoTime() - context.getStartupClockNanos();
         long seconds = TimeUnit.NANOSECONDS.toSeconds(elapsedTimeNanos);
         if (seconds > 10) {
             context.getLogger().log(Level.FINE, "Time spent in Espresso: {0} s", seconds);


### PR DESCRIPTION
This PR changes `EspressoLanguage` context sharing policy from `EXPLICIT` to `SHARED`, which is a nececary step towards context pre-initialization.

In addition, this PR also adds a `setEnv()` method to `EspressoContext` in order to allow the language to set the environment for the context at an arbitrary time. This is nececary because at some point, the language will need to update the environment of the pre-initialized context in runtime.