### PR TITLE
Register jdk.jfr.FlightRecorder for runtime reinitialization

### DIFF
--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/jdk/JDKInitializationFeature.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/jdk/JDKInitializationFeature.java
@@ -144,5 +144,7 @@ public class JDKInitializationFeature implements Feature {
         rci.rerunInitialization("java.lang.StrictMath$RandomNumberGeneratorHolder", "Contains random seeds");
 
         rci.rerunInitialization("jdk.internal.misc.InnocuousThread", "Contains a thread group INNOCUOUSTHREADGROUP.");
+
+        rci.rerunInitialization("jdk.jfr.FlightRecorder", "Contains fields that point to a running thread.");
     }
 }


### PR DESCRIPTION
Without this patch using `native-image -J-XX:StartFlightRecording` results in:

```
Error: Unsupported features in 2 methods
Detailed message:
Error: Detected a started Thread in the image heap. Threads running in
the image generator are no longer running at image runtime.  Object has
been initialized without the native-image initialization instrumentation
and the stack trace can't be tracked. The object was probably created by
a class initializer and is reachable from a static field. You can
request class initialization at image runtime by using the option
--initialize-at-run-time=<class-name>. Or you can write your own
initialization methods and call them explicitly from your main entry
point.
Trace: Object was reached by
	reading field java.util.Timer.thread of
		constant java.util.Timer@71b3dc96 reached by
	reading field jdk.jfr.internal.PlatformRecorder.timer of
		constant jdk.jfr.internal.PlatformRecorder@6c72df98 reached by
	reading field jdk.jfr.FlightRecorder.internal of
		constant jdk.jfr.FlightRecorder@4a865b07 reached by
	reading field jdk.jfr.FlightRecorder.platformRecorder
Error: No instances of java.io.RandomAccessFile are allowed in the image
heap as this class should be initialized at image runtime. To see how
this object got instantiated use
--trace-object-instantiation=java.io.RandomAccessFile.
Trace: Object was reached by
	reading field jdk.jfr.internal.RepositoryChunk.unFinishedRAF of
		constant jdk.jfr.internal.RepositoryChunk@72041e31 reached by
	reading field jdk.jfr.internal.PlatformRecorder.currentChunk of
		constant jdk.jfr.internal.PlatformRecorder@6c72df98 reached by
	reading field jdk.jfr.FlightRecorder.internal of
		constant jdk.jfr.FlightRecorder@4a865b07 reached by
	reading field jdk.jfr.FlightRecorder.platformRecorder
```