### PR TITLE
Fix: gauss-mix and als benchmarks.

### DIFF
--- a/substratevm/src/com.oracle.svm.agent/src/com/oracle/svm/agent/BreakpointInterceptor.java
+++ b/substratevm/src/com.oracle.svm.agent/src/com/oracle/svm/agent/BreakpointInterceptor.java
@@ -59,6 +59,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.function.Supplier;
 
+import com.oracle.svm.core.jdk.Package_jdk_internal_reflect;
 import org.graalvm.compiler.core.common.NumUtil;
 import org.graalvm.nativeimage.StackValue;
 import org.graalvm.nativeimage.UnmanagedMemory;
@@ -943,6 +944,45 @@ final class BreakpointInterceptor {
         return true;
     }
 
+    /*
+     * In rare occasions, the application can demand custom target constructor for serialization,
+     * using (see sun.reflect.ReflectionFactory#newConstructorForSerialization(java.lang.Class,
+     * java.lang.reflect.Constructor)) on JDK8 or (see
+     * jdk.internal.reflect.ReflectionFactory#newConstructorForSerialization(java.lang.Class,
+     * java.lang.reflect.Constructor)) on JDK11. We need to catch constructor class and create entry
+     * for that pair (serialization class, custom class constructor) in serialization configuration.
+     */
+    private static boolean customTargetConstructorSerialization(JNIEnvironment jni, @SuppressWarnings("unused") Breakpoint bp, InterceptedState state) {
+        JNIObjectHandle serializeTargetClass = getObjectArgument(1);
+        String serializeTargetClassName = getClassNameOrNull(jni, serializeTargetClass);
+
+        // Skip Lambda class serialization.
+        if (serializeTargetClassName.contains("$$Lambda$")) {
+            return true;
+        }
+
+        JNIObjectHandle customConstructorObj = getObjectArgument(2);
+        JNIObjectHandle customConstructorClass = jniFunctions().getGetObjectClass().invoke(jni, customConstructorObj);
+        JNIMethodId getDeclaringClassNameMethodID = agent.handles().getJavaLangReflectConstructorDeclaringClassName(jni, customConstructorClass);
+        JNIObjectHandle declaredClassNameObj = callObjectMethod(jni, customConstructorObj, getDeclaringClassNameMethodID);
+        String customConstructorClassName = fromJniString(jni, declaredClassNameObj);
+
+        if (tracer != null) {
+            tracer.traceCall("serialization",
+                            "ObjectStreamClass.<init>",
+                            null,
+                            null,
+                            null,
+                            true,
+                            state.getFullStackTraceOrNull(),
+                            /*- String serializationTargetClass, String customTargetConstructorClass */
+                            serializeTargetClassName, customConstructorClassName);
+
+            guarantee(!testException(jni));
+        }
+        return true;
+    }
+
     @CEntryPoint
     @CEntryPointOptions(prologue = AgentIsolate.Prologue.class)
     private static void onBreakpoint(@SuppressWarnings("unused") JvmtiEnv jvmti, JNIEnvironment jni,
@@ -1241,6 +1281,9 @@ final class BreakpointInterceptor {
                                     "(Ljava/lang/ClassLoader;[Ljava/lang/Class;Ljava/lang/reflect/InvocationHandler;)Ljava/lang/Object;", BreakpointInterceptor::newProxyInstance),
 
                     brk("java/io/ObjectStreamClass", "<init>", "(Ljava/lang/Class;)V", BreakpointInterceptor::objectStreamClassConstructor),
+                    brk(Package_jdk_internal_reflect.getQualifiedName().replace(".", "/") + "/ReflectionFactory",
+                                    "newConstructorForSerialization",
+                                    "(Ljava/lang/Class;Ljava/lang/reflect/Constructor;)Ljava/lang/reflect/Constructor;", BreakpointInterceptor::customTargetConstructorSerialization),
                     optionalBrk("java/util/ResourceBundle",
                                     "getBundleImpl",
                                     "(Ljava/lang/String;Ljava/util/Locale;Ljava/lang/ClassLoader;Ljava/util/ResourceBundle$Control;)Ljava/util/ResourceBundle;",

--- a/substratevm/src/com.oracle.svm.agent/src/com/oracle/svm/agent/NativeImageAgentJNIHandleSet.java
+++ b/substratevm/src/com.oracle.svm.agent/src/com/oracle/svm/agent/NativeImageAgentJNIHandleSet.java
@@ -67,6 +67,8 @@ public class NativeImageAgentJNIHandleSet extends JNIHandleSet {
     private JNIFieldId javaIOObjectStreamClassClassDataSlotDesc;
     private JNIFieldId javaIOObjectStreamClassClassDataSlotHasData;
 
+    private JNIMethodId javaLangReflectConstructorDeclaringClassName;
+
     NativeImageAgentJNIHandleSet(JNIEnvironment env) {
         super(env);
         javaLangClass = newClassGlobalRef(env, "java/lang/Class");
@@ -156,5 +158,12 @@ public class NativeImageAgentJNIHandleSet extends JNIHandleSet {
             javaIOObjectStreamClassClassDataSlotHasData = getFieldId(env, getJavaIOObjectStreamClassClassDataSlot(env), "hasData", "Z", false);
         }
         return javaIOObjectStreamClassClassDataSlotHasData;
+    }
+
+    JNIMethodId getJavaLangReflectConstructorDeclaringClassName(JNIEnvironment env, JNIObjectHandle customSerializationConstructorClass) {
+        if (javaLangReflectConstructorDeclaringClassName.equal(nullHandle())) {
+            javaLangReflectConstructorDeclaringClassName = getMethodId(env, customSerializationConstructorClass, "getName", "()Ljava/lang/String;", false);
+        }
+        return javaLangReflectConstructorDeclaringClassName;
     }
 }


### PR DESCRIPTION
**Stacktrace**:

> The following benchmarks failed: als
> 	at com.oracle.svm.core.util.VMError.unsupportedFeature(VMError.java:87)
> 	at com.oracle.svm.reflect.serialize.SerializationSupport.getSerializationConstructorAccessor(SerializationSupport.java:132)
> 	at jdk.internal.reflect.MethodAccessorGenerator.generateSerializationConstructor(MethodAccessorGenerator.java:48)
> 	at jdk.internal.reflect.ReflectionFactory.generateConstructor(ReflectionFactory.java:514)
> 	at jdk.internal.reflect.ReflectionFactory.newConstructorForSerialization(ReflectionFactory.java:427)
> 	at sun.reflect.ReflectionFactory.newConstructorForSerialization(ReflectionFactory.java:103)
> 	at org.apache.spark.util.ClosureCleaner$.org$apache$spark$util$ClosureCleaner$$instantiateClass(ClosureCleaner.scala:308)
> 	at org.apache.spark.util.ClosureCleaner$$anonfun$org$apache$spark$util$ClosureCleaner$$clean$23.apply(ClosureCleaner.scala:251)
> 	at org.apache.spark.util.ClosureCleaner$$anonfun$org$apache$spark$util$ClosureCleaner$$clean$23.apply(ClosureCleaner.scala:245)
> 	at scala.collection.TraversableLike$WithFilter$$anonfun$foreach$1.apply(TraversableLike.scala:778)
> 	at scala.collection.immutable.List.foreach(List.scala:381)
>      ...

Command to reproduce:
`mx --env ni-ce benchmark renaissance-native-image:als -- --jvm=native-image --jvm-config=default-ce`
`mx --env ni-ce benchmark renaissance-native-image:gauss-mix -- --jvm=native-image --jvm-config=default-ce`