### PR TITLE
Don't build LibGraal component by default

### DIFF
--- a/substratevm/mx.substratevm/suite.py
+++ b/substratevm/mx.substratevm/suite.py
@@ -942,6 +942,7 @@ suite = {
             "annotationProcessors": [
                 "compiler:GRAAL_PROCESSOR",
             ],
+            "defaultBuild": False,
         },
 
         "com.oracle.svm.configure": {
@@ -1264,6 +1265,7 @@ suite = {
             "distDependencies": [
                 "SVM",
             ],
+            "defaultBuild": False,
         },
 
         #


### PR DESCRIPTION
LibGraal fails to build with upstream OpenJDK 11 due to it's dependency
on `HotSpotJVMCIRuntime.getCurrentJavaThread()` which has not been
backported to upstream OpenJDK 11. Preventing LibGraal from being build by
default enables us to build components of GraalVM that do not depend on
it, e.g., 'Native Image'.