### PR TITLE
Add option to exclude inlining, `--engine.ExcludeInlining=`

### DIFF
--- a/compiler/src/org.graalvm.compiler.truffle.compiler/src/org/graalvm/compiler/truffle/compiler/phases/inlining/DefaultInliningPolicy.java
+++ b/compiler/src/org.graalvm.compiler.truffle.compiler/src/org/graalvm/compiler/truffle/compiler/phases/inlining/DefaultInliningPolicy.java
@@ -114,6 +114,9 @@ final class DefaultInliningPolicy implements InliningPolicy {
         final PriorityQueue<CallNode> inlineQueue = getQueue(tree, CallNode.State.Expanded);
         CallNode candidate;
         while ((candidate = inlineQueue.poll()) != null) {
+            if (!InliningPolicy.acceptForInline(candidate, options)) {
+                continue;
+            }
             if (candidate.isTrivial()) {
                 candidate.inline();
                 continue;

--- a/compiler/src/org.graalvm.compiler.truffle.compiler/src/org/graalvm/compiler/truffle/compiler/phases/inlining/TrivialOnlyInliningPolicy.java
+++ b/compiler/src/org.graalvm.compiler.truffle.compiler/src/org/graalvm/compiler/truffle/compiler/phases/inlining/TrivialOnlyInliningPolicy.java
@@ -24,10 +24,22 @@
  */
 package org.graalvm.compiler.truffle.compiler.phases.inlining;
 
+import org.graalvm.compiler.truffle.options.PolyglotCompilerOptions;
+import org.graalvm.options.OptionValues;
+
 final class TrivialOnlyInliningPolicy implements InliningPolicy {
+    private final OptionValues options;
+
+    TrivialOnlyInliningPolicy(OptionValues options) {
+        this.options = options;
+    }
+
     @Override
     public void run(CallTree tree) {
         for (CallNode child : tree.getRoot().getChildren()) {
+            if (!InliningPolicy.acceptForInline(child, options)) {
+                continue;
+            }
             if (child.isTrivial()) {
                 child.expand();
                 child.inline();

--- a/compiler/src/org.graalvm.compiler.truffle.compiler/src/org/graalvm/compiler/truffle/compiler/phases/inlining/TrivialOnlyPolicyProvider.java
+++ b/compiler/src/org.graalvm.compiler.truffle.compiler/src/org/graalvm/compiler/truffle/compiler/phases/inlining/TrivialOnlyPolicyProvider.java
@@ -40,6 +40,6 @@ public class TrivialOnlyPolicyProvider extends InliningPolicyProvider {
 
     @Override
     public InliningPolicy get(OptionValues options, CoreProviders providers) {
-        return new TrivialOnlyInliningPolicy();
+        return new TrivialOnlyInliningPolicy(options);
     }
 }

--- a/compiler/src/org.graalvm.compiler.truffle.options/src/org/graalvm/compiler/truffle/options/PolyglotCompilerOptions.java
+++ b/compiler/src/org.graalvm.compiler.truffle.options/src/org/graalvm/compiler/truffle/options/PolyglotCompilerOptions.java
@@ -385,6 +385,9 @@ public final class PolyglotCompilerOptions {
 
     // Inlining
 
+    @Option(help = "Restrict inlined methods to ','-separated list of includes (or excludes prefixed with '~').", category = OptionCategory.INTERNAL)
+    public static final OptionKey<String> InlineOnly = new OptionKey<>("", OptionType.defaultType(String.class));
+
     @Option(help = "Enable automatic inlining of guest language call targets.", category = OptionCategory.EXPERT)
     public static final OptionKey<Boolean> Inlining = new OptionKey<>(true);
 

--- a/compiler/src/org.graalvm.compiler.truffle.test/src/org/graalvm/compiler/truffle/test/inlining/InlineOnlyTest.java
+++ b/compiler/src/org.graalvm.compiler.truffle.test/src/org/graalvm/compiler/truffle/test/inlining/InlineOnlyTest.java
@@ -1,0 +1,169 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package org.graalvm.compiler.truffle.test.inlining;
+
+import com.oracle.truffle.api.CallTarget;
+import com.oracle.truffle.api.CompilerAsserts;
+import com.oracle.truffle.api.RootCallTarget;
+import com.oracle.truffle.api.Truffle;
+import com.oracle.truffle.api.TruffleLanguage;
+import com.oracle.truffle.api.TruffleRuntime;
+import com.oracle.truffle.api.frame.VirtualFrame;
+import com.oracle.truffle.api.nodes.DirectCallNode;
+import com.oracle.truffle.api.nodes.RootNode;
+import com.oracle.truffle.api.test.polyglot.ProxyLanguage;
+import org.graalvm.polyglot.Context;
+import org.junit.Test;
+
+public class InlineOnlyTest {
+    private static final String COMPILATION_ROOT_NAME = "main";
+    private static final String METHOD_EXCLUDED_FROM_INLINING = "~should-not-be-inlined";
+    private static final String METHOD_INLINED = "should-be-inlined,another-inlined-method";
+
+    @Test
+    public void testNoInliningForMethodsWithPattern() throws Exception {
+        try (Context c = Context.newBuilder().allowExperimentalOptions(true).//
+                        option("engine.CompilationFailureAction", "Throw").//
+                        option("engine.CompileImmediately", "true").//
+                        option("engine.BackgroundCompilation", "false").//
+                        option("engine.CompileOnly", COMPILATION_ROOT_NAME).//
+                        option("engine.InlineOnly", METHOD_EXCLUDED_FROM_INLINING).//
+                        build()) {
+            c.eval(InlineOnlyTest.ExcludePatternTestLanguage.ID, "");
+            c.eval(InlineOnlyTest.ExcludePatternTestLanguage.ID, "");
+        }
+    }
+
+    @Test
+    public void testInlinedMethods() throws Exception {
+        try (Context c = Context.newBuilder().allowExperimentalOptions(true).//
+                        option("engine.CompilationFailureAction", "Throw").//
+                        option("engine.CompileImmediately", "true").//
+                        option("engine.BackgroundCompilation", "false").//
+                        option("engine.CompileOnly", COMPILATION_ROOT_NAME).//
+                        option("engine.InlineOnly", METHOD_INLINED).//
+                        build()) {
+            c.eval(InlineOnlyTest.InlineSelectedMethodsTestLanguage.ID, "");
+            c.eval(InlineOnlyTest.InlineSelectedMethodsTestLanguage.ID, "");
+        }
+    }
+
+    @TruffleLanguage.Registration(id = InlineOnlyTest.ExcludePatternTestLanguage.ID, name = "InlineOnlyTest: With Exclude Pattern Test Language", version = "1.0")
+    public static class ExcludePatternTestLanguage extends ProxyLanguage {
+
+        public static final String ID = "truffle-exclude-pattern-test-language";
+
+        @Override
+        protected CallTarget parse(ParsingRequest request) throws Exception {
+            final TruffleRuntime runtime = Truffle.getRuntime();
+            final RootCallTarget rootCallTarget = runtime.createCallTarget(new RootNode(this) {
+
+                @Override
+                public String toString() {
+                    return getName();
+                }
+
+                @Override
+                public Object execute(VirtualFrame frame) {
+                    CompilerAsserts.neverPartOfCompilation("This node should not be inlined");
+                    return 99;
+                }
+
+                @Override
+                public String getName() {
+                    return METHOD_EXCLUDED_FROM_INLINING;
+                }
+            });
+            return runtime.createCallTarget(new RootNode(this) {
+
+                @Child DirectCallNode callNode = runtime.createDirectCallNode(rootCallTarget);
+
+                @Override
+                public String toString() {
+                    return getName();
+                }
+
+                @Override
+                public String getName() {
+                    return COMPILATION_ROOT_NAME;
+                }
+
+                @Override
+                public Object execute(VirtualFrame frame) {
+                    return callNode.call();
+                }
+            });
+        }
+    }
+
+    @TruffleLanguage.Registration(id = InlineOnlyTest.InlineSelectedMethodsTestLanguage.ID, name = "InlineOnlyTest: Inline Methods", version = "1.0")
+    public static class InlineSelectedMethodsTestLanguage extends ProxyLanguage {
+
+        public static final String ID = "truffle-inline-selected-methods-test-language";
+
+        @Override
+        protected CallTarget parse(ParsingRequest request) throws Exception {
+            final TruffleRuntime runtime = Truffle.getRuntime();
+            final RootCallTarget rootCallTarget = runtime.createCallTarget(new RootNode(this) {
+
+                @Override
+                public String toString() {
+                    return getName();
+                }
+
+                @Override
+                public Object execute(VirtualFrame frame) {
+                    CompilerAsserts.compilationConstant(METHOD_INLINED);
+                    return 99;
+                }
+
+                @Override
+                public String getName() {
+                    return METHOD_INLINED;
+                }
+            });
+            return runtime.createCallTarget(new RootNode(this) {
+
+                @Child DirectCallNode callNode = runtime.createDirectCallNode(rootCallTarget);
+
+                @Override
+                public String toString() {
+                    return getName();
+                }
+
+                @Override
+                public String getName() {
+                    return COMPILATION_ROOT_NAME;
+                }
+
+                @Override
+                public Object execute(VirtualFrame frame) {
+                    return callNode.call();
+                }
+            });
+        }
+    }
+}


### PR DESCRIPTION
# Issue 

https://github.com/oracle/graal/issues/3492

Add an option to exclude a method `--engine.ExcludeInlining=bloooop`  

#  Changes

When the nodes are being checked in `DefaultInliningPolicy.java`, I added a check to see if the node is a method that was excluded. If it is, we avoid the inlining and `continue;`. 

I'm not sure if you'd like this change, but I've also added a new state, `CallNode.State.Excluded` to mark a node excluded. This makes the `--engine.TraceInlining` output more readable to the user (see the trace below). Without this change, the nodes would remain as `Expanded`. 

# Test

I'm testing this change locally using this Ruby script `test.rb`:

```ruby
def baz; end

def bar
  baz
end

# Call #bar 4 times
def foo 
  bar
  bar
  bar
  bar
  baz
end

loop do
  foo
end
```

And running

`jt ruby --experimental-options --engine.ExcludeInlining=bar --engine.TraceInlining --engine.TraceCompilation --engine.MultiTier=false --engine.OSR=false --engine.CompilationThreshold=10000000 test.rb` 

Which is essentially `jt ruby --experimental-options --engine.ExcludeInlining=bar test.rb` but with additional options to remove irrelevant noise. 

The output is then:

```
➜  jt ruby --experimental-options --engine.ExcludeInlining=bar --engine.TraceInlining --engine.TraceCompilation --engine.MultiTier=false --engine.OSR=false --engine.CompilationThreshold=10000000 test.rb
WARNING: jt is not running on MRI or TruffleRuby Native, startup is slow
  Consider using following bash alias to run on MRI.
  `alias jt=/path/to/mri/bin/ruby /path/to/truffleruby/tool/jt.rb`
Using TruffleRuby with Graal: mxbuild/truffleruby-jvm-ce
$ /Users/mapleong/src/github.com/Shopify/truffleruby/mxbuild/truffleruby-jvm-ce/languages/ruby/bin/ruby \
  --experimental-options \
  --core-load-path=/Users/mapleong/src/github.com/Shopify/truffleruby/src/main/ruby/truffleruby \
  --experimental-options \
  --engine.ExcludeInlining=bar \
  --engine.TraceInlining \
  --engine.TraceCompilation \
  --engine.MultiTier=false \
  --engine.OSR=false \
  --engine.CompilationThreshold=10000000 \
  test.rb
Warning: Option 'engine.CompilationThreshold' is deprecated and might be removed from future versions.

[To redirect Truffle log output to a file use one of the following options:
* '--log.file=<path>' if the option is passed using a guest language launcher.
* '-Dpolyglot.log.file=<path>' if the option is passed using the host Java launcher.
* Configure logging using the polyglot embedding API.]
[engine] Inline start Object#baz                                                  |call diff     0.00|Recursion Depth      0|Explore/inline ratio     1.00|IR Nodes     23|Frequency     1.00|Truffle Callees      0|Forced false|Depth      0
[engine] Inline done  Object#baz                                                  |call diff     0.00|Recursion Depth      0|Explore/inline ratio     1.00|IR Nodes     23|Frequency     1.00|Truffle Callees      0|Forced false|Depth      0
[engine] opt done     Object#baz                                                  |AST    6|Tier 2|Time   85(  76+9   )ms|Inlined   0Y   0N|IR    23/   20|CodeSize    174|Addr 0x11ec9ea90|Src test.rb:1
[engine] Inline start Object#bar                                                  |call diff     0.00|Recursion Depth      0|Explore/inline ratio     1.00|IR Nodes     55|Frequency     1.00|Truffle Callees      1|Forced false|Depth      0
[engine] Inlined        Object#baz                                                |call diff    -1.00|Recursion Depth      0|Explore/inline ratio      NaN|IR Nodes     25|Frequency     1.00|Truffle Callees      0|Forced false|Depth      1
[engine] Inline done  Object#bar                                                  |call diff     0.00|Recursion Depth      0|Explore/inline ratio     1.00|IR Nodes     55|Frequency     1.00|Truffle Callees      1|Forced false|Depth      0
[engine] opt done     Object#bar                                                  |AST   14|Tier 2|Time   58(  56+2   )ms|Inlined   1Y   0N|IR    27/   28|CodeSize    214|Addr 0x11ed0ce90|Src test.rb:3
[engine] Inline start Object#foo                                                  |call diff     0.00|Recursion Depth      0|Explore/inline ratio     5.00|IR Nodes    165|Frequency     1.00|Truffle Callees      5|Forced false|Depth      0
[engine] Excluded       Object#bar                                                |call diff    -2.00|Recursion Depth      0|Explore/inline ratio      NaN|IR Nodes     66|Frequency     1.00|Truffle Callees      1|Forced false|Depth      1
[engine] Excluded       Object#bar                                                |call diff    -2.00|Recursion Depth      0|Explore/inline ratio      NaN|IR Nodes     66|Frequency     1.00|Truffle Callees      1|Forced false|Depth      1
[engine] Excluded       Object#bar                                                |call diff    -2.00|Recursion Depth      0|Explore/inline ratio      NaN|IR Nodes     66|Frequency     1.00|Truffle Callees      1|Forced false|Depth      1
[engine] Excluded       Object#bar                                                |call diff    -2.00|Recursion Depth      0|Explore/inline ratio      NaN|IR Nodes     66|Frequency     1.00|Truffle Callees      1|Forced false|Depth      1
[engine] Inlined        Object#baz                                                |call diff    -1.00|Recursion Depth      0|Explore/inline ratio      NaN|IR Nodes     25|Frequency     1.00|Truffle Callees      0|Forced false|Depth      1
[engine] Inline start block in <main> <split-6c701503>                            |call diff     0.00|Recursion Depth      0|Explore/inline ratio     3.67|IR Nodes    214|Frequency     1.00|Truffle Callees      1|Forced false|Depth      0
[engine] Inline done  Object#foo                                                  |call diff     0.00|Recursion Depth      0|Explore/inline ratio     5.00|IR Nodes    165|Frequency     1.00|Truffle Callees      5|Forced false|Depth      0
[engine] Inlined        Object#foo                                                |call diff   -10.00|Recursion Depth      0|Explore/inline ratio      NaN|IR Nodes    160|Frequency     1.00|Truffle Callees      5|Forced false|Depth      1
[engine] Excluded         Object#bar                                              |call diff    -2.00|Recursion Depth      0|Explore/inline ratio      NaN|IR Nodes     66|Frequency     1.00|Truffle Callees      1|Forced false|Depth      2
[engine] Excluded         Object#bar                                              |call diff    -2.00|Recursion Depth      0|Explore/inline ratio      NaN|IR Nodes     66|Frequency     1.00|Truffle Callees      1|Forced false|Depth      2
[engine] Excluded         Object#bar                                              |call diff    -2.00|Recursion Depth      0|Explore/inline ratio      NaN|IR Nodes     66|Frequency     1.00|Truffle Callees      1|Forced false|Depth      2
[engine] Excluded         Object#bar                                              |call diff    -2.00|Recursion Depth      0|Explore/inline ratio      NaN|IR Nodes     66|Frequency     1.00|Truffle Callees      1|Forced false|Depth      2
[engine] Inlined          Object#baz                                              |call diff    -1.00|Recursion Depth      0|Explore/inline ratio      NaN|IR Nodes     25|Frequency     1.00|Truffle Callees      0|Forced false|Depth      2
[engine] Inline done  block in <main> <split-6c701503>                            |call diff     0.00|Recursion Depth      0|Explore/inline ratio     3.67|IR Nodes    214|Frequency     1.00|Truffle Callees      1|Forced false|Depth      0
[engine] opt done     Object#foo                                                  |AST   46|Tier 2|Time  235(  52+183 )ms|Inlined   1Y   4N|IR   134/  515|CodeSize   2066|Addr 0x11edd7810|Src test.rb:8
[engine] opt done     block in <main> <split-6c701503>                            |AST   12|Tier 2|Time  241(  58+183 )ms|Inlined   2Y   4N|IR   166/  544|CodeSize   2066|Addr 0x11eddba10|Src test.rb:16
^C[engine] opt deopt    block in <main> <split-6c701503>                            |AST   12|Src test.rb:16
```

You can see trace compilation line for `#foo` contains `Inlined   1Y   4N`, where I believe [`1Y` is the inlined call to `#baz`](https://github.com/oracle/graal/blob/c7c061b3230852e9582badf788b3dab74a809ca9/comp[…]vm/compiler/truffle/runtime/debug/TraceCompilationListener.java) and `4N` refers to the 4 calls to `#bar`. 

You can also see that the `#bar` calls are marked `Excluded` in the inlining trace. 

Is there a test file for these classes? 

# Questions 

* What do you think? Was this similar to what you had in mind? 
* Do I have to add the exclusion check to other InliningPolicies as well? For example, `TrivialOnlyInliningPolicy`? 