### PR TITLE
[GR-34028] Avoid building more components than necessary for running the debug info tests

### DIFF
--- a/compiler/mx.compiler/mx_compiler.py
+++ b/compiler/mx.compiler/mx_compiler.py
@@ -1149,9 +1149,6 @@ def create_archive(srcdir, arcpath, prefix):
     arc.close()
 
 
-def _jlink_libraries():
-    return not (mx.get_opts().no_jlinking or mx.env_var_to_bool('NO_JLINKING'))
-
 def makegraaljdk_cli(args):
     """make a JDK with Graal as the default top level JIT"""
     parser = ArgumentParser(prog='mx makegraaljdk')
@@ -1321,7 +1318,7 @@ def _update_graaljdk(src_jdk, dst_jdk_dir=None, root_module_names=None, export_t
             vendor_info = {'vendor-version' : vm_name}
             # Setting dedup_legal_notices=False avoids due to license files conflicting
             # when switching JAVA_HOME from an OpenJDK to an OracleJDK or vice versa between executions.
-            if _jlink_libraries():
+            if mx_sdk_vm_impl._jlink_libraries():
                 jlink_new_jdk(jdk, tmp_dst_jdk_dir, module_dists, ignore_dists=[], root_module_names=root_module_names, vendor_info=vendor_info, dedup_legal_notices=False)
                 if export_truffle:
                     jmd = as_java_module(_graal_config().dists_dict['truffle:TRUFFLE_API'], jdk)

--- a/sdk/mx.sdk/mx_sdk_vm_impl.py
+++ b/sdk/mx.sdk/mx_sdk_vm_impl.py
@@ -958,6 +958,10 @@ def _get_graalvm_configuration(base_name, components=None, stage1=False):
             m = hashlib.sha1()
             for component in components_sorted_set:
                 m.update(_encode(component))
+            if _jlink_libraries():
+                m.update(_encode("jlinked"))
+            else:
+                m.update(_encode("not-jlinked"))
             short_sha1_digest = m.hexdigest()[:10]  # to keep paths short
             base_dir = '{base_name}_{hash}_java{jdk_version}'.format(base_name=base_name, hash=short_sha1_digest, jdk_version=_src_jdk_version)
             name = '{base_dir}{stage_suffix}'.format(base_dir=base_dir, stage_suffix='_stage1' if stage1 else '')

--- a/substratevm/mx.substratevm/mx_substratevm.py
+++ b/substratevm/mx.substratevm/mx_substratevm.py
@@ -45,6 +45,7 @@ import mx_compiler
 import mx_gate
 import mx_unittest
 import mx_sdk_vm
+import mx_sdk_vm_impl
 import mx_javamodules
 import mx_subst
 import mx_substratevm_benchmark  # pylint: disable=unused-import
@@ -176,6 +177,14 @@ def _run_graalvm_cmd(cmd_args, config, nonZeroIsFatal=True, out=None, err=None, 
         primary_suite_dir = config.primary_suite_dir
     else:
         config_args = []
+        if not mx_sdk_vm_impl._jlink_libraries():
+            config_args += ['--no-jlinking']
+        native_images = mx_sdk_vm_impl._parse_cmd_arg('native_images')
+        if native_images:
+            config_args += ['--native-images=' + ','.join(native_images)]
+        components = mx_sdk_vm_impl._components_include_list()
+        if components:
+            config_args += ['--components=' + ','.join(c.name for c in components)]
         dynamic_imports = [x for x, _ in mx.get_dynamic_imports()]
         if dynamic_imports:
             config_args += ['--dynamicimports', ','.join(dynamic_imports)]


### PR DESCRIPTION
Building 'Native Image' should be enough to run the `mx debuginfotest` if no specific profile has been provided.
This change is meant to reduce the time spent on building `native-image` for `mx debuginfotest` when it is not already available.