### PR TITLE
Fix AArch64 Mach-O relocation

### DIFF
--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/ObjectFile.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/ObjectFile.java
@@ -344,6 +344,12 @@ public abstract class ObjectFile {
                 case DIRECT_4:
                 case PC_RELATIVE_4:
                 case SECREL_4:
+                case AARCH64_R_AARCH64_ADR_PREL_PG_HI21:
+                case AARCH64_R_AARCH64_LDST64_ABS_LO12_NC:
+                case AARCH64_R_AARCH64_LDST32_ABS_LO12_NC:
+                case AARCH64_R_AARCH64_LDST16_ABS_LO12_NC:
+                case AARCH64_R_AARCH64_LDST8_ABS_LO12_NC:
+                case AARCH64_R_AARCH64_ADD_ABS_LO12_NC:
                     return 4;
                 case DIRECT_8:
                 case PC_RELATIVE_8:

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/macho/MachORelocationElement.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/macho/MachORelocationElement.java
@@ -241,7 +241,7 @@ final class RelocationInfo implements RelocationRecord, RelocationMethod {
         this.containingElement = containingElement;
         this.relocatedSection = relocatedSection;
         this.sectionOffset = offset; // gets turned into a vaddr on write-out
-        this.log2length = encodeRequestedLength(requestedLength);;
+        this.log2length = encodeRequestedLength(requestedLength);
         this.kind = kind;
         SymbolTable symtab = relocatedSection.getOwner().getSymbolTable();
         // FIXME: also allow section numbers here, for non-extern symbols

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/macho/MachORelocationElement.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/macho/MachORelocationElement.java
@@ -191,6 +191,7 @@ final class RelocationInfo implements RelocationRecord, RelocationMethod {
     public static RelocationInfo newAddend(MachORelocationElement containingElement, MachOSection relocatedSection, int offset, int requestedLength, long addend) {
         return new RelocationInfo(containingElement, relocatedSection, offset, requestedLength, addend);
     }
+
     private static byte encodeRequestedLength(int requestedLength) {
         /*
          * NOTE: the Mach-O spec claims that r_length == 3 means a 4-byte length and not an 8-byte

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/macho/MachOUserDefinedSection.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/macho/MachOUserDefinedSection.java
@@ -217,7 +217,13 @@ public class MachOUserDefinedSection extends MachOSection implements ObjectFile.
                 case AARCH64_R_AARCH64_LDST8_ABS_LO12_NC:
                 case AARCH64_R_AARCH64_ADD_ABS_LO12_NC:
                     if (explicitAddend != 0) {
-                        // Create ARM64_RELOC_ADDEND
+                        /*
+                         * These relocations should use an explicit addend reloc record instead of an embedded addend,
+                         * according to the Mach-O ld code at
+                         * https://opensource.apple.com/source/ld64/ld64-274.2/src/ld/parsers/macho_relocatable_file.cpp.auto.html
+                         *
+                         * > xxxx instruction at xxxx has embedded addend. ARM64_RELOC_ADDEND should be used instead
+                         */
                         RelocationInfo addend = RelocationInfo.newAddend(el, this, offset, length, explicitAddend);
                         el.add(addend);
                     }

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/macho/MachOUserDefinedSection.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/macho/MachOUserDefinedSection.java
@@ -170,9 +170,9 @@ public class MachOUserDefinedSection extends MachOSection implements ObjectFile.
 
         if (getOwner().cpuType == MachOCpuType.X86_64) {
             /*
-             * NOTE: X86_64 Mach-O does not support explicit addends, and inline addends are applied even
-             * during dynamic linking. So if the caller supplies an explicit addend, we turn it into an
-             * implicit one by updating our content.
+             * NOTE: X86_64 Mach-O does not support explicit addends, and inline addends are applied
+             * even during dynamic linking. So if the caller supplies an explicit addend, we turn it
+             * into an implicit one by updating our content.
              */
             long currentInlineAddendValue = sbb.readTruncatedLong(length);
             long desiredInlineAddendValue;
@@ -190,12 +190,12 @@ public class MachOUserDefinedSection extends MachOSection implements ObjectFile.
 
             /*
              * One more complication: for PC-relative relocation, at least on x86-64, Mach-O linkers
-             * (both AOT ld and dyld) adjust the calculation to compensate for the fact that it's the
-             * *next* instruction that the PC-relative reference gets resolved against. Note that ELF
-             * doesn't do this compensation. Our interface duplicates the ELF behaviour, so we have to
-             * act against this Mach-O-specific fixup here, by *adding* a little to the addend. The
-             * amount we add is always the length in bytes of the relocation site (since on x86-64 the
-             * reference is always the last field in a PC-relative instruction).
+             * (both AOT ld and dyld) adjust the calculation to compensate for the fact that it's
+             * the *next* instruction that the PC-relative reference gets resolved against. Note
+             * that ELF doesn't do this compensation. Our interface duplicates the ELF behaviour, so
+             * we have to act against this Mach-O-specific fixup here, by *adding* a little to the
+             * addend. The amount we add is always the length in bytes of the relocation site (since
+             * on x86-64 the reference is always the last field in a PC-relative instruction).
              */
             if (RelocationKind.isPCRelative(k)) {
                 desiredInlineAddendValue += length;
@@ -218,11 +218,13 @@ public class MachOUserDefinedSection extends MachOSection implements ObjectFile.
                 case AARCH64_R_AARCH64_ADD_ABS_LO12_NC:
                     if (explicitAddend != 0) {
                         /*
-                         * These relocations should use an explicit addend reloc record instead of an embedded addend,
-                         * according to the Mach-O ld code at
-                         * https://opensource.apple.com/source/ld64/ld64-274.2/src/ld/parsers/macho_relocatable_file.cpp.auto.html
+                         * These relocations should use an explicit addend reloc record instead of
+                         * an embedded addend, according to the Mach-O ld code at
+                         * https://opensource.apple.com/source/ld64/ld64-274.2/src/ld/parsers/
+                         * macho_relocatable_file.cpp.auto.html
                          *
-                         * > xxxx instruction at xxxx has embedded addend. ARM64_RELOC_ADDEND should be used instead
+                         * > xxxx instruction at xxxx has embedded addend. ARM64_RELOC_ADDEND should
+                         * be used instead
                          */
                         RelocationInfo addend = RelocationInfo.newAddend(el, this, offset, length, explicitAddend);
                         el.add(addend);


### PR DESCRIPTION
This PR adds basic support for encoding AArch64 relocations currently used by GraalVM in Mach-O file.

Mach-O requires to use `ARM64_RELOC_ADDEND` for encoding addend for certain relocation types:
https://opensource.apple.com/source/ld64/ld64-274.2/src/ld/parsers/macho_relocatable_file.cpp.auto.html