### PR TITLE
TRegex: Add ASCII encoding to reduce range of Unicode char sets to ASCII if match string is ASCII-only.

### DIFF
--- a/regex/CHANGELOG.md
+++ b/regex/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This changelog summarizes major changes between TRegex versions relevant to language implementors integrating TRegex into their language. This document will focus on API changes relevant to integrators of TRegex.
 
+## Version 22.0.0
+
+* Added new `ASCII` encoding that callers can use when compiling a regex to limit the range of code point matches to [0xx, 0x7f].
+
 ## Version 21.3.0
 
 * Support for case-insensitive matching in Ruby regular expressions.

--- a/regex/src/com.oracle.truffle.regex/src/com/oracle/truffle/regex/RegexOptions.java
+++ b/regex/src/com.oracle.truffle.regex/src/com/oracle/truffle/regex/RegexOptions.java
@@ -397,6 +397,9 @@ public final class RegexOptions {
                 throw optionsSyntaxErrorUnexpectedValue(iVal, Encodings.ALL_NAMES);
             }
             switch (src.charAt(iVal)) {
+                case 'A':
+                    encoding = Encodings.ASCII;
+                    return expectValue(iVal, Encodings.ASCII.getName(), Encodings.ALL_NAMES);
                 case 'B':
                     encoding = Encodings.LATIN_1;
                     return expectValue(iVal, "BYTES", Encodings.ALL_NAMES);

--- a/regex/src/com.oracle.truffle.regex/src/com/oracle/truffle/regex/tregex/nodes/TRegexExecutorNode.java
+++ b/regex/src/com.oracle.truffle.regex/src/com/oracle/truffle/regex/tregex/nodes/TRegexExecutorNode.java
@@ -182,7 +182,7 @@ public abstract class TRegexExecutorNode extends Node {
                 return codepoint | (c & (0xff >>> nBytes)) << (6 * (nBytes - 1));
             }
         } else {
-            assert getEncoding() == Encodings.UTF_16_RAW || getEncoding() == Encodings.UTF_32 || getEncoding() == Encodings.LATIN_1;
+            assert getEncoding() == Encodings.UTF_16_RAW || getEncoding() == Encodings.UTF_32 || getEncoding() == Encodings.LATIN_1 || getEncoding() == Encodings.ASCII;
             locals.setNextIndex(inputIncRaw(index));
             return inputReadRaw(locals);
         }

--- a/regex/src/com.oracle.truffle.regex/src/com/oracle/truffle/regex/tregex/parser/flavors/RubyFlavorProcessor.java
+++ b/regex/src/com.oracle.truffle.regex/src/com/oracle/truffle/regex/tregex/parser/flavors/RubyFlavorProcessor.java
@@ -1088,10 +1088,18 @@ public final class RubyFlavorProcessor implements RegexFlavorProcessor {
     }
 
     private CodePointSet getUnicodeCharClass(char className) {
+        if (inSource.getEncoding() == Encodings.ASCII) {
+            return ASCII_CHAR_CLASSES.get(className);
+        }
+
         return trimToEncoding(UNICODE_CHAR_CLASSES.get(className));
     }
 
     private CodePointSet getUnicodePosixCharClass(String className) {
+        if (inSource.getEncoding() == Encodings.ASCII) {
+            return ASCII_POSIX_CHAR_CLASSES.get(className);
+        }
+
         return trimToEncoding(UNICODE_POSIX_CHAR_CLASSES.get(className));
     }
 

--- a/regex/src/com.oracle.truffle.regex/src/com/oracle/truffle/regex/tregex/string/Encodings.java
+++ b/regex/src/com.oracle.truffle.regex/src/com/oracle/truffle/regex/tregex/string/Encodings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * The Universal Permissive License (UPL), Version 1.0
@@ -62,8 +62,9 @@ public final class Encodings {
     public static final Encoding UTF_32 = new Encoding.UTF32();
     public static final Encoding UTF_16_RAW = new Encoding.UTF16Raw();
     public static final Encoding LATIN_1 = new Encoding.Latin1();
+    public static final Encoding ASCII = new Encoding.Ascii();
 
-    public static final String[] ALL_NAMES = {UTF_8.getName(), UTF_16.getName(), UTF_16_RAW.getName(), UTF_32.getName(), LATIN_1.getName(), "BYTES"};
+    public static final String[] ALL_NAMES = {UTF_8.getName(), UTF_16.getName(), UTF_16_RAW.getName(), UTF_32.getName(), ASCII.getName(), LATIN_1.getName(), "BYTES"};
 
     public static Encoding getEncoding(String name) {
         switch (name) {
@@ -496,6 +497,64 @@ public final class Encodings {
             @Override
             public StringBufferLATIN1 createStringBuffer(int capacity) {
                 return new StringBufferLATIN1(capacity);
+            }
+
+            @Override
+            public LoopOptimizationNode extractLoopOptNode(CodePointSet cps) {
+                return new LoopOptIndexOfAnyByteNode(cps.inverseToByteArray(this));
+            }
+
+            @Override
+            public int getNumberOfDecodingSteps() {
+                return 1;
+            }
+
+            @Override
+            public void createMatcher(Builder matchersBuilder, int i, CodePointSet cps, CompilationBuffer compilationBuffer) {
+                matchersBuilder.getBuffer(0).set(i, CharMatchers.createMatcher(cps, compilationBuffer));
+            }
+
+            @Override
+            public Matchers toMatchers(Builder matchersBuilder) {
+                return new Matchers.SimpleMatchers(matchersBuilder.materialize(0), matchersBuilder.getNoMatchSuccessor());
+            }
+        }
+
+        public static final class Ascii extends Encoding {
+
+            @Override
+            public String getName() {
+                return "ASCII";
+            }
+
+            @Override
+            public int getMaxValue() {
+                return 0x7f;
+            }
+
+            @Override
+            public CodePointSet getFullSet() {
+                return Constants.ASCII_RANGE;
+            }
+
+            @Override
+            public int getEncodedSize(int codepoint) {
+                return 1;
+            }
+
+            @Override
+            public boolean isFixedCodePointWidth(CodePointSet set) {
+                return true;
+            }
+
+            @Override
+            public boolean isUnicode() {
+                return false;
+            }
+
+            @Override
+            public AbstractStringBuffer createStringBuffer(int capacity) {
+                return new StringBufferASCII(capacity);
             }
 
             @Override

--- a/regex/src/com.oracle.truffle.regex/src/com/oracle/truffle/regex/tregex/string/StringASCII.java
+++ b/regex/src/com.oracle.truffle.regex/src/com/oracle/truffle/regex/tregex/string/StringASCII.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 2021, 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or
+ * data (collectively the "Software"), free of charge and under any and all
+ * copyright rights in the Software, and any and all patent rights owned or
+ * freely licensable by each licensor hereunder covering either (i) the
+ * unmodified Software as contributed to or provided by such licensor, or (ii)
+ * the Larger Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ *
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ *
+ * The above copyright notice and either this complete permission notice or at a
+ * minimum a reference to the UPL must be included in all copies or substantial
+ * portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.oracle.truffle.regex.tregex.string;
+
+import java.util.Arrays;
+
+import com.oracle.truffle.api.CompilerDirectives.CompilationFinal;
+
+public final class StringASCII implements AbstractString {
+
+    @CompilationFinal(dimensions = 1) private final byte[] str;
+
+    public StringASCII(byte[] str) {
+        this.str = str;
+    }
+
+    @Override
+    public int encodedLength() {
+        return str.length;
+    }
+
+    @Override
+    public Object content() {
+        return str;
+    }
+
+    @Override
+    public String toString() {
+        return defaultToString();
+    }
+
+    @Override
+    public StringASCII substring(int start, int end) {
+        return new StringASCII(Arrays.copyOfRange(str, start, end));
+    }
+
+    @Override
+    public boolean regionMatches(int offset, AbstractString other, int ooffset, int encodedLength) {
+        byte[] o = ((StringASCII) other).str;
+        if (offset + encodedLength > str.length || ooffset + encodedLength > o.length) {
+            return false;
+        }
+        for (int i = 0; i < encodedLength; i++) {
+            if (str[offset + i] != o[ooffset + i]) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    @Override
+    public AbstractStringIterator iterator() {
+        return new StringASCIIIterator(str);
+    }
+
+    private static final class StringASCIIIterator extends AbstractStringIterator {
+
+        private final byte[] str;
+
+        private StringASCIIIterator(byte[] str) {
+            this.str = str;
+        }
+
+        @Override
+        public boolean hasNext() {
+            return i < str.length;
+        }
+
+        @Override
+        public int nextInt() {
+            return Byte.toUnsignedInt(str[i++]);
+        }
+    }
+}

--- a/regex/src/com.oracle.truffle.regex/src/com/oracle/truffle/regex/tregex/string/StringBufferASCII.java
+++ b/regex/src/com.oracle.truffle.regex/src/com/oracle/truffle/regex/tregex/string/StringBufferASCII.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2021, 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or
+ * data (collectively the "Software"), free of charge and under any and all
+ * copyright rights in the Software, and any and all patent rights owned or
+ * freely licensable by each licensor hereunder covering either (i) the
+ * unmodified Software as contributed to or provided by such licensor, or (ii)
+ * the Larger Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ *
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ *
+ * The above copyright notice and either this complete permission notice or at a
+ * minimum a reference to the UPL must be included in all copies or substantial
+ * portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.oracle.truffle.regex.tregex.string;
+
+import com.oracle.truffle.regex.tregex.buffer.ByteArrayBuffer;
+import com.oracle.truffle.regex.tregex.string.Encodings.Encoding;
+
+public final class StringBufferASCII extends ByteArrayBuffer implements AbstractStringBuffer {
+
+    public StringBufferASCII() {
+        this(16);
+    }
+
+    public StringBufferASCII(int capacity) {
+        super(capacity);
+    }
+
+    @Override
+    public Encoding getEncoding() {
+        return Encodings.ASCII;
+    }
+
+    @Override
+    public void append(int codepoint) {
+        assert codepoint <= Encodings.ASCII.getMaxValue();
+        add((byte) codepoint);
+    }
+
+    @Override
+    public void appendOR(int c1, int c2) {
+        assert c1 <= Encodings.ASCII.getMaxValue();
+        assert c2 <= Encodings.ASCII.getMaxValue();
+        add((byte) (c1 | c2));
+    }
+
+    @Override
+    public void appendXOR(int c1, int c2) {
+        assert c1 <= Encodings.ASCII.getMaxValue();
+        assert c2 <= Encodings.ASCII.getMaxValue();
+        add((byte) (c1 ^ c2));
+    }
+
+    @Override
+    public StringASCII materialize() {
+        return new StringASCII(toArray());
+    }
+}


### PR DESCRIPTION
This PR adds a new ASCII encoding to TRegex, which has half the range of valid values as Latin-1. If a guest language knows the regex consists only of ASCII characters, it can specify that when constructing a regex object.

TRegex already has a good mechanism to restrict the code point range for things like POSIX bracket expressions based on the regex's associated encoding. The new ASCII encoding hooks into that existing mechanism to further limit the set of code point ranges based on data the caller knows at regex creation time. Below is a table of the number of code point ranges for the set of POSIX bracket expressions, along with two non-POSIX bracket expressions that the Ruby language uses:

| POSIX Bracket Expr. | Full Unicode # of Ranges | LATIN-1 Range # of Ranges | ASCII # of Ranges|
|-----------------------------|:----------------------------------:|:-------------------------------------:|:------------------------:|
| [:alnum] | 732 | 9 | 3 |
| [:alpha:] | 695 | 8 | 2 |
| [:blank:] | 8 | 3 | 2 |
| [:cntrl:] | 2 | 2 | 2 |
| [:digit:] | 61 | 1 | 1 |
| [:graph:] | 682 | 2 | 1 |
| [:lower:] | 652 | 6 | 1 |
| [:print:] | 679 | 2 | 1 |
| [:punct:] | 334 | 13 | 4 |
| [:space:] | 10 | 4 | 2 |
| [:upper:] | 643 | 3 | 1 |
| [:xdigit:] | 3 | 3 | 3 |
| ↓ Non-POSIX Bracket Expr. ↓ |-----|---|----|
| [:ascii:] | 1 | 1 | 1 |
| [:word:] | 733 | 10 | 4 |

In some cases, such as `[:xdigit:]` there's no gain, but in others such as `[:lower:]` we're able to reduce the entire set to a single range. TRegex doesn't optimize for single range code point sets specifically, but the membership operation has fewer sets to search through.

I benchmarked with TruffleRuby, doing a simple one-or-more check on the bracket expression (e.g., `/[[:alnum:]]+/`). On typical inputs, the savings was not drastic (3 - 6%) for some character classes (`[:alpha:]`, `[:alnum:]`, `[:lower:]`, and `[:space:]`). On problematic inputs, such as a repeating string of `"{}"`, the savings was more pronounced (20% - 128% faster). I did not spend a great deal of time looking for pathological cases. The execution difference is a function of both the regexp pattern and the length and composition of the match string. The code point set membership check performs a binary search to determine if a codepoint belongs to any of its sorted code point ranges. As such, problematic characters could force the search procedure to check the maximum number of ranges. But, at the same time, that execution time is logarithmic.

Overall, I don't expect to see a drastic speed-up on typical workloads. Although, I reserve the right to be incorrect about that as I didn't explore regexp pattern space in great detail. However, I think this is still a worthwhile change because regexp matches are often performed against user-supplied data and we wouldn't want an adversary to force the engine down a bad path.