### PR TITLE
Require `java.logging` from `com.oracle.truffle.regex`

### DIFF
--- a/regex/mx.regex/suite.py
+++ b/regex/mx.regex/suite.py
@@ -121,6 +121,10 @@ suite = {
     "TREGEX" : {
       "moduleInfo" : {
         "name" : "com.oracle.truffle.regex",
+        "requires" : [
+          "java.logging",
+          "jdk.unsupported", # sun.misc.Unsafe
+        ],
       },
       "subDir" : "src",
       "dependencies" : ["com.oracle.truffle.regex"],


### PR DESCRIPTION
Fixes https://github.com/oracle/graal/issues/3707