### PR TITLE
Added support to register/access resource with trailing slash.

### DIFF
--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/Resources.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/Resources.java
@@ -144,7 +144,7 @@ public final class Resources {
         if (resourceName == null) {
             return null;
         }
-        Enumeration<URL> urls = createURLs(resourceName);
+        Enumeration<URL> urls = createURLs(removeTrailingSlash(resourceName));
         return urls.hasMoreElements() ? urls.nextElement() : null;
     }
 
@@ -153,7 +153,7 @@ public final class Resources {
         if (resourceName == null) {
             return null;
         }
-        ResourceStorageEntry entry = Resources.get(resourceName);
+        ResourceStorageEntry entry = Resources.get(removeTrailingSlash(resourceName));
         if (entry == null) {
             return null;
         }
@@ -165,7 +165,7 @@ public final class Resources {
         if (resourceName == null) {
             return null;
         }
-        ResourceStorageEntry entry = Resources.get(resourceName);
+        ResourceStorageEntry entry = Resources.get(removeTrailingSlash(resourceName));
         if (entry == null) {
             return Collections.emptyEnumeration();
         }
@@ -175,6 +175,10 @@ public final class Resources {
             resourcesURLs.add(createURL(resourceName, index));
         }
         return Collections.enumeration(resourcesURLs);
+    }
+
+    private static String removeTrailingSlash(String resourceName) {
+        return !resourceName.endsWith("/") ? resourceName : resourceName.substring(0, resourceName.length() - 1);
     }
 }
 

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/ResourcesFeature.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/ResourcesFeature.java
@@ -324,14 +324,15 @@ public final class ResourcesFeature implements Feature {
     }
 
     private static boolean matches(Pattern[] includePatterns, Pattern[] excludePatterns, String relativePath) {
+        String relativePathWithTrailingSlash = relativePath + "/";
         for (Pattern p : excludePatterns) {
-            if (p.matcher(relativePath).matches()) {
+            if (p.matcher(relativePath).matches() || p.matcher(relativePathWithTrailingSlash).matches()) {
                 return false;
             }
         }
 
         for (Pattern p : includePatterns) {
-            if (p.matcher(relativePath).matches()) {
+            if (p.matcher(relativePath).matches() || p.matcher(relativePathWithTrailingSlash).matches()) {
                 return true;
             }
         }


### PR DESCRIPTION
**Problem**
In most cases, directories as a resource are registered with a trailing slash, and currently, it's not supported. Similarly, when the directories as a resource are accessed with a trailing slash, they won't be found because of the same reason. This PR tries to fix both problems.

**Linked issue** 
https://github.com/micronaut-projects/micronaut-core/issues/5765