### PR TITLE
Fix `LLVMCreateEnumAttribute()` parameter to create an `EnumAttribute` instead of an `IntAttribute`

### DIFF
--- a/substratevm/src/com.oracle.svm.core.graal.llvm/src/com/oracle/svm/core/graal/llvm/util/LLVMIRBuilder.java
+++ b/substratevm/src/com.oracle.svm.core.graal.llvm/src/com/oracle/svm/core/graal/llvm/util/LLVMIRBuilder.java
@@ -24,6 +24,7 @@
  */
 package com.oracle.svm.core.graal.llvm.util;
 
+import static com.oracle.svm.core.graal.llvm.util.LLVMUtils.ENUM_ATTRIBUTE_VALUE;
 import static com.oracle.svm.core.graal.llvm.util.LLVMUtils.FALSE;
 import static com.oracle.svm.core.graal.llvm.util.LLVMUtils.TRUE;
 import static com.oracle.svm.core.graal.llvm.util.LLVMUtils.dumpTypes;
@@ -168,7 +169,7 @@ public class LLVMIRBuilder implements AutoCloseable {
         int kind = LLVM.LLVMGetEnumAttributeKindForName(attribute.name, attribute.name.length());
         LLVMAttributeRef attr;
         if (kind != 0) {
-            attr = LLVM.LLVMCreateEnumAttribute(context, kind, TRUE);
+            attr = LLVM.LLVMCreateEnumAttribute(context, kind, ENUM_ATTRIBUTE_VALUE);
         } else {
             String value = "true";
             attr = LLVM.LLVMCreateStringAttribute(context, attribute.name, attribute.name.length(), value, value.length());
@@ -725,7 +726,7 @@ public class LLVMIRBuilder implements AutoCloseable {
         int kind = LLVM.LLVMGetEnumAttributeKindForName(attribute.name, attribute.name.length());
         LLVMAttributeRef attr;
         if (kind != 0) {
-            attr = LLVM.LLVMCreateEnumAttribute(context, kind, TRUE);
+            attr = LLVM.LLVMCreateEnumAttribute(context, kind, ENUM_ATTRIBUTE_VALUE);
             LLVM.LLVMAddCallSiteAttribute(call, (int) LLVM.LLVMAttributeFunctionIndex, attr);
         } else {
             setCallSiteAttribute(call, attribute, "true");

--- a/substratevm/src/com.oracle.svm.core.graal.llvm/src/com/oracle/svm/core/graal/llvm/util/LLVMUtils.java
+++ b/substratevm/src/com.oracle.svm.core.graal.llvm/src/com/oracle/svm/core/graal/llvm/util/LLVMUtils.java
@@ -49,6 +49,7 @@ import jdk.vm.ci.meta.ValueKind;
 public class LLVMUtils {
     static final int FALSE = 0;
     static final int TRUE = 1;
+    static final long ENUM_ATTRIBUTE_VALUE = 0L;
 
     public interface LLVMValueWrapper {
         LLVMValueRef get();


### PR DESCRIPTION
The two call sites to `LLVMCreateEnumAttribute()` fixed by this patch intend to create an LLVM `EnumAttribute`, because:
1. The attribute `kind` is retrieved through calling `LLVMGetEnumAttributeKindForName()`, and
2. The attribute being set has no integer value, as it is intended to be a boolean.

However, calling `LLVMCreateEnumAttribute()` with a non-zero value (e.g., `TRUE`) causes it to create an `IntAttribute`, instead of the intended `EnumAttribute`. This behavior is not documented, but going through the LLVM source code reveals this behavior:
- `LLVMCreateEnumAttribute()` [calls `Attribute::get()`](https://github.com/llvm/llvm-project/blob/c1a0a213378a458fbea1a5c77b315c7dce08fd05/llvm/lib/IR/Core.cpp#L151).
- `Attribute::get()` only creates an `EnumAttribute` [if the provided value is zero](https://github.com/llvm/llvm-project/blob/c1a0a213378a458fbea1a5c77b315c7dce08fd05/llvm/lib/IR/Attributes.cpp#L94).