### PR TITLE
Fix agent tracing for null values inside arrays

### DIFF
--- a/substratevm/src/com.oracle.svm.agent/src/com/oracle/svm/agent/tracing/TraceFileWriter.java
+++ b/substratevm/src/com.oracle.svm.agent/src/com/oracle/svm/agent/tracing/TraceFileWriter.java
@@ -32,6 +32,7 @@ import java.nio.file.Path;
 import java.util.Base64;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Objects;
 
 import com.oracle.svm.agent.tracing.core.Tracer;
 import com.oracle.svm.agent.tracing.core.TracingResultWriter;
@@ -100,7 +101,7 @@ public class TraceFileWriter extends Tracer implements TracingResultWriter {
         if (value instanceof byte[]) {
             s = Base64.getEncoder().encodeToString((byte[]) value);
         } else if (value != null) {
-            s = value.toString();
+            s = Objects.toString(value);
         }
         json.quote(s);
     }


### PR DESCRIPTION
When using `trace-output` option, the agent currently does not handle `null` values inside arrays properly, i.e. a `NullPointerException` will be thrown from [TraceFileWriter.printValue](https://github.com/oracle/graal/blob/0bdddb159b77133ceb9ff1b6ff0e2d69531ce70f/substratevm/src/com.oracle.svm.agent/src/com/oracle/svm/agent/tracing/TraceFileWriter.java#L103) in case `value` is `null`:
https://github.com/oracle/graal/blob/0bdddb159b77133ceb9ff1b6ff0e2d69531ce70f/substratevm/src/com.oracle.svm.agent/src/com/oracle/svm/agent/tracing/TraceFileWriter.java#L103


This PR resolves this issue by replacing the `value.toString()` with `Objects.toString(value)` which properly handles `null` values.