### PR TITLE
Replaces GraalAccess.getOriginalTarget() with JVMCI.getRuntime().getH…

### DIFF
--- a/substratevm/src/com.oracle.svm.driver/src/com/oracle/svm/driver/DefaultOptionHandler.java
+++ b/substratevm/src/com.oracle.svm.driver/src/com/oracle/svm/driver/DefaultOptionHandler.java
@@ -32,11 +32,11 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.regex.Pattern;
 
+import jdk.vm.ci.runtime.JVMCI;
 import org.graalvm.compiler.options.OptionType;
 
 import com.oracle.svm.driver.MacroOption.MacroOptionKind;
 import com.oracle.svm.driver.NativeImage.ArgumentQueue;
-import com.oracle.svm.hosted.c.GraalAccess;
 
 import jdk.vm.ci.aarch64.AArch64;
 import jdk.vm.ci.amd64.AMD64;
@@ -207,7 +207,7 @@ class DefaultOptionHandler extends NativeImage.OptionHandler<NativeImage> {
                 return true;
             case "--list-cpu-features":
                 args.poll();
-                Architecture arch = GraalAccess.getOriginalTarget().arch;
+                Architecture arch = JVMCI.getRuntime().getHostJVMCIBackend().getTarget().arch;
                 if (arch instanceof AMD64) {
                     nativeImage.showMessage("All AMD64 CPUFeatures: " + Arrays.toString(AMD64.CPUFeature.values()));
                     nativeImage.showNewline();


### PR DESCRIPTION
…ostJVMCIBackend().getTarget()

Fixes #3754
Fixes https://github.com/graalvm/mandrel/issues/287

`GraalAccess.getOriginalTarget().arch` code calls into the `GraalRuntime` interface,
for which exist 2 main implementations: `SubstrateGraalRuntime`and `HotSpotGraalRuntime`.
The problem is that, as a result of using that API, at least with OpenJDK 11.0.x (not labs),
`HotSpotGraalRuntime` and a load of `org.graalvm.compiler.hotspot`
classes end up being part of the points-to analysis and that causes the errors above, e.g.

```
$ grep HotSpotGraalRuntime used_classes_libnative-image-agent_20210906_125301.txt
org.graalvm.compiler.hotspot.HotSpotGraalRuntime
```

See NPE during build with OpenJDK reported on #3754.

I propose a change that doesn't require the use of `GraalRuntime`, hence there's no possibility for the hotspot implementation to make it to the analysis:

```
$ grep hotspot used_classes_libnative-image-agent_20210906_130032.txt
<none>
$
```
THX @galderz for the analysis.
FYI @teshull 