### PR TITLE
Enables parsing units for maxsize, fixes units for delay in JfrManager.java

### DIFF
--- a/substratevm/src/com.oracle.svm.jfr/src/com/oracle/svm/jfr/JfrManager.java
+++ b/substratevm/src/com.oracle.svm.jfr/src/com/oracle/svm/jfr/JfrManager.java
@@ -193,7 +193,7 @@ public class JfrManager {
                     return Duration.ofMinutes(time).toNanos();
                 } else if ("h".equals(unit)) {
                     return Duration.ofHours(time).toNanos();
-                } else if ("f".equals(unit)) {
+                } else if ("d".equals(unit)) {
                     return Duration.ofDays(time).toNanos();
                 }
                 throw new IllegalArgumentException("Unit is invalid.");
@@ -233,6 +233,7 @@ public class JfrManager {
                     case 'G':
                         return number * 1024 * 1024 * 1024;
                     default:
+                        // Unknown unit, number is treated as plain bytes
                         return number;
                 }
             } catch (IllegalArgumentException e) {


### PR DESCRIPTION
Fixes #3638

## Unpatched :x: 

```
$ export JAVA_HOME=/home/karm/X/JDKs/graalvm-ce-java11-21.2.0/;export PATH=${JAVA_HOME}/bin:${PATH}

$ native-image --version
GraalVM 21.2.0 Java 11 CE (Java Version 11.0.12+6-jvmci-21.2-b08)

$ javac Main.java

$ native-image -H:+AllowVMInspection Main

$ java -XX:+FlightRecorder -XX:StartFlightRecording=maxsize=10M,filename=flight-java.jfr -Xlog:jfr Main
[0.279s][info][jfr] Flight Recorder initialized
[0.279s][info][jfr] Created repository /tmp/2021_07_30_15_11_00_295289
[0.309s][info][jfr] Creating thread sampler for java:20 ms, native 0 ms
[0.309s][info][jfr] Enrolling thread sampler
[0.309s][info][jfr] Enrolling thread sampler
[0.309s][info][jfr] Updated thread sampler for java: 20  ms, native 0 ms
[0.309s][info][jfr] Updated thread sampler for java: 20  ms, native 0 ms
[0.309s][info][jfr] Updated thread sampler for java: 20  ms, native 20 ms
[0.322s][info][jfr] Started recording "1" (1) {maxsize=10.0MB, dumponexit=true, filename=/tmp/rep/flight-java.jfr}
Started recording 1.
Use jcmd 295289 JFR.dump name=1 to copy recording data to file.
Meh.
[0.343s][info][jfr] Updated thread sampler for java: 0  ms, native 20 ms
[0.344s][info][jfr] Disenrolling thread sampler
[0.344s][info][jfr] Stopped recording "1" (1). Reason "Dump on exit".
[0.382s][info][jfr] Wrote recording "1" (1) to /tmp/rep/flight-java.jfr
[0.382s][info][jfr] Closed recording "1" (1)
[0.383s][info][jfr] Removed repository /tmp/2021_07_30_15_11_00_295289

$ ./main -XX:+FlightRecorder -XX:StartFlightRecording=maxsize=10M,filename=flight-native.jfr -XX:FlightRecorderLogging=jfr
Exception in thread "main" com.oracle.svm.core.util.UserError$UserException: Could not parse JFR argument 'maxsize=10M'. Expected a number.
    at com.oracle.svm.core.util.UserError.abort(UserError.java:68)
    at com.oracle.svm.jfr.JfrManager.parseLong(JfrManager.java:171)
    at com.oracle.svm.jfr.JfrManager.initRecording(JfrManager.java:107)
    at com.oracle.svm.jfr.JfrManager.setup(JfrManager.java:72)
    at com.oracle.svm.core.jdk.RuntimeSupport.executeHooks(RuntimeSupport.java:125)
    at com.oracle.svm.core.jdk.RuntimeSupport.executeStartupHooks(RuntimeSupport.java:75)
```

## Patched :heavy_check_mark: 

```
$ export JAVA_HOME=/home/karm/tmp/mandrel-java11-21.3-SNAPSHOT/;export PATH=${JAVA_HOME}/bin:${PATH}

$ native-image --version
native-image 21.3.0-deveab4c4ec5cb5 Mandrel Distribution (Java Version 11.0.12+7)

$ native-image -H:+AllowVMInspection Main

$ ./main -XX:+FlightRecorder -XX:StartFlightRecording=maxsize=10M,filename=flight-native.jfr -XX:FlightRecorderLogging=jfr
[info][jfr] Flight Recorder initialized
[info][jfr] Created repository /tmp/2021_07_30_15_13_28_295949
[info][jfr] Started recording "1" (1) {maxsize=10.0MB, dumponexit=true, filename=/tmp/rep/flight-native.jfr}
Meh.
<removed for brevity>

$ ./main -XX:+FlightRecorder -XX:StartFlightRecording=maxsize=10m,filename=flight-native.jfr -XX:FlightRecorderLogging=jfr
[info][jfr] Flight Recorder initialized
[info][jfr] Created repository /tmp/2021_07_30_15_13_55_296117
[info][jfr] Started recording "1" (1) {maxsize=10.0MB, dumponexit=true, filename=/tmp/rep/flight-native.jfr}
Meh.
<removed for brevity>

$ ./main -XX:+FlightRecorder -XX:StartFlightRecording=maxsize=10k,filename=flight-native.jfr -XX:FlightRecorderLogging=jfr
[info][jfr] Flight Recorder initialized
[info][jfr] Created repository /tmp/2021_07_30_15_14_00_296178
[info][jfr] Started recording "1" (1) {maxsize=10.0kB, dumponexit=true, filename=/tmp/rep/flight-native.jfr}
Meh.
<removed for brevity>

$ ./main -XX:+FlightRecorder -XX:StartFlightRecording=maxsize=10K,filename=flight-native.jfr -XX:FlightRecorderLogging=jfr
[info][jfr] Flight Recorder initialized
[info][jfr] Created repository /tmp/2021_07_30_15_14_05_296238
[info][jfr] Started recording "1" (1) {maxsize=10.0kB, dumponexit=true, filename=/tmp/rep/flight-native.jfr}
Meh.
<removed for brevity>

$ ./main -XX:+FlightRecorder -XX:StartFlightRecording=maxsize=10g,filename=flight-native.jfr -XX:FlightRecorderLogging=jfr
[info][jfr] Flight Recorder initialized
[info][jfr] Created repository /tmp/2021_07_30_15_14_11_296302
[info][jfr] Started recording "1" (1) {maxsize=10.0GB, dumponexit=true, filename=/tmp/rep/flight-native.jfr}
Meh.
<removed for brevity>

$ ./main -XX:+FlightRecorder -XX:StartFlightRecording=maxsize=10G,filename=flight-native.jfr -XX:FlightRecorderLogging=jfr
[info][jfr] Flight Recorder initialized
[info][jfr] Created repository /tmp/2021_07_30_15_16_04_296529
[info][jfr] Started recording "1" (1) {maxsize=10.0GB, dumponexit=true, filename=/tmp/rep/flight-native.jfr}
Meh.
<removed for brevity>

$ ./main -XX:+FlightRecorder -XX:StartFlightRecording=maxsize=10000000,filename=flight-native.jfr -XX:FlightRecorderLogging=jfr
[info][jfr] Flight Recorder initialized
[info][jfr] Created repository /tmp/2021_07_30_15_20_59_298189
[warn][jfr,system] Unable to commit. Requested size 8589 too large
[info][jfr       ] Started recording "1" (1) {maxsize=9.5MB, dumponexit=true, filename=/tmp/rep/flight-native.jfr}
Meh.
<removed for brevity>
```

FYI @jiekang  Good / no good?