### PR TITLE
3667: fix deprecated stat64 on Darwin

### DIFF
--- a/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/PosixStat.java
+++ b/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/PosixStat.java
@@ -44,8 +44,8 @@ public final class PosixStat {
             LinuxStat.stat64 stat = StackValue.get(LinuxStat.stat64.class);
             result = LinuxStat.fstat64(fd, stat);
         } else if (Platform.includedIn(Platform.DARWIN.class)) {
-            DarwinStat.stat64 stat = StackValue.get(DarwinStat.stat64.class);
-            result = DarwinStat.fstat64(fd, stat);
+            DarwinStat.stat stat = StackValue.get(DarwinStat.stat.class);
+            result = DarwinStat.fstat(fd, stat);
         } else {
             throw VMError.shouldNotReachHere("Unsupported platform");
         }
@@ -62,8 +62,8 @@ public final class PosixStat {
                 size = stat.st_size();
             }
         } else if (Platform.includedIn(Platform.DARWIN.class)) {
-            DarwinStat.stat64 stat = StackValue.get(DarwinStat.stat64.class);
-            if (DarwinStat.NoTransitions.fstat64(fd, stat) == 0) {
+            DarwinStat.stat stat = StackValue.get(DarwinStat.stat.class);
+            if (DarwinStat.NoTransitions.fstat(fd, stat) == 0) {
                 size = stat.st_size();
             }
         }

--- a/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/headers/darwin/DarwinStat.java
+++ b/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/headers/darwin/DarwinStat.java
@@ -41,16 +41,16 @@ import com.oracle.svm.core.posix.headers.PosixDirectives;
 public class DarwinStat {
 
     @CStruct(addStructKeyword = true)
-    public interface stat64 extends PointerBase {
+    public interface stat extends PointerBase {
         @CField
         long st_size();
     }
 
-    @CFunction("fstat64")
-    public static native int fstat64(int fd, stat64 buf);
+    @CFunction("fstat")
+    public static native int fstat(int fd, stat buf);
 
     public static class NoTransitions {
         @CFunction(transition = CFunction.Transition.NO_TRANSITION)
-        public static native int fstat64(int fd, stat64 buf);
+        public static native int fstat(int fd, stat buf);
     }
 }


### PR DESCRIPTION
This PR fixes #3667 by replacing stat64 symbols with stat symbols on Darwin.