### PR TITLE
Properly cast pointers to integers and vice-versa

### DIFF
--- a/truffle/src/com.oracle.truffle.nfi.native/src/api.c
+++ b/truffle/src/com.oracle.truffle.nfi.native/src/api.c
@@ -79,21 +79,21 @@ static void newClosureRef(TruffleEnv *tenv, void *closure) {
     struct __TruffleEnvInternal *ienv = (struct __TruffleEnvInternal *) tenv;
     struct __TruffleContextInternal *context = ienv->context;
     JNIEnv *env = ienv->jniEnv;
-    (*env)->CallVoidMethod(env, context->LibFFIContext, context->LibFFIContext_newClosureRef, (jlong) closure);
+    (*env)->CallVoidMethod(env, context->LibFFIContext, context->LibFFIContext_newClosureRef, (jlong)(intptr_t)closure);
 }
 
 static void releaseClosureRef(TruffleEnv *tenv, void *closure) {
     struct __TruffleEnvInternal *ienv = (struct __TruffleEnvInternal *) tenv;
     struct __TruffleContextInternal *context = ienv->context;
     JNIEnv *env = ienv->jniEnv;
-    (*env)->CallVoidMethod(env, context->LibFFIContext, context->LibFFIContext_releaseClosureRef, (jlong) closure);
+    (*env)->CallVoidMethod(env, context->LibFFIContext, context->LibFFIContext_releaseClosureRef, (jlong)(intptr_t)closure);
 }
 
 static TruffleObject getClosureObject(TruffleEnv *tenv, void *closure) {
     struct __TruffleEnvInternal *ienv = (struct __TruffleEnvInternal *) tenv;
     struct __TruffleContextInternal *context = ienv->context;
     JNIEnv *env = ienv->jniEnv;
-    jobject local = (*env)->CallObjectMethod(env, context->LibFFIContext, context->LibFFIContext_getClosureObject, (jlong) closure);
+    jobject local = (*env)->CallObjectMethod(env, context->LibFFIContext, context->LibFFIContext_getClosureObject, (jlong)(intptr_t)closure);
     jobject global = (*env)->NewGlobalRef(env, local);
     (*env)->DeleteLocalRef(env, local);
     return (TruffleObject) global;
@@ -115,7 +115,7 @@ const struct __TruffleNativeAPI truffleNativeAPI = {
 
 static TruffleEnv *lookupTruffleEnvOrError(int status, JNIEnv *env, struct __TruffleContextInternal *ctx) {
     if (status == JNI_OK) {
-        struct __TruffleEnvInternal *ret = (struct __TruffleEnvInternal *) (*env)->CallLongMethod(env, ctx->LibFFIContext, ctx->LibFFIContext_getNativeEnv);
+        struct __TruffleEnvInternal *ret = (struct __TruffleEnvInternal *)(intptr_t)(*env)->CallLongMethod(env, ctx->LibFFIContext, ctx->LibFFIContext_getNativeEnv);
         ret->jniEnv = env;
         return (TruffleEnv*) ret;
     } else {

--- a/truffle/src/com.oracle.truffle.nfi.native/src/closure.c
+++ b/truffle/src/com.oracle.truffle.nfi.native/src/closure.c
@@ -146,7 +146,7 @@ static void serialize_ret_string(struct __TruffleContextInternal *ctx, JNIEnv *e
         *((const char **) retPtr) = strdup(chars);
         (*env)->ReleaseStringUTFChars(env, str, chars);
     } else if ((*env)->IsInstanceOf(env, ret, ctx->NativeString)) {
-        *((const char **) retPtr) = (const char *) (*env)->GetLongField(env, ret, ctx->NativeString_nativePointer);
+        *((const char **) retPtr) = (const char *)(intptr_t)(*env)->GetLongField(env, ret, ctx->NativeString_nativePointer);
     } else {
         // unsupported type
         *((void **) retPtr) = NULL;
@@ -285,8 +285,8 @@ static void invoke_closure_void_ret(ffi_cif *cif, void *ret, void **args, void *
 }
 
 jobject prepare_closure(JNIEnv *env, jlong context, jobject signature, jobject receiver, jobject callTarget, void (*invoke_closure)(ffi_cif *cif, void *ret, void **args, void *user_data)) {
-    struct __TruffleContextInternal *ctx = (struct __TruffleContextInternal *) context;
-    ffi_cif *cif = (ffi_cif*) (*env)->GetLongField(env, signature, ctx->LibFFISignature_cif);
+    struct __TruffleContextInternal *ctx = (struct __TruffleContextInternal *)(intptr_t)context;
+    ffi_cif *cif = (ffi_cif*)(intptr_t)(*env)->GetLongField(env, signature, ctx->LibFFISignature_cif);
 
     jobject sigInfo;
     jobjectArray argTypes;
@@ -325,7 +325,7 @@ jobject prepare_closure(JNIEnv *env, jlong context, jobject signature, jobject r
 
     ffi_prep_closure_loc(&data->closure, cif, invoke_closure, data, code);
 
-    return (*env)->CallObjectMethod(env, ctx->LibFFIContext, ctx->LibFFIContext_createClosureNativePointer, (jlong) data, (jlong) code, callTarget, signature, receiver);
+    return (*env)->CallObjectMethod(env, ctx->LibFFIContext, ctx->LibFFIContext_createClosureNativePointer, (jlong)(intptr_t)data, (jlong)(intptr_t)code, callTarget, signature, receiver);
 }
 
 JNIEXPORT jobject JNICALL Java_com_oracle_truffle_nfi_backend_libffi_LibFFIContext_allocateClosureObjectRet(JNIEnv *env, jclass self, jlong nativeContext, jobject signature, jobject callTarget, jobject receiver) {
@@ -346,7 +346,7 @@ JNIEXPORT jobject JNICALL Java_com_oracle_truffle_nfi_backend_libffi_LibFFIConte
 
 
 JNIEXPORT void JNICALL Java_com_oracle_truffle_nfi_backend_libffi_ClosureNativePointer_freeClosure(JNIEnv *env, jclass self, jlong ptr) {
-    struct closure_data *data = (struct closure_data *) ptr;
+    struct closure_data *data = (struct closure_data *)(intptr_t)ptr;
     (*env)->DeleteWeakGlobalRef(env, data->callTarget);
     if (data->receiver) {
         (*env)->DeleteWeakGlobalRef(env, data->receiver);

--- a/truffle/src/com.oracle.truffle.nfi.native/src/internal.h
+++ b/truffle/src/com.oracle.truffle.nfi.native/src/internal.h
@@ -58,8 +58,9 @@
 
 #define __thread __declspec(thread)
 
-#else
+#else // !_WIN32
 
+#include <stdint.h>
 #include <alloca.h>
 
 #endif

--- a/truffle/src/com.oracle.truffle.nfi.native/src/jni.c
+++ b/truffle/src/com.oracle.truffle.nfi.native/src/jni.c
@@ -60,7 +60,7 @@ static void cacheFFIType(JNIEnv *env, jclass nativeSimpleType, jobject context, 
     jfieldID enumField = (*env)->GetStaticFieldID(env, nativeSimpleType, enumName, "Lcom/oracle/truffle/nfi/backend/spi/types/NativeSimpleType;");
     jobject enumValue = (*env)->GetStaticObjectField(env, nativeSimpleType, enumField);
 
-    (*env)->CallVoidMethod(env, context, initializeSimpleType, enumValue, type->size, type->alignment, (jlong) type);
+    (*env)->CallVoidMethod(env, context, initializeSimpleType, enumValue, type->size, type->alignment, (jlong)(intptr_t)type);
 }
 
 static void initializeFlag(JNIEnv *env, jclass LibFFIContext, jobject context, const char *name, int value) {
@@ -154,11 +154,11 @@ JNIEXPORT jlong JNICALL Java_com_oracle_truffle_nfi_backend_libffi_LibFFIContext
 
     initialize_intrinsics(ret);
 
-    return (jlong) ret;
+    return (jlong)(intptr_t)ret;
 }
 
 JNIEXPORT void JNICALL Java_com_oracle_truffle_nfi_backend_libffi_LibFFIContext_disposeNativeContext(JNIEnv *env, jclass clazz, jlong context) {
-    struct __TruffleContextInternal *ctx = (struct __TruffleContextInternal *) context;
+    struct __TruffleContextInternal *ctx = (struct __TruffleContextInternal *)(intptr_t)context;
 
     (*env)->DeleteGlobalRef(env, ctx->LibFFIContext);
 
@@ -177,21 +177,21 @@ JNIEXPORT void JNICALL Java_com_oracle_truffle_nfi_backend_libffi_LibFFIContext_
 }
 
 JNIEXPORT jlong JNICALL Java_com_oracle_truffle_nfi_backend_libffi_LibFFIContext_initializeNativeEnv(JNIEnv *env, jclass clazz, jlong context) {
-    struct __TruffleContextInternal *ctx = (struct __TruffleContextInternal *) context;
+    struct __TruffleContextInternal *ctx = (struct __TruffleContextInternal *)(intptr_t)context;
 
     struct __TruffleEnvInternal *ret = (struct __TruffleEnvInternal *) malloc(sizeof(*ret));
     ret->functions = &truffleNativeAPI;
     ret->context = ctx;
     ret->jniEnv = env;
 
-    return (jlong) ret;
+    return (jlong)(intptr_t)ret;
 }
 
 JNIEXPORT void JNICALL Java_com_oracle_truffle_nfi_backend_libffi_NativeAllocation_free(JNIEnv *env, jclass self, jlong pointer) {
-    free((void*) pointer);
+    free((void*)(intptr_t)pointer);
 }
 
 JNIEXPORT jstring JNICALL Java_com_oracle_truffle_nfi_backend_libffi_NativeString_toJavaString(JNIEnv *env, jclass self, jlong pointer) {
-    const char *str = (const char *) pointer;
+    const char *str = (const char *)(intptr_t)pointer;
     return (*env)->NewStringUTF(env, str);
 }

--- a/truffle/src/com.oracle.truffle.nfi.native/src/lookup.c
+++ b/truffle/src/com.oracle.truffle.nfi.native/src/lookup.c
@@ -51,7 +51,7 @@
 #if defined(ENABLE_ISOLATED_NAMESPACE)
 
 static void* loadLibraryInNamespace(JNIEnv *env, jlong context, const char *utfName, jint mode) {
-    struct __TruffleContextInternal *ctx = (struct __TruffleContextInternal *) context;
+    struct __TruffleContextInternal *ctx = (struct __TruffleContextInternal *)(intptr_t)context;
     void *handle = NULL;
 
     // Double-checked locking on the NFI context instance.
@@ -87,7 +87,7 @@ static void* loadLibraryInNamespace(JNIEnv *env, jlong context, const char *utfN
 
 JNIEXPORT jlong JNICALL Java_com_oracle_truffle_nfi_backend_libffi_LibFFIContext_loadLibrary(JNIEnv *env, jclass self, jlong context, jstring name, jint flags) {
     const char *utfName = (*env)->GetStringUTFChars(env, name, NULL);
-    struct __TruffleContextInternal *ctx = (struct __TruffleContextInternal *) context;
+    struct __TruffleContextInternal *ctx = (struct __TruffleContextInternal *)(intptr_t)context;
     void *handle = NULL;
 
 #if defined(ENABLE_ISOLATED_NAMESPACE)
@@ -106,15 +106,15 @@ JNIEXPORT jlong JNICALL Java_com_oracle_truffle_nfi_backend_libffi_LibFFIContext
     }
 
     (*env)->ReleaseStringUTFChars(env, name, utfName);
-    return (jlong) handle;
+    return (jlong)(intptr_t)handle;
 }
 
 JNIEXPORT void JNICALL Java_com_oracle_truffle_nfi_backend_libffi_LibFFIContext_freeLibrary(JNIEnv *env, jclass self, jlong handle) {
-    dlclose((void*) handle);
+    dlclose((void*)(intptr_t)handle);
 }
 
 static jlong lookup(JNIEnv *env, jlong context, void *handle, jstring name) {
-    struct __TruffleContextInternal *ctx = (struct __TruffleContextInternal *) context;
+    struct __TruffleContextInternal *ctx = (struct __TruffleContextInternal *)(intptr_t)context;
     const char *utfName = (*env)->GetStringUTFChars(env, name, NULL);
     void *ret;
 
@@ -129,14 +129,14 @@ static jlong lookup(JNIEnv *env, jlong context, void *handle, jstring name) {
         }
     }
     (*env)->ReleaseStringUTFChars(env, name, utfName);
-    return (jlong) check_intrinsify(ctx, ret);
+    return (jlong)(intptr_t)check_intrinsify(ctx, ret);
 }
 
 JNIEXPORT jlong JNICALL Java_com_oracle_truffle_nfi_backend_libffi_LibFFIContext_lookup(JNIEnv *env, jclass self, jlong context, jlong library, jstring name) {
     if (library == 0) {
         return lookup(env, context, RTLD_DEFAULT, name);
     } else {
-        return lookup(env, context, (void *) library, name);
+        return lookup(env, context, (void *)(intptr_t)library, name);
     }
 }
 

--- a/truffle/src/com.oracle.truffle.nfi.native/src/signature.c
+++ b/truffle/src/com.oracle.truffle.nfi.native/src/signature.c
@@ -169,7 +169,7 @@ static void executeHelper(JNIEnv *env, TruffleContext *ctx, void *ret, ffi_cif *
 
     errno = errnoMirror;
 
-    ffi_call(cif, (void (*)(void)) address, ret, argPtrs);
+    ffi_call(cif, (void (*)(void))(intptr_t)address, ret, argPtrs);
 
     errnoMirror = errno;
 
@@ -216,7 +216,7 @@ static void executeHelper(JNIEnv *env, TruffleContext *ctx, void *ret, ffi_cif *
 JNIEXPORT void JNICALL Java_com_oracle_truffle_nfi_backend_libffi_LibFFIContext_executeNative(JNIEnv *env, jclass self, jlong truffleContext, jlong cif, jlong address,
         jbyteArray primArgs, jint patchCount, jintArray patch, jobjectArray objArgs, jbyteArray retArray) {
     jbyte *ret = retArray ? (*env)->GetByteArrayElements(env, retArray, NULL) : NULL;
-    executeHelper(env, (TruffleContext*) truffleContext, ret, (ffi_cif*) cif, address, primArgs, patchCount, patch, objArgs);
+    executeHelper(env, (TruffleContext*)(intptr_t)truffleContext, ret, (ffi_cif*)(intptr_t)cif, address, primArgs, patchCount, patch, objArgs);
     if (retArray) {
         (*env)->ReleaseByteArrayElements(env, retArray, ret, 0);
     }
@@ -225,14 +225,14 @@ JNIEXPORT void JNICALL Java_com_oracle_truffle_nfi_backend_libffi_LibFFIContext_
 JNIEXPORT jlong JNICALL Java_com_oracle_truffle_nfi_backend_libffi_LibFFIContext_executePrimitive(JNIEnv *env, jclass self, jlong truffleContext, jlong cif, jlong address,
         jbyteArray primArgs, jint patchCount, jintArray patch, jobjectArray objArgs) {
     ffi_arg ret;
-    executeHelper(env, (TruffleContext*) truffleContext, &ret, (ffi_cif*) cif, address, primArgs, patchCount, patch, objArgs);
+    executeHelper(env, (TruffleContext*)(intptr_t)truffleContext, &ret, (ffi_cif*)(intptr_t)cif, address, primArgs, patchCount, patch, objArgs);
     return (jlong) ret;
 }
 
 JNIEXPORT jobject JNICALL Java_com_oracle_truffle_nfi_backend_libffi_LibFFIContext_executeObject(JNIEnv *env, jclass self, jlong truffleContext, jlong cif, jlong address,
         jbyteArray primArgs, jint patchCount, jintArray patch, jobjectArray objArgs) {
     jobject ret;
-    executeHelper(env, (TruffleContext*) truffleContext, &ret, (ffi_cif*) cif, address, primArgs, patchCount, patch, objArgs);
+    executeHelper(env, (TruffleContext*)(intptr_t)truffleContext, &ret, (ffi_cif*)(intptr_t)cif, address, primArgs, patchCount, patch, objArgs);
     return ret;
 }
 
@@ -242,21 +242,21 @@ static struct cif_data *prepareArgs(JNIEnv *env, struct __TruffleContextInternal
     int i;
     for (i = 0; i < nargs; i++) {
         jobject type = (*env)->GetObjectArrayElement(env, argTypes, i);
-        data->args[i] = (ffi_type*) (*env)->GetLongField(env, type, ctx->LibFFIType_type);
+        data->args[i] = (ffi_type*)(intptr_t)(*env)->GetLongField(env, type, ctx->LibFFIType_type);
     }
     return data;
 }
 
 JNIEXPORT jlong JNICALL Java_com_oracle_truffle_nfi_backend_libffi_LibFFIContext_prepareSignature(JNIEnv *env, jclass self, jlong nativeContext, jobject retType, jint nargs, jobjectArray argTypes) {
-    struct __TruffleContextInternal *ctx = (struct __TruffleContextInternal *) nativeContext;
+    struct __TruffleContextInternal *ctx = (struct __TruffleContextInternal *)(intptr_t)nativeContext;
 
     struct cif_data *data = prepareArgs(env, ctx, nargs, argTypes);
-    ffi_type *ret = (ffi_type*) (*env)->GetLongField(env, retType, ctx->LibFFIType_type);
+    ffi_type *ret = (ffi_type*)(intptr_t)(*env)->GetLongField(env, retType, ctx->LibFFIType_type);
 
     ffi_status result = ffi_prep_cif(&data->cif, FFI_DEFAULT_ABI, nargs, ret, data->args);
 
     if (result == FFI_OK) {
-        return (jlong) data;
+        return (jlong)(intptr_t)data;
     } else {
         free(data);
         return 0;
@@ -264,15 +264,15 @@ JNIEXPORT jlong JNICALL Java_com_oracle_truffle_nfi_backend_libffi_LibFFIContext
 }
 
 JNIEXPORT jlong JNICALL Java_com_oracle_truffle_nfi_backend_libffi_LibFFIContext_prepareSignatureVarargs(JNIEnv *env, jclass self, jlong nativeContext, jobject retType, jint nargs, jint nFixedArgs, jobjectArray argTypes) {
-    struct __TruffleContextInternal *ctx = (struct __TruffleContextInternal *) nativeContext;
+    struct __TruffleContextInternal *ctx = (struct __TruffleContextInternal *)(intptr_t)nativeContext;
 
     struct cif_data *data = prepareArgs(env, ctx, nargs, argTypes);
-    ffi_type *ret = (ffi_type*) (*env)->GetLongField(env, retType, ctx->LibFFIType_type);
+    ffi_type *ret = (ffi_type*)(intptr_t)(*env)->GetLongField(env, retType, ctx->LibFFIType_type);
 
     ffi_status result = ffi_prep_cif_var(&data->cif, FFI_DEFAULT_ABI, nFixedArgs, nargs, ret, data->args);
 
     if (result == FFI_OK) {
-        return (jlong) data;
+        return (jlong)(intptr_t)data;
     } else {
         free(data);
         return 0;

--- a/truffle/src/com.oracle.truffle.nfi.test.native/src/varargs.c
+++ b/truffle/src/com.oracle.truffle.nfi.test.native/src/varargs.c
@@ -106,7 +106,7 @@ static char *add_pointer(char *dest, char *end, void *value) {
         return add_string(dest, end, "(nil)");
     } else {
         dest = add_string(dest, end, "0x");
-        return add_int(dest, end, (int64_t) value, 16);
+        return add_int(dest, end, (int64_t)(intptr_t)value, 16);
     }
 }
 


### PR DESCRIPTION
Properly casting pointers to integers (and vice-versa) needs casting to `intptr_t` as an intermediary type.