### PR TITLE
TRegex: Add support for simple boolean match checking.

### DIFF
--- a/regex/src/com.oracle.truffle.regex/src/com/oracle/truffle/regex/RegexExecNode.java
+++ b/regex/src/com.oracle.truffle.regex/src/com/oracle/truffle/regex/RegexExecNode.java
@@ -60,8 +60,9 @@ public abstract class RegexExecNode extends RegexBodyNode {
     @Override
     public final RegexResult execute(VirtualFrame frame) {
         Object[] args = frame.getArguments();
-        assert args.length == 2;
-        return executeDirect(args[0], (int) args[1]);
+        assert args.length == 2 || args.length == 3;
+        boolean simpleMatch = args.length == 3 ? (boolean) args[2] : false;
+        return executeDirect(args[0], (int) args[1], simpleMatch);
     }
 
     private int adjustFromIndex(int fromIndex, Object input) {
@@ -89,17 +90,17 @@ public abstract class RegexExecNode extends RegexBodyNode {
         return charAtNode.execute(input, i);
     }
 
-    public RegexResult executeDirect(Object input, int fromIndex) {
+    public RegexResult executeDirect(Object input, int fromIndex, boolean simpleMatch) {
         if (fromIndex < 0 || fromIndex > inputLength(input)) {
             CompilerDirectives.transferToInterpreterAndInvalidate();
             throw new IllegalArgumentException(String.format("got illegal fromIndex value: %d. fromIndex must be >= 0 and <= input length (%d)", fromIndex, inputLength(input)));
         }
-        return execute(input, adjustFromIndex(fromIndex, input));
+        return execute(input, adjustFromIndex(fromIndex, input), simpleMatch);
     }
 
     public boolean isBacktracking() {
         return false;
     }
 
-    protected abstract RegexResult execute(Object input, int fromIndex);
+    protected abstract RegexResult execute(Object input, int fromIndex, boolean simpleMatch);
 }

--- a/regex/src/com.oracle.truffle.regex/src/com/oracle/truffle/regex/dead/DeadRegexExecNode.java
+++ b/regex/src/com.oracle.truffle.regex/src/com/oracle/truffle/regex/dead/DeadRegexExecNode.java
@@ -56,7 +56,7 @@ public final class DeadRegexExecNode extends RegexExecNode {
     }
 
     @Override
-    protected RegexResult execute(Object input, int fromIndex) {
+    protected RegexResult execute(Object input, int fromIndex, boolean simpleMatch) {
         return RegexResult.getNoMatchInstance();
     }
 

--- a/regex/src/com.oracle.truffle.regex/src/com/oracle/truffle/regex/literal/LiteralRegexExecNode.java
+++ b/regex/src/com.oracle.truffle.regex/src/com/oracle/truffle/regex/literal/LiteralRegexExecNode.java
@@ -98,8 +98,8 @@ public abstract class LiteralRegexExecNode extends RegexExecNode implements Json
         }
 
         @Override
-        protected RegexResult execute(Object input, int fromIndex) {
-            return resultFactory.createFromStart(fromIndex);
+        protected RegexResult execute(Object input, int fromIndex, boolean simpleMatch) {
+            return simpleMatch ? RegexResult.getSimpleMatchInstance() : resultFactory.createFromStart(fromIndex);
         }
     }
 
@@ -115,8 +115,8 @@ public abstract class LiteralRegexExecNode extends RegexExecNode implements Json
         }
 
         @Override
-        protected RegexResult execute(Object input, int fromIndex) {
-            return fromIndex == 0 ? resultFactory.createFromStart(0) : RegexResult.getNoMatchInstance();
+        protected RegexResult execute(Object input, int fromIndex, boolean simpleMatch) {
+            return fromIndex == 0 ? (simpleMatch ? RegexResult.getSimpleMatchInstance() : resultFactory.createFromStart(0)) : RegexResult.getNoMatchInstance();
         }
     }
 
@@ -135,9 +135,12 @@ public abstract class LiteralRegexExecNode extends RegexExecNode implements Json
         }
 
         @Override
-        protected RegexResult execute(Object input, int fromIndex) {
+        protected RegexResult execute(Object input, int fromIndex, boolean simpleMatch) {
             assert fromIndex <= inputLength(input);
             if (!sticky || fromIndex == inputLength(input)) {
+                if (simpleMatch) {
+                    return RegexResult.getSimpleMatchInstance();
+                }
                 return resultFactory.createFromEnd(inputLength(input));
             } else {
                 return RegexResult.getNoMatchInstance();
@@ -157,9 +160,9 @@ public abstract class LiteralRegexExecNode extends RegexExecNode implements Json
         }
 
         @Override
-        protected RegexResult execute(Object input, int fromIndex) {
+        protected RegexResult execute(Object input, int fromIndex, boolean simpleMatch) {
             assert fromIndex <= inputLength(input);
-            return inputLength(input) == 0 ? resultFactory.createFromStart(0) : RegexResult.getNoMatchInstance();
+            return inputLength(input) == 0 ? (simpleMatch ? RegexResult.getSimpleMatchInstance() : resultFactory.createFromStart(0)) : RegexResult.getNoMatchInstance();
         }
     }
 
@@ -202,12 +205,12 @@ public abstract class LiteralRegexExecNode extends RegexExecNode implements Json
         }
 
         @Override
-        protected RegexResult execute(Object input, int fromIndex) {
+        protected RegexResult execute(Object input, int fromIndex, boolean simpleMatch) {
             int start = indexOfStringNode.execute(input, fromIndex, inputLength(input), literalContent(), maskContent());
             if (start == -1) {
                 return RegexResult.getNoMatchInstance();
             }
-            return resultFactory.createFromStart(start);
+            return simpleMatch ? RegexResult.getSimpleMatchInstance() : resultFactory.createFromStart(start);
         }
     }
 
@@ -225,9 +228,9 @@ public abstract class LiteralRegexExecNode extends RegexExecNode implements Json
         }
 
         @Override
-        protected RegexResult execute(Object input, int fromIndex) {
+        protected RegexResult execute(Object input, int fromIndex, boolean simpleMatch) {
             if (fromIndex == 0 && startsWithNode.execute(input, literalContent(), maskContent())) {
-                return resultFactory.createFromStart(0);
+                return simpleMatch ? RegexResult.getSimpleMatchInstance() : resultFactory.createFromStart(0);
             } else {
                 return RegexResult.getNoMatchInstance();
             }
@@ -250,10 +253,10 @@ public abstract class LiteralRegexExecNode extends RegexExecNode implements Json
         }
 
         @Override
-        protected RegexResult execute(Object input, int fromIndex) {
+        protected RegexResult execute(Object input, int fromIndex, boolean simpleMatch) {
             int matchStart = inputLength(input) - literal.encodedLength();
             if ((sticky ? fromIndex == matchStart : fromIndex <= matchStart) && endsWithNode.execute(input, literalContent(), maskContent())) {
-                return resultFactory.createFromEnd(inputLength(input));
+                return simpleMatch ? RegexResult.getSimpleMatchInstance() : resultFactory.createFromEnd(inputLength(input));
             } else {
                 return RegexResult.getNoMatchInstance();
             }
@@ -274,9 +277,9 @@ public abstract class LiteralRegexExecNode extends RegexExecNode implements Json
         }
 
         @Override
-        protected RegexResult execute(Object input, int fromIndex) {
+        protected RegexResult execute(Object input, int fromIndex, boolean simpleMatch) {
             if (fromIndex == 0 && equalsNode.execute(input, literalContent(), maskContent())) {
-                return resultFactory.createFromStart(0);
+                return simpleMatch ? RegexResult.getSimpleMatchInstance() : resultFactory.createFromStart(0);
             } else {
                 return RegexResult.getNoMatchInstance();
             }
@@ -297,9 +300,9 @@ public abstract class LiteralRegexExecNode extends RegexExecNode implements Json
         }
 
         @Override
-        protected RegexResult execute(Object input, int fromIndex) {
+        protected RegexResult execute(Object input, int fromIndex, boolean simpleMatch) {
             if (regionMatchesNode.execute(input, fromIndex, literalContent(), 0, literal.encodedLength(), maskContent())) {
-                return resultFactory.createFromStart(fromIndex);
+                return simpleMatch ? RegexResult.getSimpleMatchInstance() : resultFactory.createFromStart(fromIndex);
             } else {
                 return RegexResult.getNoMatchInstance();
             }

--- a/regex/src/com.oracle.truffle.regex/src/com/oracle/truffle/regex/result/RegexResult.java
+++ b/regex/src/com.oracle.truffle.regex/src/com/oracle/truffle/regex/result/RegexResult.java
@@ -64,6 +64,7 @@ import com.oracle.truffle.regex.RegexObject;
 import com.oracle.truffle.regex.runtime.nodes.DispatchNode;
 import com.oracle.truffle.regex.runtime.nodes.ToIntNode;
 import com.oracle.truffle.regex.util.TruffleReadOnlyKeysArray;
+import jdk.nashorn.internal.runtime.regexp.joni.Regex;
 
 import java.util.Arrays;
 
@@ -113,9 +114,14 @@ public final class RegexResult extends AbstractConstantKeysObject {
     }
 
     private static final RegexResult NO_MATCH_RESULT = new RegexResult(null, -1, -1, -1, new int[]{}, null);
+    private static final RegexResult SIMPLE_MATCH_RESULT = new RegexResult(null, -1, -1, -1, new int[]{}, null);
 
     public static RegexResult getNoMatchInstance() {
         return NO_MATCH_RESULT;
+    }
+
+    public static RegexResult getSimpleMatchInstance() {
+        return SIMPLE_MATCH_RESULT;
     }
 
     public static RegexResult create(int start, int end) {


### PR DESCRIPTION
The purpose of this PR is to add support for regex matches where there is no need for the match results beyond a boolean. In particular, it would make Ruby's `Regexp#match?` method avoid any match data allocation. Naturally, we can assure we don't create a Ruby `MatchData` from TruffleRuby, but without this PR we end up creating the resulting `int[]` in TRegex, which then goes unused.

I'm not sure I've done this the best we can with TRegex, but it does work. It's implemented as an additional, optional argument to the `exec` and `execBytes` interop calls. If the argument is not provided, the `simpleMatch` option is disabled and everything works the way it does today. If the `simpleMatch` argument is `true`, then a static instance of `RegexResult` is used on a match (similar to the way the `NO_MATCH`  works already).

With a corresponding set of changes I have for TruffleRuby to take advantage of this new option and using a simple expression like:

```ruby
1_000_000.times { /./.match?("abc") }
```

I end up with a decent code size savings.

Without PR:
```
[engine] opt done     Regexp#match?                                               |AST   30|Tier 2|Time 1176( 526+649 )ms|Inlined   9Y   0N|IR   521/  729|CodeSize   2024|Addr 0x7fd42e5d0890|Src resource:/truffleruby/core/regexp.rb:179
```

With PR:
```
[engine] opt done     Regexp#match?                                               |AST   30|Tier 2|Time  831( 402+430 )ms|Inlined   9Y   0N|IR   520/  590|CodeSize   1558|Addr 0x7f50da625810|Src resource:/truffleruby/core/regexp.rb:179
```

I'm currently seeing a 10 - 15% improvement on some benchmarks, but I need to iron those out. For the time being, I'm using a simple microbenchmark with a variety of regexps, both those that pass and fail, against a fixed size string.

I'm happy to rework the PR as necessary. This was more of a proof of concept to see if it's something the TRegex team would entertain adding.