### PR TITLE
docs(readme): update SubstrateVM link

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ the Java HotSpot VM or run standalone.
 * [Tools](tools/README.md) contains a set of tools for GraalVM languages
 implemented with the instrumentation framework.
 
-* [Substrate VM](substratevm/README.md) framework that allows ahead-of-time (AOT)
+* [Substrate VM](substratevm/SubstrateVM.md) framework that allows ahead-of-time (AOT)
 compilation of Java applications under closed-world assumption into executable
 images or shared objects.
 


### PR DESCRIPTION
the link was 404ing i'm not sure if this would be the solution or  you'd want to updating `SubstrateVM.md` to `README.md`