### PR TITLE
[GR-34455] Use correct form code (DW_FORM_sec_offset) for stmt_list attribute.

### DIFF
--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfAbbrevSectionImpl.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfAbbrevSectionImpl.java
@@ -277,8 +277,8 @@ public class DwarfAbbrevSectionImpl extends DwarfSectionImpl {
          *
          * <li><code>DW_AT_use_UTF8 : ... DW_FORM_flag</code>
          *
-         * <li><code>DW_AT_stmt_list : .. DW_FORM_data4</code> n.b only for <code>abbrev-code ==
-         * class_unit1</code>
+         * <li><code>DW_AT_stmt_list : .. DW_FORM_sec_offset</code> n.b only for <code>abbrev-code
+         * == class_unit1</code>
          *
          * </ul>
          *
@@ -886,7 +886,7 @@ public class DwarfAbbrevSectionImpl extends DwarfSectionImpl {
         }
         if (abbrevCode == DwarfDebugInfo.DW_ABBREV_CODE_class_unit1) {
             pos = writeAttrType(DwarfDebugInfo.DW_AT_stmt_list, buffer, pos);
-            pos = writeAttrForm(DwarfDebugInfo.DW_FORM_data4, buffer, pos);
+            pos = writeAttrForm(DwarfDebugInfo.DW_FORM_sec_offset, buffer, pos);
         }
         /*
          * Now terminate.

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfDebugInfo.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfDebugInfo.java
@@ -169,11 +169,12 @@ public class DwarfDebugInfo extends DebugInfoBase {
     @SuppressWarnings("unused") public static final int DW_FORM_data8 = 0x7;
     @SuppressWarnings("unused") private static final int DW_FORM_string = 0x8;
     @SuppressWarnings("unused") public static final int DW_FORM_block1 = 0x0a;
+    public static final int DW_FORM_ref_addr = 0x10;
     @SuppressWarnings("unused") public static final int DW_FORM_ref1 = 0x11;
     @SuppressWarnings("unused") public static final int DW_FORM_ref2 = 0x12;
     @SuppressWarnings("unused") public static final int DW_FORM_ref4 = 0x13;
     @SuppressWarnings("unused") public static final int DW_FORM_ref8 = 0x14;
-    public static final int DW_FORM_ref_addr = 0x10;
+    public static final int DW_FORM_sec_offset = 0x17;
     public static final int DW_FORM_data1 = 0x0b;
     public static final int DW_FORM_flag = 0xc;
     public static final int DW_FORM_strp = 0xe;

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfInfoSectionImpl.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfInfoSectionImpl.java
@@ -457,7 +457,7 @@ public class DwarfInfoSectionImpl extends DwarfSectionImpl {
         /* Only write stmt_list if the entry actually has line number info. */
         if (abbrevCode == DwarfDebugInfo.DW_ABBREV_CODE_class_unit1) {
             log(context, "  [0x%08x]     stmt_list  0x%08x", pos, lineIndex);
-            pos = writeAttrData4(lineIndex, buffer, pos);
+            pos = writeAttrSecOffset(lineIndex, buffer, pos);
         }
 
         /* Now write the child DIEs starting with the layout and pointer type. */

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfSectionImpl.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfSectionImpl.java
@@ -340,6 +340,10 @@ public abstract class DwarfSectionImpl extends BasicProgbitsSectionImpl {
         }
     }
 
+    protected int writeAttrSecOffset(int value, byte[] buffer, int pos) {
+        return writeAttrData4(value, buffer, pos);
+    }
+
     protected int writeAttrData2(short value, byte[] buffer, int pos) {
         if (buffer == null) {
             return pos + putShort(value, scratch, 0);


### PR DESCRIPTION
This trivial fix adjusts the DWARF info model for a compile unit. The stmt_list attribute was originally defined using a data4 FORM which was correct when the version was DWARF2. When the version was upgraded to DWARF4 this field should have been upgraded to employ a sec_offset FORM.