### PR TITLE
[GR-33796] Non-jlinked-build fixes for breakage after cc11ae1

### DIFF
--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/NashornSupport.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/NashornSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,11 +22,30 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+
 package com.oracle.svm.core.jdk;
 
-import com.oracle.svm.core.annotate.TargetClass;
-import com.oracle.svm.core.jdk.NashornSupport.NashornAvailable;
+import java.util.function.BooleanSupplier;
 
-@TargetClass(className = "jdk.nashorn.api.scripting.ClassFilter", onlyWith = {JDK14OrEarlier.class, NashornAvailable.class})
-public final class Target_jdk_nashorn_api_scripting_ClassFilter {
+public final class NashornSupport {
+
+    // Determine if the jdk.scripting.nashorn module (or jar) is available. If it's not,
+    // the boolean supplier should return false.
+    static class NashornAvailable implements BooleanSupplier {
+
+        private static final String CLASSFILTER_NAME = "jdk.nashorn.api.scripting.ClassFilter";
+
+        @Override
+        public boolean getAsBoolean() {
+            try {
+                // Checkstyle: stop
+                Class.forName(CLASSFILTER_NAME);
+                // Checkstyle: resume
+                return true;
+            } catch (ClassNotFoundException e) {
+                return false;
+            }
+        }
+
+    }
 }

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/Target_jdk_nashorn_api_scripting_NashornScriptEngineFactory.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/Target_jdk_nashorn_api_scripting_NashornScriptEngineFactory.java
@@ -28,9 +28,10 @@ import javax.script.ScriptEngine;
 
 import com.oracle.svm.core.annotate.Substitute;
 import com.oracle.svm.core.annotate.TargetClass;
+import com.oracle.svm.core.jdk.NashornSupport.NashornAvailable;
 import com.oracle.svm.core.util.VMError;
 
-@TargetClass(className = "jdk.nashorn.api.scripting.NashornScriptEngineFactory", onlyWith = JDK14OrEarlier.class)
+@TargetClass(className = "jdk.nashorn.api.scripting.NashornScriptEngineFactory", onlyWith = {JDK14OrEarlier.class, NashornAvailable.class})
 public final class Target_jdk_nashorn_api_scripting_NashornScriptEngineFactory {
     @Substitute
     @SuppressWarnings({"unused", "static-method"})

--- a/substratevm/src/com.oracle.svm.driver/src/com/oracle/svm/driver/NativeImage.java
+++ b/substratevm/src/com.oracle.svm.driver/src/com/oracle/svm/driver/NativeImage.java
@@ -481,12 +481,6 @@ public class NativeImage {
                 }
             }
 
-            if (useJVMCINativeLibrary) {
-                builderJavaArgs.add("-XX:+UseJVMCINativeLibrary");
-            } else {
-                builderJavaArgs.add("-XX:-UseJVMCICompiler");
-            }
-
             String javaVersion = String.valueOf(JavaVersionUtil.JAVA_SPEC);
             String[] flagsForVersion = graalCompilerFlags.get(javaVersion);
             if (flagsForVersion == null) {
@@ -516,6 +510,12 @@ public class NativeImage {
                 }
             }
 
+            if (useJVMCINativeLibrary) {
+                builderJavaArgs.add("-XX:+UseJVMCINativeLibrary");
+            } else {
+                builderJavaArgs.add("-XX:-UseJVMCICompiler");
+            }
+
             return builderJavaArgs;
         }
 
@@ -524,11 +524,12 @@ public class NativeImage {
          */
         public List<Path> getBuilderModulePath() {
             List<Path> result = new ArrayList<>();
+            // Non-jlinked JDKs need truffle and graal-sdk on the module path since they
+            // don't have those modules as part of the JDK.
+            result.addAll(getJars(rootDir.resolve(Paths.get("lib", "jvmci")), "graal-sdk", "enterprise-graal"));
+            result.addAll(getJars(rootDir.resolve(Paths.get("lib", "truffle")), "truffle-api"));
             if (modulePathBuild) {
                 result.addAll(getJars(rootDir.resolve(Paths.get("lib", "svm", "builder"))));
-            } else {
-                result.addAll(getJars(rootDir.resolve(Paths.get("lib", "jvmci")), "graal-sdk", "enterprise-graal"));
-                result.addAll(getJars(rootDir.resolve(Paths.get("lib", "truffle")), "truffle-api"));
             }
             return result;
         }


### PR DESCRIPTION
Add jdk.scripting.nashorn modules for module look-up on JDK 11.
Target_jdk_nashorn_api_scripting_ClassFilter substitution needs nashorn
target class loaded.

cc11ae1d1fad550424b1fdc0a6cf7e9d6815874a re-ordered arguments passed to
the native image generator. Add -XX:+UnlockExperimentalVMOptions before
actually using any one of those experimental options as that's needed
for some JVMs.

Add relevant modules to the upgraded module path list since for
non-jlinked-builds they are either not there or too old.

Closes #3778