### PR TITLE
parse sret attribute by treating as ret-by-value

### DIFF
--- a/sulong/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/listeners/ParameterAttributes.java
+++ b/sulong/projects/com.oracle.truffle.llvm.parser/src/com/oracle/truffle/llvm/parser/listeners/ParameterAttributes.java
@@ -257,6 +257,9 @@ public class ParameterAttributes implements ParserListener {
                     if (attr == Attribute.Kind.BYVAL) {
                         final Type valueType = types.get(buffer.read());
                         group.addAttribute(new Attribute.KnownTypedAttribute(Attribute.Kind.BYVAL, valueType));
+                    } else if (attr == Attribute.Kind.SRET) {
+                        final Type retType = types.get(buffer.read());
+                        group.addAttribute(new Attribute.KnownTypedAttribute(Attribute.Kind.SRET, retType));
                     }
                     break;
                 }


### PR DESCRIPTION
Parsing sret attribute correctly (by treating as ret-by-value) as it is done in LLVM: 
https://github.com/llvm/llvm-project/blob/main/llvm/lib/Bitcode/Reader/BitcodeReader.cpp, line 3348