### PR TITLE
Redict the initilization work to HostVM

### DIFF
--- a/substratevm/src/com.oracle.graal.pointsto/src/com/oracle/graal/pointsto/meta/AnalysisType.java
+++ b/substratevm/src/com.oracle.graal.pointsto/src/com/oracle/graal/pointsto/meta/AnalysisType.java
@@ -823,7 +823,7 @@ public class AnalysisType implements WrappedJavaType, OriginalClassProvider, Com
     @Override
     public void initialize() {
         if (!wrapped.isInitialized()) {
-            throw GraalError.shouldNotReachHere("Classes can only be initialized using methods in ClassInitializationFeature: " + toClassName());
+            universe.hostVM.initializeType(this);
         }
     }
 


### PR DESCRIPTION
Different HostVM subclasses can have different initilization strategy.
The actual work should be implemented in the concrete HostVM subclasses.