### PR TITLE
[GR-33359] Fix image name argument parsing when combined with -m option

### DIFF
--- a/substratevm/src/com.oracle.svm.driver/src/com/oracle/svm/driver/DefaultOptionHandler.java
+++ b/substratevm/src/com.oracle.svm.driver/src/com/oracle/svm/driver/DefaultOptionHandler.java
@@ -133,6 +133,7 @@ class DefaultOptionHandler extends NativeImage.OptionHandler<NativeImage> {
                     nativeImage.addPlainImageBuilderArg(nativeImage.oHClass + mainClassModuleArgParts[1]);
                 }
                 nativeImage.addPlainImageBuilderArg(nativeImage.oHModule + mainClassModuleArgParts[0]);
+                nativeImage.setModuleOptionMode(true);
                 return true;
             case "--configurations-path":
                 args.poll();

--- a/substratevm/src/com.oracle.svm.driver/src/com/oracle/svm/driver/NativeImage.java
+++ b/substratevm/src/com.oracle.svm.driver/src/com/oracle/svm/driver/NativeImage.java
@@ -1166,7 +1166,7 @@ public class NativeImage {
                 }
             }
 
-            if (!jarOptionMode && !moduleOptionMode) {
+            if (!jarOptionMode) {
                 /* Main-class from customImageBuilderArgs counts as explicitMainClass */
                 boolean explicitMainClass = getHostedOptionFinalArgumentValue(customImageBuilderArgs, oHClass) != null;
                 String mainClassModule = getHostedOptionFinalArgumentValue(imageBuilderArgs, oHModule);
@@ -1178,7 +1178,7 @@ public class NativeImage {
                         String moduleMsg = USE_NI_JPMS ? " (or <module>/<mainclass>)" : "";
                         showError("Please specify class" + moduleMsg + " containing the main entry point method. (see --help)");
                     }
-                } else {
+                } else if (!moduleOptionMode) {
                     /* extraImageArgs main-class overrules previous main-class specification */
                     explicitMainClass = true;
                     mainClass = extraImageArgs.remove(0);

--- a/substratevm/src/com.oracle.svm.driver/src/com/oracle/svm/driver/NativeImage.java
+++ b/substratevm/src/com.oracle.svm.driver/src/com/oracle/svm/driver/NativeImage.java
@@ -254,6 +254,7 @@ public class NativeImage {
     private boolean diagnostics = false;
     String diagnosticsDir;
     private boolean jarOptionMode = false;
+    private boolean moduleOptionMode = false;
     private boolean dryRun = false;
     private String printFlagsOptionQuery = null;
     private String printFlagsWithExtraHelpOptionQuery = null;
@@ -1165,7 +1166,7 @@ public class NativeImage {
                 }
             }
 
-            if (!jarOptionMode) {
+            if (!jarOptionMode && !moduleOptionMode) {
                 /* Main-class from customImageBuilderArgs counts as explicitMainClass */
                 boolean explicitMainClass = getHostedOptionFinalArgumentValue(customImageBuilderArgs, oHClass) != null;
                 String mainClassModule = getHostedOptionFinalArgumentValue(imageBuilderArgs, oHModule);
@@ -1781,6 +1782,10 @@ public class NativeImage {
 
     void setJarOptionMode(boolean val) {
         jarOptionMode = val;
+    }
+
+    void setModuleOptionMode(boolean val) {
+        moduleOptionMode = val;
     }
 
     boolean isVerbose() {

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/NativeImageGeneratorRunner.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/NativeImageGeneratorRunner.java
@@ -338,6 +338,9 @@ public class NativeImageGeneratorRunner {
                                         .orElseThrow(() -> UserError.abort("module %s does not have a ModuleMainClass attribute, use -m <module>/<main-class>", moduleName));
                     }
                     mainClass = classLoader.forName(className, mainModule);
+                    if (mainClass == null) {
+                        throw UserError.abort("Main entry point class '%s' not found.", className);
+                    }
                 } catch (ClassNotFoundException ex) {
                     throw UserError.abort("Main entry point class '%s' not found.", className);
                 }


### PR DESCRIPTION
## Summary
This PR adresses two problems related to `native-image` argument handling. Namely, it:
- fixes `NullPointerException` in cases when a class could not be found on the provided module path
- modifies argument handling so that when image name is combined with `--module` argument, the image name is not mistakenly interpreted as a class name

## Details
### Main class resolving
Currently, our main class resolving is done via:
https://github.com/oracle/graal/blob/8d70605a5ec73bb2f0f0aef9a84cf4d8d8816366/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/NativeImageGeneratorRunner.java#L340

There is a catch block present for `ClassNotFoundException`, however, looking at the call chain, it is possible that control will reach `java.lang.Class.forName(Module, String)`, and by looking at the documentation for this method the return value could be `null` - which is currently not covered. Therefore, the following line will produce a `NullPointerException`:
https://github.com/oracle/graal/blob/8d70605a5ec73bb2f0f0aef9a84cf4d8d8816366/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/NativeImageGeneratorRunner.java#L351

### Image name handling in the presence of `--module` option
Invoking `native-image` with the following arguments
```sh
$ native-image MyClass foo
```
will produce a binary with the name `foo`. However, combining this with the `--module` (`-m` for short) option, for example
```sh
$ native-image -m my.module/MyClass foo
```
will cause a `NullPointerException` in the same line as mentioned above. This is tied to class resolving which could return `null`, however it is a misinterpreted main class argument when `-m` option is present - the image name will be interpreted as an overrule for the class name.

## Implementation details
This PR solves this problem by reusing the same overrule exclusion code used when `-jar` option is present:
https://github.com/oracle/graal/blob/8d70605a5ec73bb2f0f0aef9a84cf4d8d8816366/substratevm/src/com.oracle.svm.driver/src/com/oracle/svm/driver/NativeImage.java#L1168
As for main class resolving, a check is added to ensure that the `mainClass` field is not `null` before proceeding onto entry method lookup.