### PR TITLE
Process custom image classpath after parsing options

### DIFF
--- a/substratevm/src/com.oracle.svm.driver/src/com/oracle/svm/driver/DefaultOptionHandler.java
+++ b/substratevm/src/com.oracle.svm.driver/src/com/oracle/svm/driver/DefaultOptionHandler.java
@@ -154,7 +154,9 @@ class DefaultOptionHandler extends NativeImage.OptionHandler<NativeImage> {
                 if (jarFilePathStr == null) {
                     NativeImage.showError(requireValidJarFileMessage);
                 }
-                handleJarFileArg(nativeImage.canonicalize(Paths.get(jarFilePathStr)));
+                final Path filePath = nativeImage.canonicalize(Paths.get(jarFilePathStr));
+                nativeImage.setJarFilePath(filePath);
+                handleJarFileArg(filePath);
                 nativeImage.setJarOptionMode(true);
                 return true;
             case verboseOption:
@@ -320,7 +322,6 @@ class DefaultOptionHandler extends NativeImage.OptionHandler<NativeImage> {
         if (!NativeImage.processJarManifestMainAttributes(filePath, nativeImage::handleMainClassAttribute)) {
             NativeImage.showError("No manifest in " + filePath);
         }
-        nativeImage.addCustomImageClasspath(filePath);
     }
 
     @Override


### PR DESCRIPTION
Closes #3742

* Custom image classpath processing can be impacted by exclude-config.
* Moved the code out of -jar parsing, to avoid the need for specific parameter order.
* Without this change, --exclude-config needs to be passed before -jar for it to have an effect.
* Added some verbose messages for easier debugging of native-image binary.