### PR TITLE
Fix: finagle-chirper and finagle-http benchmark.

### DIFF
--- a/substratevm/src/com.oracle.svm.jni/src/com/oracle/svm/jni/access/JNIReflectionDictionary.java
+++ b/substratevm/src/com.oracle.svm.jni/src/com/oracle/svm/jni/access/JNIReflectionDictionary.java
@@ -34,7 +34,6 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.function.Function;
 
-import org.graalvm.compiler.options.OptionsParser;
 import org.graalvm.compiler.word.Word;
 import org.graalvm.nativeimage.CurrentIsolate;
 import org.graalvm.nativeimage.ImageSingletons;
@@ -143,34 +142,6 @@ public final class JNIReflectionDictionary {
     public JNINativeLinkage getLinkage(String declaringClass, String name, String descriptor) {
         JNINativeLinkage key = new JNINativeLinkage(declaringClass, name, descriptor);
         return nativeLinkages.get(key);
-    }
-
-    /**
-     * Gets the linkage for a method that most closely matches a given method description above the
-     * fuzzy matching threshold defined by {@link OptionsParser#FUZZY_MATCH_THRESHOLD}.
-     *
-     * @param declaringClass the {@linkplain JavaType#getName() name} of the class declaring the
-     *            native method
-     * @param name the name of the native method
-     * @param descriptor the {@linkplain Signature#toMethodDescriptor() descriptor} of the native
-     *            method
-     * @return the linkage that most closely matches the method described by {@code declaringClass},
-     *         {@code name} and {@code descriptor} or {@code null} if there is no close match
-     */
-    public JNINativeLinkage getClosestLinkage(String declaringClass, String name, String descriptor) {
-        JNINativeLinkage key = new JNINativeLinkage(declaringClass, name, descriptor);
-        String keyString = key.toString();
-        float threshold = OptionsParser.FUZZY_MATCH_THRESHOLD;
-        JNINativeLinkage closest = null;
-        for (JNINativeLinkage l : nativeLinkages.keySet()) {
-            String s = l.toString();
-            float similarity = OptionsParser.stringSimilarity(s, keyString);
-            if (similarity > threshold) {
-                threshold = similarity;
-                closest = l;
-            }
-        }
-        return closest;
     }
 
     public void unsetEntryPoints(String declaringClass) {

--- a/substratevm/src/com.oracle.svm.jni/src/com/oracle/svm/jni/functions/JNIFunctions.java
+++ b/substratevm/src/com.oracle.svm.jni/src/com/oracle/svm/jni/functions/JNIFunctions.java
@@ -371,14 +371,13 @@ public final class JNIFunctions {
             if (linkage != null) {
                 linkage.setEntryPoint(fnPtr);
             } else {
-                String message = clazz.getName() + '.' + name + signature;
-                JNINativeLinkage l = JNIReflectionDictionary.singleton().getClosestLinkage(declaringClass, name, signature);
-                if (l != null) {
-                    message += " (found closely matching JNI-accessible method: " +
-                                    MetaUtil.internalNameToJava(l.getDeclaringClassName(), true, false) +
-                                    "." + l.getName() + l.getDescriptor() + ")";
-                }
-                throw new NoSuchMethodError(message);
+                /*
+                 * It happens that libraries register arbitrary Java native methods from their
+                 * native code. If during analysis, we didn't reach some of those JNI methods (see
+                 * com.oracle.svm.jni.hosted.JNINativeCallWrapperSubstitutionProcessor.lookup and
+                 * com.oracle.svm.jni.access.JNIAccessFeature.duringAnalysis) we shouldn't fail:
+                 * those native method can never be invoked.
+                 */
             }
 
             p = p.add(SizeOf.get(JNINativeMethod.class));


### PR DESCRIPTION
**Stacktraces**:

> Fatal error:com.oracle.svm.core.util.VMError$HostedError: java.lang.RuntimeException: oops : expected ASCII string! ε
> 	at com.oracle.svm.core.util.VMError.shouldNotReachHere(VMError.java:72)
> 	at com.oracle.svm.hosted.image.NativeImage.write(NativeImage.java:172)
> 	at com.oracle.svm.hosted.image.NativeImageViaCC.write(NativeImageViaCC.java:409)
> 	at com.oracle.svm.hosted.NativeImageGenerator.doRun(NativeImageGenerator.java:658)
> 	at com.oracle.svm.hosted.NativeImageGenerator.run(NativeImageGenerator.java:489)
> 	at com.oracle.svm.hosted.NativeImageGeneratorRunner.buildImage(NativeImageGeneratorRunner.java:382)
> 	at com.oracle.svm.hosted.NativeImageGeneratorRunner.build(NativeImageGeneratorRunner.java:545)
> 	at com.oracle.svm.hosted.NativeImageGeneratorRunner.main(NativeImageGeneratorRunner.java:119)
> 	at com.oracle.svm.hosted.NativeImageGeneratorRunner$JDK9Plus.main(NativeImageGeneratorRunner.java:575)
>      ...

After solving first issue with debug symbols, the next problem occurred:

> java.net.BindException: Failed to bind to 0.0.0.0/0.0.0.0:0: Unable to create Channel from class class io.netty.channel.socket.nio.NioServerSocketChannel
> 	at com.twitter.finagle.netty4.ListeningServerBuilder$$anon$1.<init>(ListeningServerBuilder.scala:162)
> The following benchmarks failed: finagle-http
> 	at com.twitter.finagle.netty4.ListeningServerBuilder.bindWithBridge(ListeningServerBuilder.scala:77)
> 	at com.twitter.finagle.netty4.Netty4Listener.listen(Netty4Listener.scala:103)
> 	at com.twitter.finagle.server.StdStackServer$class.newListeningServer(StdStackServer.scala:82)
> 	at com.twitter.finagle.Http$Server.newListeningServer(Http.scala:483)
> 	at com.twitter.finagle.server.ListeningStackServer$$anon$1.<init>(ListeningStackServer.scala:87)
> 	at com.twitter.finagle.server.ListeningStackServer$class.serve(ListeningStackServer.scala:39)
> 	at com.twitter.finagle.Http$Server.superServe(Http.scala:670)
> 	at com.twitter.finagle.Http$Server.serve(Http.scala:683)
> 	at com.twitter.finagle.Server$class.serve(Server.scala:131)
> 	at com.twitter.finagle.Http$Server.serve(Http.scala:483)
>      ...


Command to reproduce:
`mx --env ni-ce benchmark renaissance-native-image:finagle-chirper -- --jvm=native-image --jvm-config=default-ce`
`mx --env ni-ce benchmark renaissance-native-image:finagle-http -- --jvm=native-image --jvm-config=default-ce`