### PR TITLE
Truncation in JVM_GetNanoTimeAdjustment() on 32-bits archs

### DIFF
--- a/substratevm/src/com.oracle.svm.native.jvm.posix/src/JvmFuncs.c
+++ b/substratevm/src/com.oracle.svm.native.jvm.posix/src/JvmFuncs.c
@@ -257,19 +257,19 @@ JNIEXPORT jlong JNICALL JVM_NanoTime(void *env, void * ignored) {
 }
 
 JNIEXPORT jlong JNICALL JVM_GetNanoTimeAdjustment(void *env, void * ignored, jlong offset_secs) {
-    long maxDiffSecs = 0x0100000000L;
-    long minDiffSecs = -maxDiffSecs;
+    int64_t maxDiffSecs = 0x0100000000LL;
+    int64_t minDiffSecs = -maxDiffSecs;
     struct timeval time;
     int status = gettimeofday(&time, NULL);
 
-    long seconds = time.tv_sec;
-    long nanos = time.tv_usec * 1000;
+    int64_t seconds = time.tv_sec;
+    int64_t nanos = time.tv_usec * 1000;
 
-    long diff = seconds - offset_secs;
+    int64_t diff = seconds - offset_secs;
     if (diff >= maxDiffSecs || diff <= minDiffSecs) {
         return -1;
     }
-    return diff * 1000000000 + nanos;
+    return diff * 1000000000LL + nanos;
 }
 
 JNIEXPORT jlong JNICALL Java_jdk_internal_misc_VM_getNanoTimeAdjustment(void *env, void * ignored, jlong offset_secs) {


### PR DESCRIPTION
The C `long` type is only 64-bits-wide on LP64 systems and the like. In 32-bits systems, `long` is usually 32-bits-wide. On such systems:
- The constant `0x0100000000L` cannot be represented on 32-bits, and should be `0x0100000000LL` instead, in order to explicitly mark its type as a `long long`.
- The Java `jlong` cannot be represented in a C `long` and it can cause unintentional data loss (truncation). `jlong` always corresponds to `int64_t`.