### PR TITLE
[GR-33549] Run image-builder on modulepath when module options are used.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -84,7 +84,6 @@ jobs:
               JDK: "labsjdk-ce-11"
               GATE: "hellomodule"
               PRIMARY: "substratevm"
-              USE_NATIVE_IMAGE_JAVA_PLATFORM_MODULE_SYSTEM: true
           - env:
               JDK: "labsjdk-ce-11"
               GATE: "style,fullbuild"

--- a/compiler/src/org.graalvm.compiler.options.jdk11/src/org/graalvm/compiler/options/ModuleSupport.java
+++ b/compiler/src/org.graalvm.compiler.options.jdk11/src/org/graalvm/compiler/options/ModuleSupport.java
@@ -28,7 +28,7 @@ import java.util.ServiceLoader;
 
 public class ModuleSupport {
 
-    public static final boolean USE_NI_JPMS = System.getenv().getOrDefault("USE_NATIVE_IMAGE_JAVA_PLATFORM_MODULE_SYSTEM", "false").toLowerCase().equals("true");
+    public static final boolean USE_NI_JPMS = Boolean.parseBoolean(System.getenv().get("USE_NATIVE_IMAGE_JAVA_PLATFORM_MODULE_SYSTEM"));
 
     static Iterable<OptionDescriptors> getOptionsLoader() {
         /*

--- a/sdk/mx.sdk/mx_sdk_vm_impl.py
+++ b/sdk/mx.sdk/mx_sdk_vm_impl.py
@@ -1999,6 +1999,7 @@ def graalvm_home_relative_classpath(dependencies, start=None, with_boot_jars=Fal
     mx.logv("Composing classpath for " + str(dependencies) + ". Entries:\n" + '\n'.join(('- {}:{}'.format(d.suite, d.name) for d in mx.classpath_entries(dependencies))))
     cp_entries = mx.classpath_entries(dependencies)
 
+    # Compute the set-difference of the transitive dependencies of `dependencies` and the transitive dependencies of `exclude_names`
     if exclude_names:
         for exclude_entry in mx.classpath_entries(names=exclude_names):
             if exclude_entry in cp_entries:

--- a/substratevm/ci_includes/gate.hocon
+++ b/substratevm/ci_includes/gate.hocon
@@ -45,9 +45,6 @@ builds += [
   }
   ${labsjdk-ee-11} ${svm-common-linux-gate} ${linux-deploy} {
     name: "gate-svm-modules-basic"
-    environment : {
-      USE_NATIVE_IMAGE_JAVA_PLATFORM_MODULE_SYSTEM : "true"
-    }
     run: [
       ${svm-cmd-gate} ["build,hellomodule,test"]
     ]

--- a/substratevm/mx.substratevm/mx_substratevm.py
+++ b/substratevm/mx.substratevm/mx_substratevm.py
@@ -60,8 +60,6 @@ if sys.version_info[0] < 3:
 else:
     from io import StringIO
 
-USE_NI_JPMS = os.environ.get('USE_NATIVE_IMAGE_JAVA_PLATFORM_MODULE_SYSTEM', 'false').lower() == 'true'
-
 suite = mx.suite('substratevm')
 svmSuites = [suite]
 
@@ -71,13 +69,19 @@ def svm_java_compliance():
 def svm_java8():
     return svm_java_compliance() <= mx.JavaCompliance('1.8')
 
-def graal_compiler_flags(all_unnamed=True):
+def graal_compiler_flags():
     version_tag = svm_java_compliance().value
-    compiler_flags = mx.dependency('substratevm:svm-compiler-flags-builder').compute_graal_compiler_flags_map(all_unnamed=all_unnamed)
+    compiler_flags = mx.dependency('substratevm:svm-compiler-flags-builder').compute_graal_compiler_flags_map()
     if version_tag not in compiler_flags:
         missing_flags_message = 'Missing graal-compiler-flags for {0}.\n Did you forget to run "mx build"?'
         mx.abort(missing_flags_message.format(version_tag))
-    return compiler_flags[version_tag]
+    def adjusted_exports(line):
+        if line.startswith('--add-exports='):
+            before, sep, _ = line.rpartition('=')
+            return before + sep + 'ALL-UNNAMED'
+        else:
+            return line
+    return [adjusted_exports(line) for line in compiler_flags[version_tag]]
 
 def svm_unittest_config_participant(config):
     vmArgs, mainClass, mainClassArgs = config
@@ -839,7 +843,7 @@ mx_sdk_vm.register_graalvm_component(mx_sdk_vm.GraalVmJreComponent(
     support_distributions=['substratevm:NATIVE_IMAGE_GRAALVM_SUPPORT'],
     launcher_configs=[
         mx_sdk_vm.LauncherConfig(
-            use_modules='image' if USE_NI_JPMS else 'launcher' if not svm_java8() else None,
+            use_modules='image' if not svm_java8() else None,
             main_module="org.graalvm.nativeimage.driver",
             destination="bin/<exe:native-image>",
             jar_distributions=["substratevm:SVM_DRIVER"],
@@ -850,7 +854,7 @@ mx_sdk_vm.register_graalvm_component(mx_sdk_vm.GraalVmJreComponent(
     ],
     library_configs=[
         mx_sdk_vm.LibraryConfig(
-            use_modules='image' if USE_NI_JPMS else 'launcher' if not svm_java8() else None,
+            use_modules='image' if not svm_java8() else None,
             destination="<lib:native-image-agent>",
             jvm_library=True,
             jar_distributions=[
@@ -864,7 +868,7 @@ mx_sdk_vm.register_graalvm_component(mx_sdk_vm.GraalVmJreComponent(
             ],
         ),
         mx_sdk_vm.LibraryConfig(
-            use_modules='image' if USE_NI_JPMS else 'launcher' if not svm_java8() else None,
+            use_modules='image' if not svm_java8() else None,
             destination="<lib:native-image-diagnostics-agent>",
             jvm_library=True,
             jar_distributions=[
@@ -1017,7 +1021,7 @@ mx_sdk_vm.register_graalvm_component(mx_sdk_vm.GraalVmJreComponent(
     support_distributions=[],
     launcher_configs=[
         mx_sdk_vm.LauncherConfig(
-            use_modules='image' if USE_NI_JPMS else 'launcher' if not svm_java8() else None,
+            use_modules='image' if not svm_java8() else None,
             main_module="org.graalvm.nativeimage.configure",
             destination="bin/<exe:native-image-configure>",
             jar_distributions=["substratevm:SVM_CONFIGURE"],
@@ -1088,8 +1092,6 @@ def hellomodule(args):
     """
     if svm_java8():
         mx.abort('Experimental module support requires Java 11+')
-    if os.environ.get('USE_NATIVE_IMAGE_JAVA_PLATFORM_MODULE_SYSTEM', 'false') != 'true':
-        mx.abort('Experimental module support requires USE_NATIVE_IMAGE_JAVA_PLATFORM_MODULE_SYSTEM=true for "mx build" and "mx hellomodule"')
 
     # Build a helloworld Java module with maven
     module_path = []
@@ -1440,7 +1442,7 @@ class SubstrateCompilerFlagsBuilder(mx.ArchivableProject):
 
     # If renaming or moving this method, please update the error message in
     # com.oracle.svm.driver.NativeImage.BuildConfiguration.getBuilderJavaArgs().
-    def compute_graal_compiler_flags_map(self, all_unnamed=not USE_NI_JPMS):
+    def compute_graal_compiler_flags_map(self):
         graal_compiler_flags_map = dict()
         graal_compiler_flags_map[8] = [
             '-d64',
@@ -1457,15 +1459,9 @@ class SubstrateCompilerFlagsBuilder(mx.ArchivableProject):
             distributions_transitive = mx.classpath_entries(self.deps)
             jdk = mx.get_jdk(tag='default')
             required_exports = mx_javamodules.requiredExports(distributions_transitive, jdk)
-            target_module = 'ALL-UNNAMED' if all_unnamed else None
-            exports_flags = mx_sdk_vm.AbstractNativeImageConfig.get_add_exports_list(required_exports, target_module)
+            exports_flags = mx_sdk_vm.AbstractNativeImageConfig.get_add_exports_list(required_exports)
             graal_compiler_flags_map[11].extend(exports_flags)
-
-            # Currently JDK 13, 14, 15 and JDK 11 have the same flags
-            graal_compiler_flags_map[13] = graal_compiler_flags_map[11]
-            graal_compiler_flags_map[14] = graal_compiler_flags_map[11]
-            graal_compiler_flags_map[15] = graal_compiler_flags_map[11]
-            graal_compiler_flags_map[16] = graal_compiler_flags_map[11]
+            # Currently JDK 17 and JDK 11 have the same flags
             graal_compiler_flags_map[17] = graal_compiler_flags_map[11]
             # DO NOT ADD ANY NEW ADD-OPENS OR ADD-EXPORTS HERE!
             #

--- a/substratevm/mx.substratevm/mx_substratevm.py
+++ b/substratevm/mx.substratevm/mx_substratevm.py
@@ -76,6 +76,12 @@ def graal_compiler_flags():
         missing_flags_message = 'Missing graal-compiler-flags for {0}.\n Did you forget to run "mx build"?'
         mx.abort(missing_flags_message.format(version_tag))
     def adjusted_exports(line):
+        """
+        Turns e.g.
+        --add-exports=jdk.internal.vm.ci/jdk.vm.ci.code.stack=jdk.internal.vm.compiler,org.graalvm.nativeimage.builder
+        into:
+        --add-exports=jdk.internal.vm.ci/jdk.vm.ci.code.stack=ALL-UNNAMED
+        """
         if line.startswith('--add-exports='):
             before, sep, _ = line.rpartition('=')
             return before + sep + 'ALL-UNNAMED'

--- a/substratevm/mx.substratevm/mx_substratevm.py
+++ b/substratevm/mx.substratevm/mx_substratevm.py
@@ -1385,9 +1385,18 @@ JNIEXPORT void JNICALL {0}() {{
     def __str__(self):
         return 'JvmFuncsFallbacksBuildTask {}'.format(self.subject)
 
+def mx_register_dynamic_suite_constituents(register_project, _):
+    register_project(SubstrateCompilerFlagsBuilder())
+
 class SubstrateCompilerFlagsBuilder(mx.ArchivableProject):
 
-    extra_deps = []
+    flags_build_dependencies = [
+        'substratevm:SVM'
+    ]
+
+    def __init__(self):
+        mx.ArchivableProject.__init__(self, suite, 'svm-compiler-flags-builder', [], None, None)
+        self.buildDependencies = list(SubstrateCompilerFlagsBuilder.flags_build_dependencies)
 
     def config_file(self, ver):
         return 'graal-compiler-flags-' + str(ver) + '.config'
@@ -1458,7 +1467,7 @@ class SubstrateCompilerFlagsBuilder(mx.ArchivableProject):
             ]
 
             # Packages to add-export
-            distributions_transitive = mx.classpath_entries(self.deps + SubstrateCompilerFlagsBuilder.extra_deps)
+            distributions_transitive = mx.classpath_entries(self.buildDependencies)
             jdk = mx.get_jdk(tag='default')
             required_exports = mx_javamodules.requiredExports(distributions_transitive, jdk)
             exports_flags = mx_sdk_vm.AbstractNativeImageConfig.get_add_exports_list(required_exports)

--- a/substratevm/mx.substratevm/mx_substratevm.py
+++ b/substratevm/mx.substratevm/mx_substratevm.py
@@ -1387,6 +1387,8 @@ JNIEXPORT void JNICALL {0}() {{
 
 class SubstrateCompilerFlagsBuilder(mx.ArchivableProject):
 
+    extra_deps = []
+
     def config_file(self, ver):
         return 'graal-compiler-flags-' + str(ver) + '.config'
 
@@ -1456,7 +1458,7 @@ class SubstrateCompilerFlagsBuilder(mx.ArchivableProject):
             ]
 
             # Packages to add-export
-            distributions_transitive = mx.classpath_entries(self.deps)
+            distributions_transitive = mx.classpath_entries(self.deps + SubstrateCompilerFlagsBuilder.extra_deps)
             jdk = mx.get_jdk(tag='default')
             required_exports = mx_javamodules.requiredExports(distributions_transitive, jdk)
             exports_flags = mx_sdk_vm.AbstractNativeImageConfig.get_add_exports_list(required_exports)

--- a/substratevm/mx.substratevm/suite.py
+++ b/substratevm/mx.substratevm/suite.py
@@ -1174,6 +1174,11 @@ suite = {
                     "com.oracle.svm.jvmtiagentbase",
                     "com.oracle.svm.jvmtiagentbase.jvmti",
                 ],
+                "requires" : [
+                    "static com.oracle.mxtool.junit",
+                    "static junit",
+                    "static hamcrest",
+                ],
             },
         },
 
@@ -1323,6 +1328,11 @@ suite = {
                 "exports" : [
                     "com.oracle.svm.agent",
                 ],
+                "requires" : [
+                    "static com.oracle.mxtool.junit",
+                    "static junit",
+                    "static hamcrest",
+                ],
                 "requiresConcealed" : {
                     "jdk.internal.vm.ci" : [
                         "jdk.vm.ci.meta",
@@ -1347,6 +1357,11 @@ suite = {
                 "exports" : [
                     "com.oracle.svm.diagnosticsagent",
                 ],
+                "requires" : [
+                    "static com.oracle.mxtool.junit",
+                    "static junit",
+                    "static hamcrest",
+                ],
             },
         },
 
@@ -1366,6 +1381,11 @@ suite = {
                 "exports" : [
                     "* to org.graalvm.nativeimage.agent.tracing",
                     "com.oracle.svm.configure",
+                ],
+                "requires" : [
+                    "static com.oracle.mxtool.junit",
+                    "static junit",
+                    "static hamcrest",
                 ],
             },
         },

--- a/substratevm/mx.substratevm/suite.py
+++ b/substratevm/mx.substratevm/suite.py
@@ -624,13 +624,6 @@ suite = {
             "spotbugs": "false",
         },
 
-        "svm-compiler-flags-builder": {
-            "class" : "SubstrateCompilerFlagsBuilder",
-            "buildDependencies" : [
-                "SVM",
-            ],
-        },
-
         "com.oracle.svm.junit": {
             "subDir": "src",
             "sourceDirs": ["src"],

--- a/substratevm/mx.substratevm/suite.py
+++ b/substratevm/mx.substratevm/suite.py
@@ -626,7 +626,7 @@ suite = {
 
         "svm-compiler-flags-builder": {
             "class" : "SubstrateCompilerFlagsBuilder",
-            "dependencies" : [
+            "buildDependencies" : [
                 "SVM",
             ],
         },

--- a/substratevm/mx.substratevm/suite.py
+++ b/substratevm/mx.substratevm/suite.py
@@ -1225,6 +1225,7 @@ suite = {
                 "com.oracle.objectfile",
                 "com.oracle.objectfile.io",
                 "com.oracle.objectfile.debuginfo",
+                "com.oracle.objectfile.macho",
               ],
 
               "requires" : ["jdk.unsupported"],

--- a/substratevm/src/com.oracle.svm.driver/src/com/oracle/svm/driver/MacroOptionHandler.java
+++ b/substratevm/src/com.oracle.svm.driver/src/com/oracle/svm/driver/MacroOptionHandler.java
@@ -91,11 +91,7 @@ class MacroOptionHandler extends NativeImage.OptionHandler<NativeImage> {
         boolean explicitImageClasspath = enabledOption.forEachPropertyValue(
                         config, "ImageClasspath", entry -> nativeImage.addImageClasspath(ClasspathUtils.stringToClasspath(entry)), PATH_SEPARATOR_REGEX);
         if (!explicitImageModulePath && !explicitImageClasspath) {
-            if (NativeImage.USE_NI_JPMS) {
-                NativeImage.getJars(imageJarsDirectory).forEach(nativeImage::addImageModulePath);
-            } else {
-                NativeImage.getJars(imageJarsDirectory).forEach(nativeImage::addImageClasspath);
-            }
+            NativeImage.getJars(imageJarsDirectory).forEach(nativeImage::addImageClasspath);
         }
 
         String imageName = enabledOption.getProperty(config, "ImageName");

--- a/substratevm/src/com.oracle.svm.driver/src/com/oracle/svm/driver/NativeImage.java
+++ b/substratevm/src/com.oracle.svm.driver/src/com/oracle/svm/driver/NativeImage.java
@@ -504,6 +504,12 @@ public class NativeImage {
 
             for (String line : flagsForVersion) {
                 if (!modulePathBuild && line.startsWith("--add-exports=")) {
+                    /*-
+                     * Turns e.g.
+                     * --add-exports=jdk.internal.vm.ci/jdk.vm.ci.code.stack=jdk.internal.vm.compiler,org.graalvm.nativeimage.builder
+                     * into:
+                     * --add-exports=jdk.internal.vm.ci/jdk.vm.ci.code.stack=ALL-UNNAMED
+                     */
                     builderJavaArgs.add(line.substring(0, line.lastIndexOf('=') + 1) + "ALL-UNNAMED");
                 } else {
                     builderJavaArgs.add(line);

--- a/substratevm/src/com.oracle.svm.driver/src/com/oracle/svm/driver/NativeImage.java
+++ b/substratevm/src/com.oracle.svm.driver/src/com/oracle/svm/driver/NativeImage.java
@@ -260,7 +260,7 @@ public class NativeImage {
 
     static class BuildConfiguration {
 
-        boolean modulePathBuild = Boolean.parseBoolean(System.getenv().get(ENV_VAR_USE_MODULE_SYSTEM));
+        boolean modulePathBuild;
 
         protected final Path workDir;
         protected final Path rootDir;
@@ -279,6 +279,7 @@ public class NativeImage {
 
         @SuppressWarnings("deprecation")
         BuildConfiguration(Path rootDir, Path workDir, List<String> args) {
+            modulePathBuild = Boolean.parseBoolean(System.getenv().get(ENV_VAR_USE_MODULE_SYSTEM));
             this.args = args;
             this.workDir = workDir != null ? workDir : Paths.get(".").toAbsolutePath().normalize();
             if (rootDir != null) {


### PR DESCRIPTION
@ivan-ristovic please have a look. This will eliminate the need for using `USE_NATIVE_IMAGE_JAVA_PLATFORM_MODULE_SYSTEM=true`.
Whenever native-images gets passed `-p` or `-m` (or the equivalent long forms) the driver will switch to running the image builder on modulepath.  Note that `USE_NATIVE_IMAGE_JAVA_PLATFORM_MODULE_SYSTEM=true` can still be used to force running the image builder on modulepath even when no `-p` or `-m` is used.