### PR TITLE
Use correct Java system properties for target platform

### DIFF
--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/SystemPropertiesSupport.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/SystemPropertiesSupport.java
@@ -127,14 +127,14 @@ public abstract class SystemPropertiesSupport {
         lazyRuntimeValues.put("java.library.path", this::javaLibraryPath);
         lazyRuntimeValues.put("os.version", this::osVersionValue);
 
-        String targetName = System.getProperty("svm.targetName");
-        if (targetName != null) {
-            initializeProperty("os.name", targetName);
+        String targetOS = System.getProperty("svm.targetPlatformOS");
+        if (targetOS != null) {
+            initializeProperty("os.name", targetOS);
         } else {
             lazyRuntimeValues.put("os.name", this::osNameValue);
         }
 
-        String targetArch = System.getProperty("svm.targetArch");
+        String targetArch = System.getProperty("svm.targetPlatformArch");
         if (targetArch != null) {
             initializeProperty("os.arch", targetArch);
         } else {


### PR DESCRIPTION
Use the correct Java system properties to determine target platform operating system and architecture. These are `svm.targetPlatformOS` and `svm.targetPlatformArch`, instead of the old names `svm.targetName` and `svm.targetArch`.

This allows native images to resolve the Java system properties `os.name` and `os.arch` without the need to extract this information from the target system at runtime.