### PR TITLE
Register String(byte[]) constructor for runtime JNI access

### DIFF
--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/jdk/JNIRegistrationJava.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/jdk/JNIRegistrationJava.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/jdk/JNIRegistrationJava.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/jdk/JNIRegistrationJava.java
@@ -109,6 +109,7 @@ class JNIRegistrationJava extends JNIRegistrationUtil implements Feature {
         JNIRuntimeAccess.register(method(a, "java.lang.System", "getProperty", String.class));
         JNIRuntimeAccess.register(java.nio.charset.Charset.class);
         JNIRuntimeAccess.register(method(a, "java.nio.charset.Charset", "isSupported", String.class));
+        JNIRuntimeAccess.register(constructor(a, "java.lang.String", byte[].class));
         JNIRuntimeAccess.register(constructor(a, "java.lang.String", byte[].class, String.class));
         JNIRuntimeAccess.register(method(a, "java.lang.String", "getBytes", String.class));
         JNIRuntimeAccess.register(method(a, "java.lang.String", "getBytes"));


### PR DESCRIPTION
More than one user in the Quarkus project has reported that they run into the following exception when building a native image for a Quarkus application:

```
java.lang.NoSuchMethodError: java.lang.String.<init>([B)V 
 at com.oracle.svm.jni.functions.JNIFunctions$Support.getMethodID(JNIFunctions.java:1113) 
 at com.oracle.svm.jni.functions.JNIFunctions$Support.getMethodID(JNIFunctions.java:1098) 
 at com.oracle.svm.jni.functions.JNIFunctions.GetMethodID(JNIFunctions.java:411) 
 at java.io.UnixFileSystem.canonicalize0(UnixFileSystem.java) 
 at java.io.UnixFileSystem.canonicalize(UnixFileSystem.java:178) 
 at java.io.File.getCanonicalPath(File.java:626) 
 at java.io.File.getCanonicalFile(File.java:651) 
 at sun.security.provider.FileInputStreamPool.getInputStream(FileInputStreamPool.java:84) 
 at sun.security.provider.NativePRNG$RandomIO.<init>(NativePRNG.java:388) 
 at sun.security.provider.NativePRNG$1.run(NativePRNG.java:190) 
 at sun.security.provider.NativePRNG$1.run(NativePRNG.java:130) 
 at java.security.AccessController.doPrivileged(AccessController.java:82) 
 at sun.security.provider.NativePRNG.initIO(NativePRNG.java:129) 
 at sun.security.provider.NativePRNG.<clinit>(NativePRNG.java:93) 
 at com.oracle.svm.core.classinitialization.ClassInitializationInfo.invokeClassInitializer(ClassInitializationInfo.java:375) 
 at com.oracle.svm.core.classinitialization.ClassInitializationInfo.initialize(ClassInitializationInfo.java:295) 
 at java.lang.reflect.Constructor.newInstance(Constructor.java:490) 
 at java.security.Provider.newInstanceUtil(Provider.java:176) 
 at java.security.Provider$Service.newInstance(Provider.java:1894) 
 at java.security.SecureRandom.getDefaultPRNG(SecureRandom.java:290) 
 at java.security.SecureRandom.<init>(SecureRandom.java:219) 
 at java.util.UUID$Holder.<clinit>(UUID.java:101) 
 at com.oracle.svm.core.classinitialization.ClassInitializationInfo.invokeClassInitializer(ClassInitializationInfo.java:375) 
 at com.oracle.svm.core.classinitialization.ClassInitializationInfo.initialize(ClassInitializationInfo.java:295) 
 at java.util.UUID.randomUUID(UUID.java:147) 
 
```

The previous report of this was in [1] but reproducing that wasn't working out. The more recent report is here [2] and has more clear instructions on how to reproduce this. Looking at the code in these stacktraces and then looking at the JRE code, it comes down to a code path in `jni_util.c` which can lead to a call to the `java.lang.String` constructor which just takes the `byte[]` as a param (as uses the platform encoding internally). This is the place in `jni_util.c` where that call happens https://github.com/openjdk/jdk11u-dev/blob/master/src/java.base/share/native/libjava/jni_util.c#L732 :
```
/*If the encoding specified in sun.jnu.encoding is not endorsed
  by "Charset.isSupported" we have to fall back to use String(byte[])
  explicitly here without specifying the encoding name, in which the
  StringCoding class will pickup the iso-8859-1 as the fallback
  converter for us.
 */
jmethodID mid = (*env)->GetMethodID(env, strClazz,
                                    "<init>", "([B)V");
if (mid != NULL) {
    result = (*env)->NewObject(env, strClazz, mid, bytes);
}
```
The commit in this PR registers this constructor for JNI runtime access to prevent this exception.

[1] https://github.com/quarkusio/quarkus/issues/10682#issuecomment-729064863
[2] https://github.com/quarkusio/quarkus/issues/19082