### PR TITLE
TRegex: Update assertion to allow usage of ASCII encoding.

### DIFF
--- a/regex/src/com.oracle.truffle.regex/src/com/oracle/truffle/regex/tregex/nodes/TRegexExecutorNode.java
+++ b/regex/src/com.oracle.truffle.regex/src/com/oracle/truffle/regex/tregex/nodes/TRegexExecutorNode.java
@@ -261,7 +261,7 @@ public abstract class TRegexExecutorNode extends Node {
                 } while (inputHasNext(locals, false) && inputUTF8IsTrailingByte(c));
             }
         } else {
-            assert getEncoding() == Encodings.UTF_16_RAW || getEncoding() == Encodings.UTF_32 || getEncoding() == Encodings.LATIN_1;
+            assert getEncoding() == Encodings.UTF_16_RAW || getEncoding() == Encodings.UTF_32 || getEncoding() == Encodings.LATIN_1 || getEncoding() == Encodings.ASCII;
             inputIncRaw(locals, forward);
         }
     }


### PR DESCRIPTION
This is a bug fix for #3806. It looks like I had amended a commit to add the assertion, but failed to force-push over my branch, so it never ended up being part of the PR. I've updated TruffleRuby to use Graal 4b94d2d384460319d02e5a1706d7fb4e4165bd6b with this patch applied and the TruffleRuby test suite passes.

Please feel free to apply the patch as part of another PR if that's easier.