### PR TITLE
Move platform from AnalysisUniverse to SVMHost

### DIFF
--- a/substratevm/src/com.oracle.graal.pointsto/src/com/oracle/graal/pointsto/api/HostVM.java
+++ b/substratevm/src/com.oracle.graal.pointsto/src/com/oracle/graal/pointsto/api/HostVM.java
@@ -24,6 +24,7 @@
  */
 package com.oracle.graal.pointsto.api;
 
+import java.lang.reflect.AnnotatedElement;
 import java.util.Optional;
 import java.util.concurrent.ForkJoinPool;
 
@@ -120,5 +121,10 @@ public interface HostVM {
     @SuppressWarnings("unused")
     default boolean skipInterface(AnalysisUniverse universe, ResolvedJavaType interfaceType, ResolvedJavaType implementingType) {
         return false;
+    }
+
+    @SuppressWarnings("unused")
+    default boolean platformSupported(AnalysisUniverse universe, AnnotatedElement element) {
+        return true;
     }
 }

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/HostedConfiguration.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/HostedConfiguration.java
@@ -64,6 +64,7 @@ import com.oracle.svm.hosted.meta.HostedUniverse;
 import com.oracle.svm.hosted.substitute.UnsafeAutomaticSubstitutionProcessor;
 
 import jdk.vm.ci.meta.JavaKind;
+import org.graalvm.nativeimage.Platform;
 
 public class HostedConfiguration {
 
@@ -129,8 +130,8 @@ public class HostedConfiguration {
     }
 
     public SVMHost createHostVM(OptionValues options, ForkJoinPool buildExecutor, ClassLoader classLoader, ClassInitializationSupport classInitializationSupport,
-                    UnsafeAutomaticSubstitutionProcessor automaticSubstitutions) {
-        return new SVMHost(options, buildExecutor, classLoader, classInitializationSupport, automaticSubstitutions);
+                    UnsafeAutomaticSubstitutionProcessor automaticSubstitutions, Platform platform) {
+        return new SVMHost(options, buildExecutor, classLoader, classInitializationSupport, automaticSubstitutions, platform);
     }
 
     public CompileQueue createCompileQueue(DebugContext debug, FeatureHandler featureHandler, HostedUniverse hostedUniverse,

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/NativeImageGenerator.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/NativeImageGenerator.java
@@ -926,12 +926,12 @@ public class NativeImageGenerator {
         SubstitutionProcessor aSubstitutions = createAnalysisSubstitutionProcessor(originalMetaAccess, originalSnippetReflection, cEnumProcessor, automaticSubstitutions,
                         annotationSubstitutions, additionalSubstitutions);
 
-        SVMHost hostVM = HostedConfiguration.instance().createHostVM(options, buildExecutor, loader.getClassLoader(), classInitializationSupport, automaticSubstitutions);
+        SVMHost hostVM = HostedConfiguration.instance().createHostVM(options, buildExecutor, loader.getClassLoader(), classInitializationSupport, automaticSubstitutions, loader.platform);
 
         automaticSubstitutions.init(loader, originalMetaAccess);
         AnalysisPolicy analysisPolicy = PointstoOptions.AllocationSiteSensitiveHeap.getValue(options) ? new BytecodeSensitiveAnalysisPolicy(options)
                         : new DefaultAnalysisPolicy(options);
-        return new AnalysisUniverse(hostVM, target.wordJavaKind, loader.platform, analysisPolicy, aSubstitutions, originalMetaAccess, originalSnippetReflection,
+        return new AnalysisUniverse(hostVM, target.wordJavaKind, analysisPolicy, aSubstitutions, originalMetaAccess, originalSnippetReflection,
                         new SubstrateSnippetReflectionProvider(new SubstrateWordTypes(originalMetaAccess, FrameAccess.getWordKind())));
     }
 

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/analysis/Inflation.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/analysis/Inflation.java
@@ -414,7 +414,7 @@ public class Inflation extends BigBang {
     private boolean isTypeAllowed(Type t) {
         if (t instanceof Class) {
             Optional<? extends ResolvedJavaType> resolved = metaAccess.optionalLookupJavaType((Class<?>) t);
-            return resolved.isPresent() && universe.platformSupported(resolved.get());
+            return resolved.isPresent() && hostVM.platformSupported(universe, resolved.get());
         }
         return true;
     }

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/substitute/SubstitutionReflectivityFilter.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/substitute/SubstitutionReflectivityFilter.java
@@ -46,7 +46,7 @@ public class SubstitutionReflectivityFilter {
     public static boolean shouldExclude(Class<?> classObj, AnalysisMetaAccess metaAccess, AnalysisUniverse universe) {
         try {
             ResolvedJavaType analysisClass = metaAccess.lookupJavaType(classObj);
-            if (!universe.platformSupported(analysisClass)) {
+            if (!universe.hostVM().platformSupported(universe, analysisClass)) {
                 return true;
             } else if (analysisClass.isAnnotationPresent(Delete.class)) {
                 return true; // accesses would fail at runtime
@@ -60,7 +60,7 @@ public class SubstitutionReflectivityFilter {
     public static boolean shouldExclude(Executable method, AnalysisMetaAccess metaAccess, AnalysisUniverse universe) {
         try {
             AnalysisMethod aMethod = metaAccess.lookupJavaMethod(method);
-            if (!universe.platformSupported(aMethod)) {
+            if (!universe.hostVM().platformSupported(universe, aMethod)) {
                 return true;
             } else if (aMethod.isAnnotationPresent(Delete.class)) {
                 return true; // accesses would fail at runtime
@@ -83,7 +83,7 @@ public class SubstitutionReflectivityFilter {
     public static boolean shouldExclude(Field field, AnalysisMetaAccess metaAccess, AnalysisUniverse universe) {
         try {
             AnalysisField aField = metaAccess.lookupJavaField(field);
-            if (!universe.platformSupported(aField)) {
+            if (!universe.hostVM().platformSupported(universe, aField)) {
                 return true;
             }
             if (aField.isAnnotationPresent(Delete.class)) {

--- a/substratevm/src/com.oracle.svm.truffle.tck/src/com/oracle/svm/truffle/tck/WhiteListParser.java
+++ b/substratevm/src/com.oracle.svm.truffle.tck/src/com/oracle/svm/truffle/tck/WhiteListParser.java
@@ -207,12 +207,12 @@ final class WhiteListParser extends ConfigurationParser {
     private void verifySupportedOnActivePlatform(Class<?> clz) throws UnsupportedPlatformException {
         AnalysisUniverse universe = bigBang.getUniverse();
         Package pkg = clz.getPackage();
-        if (pkg != null && !universe.platformSupported(pkg)) {
+        if (pkg != null && !universe.hostVM().platformSupported(universe, pkg)) {
             throw new UnsupportedPlatformException(clz.getPackage());
         }
         Class<?> current = clz;
         do {
-            if (!universe.platformSupported(current)) {
+            if (!universe.hostVM().platformSupported(universe, current)) {
                 throw new UnsupportedPlatformException(current);
             }
             current = current.getEnclosingClass();


### PR DESCRIPTION
It is not necessary to keep platform field in AnalysisUniverse class.
All usages of "platform" field are in com.oravle.svm.hosted package, and
it is irrelevent for general purpose Java program pointsto analysis.