### PR TITLE
[GR-32241] Support serialization of abstract classed

### DIFF
--- a/substratevm/src/com.oracle.svm.reflect/src/com/oracle/svm/reflect/serialize/hosted/SerializationFeature.java
+++ b/substratevm/src/com.oracle.svm.reflect/src/com/oracle/svm/reflect/serialize/hosted/SerializationFeature.java
@@ -231,7 +231,7 @@ final class SerializationBuilder {
         }
         stubConstructor = newConstructorForSerialization(SerializationSupport.StubForAbstractClass.class, null);
 
-        serializationSupport = new SerializationSupport();
+        serializationSupport = new SerializationSupport(stubConstructor);
         ImageSingletons.add(SerializationRegistry.class, serializationSupport);
     }
 

--- a/substratevm/src/com.oracle.svm.test/src/META-INF/native-image/com.oracle.svm.test/native-image.properties
+++ b/substratevm/src/com.oracle.svm.test/src/META-INF/native-image/com.oracle.svm.test/native-image.properties
@@ -1,1 +1,1 @@
-Args = --initialize-at-run-time=com.oracle.svm.test
+Args = --initialize-at-run-time=com.oracle.svm.test --initialize-at-build-time=com.oracle.svm.test.AbstractClassSerializationTest

--- a/substratevm/src/com.oracle.svm.test/src/META-INF/native-image/serialization-config.json
+++ b/substratevm/src/com.oracle.svm.test/src/META-INF/native-image/serialization-config.json
@@ -1,0 +1,14 @@
+[
+  {
+  "name":"java.util.HashMap"
+  },
+  {
+  "name":"java.lang.String"
+  },
+  {
+  "name":"java.lang.Number"
+  },
+  {
+  "name":"java.lang.Integer"
+  }
+]

--- a/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/AbstractClassSerializationTest.java
+++ b/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/AbstractClassSerializationTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2021, 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package com.oracle.svm.test;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.util.HashMap;
+import java.util.Map;
+
+public class AbstractClassSerializationTest {
+    private static final byte[] serializedObject;
+    private static final Map<Integer, String> map;
+
+    static {
+        map = new HashMap<>();
+        map.put(1, "Test");
+        map.put(2, "This is a test");
+
+        ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+        ObjectOutputStream objectOutputStream = null;
+        try {
+            objectOutputStream = new ObjectOutputStream(byteArrayOutputStream);
+            objectOutputStream.writeObject(map);
+            objectOutputStream.flush();
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+
+        serializedObject = byteArrayOutputStream.toByteArray();
+    }
+
+    @Test
+    public void testAbstractClassSerialization() {
+        ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(serializedObject);
+        try {
+            ObjectInputStream objectInputStream = new ObjectInputStream(byteArrayInputStream);
+            Object deserializedObject = objectInputStream.readObject();
+            Assert.assertEquals(deserializedObject.toString(), map.toString());
+        } catch (IOException | ClassNotFoundException e) {
+            e.printStackTrace();
+        }
+    }
+}


### PR DESCRIPTION
There was a problem in native image when trying to serialize an abstract class. More about the problem can be found at https://github.com/oracle/graal/issues/3485.

Problem was that when building native image of a program class which constructor is used is set to be java.lang.Object. And in runtime, that class was found to be java.util.Dictionary. Chosen class is the first class in hierarchy that is not serializable. In the serialization map in project key was created using java.lang.Object in build time and using java.util.Dictionary in runtime. This problem occurs only for abstract classes. In build time target class constructor is being set to stubConstructor (created in file SerializationFeature, line ).

Problem was fixed by adding stubConstructor to SerializationSupport class in its constructor, and retrieving class name from that variable during runtime. This approach was used only for abstract classes. So, for abstract classes, in build time, targetClass is set to be the class that corresponds to stubConstructor, and now, in runtime is the same.

Changing constructor of SerializationSupport class:
```
public SerializationSupport(Constructor<?> stubConstructor) {
        constructorAccessors = new ConcurrentHashMap<>();
        this.stubConstructor = stubConstructor;
}
```

Creation of SerializationSupport class instance:

```
serializationSupport = new SerializationSupport(stubConstructor);
```

Changing targetConstructorClass variable according to stubConstructor class for abstract classes:
```
if (Modifier.isAbstract(declaringClass.getModifiers()))
            targetConstructorClass = stubConstructor.getDeclaringClass();
```