### PR TITLE
Add call tree csv links for easier imports into graph db

### DIFF
--- a/substratevm/src/com.oracle.graal.pointsto/src/com/oracle/graal/pointsto/reports/ReportUtils.java
+++ b/substratevm/src/com.oracle.graal.pointsto/src/com/oracle/graal/pointsto/reports/ReportUtils.java
@@ -75,10 +75,11 @@ public class ReportUtils {
      * @param extension the extension of the report
      * @param reporter a consumer that writes to a PrintWriter
      */
-    public static void report(String description, String path, String name, String extension, Consumer<PrintWriter> reporter) {
+    public static String report(String description, String path, String name, String extension, Consumer<PrintWriter> reporter) {
         String fileName = timeStampedFileName(name, extension);
         Path reportDir = Paths.get(path);
         reportImpl(description, reportDir, fileName, reporter);
+        return fileName;
     }
 
     public static String timeStampedFileName(String name, String extension) {


### PR DESCRIPTION
FYI @cstancu a follow up to https://github.com/oracle/graal/pull/3128

During that PR I added symbolic links for the CSV files to make it easier to import them into graph dbs. However, amongst all the rebasing I somehow lost that commit. So, sending this PR to add this bit.