### PR TITLE
[Espresso] Re-compute StaticPropertyKind.Object offsets for SVM

### DIFF
--- a/substratevm/src/com.oracle.svm.truffle/src/com/oracle/svm/truffle/TruffleBaseFeature.java
+++ b/substratevm/src/com.oracle.svm.truffle/src/com/oracle/svm/truffle/TruffleBaseFeature.java
@@ -749,35 +749,6 @@ final class Target_com_oracle_truffle_api_staticobject_ArrayBasedShapeGenerator 
 
 // Checkstyle: stop
 
-@TargetClass(className = "com.oracle.truffle.polyglot.PolyglotContextImpl", onlyWith = TruffleBaseFeature.IsEnabled.class)
-final class Target_com_oracle_truffle_polyglot_PolyglotContextImpl {
-
-    /**
-     * Truffle code can run during image generation, i.e., one or many contexts can be used during
-     * image generation. Truffle optimizes the case where only one context is ever created, and also
-     * stores additional information regarding which thread or threads used the context. We need to
-     * start with a completely fresh specialization state. To simplify that, all static state that
-     * stores context information is abstracted in the SingleContextState class, and it is enough to
-     * recompute a single static field to a new SingleContextState instance.
-     */
-    @Alias @RecomputeFieldValue(kind = Kind.NewInstance, declClassName = "com.oracle.truffle.polyglot.PolyglotContextImpl$SingleContextState", isFinal = true) //
-    static Target_com_oracle_truffle_polyglot_PolyglotContextImpl_SingleContextState singleContextState;
-}
-
-@TargetClass(className = "com.oracle.truffle.polyglot.PolyglotContextThreadLocal", onlyWith = TruffleBaseFeature.IsEnabled.class)
-final class Target_com_oracle_truffle_polyglot_PolyglotContextThreadLocal {
-
-    /**
-     * Don't store any threads in the image.
-     */
-    @Alias @RecomputeFieldValue(kind = Kind.Reset) //
-    Thread activeSingleThread;
-}
-
-@TargetClass(className = "com.oracle.truffle.polyglot.PolyglotContextImpl$SingleContextState", onlyWith = TruffleBaseFeature.IsEnabled.class)
-final class Target_com_oracle_truffle_polyglot_PolyglotContextImpl_SingleContextState {
-}
-
 /*
  * If allowProcess() is disabled at build time, then we ensure that
  * ProcessBuilder is not reachable.

--- a/substratevm/src/com.oracle.svm.truffle/src/com/oracle/svm/truffle/TruffleBaseFeature.java
+++ b/substratevm/src/com.oracle.svm.truffle/src/com/oracle/svm/truffle/TruffleBaseFeature.java
@@ -717,6 +717,8 @@ final class Target_com_oracle_truffle_api_staticobject_StaticProperty {
                     return originalValue;
             }
 
+            assert offset >= baseOffset && (offset - baseOffset) % indexScale == 0;
+
             /*
              * Reverse the offset computation to find the index
              */

--- a/substratevm/src/com.oracle.svm.truffle/src/com/oracle/svm/truffle/TruffleBaseFeature.java
+++ b/substratevm/src/com.oracle.svm.truffle/src/com/oracle/svm/truffle/TruffleBaseFeature.java
@@ -650,6 +650,14 @@ final class Target_com_oracle_truffle_api_staticobject_StaticProperty {
         public Object transform(MetaAccessProvider metaAccess, ResolvedJavaField original, ResolvedJavaField annotated,
                         Object receiver, Object originalValue) {
             int offset = (int) originalValue;
+            if (offset == 0) {
+                /*
+                 * The offset is not yet initialized, probably because no shape was built for the
+                 * receiver static property
+                 */
+                return offset;
+            }
+
             StaticProperty receiverStaticProperty = (StaticProperty) receiver;
 
             String internalKindName;

--- a/substratevm/src/com.oracle.svm.truffle/src/com/oracle/svm/truffle/TruffleBaseFeature.java
+++ b/substratevm/src/com.oracle.svm.truffle/src/com/oracle/svm/truffle/TruffleBaseFeature.java
@@ -667,54 +667,14 @@ final class Target_com_oracle_truffle_api_staticobject_StaticProperty {
             int baseOffset;
             int indexScale;
             JavaKind javaKind;
-            switch (internalKindName) {
-                case "boolean":
-                    javaKind = JavaKind.Boolean;
-                    baseOffset = Unsafe.ARRAY_BOOLEAN_BASE_OFFSET;
-                    indexScale = Unsafe.ARRAY_BOOLEAN_INDEX_SCALE;
-                    break;
-                case "byte":
-                    javaKind = JavaKind.Byte;
-                    baseOffset = Unsafe.ARRAY_BYTE_BASE_OFFSET;
-                    indexScale = Unsafe.ARRAY_BYTE_INDEX_SCALE;
-                    break;
-                case "char":
-                    javaKind = JavaKind.Char;
-                    baseOffset = Unsafe.ARRAY_CHAR_BASE_OFFSET;
-                    indexScale = Unsafe.ARRAY_CHAR_INDEX_SCALE;
-                    break;
-                case "double":
-                    javaKind = JavaKind.Double;
-                    baseOffset = Unsafe.ARRAY_DOUBLE_BASE_OFFSET;
-                    indexScale = Unsafe.ARRAY_DOUBLE_INDEX_SCALE;
-                    break;
-                case "float":
-                    javaKind = JavaKind.Float;
-                    baseOffset = Unsafe.ARRAY_FLOAT_BASE_OFFSET;
-                    indexScale = Unsafe.ARRAY_FLOAT_INDEX_SCALE;
-                    break;
-                case "int":
-                    javaKind = JavaKind.Int;
-                    baseOffset = Unsafe.ARRAY_INT_BASE_OFFSET;
-                    indexScale = Unsafe.ARRAY_INT_INDEX_SCALE;
-                    break;
-                case "long":
-                    javaKind = JavaKind.Long;
-                    baseOffset = Unsafe.ARRAY_LONG_BASE_OFFSET;
-                    indexScale = Unsafe.ARRAY_LONG_INDEX_SCALE;
-                    break;
-                case "Object":
-                    javaKind = JavaKind.Object;
-                    baseOffset = Unsafe.ARRAY_OBJECT_BASE_OFFSET;
-                    indexScale = Unsafe.ARRAY_OBJECT_INDEX_SCALE;
-                    break;
-                case "short":
-                    javaKind = JavaKind.Short;
-                    baseOffset = Unsafe.ARRAY_SHORT_BASE_OFFSET;
-                    indexScale = Unsafe.ARRAY_SHORT_INDEX_SCALE;
-                    break;
-                default:
-                    return originalValue;
+            if (internalKindName.equals("Object")) {
+                javaKind = JavaKind.Object;
+                baseOffset = Unsafe.ARRAY_OBJECT_BASE_OFFSET;
+                indexScale = Unsafe.ARRAY_OBJECT_INDEX_SCALE;
+            } else {
+                javaKind = JavaKind.Byte;
+                baseOffset = Unsafe.ARRAY_BYTE_BASE_OFFSET;
+                indexScale = Unsafe.ARRAY_BYTE_INDEX_SCALE;
             }
 
             assert offset >= baseOffset && (offset - baseOffset) % indexScale == 0;

--- a/substratevm/src/com.oracle.svm.truffle/src/com/oracle/svm/truffle/TruffleBaseFeature.java
+++ b/substratevm/src/com.oracle.svm.truffle/src/com/oracle/svm/truffle/TruffleBaseFeature.java
@@ -223,8 +223,7 @@ public final class TruffleBaseFeature implements com.oracle.svm.core.graal.Graal
     @Override
     public void cleanup() {
         /*
-         * Clean the cached call target nodes to prevent them from keeping application
-         * classes alive
+         * Clean the cached call target nodes to prevent them from keeping application classes alive
          */
         TruffleRuntime runtime = Truffle.getRuntime();
         if (!(runtime instanceof DefaultTruffleRuntime) && !(runtime instanceof SubstrateTruffleRuntime)) {
@@ -518,14 +517,12 @@ public final class TruffleBaseFeature implements com.oracle.svm.core.graal.Graal
         static void duringAnalysis(DuringAnalysisAccess access) {
             boolean requiresIteration = false;
             /*
-             * We need to register as unsafe-accessed the primitive, object, and shape
-             * fields of generated storage classes. However, these classes do not share
-             * a common super type, and their fields are not annotated. Plus, the
-             * invocation plugin does not intercept calls to `StaticShape.Builder.build()`
-             * that happen during the analysis, for example because of context
-             * pre-initialization. Therefore, we inspect the generator cache in
-             * ArrayBasedShapeGenerator, which contains references to all generated
-             * storage classes.
+             * We need to register as unsafe-accessed the primitive, object, and shape fields of
+             * generated storage classes. However, these classes do not share a common super type,
+             * and their fields are not annotated. Plus, the invocation plugin does not intercept
+             * calls to `StaticShape.Builder.build()` that happen during the analysis, for example
+             * because of context pre-initialization. Therefore, we inspect the generator cache in
+             * ArrayBasedShapeGenerator, which contains references to all generated storage classes.
              */
             ConcurrentHashMap<?, ?> generatorCache = ReflectionUtil.readStaticField(SHAPE_GENERATOR, "generatorCache");
             for (Map.Entry<?, ?> entry : generatorCache.entrySet()) {
@@ -638,8 +635,8 @@ final class Target_com_oracle_truffle_api_staticobject_StaticProperty {
 
     public static final class OffsetTransformer implements RecomputeFieldValue.CustomFieldValueTransformer {
         /*
-         * We have to use reflection to access private members instead of aliasing them
-         * in the substitution class since substitutions are present only at runtime
+         * We have to use reflection to access private members instead of aliasing them in the
+         * substitution class since substitutions are present only at runtime
          */
         private static final Method staticPropertyGetInternalKind;
 
@@ -750,11 +747,10 @@ final class Target_com_oracle_truffle_api_staticobject_ArrayBasedShapeGenerator 
 // Checkstyle: stop
 
 /*
- * If allowProcess() is disabled at build time, then we ensure that
- * ProcessBuilder is not reachable.
- * The main purpose of this is to test that ProcessBuilder is not part of the
- * image when building language images with allowProcess() disabled, which
- * we interpret as "forbid shelling out to external processes" (GR-14041).
+ * If allowProcess() is disabled at build time, then we ensure that ProcessBuilder is not reachable.
+ * The main purpose of this is to test that ProcessBuilder is not part of the image when building
+ * language images with allowProcess() disabled, which we interpret as
+ * "forbid shelling out to external processes" (GR-14041).
  */
 @Delete
 @TargetClass(className = "java.lang.ProcessBuilder", onlyWith = {TruffleBaseFeature.IsEnabled.class,
@@ -763,8 +759,7 @@ final class Target_java_lang_ProcessBuilder {
 }
 
 /*
- * If allowProcess() is disabled at build time, then we ensure
- * ObjdumpDisassemblerProvider does not
+ * If allowProcess() is disabled at build time, then we ensure ObjdumpDisassemblerProvider does not
  * try to invoke the nonexistent ProcessBuilder.
  */
 @TargetClass(className = "org.graalvm.compiler.code.ObjdumpDisassemblerProvider", onlyWith = {

--- a/truffle/src/com.oracle.truffle.api.staticobject.test/src/com/oracle/truffle/api/staticobject/test/StaticTest.java
+++ b/truffle/src/com.oracle.truffle.api.staticobject.test/src/com/oracle/truffle/api/staticobject/test/StaticTest.java
@@ -53,22 +53,32 @@ import org.junit.Test;
  * built time for context pre-initialization.
  */
 public class StaticTest {
-    private static final StaticProperty property;
+    private static final StaticProperty property1;
+    private static final StaticProperty property2;
     private static final Object staticObject;
+    private static final Object testValue1 = "object1";
+    private static final Object testValue2 = "object2";
 
     static {
         TestEnvironment environment = new TestEnvironment(new TestConfiguration(true, false));
         StaticShape.Builder builder = StaticShape.newBuilder(environment.testLanguage);
-        property = new DefaultStaticProperty("property");
-        builder.property(property, int.class, false);
+        property1 = new DefaultStaticProperty("property1");
+        property2 = new DefaultStaticProperty("property2");
+        builder.property(property1, Object.class, false);
+        builder.property(property2, Object.class, false);
         staticObject = builder.build().getFactory().create();
-        property.setInt(staticObject, 42);
+        property1.setObject(staticObject, testValue1);
+        property2.setObject(staticObject, testValue2);
     }
 
     @Test
     public void staticallyDeclaredStaticObject() {
-        Assert.assertEquals(42, property.getInt(staticObject));
-        property.setInt(staticObject, 24);
-        Assert.assertEquals(24, property.getInt(staticObject));
+        Assert.assertEquals(testValue1, property1.getObject(staticObject));
+        Assert.assertEquals(testValue2, property2.getObject(staticObject));
+        Object newTestValue = "object3";
+        property1.setObject(staticObject, newTestValue);
+        Assert.assertEquals(newTestValue, property1.getObject(staticObject));
+        property2.setObject(staticObject, newTestValue);
+        Assert.assertEquals(newTestValue, property2.getObject(staticObject));
     }
 }

--- a/truffle/src/com.oracle.truffle.api.staticobject.test/src/com/oracle/truffle/api/staticobject/test/StaticTest.java
+++ b/truffle/src/com.oracle.truffle.api.staticobject.test/src/com/oracle/truffle/api/staticobject/test/StaticTest.java
@@ -53,32 +53,112 @@ import org.junit.Test;
  * built time for context pre-initialization.
  */
 public class StaticTest {
-    private static final StaticProperty property1;
-    private static final StaticProperty property2;
+    private static final StaticProperty propertyB;
+    private static final StaticProperty propertyS;
+    private static final StaticProperty propertyC;
+    private static final StaticProperty propertyI;
+    private static final StaticProperty propertyL;
+    private static final StaticProperty propertyF;
+    private static final StaticProperty propertyD;
+    private static final StaticProperty propertyTF;
+    private static final StaticProperty propertyO1;
+    private static final StaticProperty propertyO2;
     private static final Object staticObject;
-    private static final Object testValue1 = "object1";
-    private static final Object testValue2 = "object2";
+    private static final byte testValueB = 1;
+    private static final short testValueS = 2;
+    private static final char testValueC = 'a';
+    private static final int testValueI = 3;
+    private static final long testValueL = 4;
+    private static final float testValueF = 5.0f;
+    private static final double testValueD = 6.0;
+    private static final boolean testValueTF = true;
+    private static final Object testValueO1 = "object1";
+    private static final Object testValueO2 = "object2";
 
     static {
         TestEnvironment environment = new TestEnvironment(new TestConfiguration(true, false));
         StaticShape.Builder builder = StaticShape.newBuilder(environment.testLanguage);
-        property1 = new DefaultStaticProperty("property1");
-        property2 = new DefaultStaticProperty("property2");
-        builder.property(property1, Object.class, false);
-        builder.property(property2, Object.class, false);
+        propertyB = new DefaultStaticProperty("propertyB");
+        propertyS = new DefaultStaticProperty("propertyS");
+        propertyC = new DefaultStaticProperty("propertyC");
+        propertyI = new DefaultStaticProperty("propertyI");
+        propertyL = new DefaultStaticProperty("propertyL");
+        propertyF = new DefaultStaticProperty("propertyF");
+        propertyD = new DefaultStaticProperty("propertyD");
+        propertyTF = new DefaultStaticProperty("propertyTF");
+        propertyO1 = new DefaultStaticProperty("propertyO1");
+        propertyO2 = new DefaultStaticProperty("propertyO2");
+        builder.property(propertyB, byte.class, false);
+        builder.property(propertyS, short.class, false);
+        builder.property(propertyC, char.class, false);
+        builder.property(propertyI, int.class, false);
+        builder.property(propertyL, long.class, false);
+        builder.property(propertyF, float.class, false);
+        builder.property(propertyD, double.class, false);
+        builder.property(propertyTF, boolean.class, false);
+        builder.property(propertyO1, Object.class, false);
+        builder.property(propertyO2, Object.class, false);
         staticObject = builder.build().getFactory().create();
-        property1.setObject(staticObject, testValue1);
-        property2.setObject(staticObject, testValue2);
+        propertyB.setByte(staticObject, testValueB);
+        propertyS.setShort(staticObject, testValueS);
+        propertyC.setChar(staticObject, testValueC);
+        propertyI.setInt(staticObject, testValueI);
+        propertyL.setLong(staticObject, testValueL);
+        propertyF.setFloat(staticObject, testValueF);
+        propertyD.setDouble(staticObject, testValueD);
+        propertyTF.setBoolean(staticObject, testValueTF);
+        propertyO1.setObject(staticObject, testValueO1);
+        propertyO2.setObject(staticObject, testValueO2);
     }
 
     @Test
     public void staticallyDeclaredStaticObject() {
-        Assert.assertEquals(testValue1, property1.getObject(staticObject));
-        Assert.assertEquals(testValue2, property2.getObject(staticObject));
-        Object newTestValue = "object3";
-        property1.setObject(staticObject, newTestValue);
-        Assert.assertEquals(newTestValue, property1.getObject(staticObject));
-        property2.setObject(staticObject, newTestValue);
-        Assert.assertEquals(newTestValue, property2.getObject(staticObject));
+        Assert.assertEquals(testValueB, propertyB.getByte(staticObject));
+        Assert.assertEquals(testValueS, propertyS.getShort(staticObject));
+        Assert.assertEquals(testValueC, propertyC.getChar(staticObject));
+        Assert.assertEquals(testValueI, propertyI.getInt(staticObject));
+        Assert.assertEquals(testValueL, propertyL.getLong(staticObject));
+        Assert.assertEquals(testValueF, propertyF.getFloat(staticObject), 1e-6f);
+        Assert.assertEquals(testValueD, propertyD.getDouble(staticObject), 1e-6);
+        Assert.assertEquals(testValueTF, propertyTF.getBoolean(staticObject));
+        Assert.assertEquals(testValueO1, propertyO1.getObject(staticObject));
+        Assert.assertEquals(testValueO2, propertyO2.getObject(staticObject));
+
+        byte newTestValueB = 11;
+        propertyB.setByte(staticObject, newTestValueB);
+        Assert.assertEquals(newTestValueB, propertyB.getByte(staticObject));
+
+        short newTestValueS = 22;
+        propertyS.setShort(staticObject, newTestValueS);
+        Assert.assertEquals(newTestValueS, propertyS.getShort(staticObject));
+
+        char newTestValueC = 'b';
+        propertyC.setChar(staticObject, newTestValueC);
+        Assert.assertEquals(newTestValueC, propertyC.getChar(staticObject));
+
+        int newTestValueI = 33;
+        propertyI.setInt(staticObject, newTestValueI);
+        Assert.assertEquals(newTestValueI, propertyI.getInt(staticObject));
+
+        long newTestValueL = 44;
+        propertyL.setLong(staticObject, newTestValueL);
+        Assert.assertEquals(newTestValueL, propertyL.getLong(staticObject));
+
+        float newTestValueF = 55.0f;
+        propertyF.setFloat(staticObject, newTestValueF);
+        Assert.assertEquals(newTestValueF, propertyF.getFloat(staticObject), 1e-6f);
+
+        double newTestValueD = 66.0;
+        propertyD.setDouble(staticObject, newTestValueD);
+        Assert.assertEquals(newTestValueD, propertyD.getDouble(staticObject), 1e-6);
+
+        propertyTF.setBoolean(staticObject, false);
+        Assert.assertFalse(propertyTF.getBoolean(staticObject));
+
+        Object newTestValueO = "object3";
+        propertyO1.setObject(staticObject, newTestValueO);
+        Assert.assertEquals(newTestValueO, propertyO1.getObject(staticObject));
+        propertyO2.setObject(staticObject, newTestValueO);
+        Assert.assertEquals(newTestValueO, propertyO2.getObject(staticObject));
     }
 }

--- a/truffle/src/com.oracle.truffle.api.staticobject/src/com/oracle/truffle/api/staticobject/ArrayBasedStaticShape.java
+++ b/truffle/src/com.oracle.truffle.api.staticobject/src/com/oracle/truffle/api/staticobject/ArrayBasedStaticShape.java
@@ -225,6 +225,7 @@ final class ArrayBasedStaticShape<T> extends StaticShape<T> {
                 byte propertyKind = staticProperty.getInternalKind();
                 int index;
                 if (propertyKind == StaticPropertyKind.Object.toByte()) {
+                    // These offsets are re-computed for SVM: TruffleBaseFeature.Target_com_oracle_truffle_api_staticobject_StaticProperty
                     index = Unsafe.ARRAY_OBJECT_BASE_OFFSET + Unsafe.ARRAY_OBJECT_INDEX_SCALE * objArraySize++;
                 } else {
                     index = primitiveFieldIndexes.getIndex(propertyKind);


### PR DESCRIPTION
This PR is a pre-requisite for `LinkedKlass` caching during context pre-initialization (see https://github.com/oracle/graal/pull/3482). These offsets need to be re-computed so cached `LinkedKlass`es can be re-used on SVM.