### PR TITLE
native-image, JFR, buffers "[warn][jfr,system] Unable to commit. Requested size too large"

### DIFF
--- a/substratevm/src/com.oracle.svm.jfr/src/com/oracle/svm/jfr/JfrBuffer.java
+++ b/substratevm/src/com.oracle.svm.jfr/src/com/oracle/svm/jfr/JfrBuffer.java
@@ -96,4 +96,10 @@ public interface JfrBuffer extends PointerBase {
     static int offsetOfAcquired() {
         throw VMError.unimplemented(); // replaced
     }
+
+    @RawField
+    boolean isTempBuffer();
+
+    @RawField
+    void setTempBuffer(boolean b);
 }


### PR DESCRIPTION
This patch address issue #3636

Current Jfr implementation can not handle events larger than default JfrBuffer size (8k), that results those events discarded.

The solution I purpose here, is to create temporary buffers to hold the large events, free them once they are flushed.
