### PR TITLE
Use relative path in DW_AT_comp_dir if possible

### DIFF
--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debuginfo/DebugInfoProvider.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debuginfo/DebugInfoProvider.java
@@ -82,8 +82,10 @@ public interface DebugInfoProvider {
         Path filePath();
 
         /**
-         * @return a relative path to the source cache containing the cached source file of a file
-         *         element or {@code null} if sources are not available.
+         * @return the path to the source cache containing the cached source file of a file element
+         *         or {@code null} if sources are not available. Relative paths to the target
+         *         directory are preferred over absolute paths, to make it easier to move the binary
+         *         and the cache directory around.
          */
         Path cachePath();
     }

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/SubstrateOptions.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/SubstrateOptions.java
@@ -476,9 +476,23 @@ public class SubstrateOptions {
     @Option(help = "Directory under which to create source file cache for Application or GraalVM classes")//
     public static final HostedOptionKey<String> DebugInfoSourceCacheRoot = new HostedOptionKey<>("sources");
 
-    public static Path getDebugInfoSourceCacheRoot() {
+    /**
+     * Returns {@link SubstrateOptions#DebugInfoSourceCacheRoot} as an absolute path, by resolving
+     * it on {@link SubstrateOptions#Path} if it's not already an absolute path.
+     *
+     * @return the source cache root as an absolute path
+     */
+    public static Path getDebugInfoSourceCacheRootAsAbsolutePath() {
         try {
             return Paths.get(Path.getValue()).resolve(DebugInfoSourceCacheRoot.getValue());
+        } catch (InvalidPathException ipe) {
+            throw UserError.abort("Invalid path provided for option DebugInfoSourceCacheRoot %s", DebugInfoSourceCacheRoot.getValue());
+        }
+    }
+
+    public static Path getDebugInfoSourceCacheRoot() {
+        try {
+            return Paths.get(DebugInfoSourceCacheRoot.getValue());
         } catch (InvalidPathException ipe) {
             throw UserError.abort("Invalid path provided for option DebugInfoSourceCacheRoot %s", DebugInfoSourceCacheRoot.getValue());
         }

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/image/NativeImageDebugInfoProvider.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/image/NativeImageDebugInfoProvider.java
@@ -87,6 +87,7 @@ import jdk.vm.ci.meta.Signature;
 class NativeImageDebugInfoProvider implements DebugInfoProvider {
     private final DebugContext debugContext;
     private final NativeImageCodeCache codeCache;
+    private final Path cachePath;
     @SuppressWarnings("unused") private final NativeImageHeap heap;
     boolean useHeapBase;
     int compressShift;
@@ -101,6 +102,7 @@ class NativeImageDebugInfoProvider implements DebugInfoProvider {
         super();
         this.debugContext = debugContext;
         this.codeCache = codeCache;
+        this.cachePath = SubstrateOptions.getDebugInfoSourceCacheRoot();
         this.heap = heap;
         ObjectHeader objectHeader = Heap.getHeap().getObjectHeader();
         ObjectInfo primitiveFields = heap.getObjectInfo(StaticFieldsSupport.getStaticPrimitiveFields());
@@ -235,8 +237,6 @@ class NativeImageDebugInfoProvider implements DebugInfoProvider {
         }
         return javaType.toJavaName();
     }
-
-    private final Path cachePath = SubstrateOptions.getDebugInfoSourceCacheRoot();
 
     private abstract class NativeImageDebugFileInfo implements DebugFileInfo {
         private Path fullFilePath;

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/image/NativeImageViaCC.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/image/NativeImageViaCC.java
@@ -461,7 +461,7 @@ public abstract class NativeImageViaCC extends NativeImage {
                 }
 
                 if (SubstrateOptions.GenerateDebugInfo.getValue() > 0) {
-                    BuildArtifacts.singleton().add(ArtifactType.DEBUG_INFO, SubstrateOptions.getDebugInfoSourceCacheRoot());
+                    BuildArtifacts.singleton().add(ArtifactType.DEBUG_INFO, SubstrateOptions.getDebugInfoSourceCacheRootAsAbsolutePath());
                     if (OS.getCurrent() == OS.WINDOWS) {
                         BuildArtifacts.singleton().add(ArtifactType.DEBUG_INFO, imagePath.resolveSibling(imageName + ".pdb"));
                     } else {

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/image/sources/SourceCache.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/image/sources/SourceCache.java
@@ -94,7 +94,7 @@ public class SourceCache {
      * Create the source cache.
      */
     protected SourceCache() {
-        basePath = SubstrateOptions.getDebugInfoSourceCacheRoot();
+        basePath = SubstrateOptions.getDebugInfoSourceCacheRootAsAbsolutePath();
         srcRoots = new ArrayList<>();
         specialSrcRoots = new HashMap<>();
         addJDKSources();


### PR DESCRIPTION
dee66ca6e28fd519cef061130d20e28ec35d1a1f started enforcing the use of
absolute paths in DW_AT_comp_dir which results in the following issue.

After compilation is done and one wants to debug their binary on their
deployment machine they will need to transfer both the binary and the
sources directory. As a result any absolute paths in the dwarf info will
now be invalid. However, if the sources directory are kept in the expected
relative-to-the-binary path, a relative DW_AT_comp_dir will remain valid
and gdb (as well as other tools) will be able to pick the sources up
without any additional configuration (e.g. `directory path/to/sources/`
in gdb.

Closes: https://github.com/quarkusio/quarkus/issues/20321