### PR TITLE
#3602 Make checks before error is thrown clear

### DIFF
--- a/vm/src/org.graalvm.component.installer/src/org/graalvm/component/installer/Bundle.properties
+++ b/vm/src/org.graalvm.component.installer/src/org/graalvm/component/installer/Bundle.properties
@@ -56,7 +56,9 @@ ERROR_CorruptedRelease=Release file corrupted in GraalVM installation at: {0}
 ERROR_ReleaseSourceRevisions=Could not parse source revisions in: {0}
 ERROR_ReadingRealeaseFile=Error accessing release file {0}: {1}
 ERROR_AmbiguousCommand=Command {0} is ambiguous. Could be {1} or {2}
-ERROR_InvalidGraalVMDirectory=The GraalVM directory {0} is invalid.
+ERROR_InvalidGraalVMDirectory=The GraalVM directory {0} is invalid. \n\
+    A value for the GraalVM home directory is required, and could not be found through either \
+    the "GRAALVM_HOME" or "GRAAL_HOME" environment variables, or by checking the location of the executing JAR.
 ERROR_MultipleSourcesUnsupported=The Updater cannot download from catalog and from specific URL at the same time. \
     Please run the Updater separately for components from a catalog and components from custom URLs.
 INSTALLER_Error=Error: {0}


### PR DESCRIPTION
No information/reason is currently provided so you have no idea what is going on unless you grep the codebase.
NOTE: `GRAAL_HOME` is marked for deprecation in the code by `v22.0.0`, so unsure if this should be visibly included or not.