### PR TITLE
Refactor Native Image heap scanning.

### DIFF
--- a/sdk/src/org.graalvm.nativeimage/snapshot.sigtest
+++ b/sdk/src/org.graalvm.nativeimage/snapshot.sigtest
@@ -893,6 +893,7 @@ CLSS public abstract interface static org.graalvm.nativeimage.hosted.Feature$Dur
 intf org.graalvm.nativeimage.hosted.Feature$BeforeAnalysisAccess
 intf org.graalvm.nativeimage.hosted.Feature$QueryReachabilityAccess
 meth public abstract void requireAnalysisIteration()
+meth public abstract void rescanObject(java.lang.Object)
 
 CLSS public abstract interface static org.graalvm.nativeimage.hosted.Feature$DuringSetupAccess
  outer org.graalvm.nativeimage.hosted.Feature

--- a/sdk/src/org.graalvm.nativeimage/src/org/graalvm/nativeimage/hosted/Feature.java
+++ b/sdk/src/org.graalvm.nativeimage/src/org/graalvm/nativeimage/hosted/Feature.java
@@ -277,6 +277,13 @@ public interface Feature {
          * @since 19.0
          */
         void requireAnalysisIteration();
+
+        /**
+         * Rescan an object to be included in the image heap.
+         *
+         * @since 22.0
+         */
+        void rescanObject(Object obj);
     }
 
     /**

--- a/substratevm/ci_includes/gate.hocon
+++ b/substratevm/ci_includes/gate.hocon
@@ -69,6 +69,7 @@ builds += [
   }
   ${labsjdk-ce-17} ${svm-common-gate} ${svm-common-windows-jdk17} ${svmUnittest} {
     name: "gate-svm-windows-basics"
+    timelimit: "1:30:00"
     run: [
       ${svm-cmd-gate} ["build,helloworld,test,svmjunit"]
     ]

--- a/substratevm/mx.substratevm/suite.py
+++ b/substratevm/mx.substratevm/suite.py
@@ -1155,6 +1155,7 @@ suite = {
                         "sun.reflect.generics.reflectiveObjects",
                         "sun.reflect.generics.repository",
                         "sun.reflect.generics.tree",
+                        "sun.reflect.generics.scope",
                         "sun.util.calendar",
                         "sun.security.jca",
                         "sun.security.util",

--- a/substratevm/mx.substratevm/suite.py
+++ b/substratevm/mx.substratevm/suite.py
@@ -1457,6 +1457,8 @@ suite = {
               "exports" : [
                 "com.oracle.graal.pointsto",
                 "com.oracle.graal.pointsto.api",
+                "com.oracle.graal.pointsto.heap",
+                "com.oracle.graal.pointsto.heap.value",
                 "com.oracle.graal.pointsto.reports",
                 "com.oracle.graal.pointsto.constraints",
                 "com.oracle.graal.pointsto.util",

--- a/substratevm/mx.substratevm/suite.py
+++ b/substratevm/mx.substratevm/suite.py
@@ -1157,6 +1157,7 @@ suite = {
                         "sun.reflect.generics.tree",
                         "sun.reflect.generics.scope",
                         "sun.util.calendar",
+                        "sun.util.locale",
                         "sun.security.jca",
                         "sun.security.util",
                         "sun.security.provider",

--- a/substratevm/src/com.oracle.graal.pointsto/src/com/oracle/graal/pointsto/AnalysisObjectScanningObserver.java
+++ b/substratevm/src/com.oracle.graal.pointsto/src/com/oracle/graal/pointsto/AnalysisObjectScanningObserver.java
@@ -61,7 +61,7 @@ public class AnalysisObjectScanningObserver implements ObjectScanningObserver {
     }
 
     @Override
-    public void forNonNullFieldValue(JavaConstant receiver, AnalysisField field, JavaConstant fieldValue, ScanReason reason) {
+    public boolean forNonNullFieldValue(JavaConstant receiver, AnalysisField field, JavaConstant fieldValue, ScanReason reason) {
         PointsToAnalysis analysis = getAnalysis();
         AnalysisType fieldType = analysis.getMetaAccess().lookupJavaType(analysis.getSnippetReflectionProvider().asObject(Object.class, fieldValue).getClass());
         assert fieldType.isInstantiated() : fieldType;
@@ -72,8 +72,9 @@ public class AnalysisObjectScanningObserver implements ObjectScanningObserver {
         if (!fieldTypeFlow.getState().containsObject(constantObject)) {
             /* Add the new constant to the field's flow state. */
             TypeState constantTypeState = TypeState.forNonNullObject(analysis, constantObject);
-            fieldTypeFlow.addState(analysis, constantTypeState);
+            return fieldTypeFlow.addState(analysis, constantTypeState);
         }
+        return false;
     }
 
     /**
@@ -107,7 +108,7 @@ public class AnalysisObjectScanningObserver implements ObjectScanningObserver {
     }
 
     @Override
-    public void forNonNullArrayElement(JavaConstant array, AnalysisType arrayType, JavaConstant elementConstant, AnalysisType elementType, int elementIndex, ScanReason reason) {
+    public boolean forNonNullArrayElement(JavaConstant array, AnalysisType arrayType, JavaConstant elementConstant, AnalysisType elementType, int elementIndex, ScanReason reason) {
         assert elementType.isInstantiated() : elementType;
         ArrayElementsTypeFlow arrayObjElementsFlow = getArrayElementsFlow(array, arrayType);
         PointsToAnalysis analysis = getAnalysis();
@@ -115,8 +116,9 @@ public class AnalysisObjectScanningObserver implements ObjectScanningObserver {
         if (!arrayObjElementsFlow.getState().containsObject(constantObject)) {
             /* Add the constant element to the constant's array type flow. */
             TypeState elementTypeState = TypeState.forNonNullObject(analysis, constantObject);
-            arrayObjElementsFlow.addState(analysis, elementTypeState);
+            return arrayObjElementsFlow.addState(analysis, elementTypeState);
         }
+        return false;
     }
 
     /**

--- a/substratevm/src/com.oracle.graal.pointsto/src/com/oracle/graal/pointsto/AnalysisObjectScanningObserver.java
+++ b/substratevm/src/com.oracle.graal.pointsto/src/com/oracle/graal/pointsto/AnalysisObjectScanningObserver.java
@@ -24,6 +24,7 @@
  */
 package com.oracle.graal.pointsto;
 
+import com.oracle.graal.pointsto.ObjectScanner.ScanReason;
 import com.oracle.graal.pointsto.flow.ArrayElementsTypeFlow;
 import com.oracle.graal.pointsto.flow.FieldTypeFlow;
 import com.oracle.graal.pointsto.flow.context.object.AnalysisObject;
@@ -42,23 +43,25 @@ public class AnalysisObjectScanningObserver implements ObjectScanningObserver {
     }
 
     @Override
-    public void forRelocatedPointerFieldValue(JavaConstant receiver, AnalysisField field, JavaConstant fieldValue) {
+    public boolean forRelocatedPointerFieldValue(JavaConstant receiver, AnalysisField field, JavaConstant fieldValue, ScanReason reason) {
         if (!field.isWritten()) {
-            field.registerAsWritten(null);
+            return field.registerAsWritten(null);
         }
+        return false;
     }
 
     @Override
-    public void forNullFieldValue(JavaConstant receiver, AnalysisField field) {
+    public boolean forNullFieldValue(JavaConstant receiver, AnalysisField field, ScanReason reason) {
         FieldTypeFlow fieldTypeFlow = getFieldTypeFlow(field, receiver);
         if (!fieldTypeFlow.getState().canBeNull()) {
             /* Signal that the field can contain null. */
-            fieldTypeFlow.addState(getAnalysis(), TypeState.forNull());
+            return fieldTypeFlow.addState(getAnalysis(), TypeState.forNull());
         }
+        return false;
     }
 
     @Override
-    public void forNonNullFieldValue(JavaConstant receiver, AnalysisField field, JavaConstant fieldValue) {
+    public void forNonNullFieldValue(JavaConstant receiver, AnalysisField field, JavaConstant fieldValue, ScanReason reason) {
         PointsToAnalysis analysis = getAnalysis();
         AnalysisType fieldType = analysis.getMetaAccess().lookupJavaType(analysis.getSnippetReflectionProvider().asObject(Object.class, fieldValue).getClass());
         assert fieldType.isInstantiated() : fieldType;
@@ -94,16 +97,17 @@ public class AnalysisObjectScanningObserver implements ObjectScanningObserver {
     }
 
     @Override
-    public void forNullArrayElement(JavaConstant array, AnalysisType arrayType, int elementIndex) {
+    public boolean forNullArrayElement(JavaConstant array, AnalysisType arrayType, int elementIndex, ScanReason reason) {
         ArrayElementsTypeFlow arrayObjElementsFlow = getArrayElementsFlow(array, arrayType);
         if (!arrayObjElementsFlow.getState().canBeNull()) {
             /* Signal that the constant array can contain null. */
-            arrayObjElementsFlow.addState(getAnalysis(), TypeState.forNull());
+            return arrayObjElementsFlow.addState(getAnalysis(), TypeState.forNull());
         }
+        return false;
     }
 
     @Override
-    public void forNonNullArrayElement(JavaConstant array, AnalysisType arrayType, JavaConstant elementConstant, AnalysisType elementType, int elementIndex) {
+    public void forNonNullArrayElement(JavaConstant array, AnalysisType arrayType, JavaConstant elementConstant, AnalysisType elementType, int elementIndex, ScanReason reason) {
         assert elementType.isInstantiated() : elementType;
         ArrayElementsTypeFlow arrayObjElementsFlow = getArrayElementsFlow(array, arrayType);
         PointsToAnalysis analysis = getAnalysis();
@@ -125,7 +129,7 @@ public class AnalysisObjectScanningObserver implements ObjectScanningObserver {
     }
 
     @Override
-    public void forScannedConstant(JavaConstant value, ObjectScanner.ScanReason reason) {
+    public void forScannedConstant(JavaConstant value, ScanReason reason) {
         PointsToAnalysis analysis = getAnalysis();
         Object valueObj = analysis.getSnippetReflectionProvider().asObject(Object.class, value);
         AnalysisType type = bb.getMetaAccess().lookupJavaType(valueObj.getClass());

--- a/substratevm/src/com.oracle.graal.pointsto/src/com/oracle/graal/pointsto/BigBang.java
+++ b/substratevm/src/com.oracle.graal.pointsto/src/com/oracle/graal/pointsto/BigBang.java
@@ -122,4 +122,7 @@ public interface BigBang extends ReachabilityAnalysis, HeapScanning {
     default void onTypeInstantiated(AnalysisType type, UsageKind usageKind) {
     }
 
+    @SuppressWarnings("unused")
+    default void onTypeScanned(AnalysisType type) {
+    }
 }

--- a/substratevm/src/com.oracle.graal.pointsto/src/com/oracle/graal/pointsto/BigBang.java
+++ b/substratevm/src/com.oracle.graal.pointsto/src/com/oracle/graal/pointsto/BigBang.java
@@ -24,22 +24,25 @@
  */
 package com.oracle.graal.pointsto;
 
-import com.oracle.graal.pointsto.api.HostVM;
-import com.oracle.graal.pointsto.constraints.UnsupportedFeatures;
-import com.oracle.graal.pointsto.meta.AnalysisMethod;
-import com.oracle.graal.pointsto.meta.AnalysisUniverse;
-import com.oracle.graal.pointsto.meta.HostedProviders;
-import com.oracle.graal.pointsto.util.Timer;
-import jdk.vm.ci.meta.ConstantReflectionProvider;
+import java.io.PrintWriter;
+import java.util.List;
+import java.util.function.Function;
+
 import org.graalvm.compiler.api.replacements.SnippetReflectionProvider;
 import org.graalvm.compiler.debug.DebugContext;
 import org.graalvm.compiler.debug.DebugHandlersFactory;
 import org.graalvm.compiler.graph.NodeSourcePosition;
 import org.graalvm.compiler.options.OptionValues;
 
-import java.io.PrintWriter;
-import java.util.List;
-import java.util.function.Function;
+import com.oracle.graal.pointsto.api.HostVM;
+import com.oracle.graal.pointsto.constraints.UnsupportedFeatures;
+import com.oracle.graal.pointsto.meta.AnalysisField;
+import com.oracle.graal.pointsto.meta.AnalysisMethod;
+import com.oracle.graal.pointsto.meta.AnalysisUniverse;
+import com.oracle.graal.pointsto.meta.HostedProviders;
+import com.oracle.graal.pointsto.util.Timer;
+
+import jdk.vm.ci.meta.ConstantReflectionProvider;
 
 /**
  * Central static analysis interface that groups together the functionality of reachability analysis
@@ -104,4 +107,13 @@ public interface BigBang extends ReachabilityAnalysis, HeapScanning {
     default boolean isCallAllowed(PointsToAnalysis bb, AnalysisMethod caller, AnalysisMethod target, NodeSourcePosition srcPosition) {
         return true;
     }
+
+    /**
+     * Callback for when a field is marked as read, written, or unsafe accessed. See
+     * {@link AnalysisField#isAccessed()} for field accessibility definition.
+     */
+    @SuppressWarnings("unused")
+    default void onFieldAccessed(AnalysisField field) {
+    }
+
 }

--- a/substratevm/src/com.oracle.graal.pointsto/src/com/oracle/graal/pointsto/BigBang.java
+++ b/substratevm/src/com.oracle.graal.pointsto/src/com/oracle/graal/pointsto/BigBang.java
@@ -38,6 +38,8 @@ import com.oracle.graal.pointsto.api.HostVM;
 import com.oracle.graal.pointsto.constraints.UnsupportedFeatures;
 import com.oracle.graal.pointsto.meta.AnalysisField;
 import com.oracle.graal.pointsto.meta.AnalysisMethod;
+import com.oracle.graal.pointsto.meta.AnalysisType;
+import com.oracle.graal.pointsto.meta.AnalysisType.UsageKind;
 import com.oracle.graal.pointsto.meta.AnalysisUniverse;
 import com.oracle.graal.pointsto.meta.HostedProviders;
 import com.oracle.graal.pointsto.util.Timer;
@@ -114,6 +116,10 @@ public interface BigBang extends ReachabilityAnalysis, HeapScanning {
      */
     @SuppressWarnings("unused")
     default void onFieldAccessed(AnalysisField field) {
+    }
+
+    @SuppressWarnings("unused")
+    default void onTypeInstantiated(AnalysisType type, UsageKind usageKind) {
     }
 
 }

--- a/substratevm/src/com.oracle.graal.pointsto/src/com/oracle/graal/pointsto/ObjectScanner.java
+++ b/substratevm/src/com.oracle.graal.pointsto/src/com/oracle/graal/pointsto/ObjectScanner.java
@@ -373,7 +373,7 @@ public class ObjectScanner {
         return bb.getMetaAccess().lookupJavaType(constant.getClass());
     }
 
-    protected static AnalysisType constantType(BigBang bb, JavaConstant constant) {
+    public static AnalysisType constantType(BigBang bb, JavaConstant constant) {
         return bb.getMetaAccess().lookupJavaType(constant);
     }
 

--- a/substratevm/src/com.oracle.graal.pointsto/src/com/oracle/graal/pointsto/ObjectScanner.java
+++ b/substratevm/src/com.oracle.graal.pointsto/src/com/oracle/graal/pointsto/ObjectScanner.java
@@ -59,13 +59,17 @@ import jdk.vm.ci.meta.JavaKind;
  * structure can be reused over multiple scanning iterations to save CPU resources. (For details
  * {@link ReusableSet}).
  */
-public abstract class ObjectScanner {
+public class ObjectScanner {
 
     protected final BigBang bb;
     private final ReusableSet scannedObjects;
     private final CompletionExecutor executor;
     private final Deque<WorklistEntry> worklist;
     private final ObjectScanningObserver scanningObserver;
+
+    public ObjectScanner(BigBang bb, ObjectScanningObserver scanningObserver) {
+        this(bb, null, new ObjectScanner.ReusableSet(), scanningObserver);
+    }
 
     public ObjectScanner(BigBang bb, CompletionExecutor executor, ReusableSet scannedObjects, ObjectScanningObserver scanningObserver) {
         this.bb = bb;
@@ -78,6 +82,10 @@ public abstract class ObjectScanner {
             this.worklist = new ConcurrentLinkedDeque<>();
         }
         this.scannedObjects = scannedObjects;
+    }
+
+    public void scanBootImageHeapRoots() {
+        scanBootImageHeapRoots(null, null);
     }
 
     public void scanBootImageHeapRoots(Comparator<AnalysisField> fieldComparator, Comparator<BytecodePosition> embeddedRootComparator) {
@@ -125,7 +133,9 @@ public abstract class ObjectScanner {
     private void scanEmbeddedRoot(JavaConstant root, BytecodePosition position) {
         AnalysisMethod method = (AnalysisMethod) position.getMethod();
         try {
-            scanConstant(root, new MethodScan(method, position));
+            EmbeddedRootScan reason = new EmbeddedRootScan(method, position, root);
+            scanConstant(root, reason);
+            scanningObserver.forEmbeddedRoot(root, reason);
         } catch (UnsupportedFeatureException ex) {
             bb.getUnsupportedFeatures().addMessage(method.format("%H.%n(%p)"), method, ex.getMessage(), null, ex);
         }
@@ -145,34 +155,33 @@ public abstract class ObjectScanner {
      *
      * @param field the scanned field
      * @param receiver the receiver object
-     * @param previous reference to the work list entry containing parent object
      */
-    protected final void scanField(AnalysisField field, JavaConstant receiver, WorklistEntry previous) {
-        ScanReason reason = new FieldScan(field);
+    protected final void scanField(AnalysisField field, JavaConstant receiver, ScanReason prevReason) {
+        ScanReason reason = new FieldScan(field, receiver, prevReason);
         try {
             JavaConstant fieldValue = bb.getConstantReflectionProvider().readFieldValue(field, receiver);
 
             if (fieldValue == null) {
                 StringBuilder backtrace = new StringBuilder();
-                buildObjectBacktrace(reason, previous, backtrace);
+                buildObjectBacktrace(bb, reason, backtrace);
                 throw AnalysisError.shouldNotReachHere("Could not find field " + field.format("%H.%n") +
                                 (receiver == null ? "" : " on " + constantType(bb, receiver).toJavaName()) +
                                 System.lineSeparator() + backtrace);
             }
 
             if (fieldValue.getJavaKind() == JavaKind.Object && bb.getHostVM().isRelocatedPointer(constantAsObject(bb, fieldValue))) {
-                scanningObserver.forRelocatedPointerFieldValue(receiver, field, fieldValue);
+                scanningObserver.forRelocatedPointerFieldValue(receiver, field, fieldValue, reason);
             } else if (fieldValue.isNull()) {
-                scanningObserver.forNullFieldValue(receiver, field);
+                scanningObserver.forNullFieldValue(receiver, field, reason);
             } else if (fieldValue.getJavaKind() == JavaKind.Object) {
                 /* Scan the field value. */
-                scanConstant(fieldValue, reason, previous);
+                scanConstant(fieldValue, reason);
                 /* Process the field value. */
-                scanningObserver.forNonNullFieldValue(receiver, field, fieldValue);
+                scanningObserver.forNonNullFieldValue(receiver, field, fieldValue, reason);
             }
 
         } catch (UnsupportedFeatureException ex) {
-            unsupportedFeature(field.format("%H.%n"), ex.getMessage(), reason, previous);
+            unsupportedFeature(field.format("%H.%n"), ex.getMessage(), reason);
         }
     }
 
@@ -180,42 +189,37 @@ public abstract class ObjectScanner {
      * Scans constant arrays, one element at the time.
      *
      * @param array the array to be scanned
-     * @param previous reference to the work list entry containing parent object
      */
-    protected final void scanArray(JavaConstant array, WorklistEntry previous) {
+    protected final void scanArray(JavaConstant array, ScanReason prevReason) {
 
         Object valueObj = constantAsObject(bb, array);
         AnalysisType arrayType = analysisType(bb, valueObj);
         assert valueObj instanceof Object[];
 
-        ScanReason reason = new ArrayScan(arrayType);
+        ScanReason reason = new ArrayScan(arrayType, array, prevReason);
         Object[] arrayObject = (Object[]) valueObj;
         for (int idx = 0; idx < arrayObject.length; idx++) {
             Object e = arrayObject[idx];
             try {
                 if (e == null) {
-                    scanningObserver.forNullArrayElement(array, arrayType, idx);
+                    scanningObserver.forNullArrayElement(array, arrayType, idx, reason);
                 } else {
                     Object element = bb.getUniverse().replaceObject(e);
                     JavaConstant elementConstant = bb.getSnippetReflectionProvider().forObject(element);
                     AnalysisType elementType = analysisType(bb, element);
 
                     /* Scan the array element. */
-                    scanConstant(elementConstant, reason, previous);
+                    scanConstant(elementConstant, reason);
                     /* Process the array element. */
-                    scanningObserver.forNonNullArrayElement(array, arrayType, elementConstant, elementType, idx);
+                    scanningObserver.forNonNullArrayElement(array, arrayType, elementConstant, elementType, idx, reason);
                 }
             } catch (UnsupportedFeatureException ex) {
-                unsupportedFeature(arrayType.toJavaName(true), ex.getMessage(), reason, previous);
+                unsupportedFeature(arrayType.toJavaName(true), ex.getMessage(), reason);
             }
         }
     }
 
     public final void scanConstant(JavaConstant value, ScanReason reason) {
-        scanConstant(value, reason, null);
-    }
-
-    public final void scanConstant(JavaConstant value, ScanReason reason, WorklistEntry previous) {
         Object valueObj = constantAsObject(bb, value);
         if (valueObj == null || valueObj instanceof WordBase) {
             return;
@@ -229,7 +233,7 @@ public abstract class ObjectScanner {
                 scanningObserver.forScannedConstant(value, reason);
             } finally {
                 scannedObjects.release(valueObj);
-                WorklistEntry worklistEntry = new WorklistEntry(previous, value, reason);
+                WorklistEntry worklistEntry = new WorklistEntry(value, reason);
                 if (executor != null) {
                     executor.execute((ObjectScannerRunnable) debug -> doScan(worklistEntry));
                 } else {
@@ -239,53 +243,83 @@ public abstract class ObjectScanner {
         }
     }
 
-    private void unsupportedFeature(String key, String message, ScanReason reason, WorklistEntry entry) {
+    private void unsupportedFeature(String key, String message, ScanReason reason) {
         StringBuilder objectBacktrace = new StringBuilder();
-        AnalysisMethod method = buildObjectBacktrace(reason, entry, objectBacktrace);
+        AnalysisMethod method = buildObjectBacktrace(bb, reason, objectBacktrace);
         bb.getUnsupportedFeatures().addMessage(key, method, message, objectBacktrace.toString());
     }
 
-    private AnalysisMethod buildObjectBacktrace(ScanReason reason, WorklistEntry entry, StringBuilder objectBacktrace) {
-        WorklistEntry cur = entry;
-        objectBacktrace.append("Object was reached by ").append(System.lineSeparator());
-        objectBacktrace.append('\t').append(asString(reason));
-        ScanReason rootReason = null;
+    static final String indent = "  ";
+
+    public static AnalysisMethod buildObjectBacktrace(BigBang bb, ScanReason reason, StringBuilder objectBacktrace) {
+        ScanReason cur = reason;
+        objectBacktrace.append("Object was reached by ");
+        objectBacktrace.append(System.lineSeparator()).append(indent).append(asString(bb, cur));
+        ScanReason rootReason = cur;
+        cur = cur.previous;
         while (cur != null) {
-            objectBacktrace.append(System.lineSeparator());
-            objectBacktrace.append("\t\t").append("constant ").append(asString(cur.constant)).append(" reached by ").append(System.lineSeparator());
-            objectBacktrace.append('\t').append(asString(cur.reason));
-            rootReason = cur.reason;
+            objectBacktrace.append(System.lineSeparator()).append(indent).append(asString(bb, cur));
+            rootReason = cur.previous;
             cur = cur.previous;
         }
-        if (rootReason instanceof MethodScan) {
+        if (rootReason instanceof EmbeddedRootScan) {
             /* The root constant was found during scanning of 'method'. */
-            return ((MethodScan) rootReason).method;
+            return ((EmbeddedRootScan) rootReason).getMethod();
         }
         /* The root constant was not found during method scanning. */
         return null;
     }
 
-    String asString(ScanReason reason) {
+    static String asString(BigBang bb, ScanReason reason) {
         if (reason instanceof FieldScan) {
             FieldScan fieldScan = (FieldScan) reason;
             if (fieldScan.field.isStatic()) {
-                return "reading field " + reason;
+                return "reading static field " + reason;
             } else {
                 /* Instance field scans must have a receiver, hence the 'of'. */
-                return "reading field " + reason + " of";
+                return "reading field " + reason + " of constant \n    " + asString(bb, reason.constant);
             }
-        } else if (reason instanceof MethodScan) {
-            return "scanning method " + reason;
+        } else if (reason instanceof EmbeddedRootScan) {
+            return "scanning root " + asString(bb, reason.constant) + " embedded in \n    " + reason;
         } else if (reason instanceof ArrayScan) {
-            return "indexing into array";
+            return "indexing into array " + asString(bb, reason.constant);
         } else {
             return reason.toString();
         }
     }
 
-    private String asString(JavaConstant constant) {
+    public static String asString(BigBang bb, JavaConstant constant) {
+        return asString(bb, constant, true);
+    }
+
+    public static String asString(BigBang bb, JavaConstant constant, boolean appendToString) {
+        if (constant == null) {
+            return "null";
+        }
         Object obj = constantAsObject(bb, constant);
-        return obj.getClass().getTypeName() + '@' + Integer.toHexString(System.identityHashCode(obj));
+        if (obj == null) {
+            return "null";
+        }
+        String str = obj.getClass().getTypeName() + '@' + Integer.toHexString(System.identityHashCode(obj));
+        if (appendToString) {
+            try {
+                str += ": " + limit(obj.toString(), 80).replace(System.lineSeparator(), "");
+            } catch (Throwable e) {
+                // ignore any error in creating the string representation
+            }
+        }
+
+        return str;
+    }
+
+    public static String limit(String value, int length) {
+        StringBuilder buf = new StringBuilder(value);
+        if (buf.length() > length) {
+            buf.setLength(length);
+            buf.append("...");
+        }
+
+        return buf.toString();
     }
 
     /**
@@ -305,15 +339,15 @@ public abstract class ObjectScanner {
                 for (AnalysisField field : type.getInstanceFields(true)) {
                     if (field.getJavaKind() == JavaKind.Object && field.isRead()) {
                         assert !Modifier.isStatic(field.getModifiers());
-                        scanField(field, entry.constant, entry);
+                        scanField(field, entry.constant, entry.reason);
                     }
                 }
             } else if (type.isArray() && bb.getProviders().getWordTypes().asKind(type.getComponentType()) == JavaKind.Object) {
                 /* Scan the array elements. */
-                scanArray(entry.constant, entry);
+                scanArray(entry.constant, entry.reason);
             }
         } catch (UnsupportedFeatureException ex) {
-            unsupportedFeature("", ex.getMessage(), entry.reason, entry.previous);
+            unsupportedFeature("", ex.getMessage(), entry.reason);
         }
     }
 
@@ -343,13 +377,11 @@ public abstract class ObjectScanner {
         return bb.getMetaAccess().lookupJavaType(constant);
     }
 
-    protected static Object constantAsObject(BigBang bb, JavaConstant constant) {
+    public static Object constantAsObject(BigBang bb, JavaConstant constant) {
         return bb.getSnippetReflectionProvider().asObject(Object.class, constant);
     }
 
     static class WorklistEntry {
-        /** The previously processed entry. */
-        private final WorklistEntry previous;
         /** The constant to be scanned. */
         private final JavaConstant constant;
         /**
@@ -359,18 +391,9 @@ public abstract class ObjectScanner {
          */
         private final ScanReason reason;
 
-        WorklistEntry(WorklistEntry previous, JavaConstant constant, ScanReason reason) {
-            this.previous = previous;
+        WorklistEntry(JavaConstant constant, ScanReason reason) {
             this.constant = constant;
             this.reason = reason;
-        }
-
-        public WorklistEntry getPrevious() {
-            return previous;
-        }
-
-        public JavaConstant getConstant() {
-            return constant;
         }
 
         public ScanReason getReason() {
@@ -378,27 +401,42 @@ public abstract class ObjectScanner {
         }
     }
 
-    public interface ScanReason {
-        OtherReason HUB = new OtherReason("Hub");
+    public abstract static class ScanReason {
+        final ScanReason previous;
+        final JavaConstant constant;
+
+        protected ScanReason(ScanReason previous, JavaConstant constant) {
+            this.previous = previous;
+            this.constant = constant;
+        }
+
+        public ScanReason getPrevious() {
+            return previous;
+        }
     }
 
-    static class OtherReason implements ScanReason {
+    public static class OtherReason extends ScanReason {
+        public static final ScanReason SCAN = new OtherReason("SCAN");
+        public static final ScanReason RESCAN = new OtherReason("RESCAN");
+        public static final ScanReason HUB = new OtherReason("HUB");
+
         final String reason;
 
-        OtherReason(String reason) {
+        protected OtherReason(String reason) {
+            super(null, null);
             this.reason = reason;
-        }
-
-        @Override
-        public String toString() {
-            return reason;
         }
     }
 
-    protected static class FieldScan implements ScanReason {
+    public static class FieldScan extends ScanReason {
         final AnalysisField field;
 
-        FieldScan(AnalysisField field) {
+        public FieldScan(AnalysisField field) {
+            this(field, null, null);
+        }
+
+        public FieldScan(AnalysisField field, JavaConstant receiver, ScanReason previous) {
+            super(previous, receiver);
             this.field = field;
         }
 
@@ -412,10 +450,11 @@ public abstract class ObjectScanner {
         }
     }
 
-    static class ArrayScan implements ScanReason {
+    public static class ArrayScan extends ScanReason {
         final AnalysisType arrayType;
 
-        ArrayScan(AnalysisType arrayType) {
+        public ArrayScan(AnalysisType arrayType, JavaConstant array, ScanReason previous) {
+            super(previous, array);
             this.arrayType = arrayType;
         }
 
@@ -425,11 +464,16 @@ public abstract class ObjectScanner {
         }
     }
 
-    protected static class MethodScan implements ScanReason {
+    public static class EmbeddedRootScan extends ScanReason {
         final AnalysisMethod method;
         final BytecodePosition sourcePosition;
 
-        MethodScan(AnalysisMethod method, BytecodePosition nodeSourcePosition) {
+        public EmbeddedRootScan(AnalysisMethod method, BytecodePosition nodeSourcePosition, JavaConstant root) {
+            this(method, nodeSourcePosition, root, null);
+        }
+
+        public EmbeddedRootScan(AnalysisMethod method, BytecodePosition nodeSourcePosition, JavaConstant root, ScanReason previous) {
+            super(previous, root);
             this.method = method;
             this.sourcePosition = nodeSourcePosition;
         }

--- a/substratevm/src/com.oracle.graal.pointsto/src/com/oracle/graal/pointsto/ObjectScanner.java
+++ b/substratevm/src/com.oracle.graal.pointsto/src/com/oracle/graal/pointsto/ObjectScanner.java
@@ -71,6 +71,10 @@ public class ObjectScanner {
         this(bb, null, new ObjectScanner.ReusableSet(), scanningObserver);
     }
 
+    public ObjectScanner(BigBang bb, ReusableSet scannedObjects, ObjectScanningObserver scanningObserver) {
+        this(bb, null, scannedObjects, scanningObserver);
+    }
+
     public ObjectScanner(BigBang bb, CompletionExecutor executor, ReusableSet scannedObjects, ObjectScanningObserver scanningObserver) {
         this.bb = bb;
         this.scanningObserver = scanningObserver;

--- a/substratevm/src/com.oracle.graal.pointsto/src/com/oracle/graal/pointsto/ObjectScanner.java
+++ b/substratevm/src/com.oracle.graal.pointsto/src/com/oracle/graal/pointsto/ObjectScanner.java
@@ -131,12 +131,12 @@ public class ObjectScanner {
     }
 
     private void scanEmbeddedRoot(JavaConstant root, BytecodePosition position) {
-        AnalysisMethod method = (AnalysisMethod) position.getMethod();
         try {
-            EmbeddedRootScan reason = new EmbeddedRootScan(method, position, root);
+            EmbeddedRootScan reason = new EmbeddedRootScan(position, root);
             scanConstant(root, reason);
             scanningObserver.forEmbeddedRoot(root, reason);
         } catch (UnsupportedFeatureException ex) {
+            AnalysisMethod method = (AnalysisMethod) position.getMethod();
             bb.getUnsupportedFeatures().addMessage(method.format("%H.%n(%p)"), method, ex.getMessage(), null, ex);
         }
     }
@@ -465,26 +465,24 @@ public class ObjectScanner {
     }
 
     public static class EmbeddedRootScan extends ScanReason {
-        final AnalysisMethod method;
-        final BytecodePosition sourcePosition;
+        final BytecodePosition position;
 
-        public EmbeddedRootScan(AnalysisMethod method, BytecodePosition nodeSourcePosition, JavaConstant root) {
-            this(method, nodeSourcePosition, root, null);
+        public EmbeddedRootScan(BytecodePosition nodeSourcePosition, JavaConstant root) {
+            this(nodeSourcePosition, root, null);
         }
 
-        public EmbeddedRootScan(AnalysisMethod method, BytecodePosition nodeSourcePosition, JavaConstant root, ScanReason previous) {
+        public EmbeddedRootScan(BytecodePosition nodeSourcePosition, JavaConstant root, ScanReason previous) {
             super(previous, root);
-            this.method = method;
-            this.sourcePosition = nodeSourcePosition;
+            this.position = nodeSourcePosition;
         }
 
         public AnalysisMethod getMethod() {
-            return method;
+            return (AnalysisMethod) position.getMethod();
         }
 
         @Override
         public String toString() {
-            return sourcePosition == null ? method.format("%H.%n(%p)") : method.asStackTraceElement(sourcePosition.getBCI()).toString();
+            return position.getMethod().asStackTraceElement(position.getBCI()).toString();
         }
     }
 

--- a/substratevm/src/com.oracle.graal.pointsto/src/com/oracle/graal/pointsto/ObjectScanningObserver.java
+++ b/substratevm/src/com.oracle.graal.pointsto/src/com/oracle/graal/pointsto/ObjectScanningObserver.java
@@ -60,8 +60,11 @@ public interface ObjectScanningObserver {
 
     /**
      * Hook for scanned non-null field value.
+     * 
+     * @return true if value is consumed, false otherwise
      */
-    default void forNonNullFieldValue(JavaConstant receiver, AnalysisField field, JavaConstant fieldValue, ScanReason reason) {
+    default boolean forNonNullFieldValue(JavaConstant receiver, AnalysisField field, JavaConstant fieldValue, ScanReason reason) {
+        return false;
     }
 
     /**
@@ -73,8 +76,11 @@ public interface ObjectScanningObserver {
 
     /**
      * Hook for scanned non-null element value.
+     * 
+     * @return true if value is consumed, false otherwise
      */
-    default void forNonNullArrayElement(JavaConstant array, AnalysisType arrayType, JavaConstant elementConstant, AnalysisType elementType, int elementIndex, ScanReason reason) {
+    default boolean forNonNullArrayElement(JavaConstant array, AnalysisType arrayType, JavaConstant elementConstant, AnalysisType elementType, int elementIndex, ScanReason reason) {
+        return false;
     }
 
     /**

--- a/substratevm/src/com.oracle.graal.pointsto/src/com/oracle/graal/pointsto/ObjectScanningObserver.java
+++ b/substratevm/src/com.oracle.graal.pointsto/src/com/oracle/graal/pointsto/ObjectScanningObserver.java
@@ -38,6 +38,7 @@ import jdk.vm.ci.meta.JavaConstant;
  * possible cases: the element value is either null or the field value is non-null. The implementers
  * of this API will call the appropriate method during scanning.
  */
+@SuppressWarnings("unused")
 public interface ObjectScanningObserver {
 
     /**
@@ -46,30 +47,45 @@ public interface ObjectScanningObserver {
      * For relocated pointers the value is only known at runtime after methods are relocated, which
      * is pretty much the same as a field written at runtime: we do not have a constant value.
      */
-    void forRelocatedPointerFieldValue(JavaConstant receiver, AnalysisField field, JavaConstant fieldValue);
+    default boolean forRelocatedPointerFieldValue(JavaConstant receiver, AnalysisField field, JavaConstant fieldValue, ScanReason reason) {
+        return false;
+    }
 
     /**
      * Hook for scanned null field value.
      */
-    void forNullFieldValue(JavaConstant receiver, AnalysisField field);
+    default boolean forNullFieldValue(JavaConstant receiver, AnalysisField field, ScanReason reason) {
+        return false;
+    }
 
     /**
      * Hook for scanned non-null field value.
      */
-    void forNonNullFieldValue(JavaConstant receiver, AnalysisField field, JavaConstant fieldValue);
+    default void forNonNullFieldValue(JavaConstant receiver, AnalysisField field, JavaConstant fieldValue, ScanReason reason) {
+    }
 
     /**
      * Hook for scanned null element value.
      */
-    void forNullArrayElement(JavaConstant array, AnalysisType arrayType, int elementIndex);
+    default boolean forNullArrayElement(JavaConstant array, AnalysisType arrayType, int elementIndex, ScanReason reason) {
+        return false;
+    }
 
     /**
      * Hook for scanned non-null element value.
      */
-    void forNonNullArrayElement(JavaConstant array, AnalysisType arrayType, JavaConstant elementConstant, AnalysisType elementType, int elementIndex);
+    default void forNonNullArrayElement(JavaConstant array, AnalysisType arrayType, JavaConstant elementConstant, AnalysisType elementType, int elementIndex, ScanReason reason) {
+    }
+
+    /**
+     * Hook for scanned embedded root.
+     */
+    default void forEmbeddedRoot(JavaConstant root, ScanReason reason) {
+    }
 
     /**
      * Hook for scanned constant.
      */
-    void forScannedConstant(JavaConstant scannedValue, ScanReason reason);
+    default void forScannedConstant(JavaConstant scannedValue, ScanReason reason) {
+    }
 }

--- a/substratevm/src/com.oracle.graal.pointsto/src/com/oracle/graal/pointsto/PointsToAnalysis.java
+++ b/substratevm/src/com.oracle.graal.pointsto/src/com/oracle/graal/pointsto/PointsToAnalysis.java
@@ -572,10 +572,6 @@ public abstract class PointsToAnalysis implements BigBang {
         return providers.getConstantFieldProvider();
     }
 
-    public CompletionExecutor getExecutor() {
-        return executor;
-    }
-
     @Override
     public void checkUserLimitations() {
     }
@@ -636,22 +632,9 @@ public abstract class PointsToAnalysis implements BigBang {
     public boolean finish() throws InterruptedException {
         try (Indent indent = debug.logAndIndent("starting analysis in BigBang.finish")) {
             universe.setAnalysisDataValid(false);
-            boolean didSomeWork = false;
-
-            int numTypes;
-            do {
-                didSomeWork |= doTypeflow();
-
-                /*
-                 * Check if the object graph introduces any new types, which leads to new operations
-                 * being posted.
-                 */
-                assert executor.getPostedOperations() == 0;
-                numTypes = universe.getTypes().size();
-            } while (executor.getPostedOperations() != 0 || numTypes != universe.getTypes().size());
-
+            boolean didSomeWork = doTypeflow();
+            assert executor.getPostedOperations() == 0;
             universe.setAnalysisDataValid(true);
-
             return didSomeWork;
         }
     }
@@ -718,7 +701,6 @@ public abstract class PointsToAnalysis implements BigBang {
                                     "The analysis itself %s find a change in type states in the last iteration.",
                                     numIterations, analysisChanged ? "DID" : "DID NOT"));
                 }
-
                 /*
                  * Allow features to change the universe.
                  */

--- a/substratevm/src/com.oracle.graal.pointsto/src/com/oracle/graal/pointsto/PointsToAnalysis.java
+++ b/substratevm/src/com.oracle.graal.pointsto/src/com/oracle/graal/pointsto/PointsToAnalysis.java
@@ -753,8 +753,7 @@ public abstract class PointsToAnalysis implements BigBang {
         boolean foundMismatch;
         try (StopTimer ignored = verifyHeapTimer.start()) {
             foundMismatch = universe.getHeapVerifier().verifyHeapSnapshot(executor);
-            // System.out.println("Verification " + (foundMismatch ? " found " : " didn't find ") +
-            // " a mismatch.");
+            System.out.println("Verification " + (foundMismatch ? " found " : " didn't find ") + " a mismatch.");
         }
         /* Initialize for the next iteration. */
         executor.init(timing);

--- a/substratevm/src/com.oracle.graal.pointsto/src/com/oracle/graal/pointsto/PointsToAnalysis.java
+++ b/substratevm/src/com.oracle.graal.pointsto/src/com/oracle/graal/pointsto/PointsToAnalysis.java
@@ -721,8 +721,8 @@ public abstract class PointsToAnalysis implements BigBang {
                         System.out.println("Found pending operations, continuing analysis.");
                         continue;
                     }
-                    /* Outer analysis loop is done. Check if the heap snapshot is stable. */
-                    if (isHeapStable()) {
+                    /* Outer analysis loop is done. Check if heap verification modifies analysis. */
+                    if (!analysisModified()) {
                         return;
                     }
                 }
@@ -731,15 +731,15 @@ public abstract class PointsToAnalysis implements BigBang {
     }
 
     @SuppressWarnings("try")
-    private boolean isHeapStable() throws InterruptedException {
-        boolean foundMismatch;
+    private boolean analysisModified() throws InterruptedException {
+        boolean analysisModified;
         try (StopTimer ignored = verifyHeapTimer.start()) {
-            foundMismatch = universe.getHeapVerifier().verifyHeapSnapshot(executor);
-            System.out.println("Verification " + (foundMismatch ? " found " : " didn't find ") + " a mismatch.");
+            analysisModified = universe.getHeapVerifier().verifyHeapSnapshot(executor);
+            System.out.println("Heap verification " + (analysisModified ? "modified" : "didn't modify") + " analysis state.");
         }
         /* Initialize for the next iteration. */
         executor.init(timing);
-        return !foundMismatch;
+        return analysisModified;
     }
 
     @SuppressFBWarnings(value = "NP_NONNULL_PARAM_VIOLATION", justification = "ForkJoinPool does support null for the exception handler.")

--- a/substratevm/src/com.oracle.graal.pointsto/src/com/oracle/graal/pointsto/api/HostVM.java
+++ b/substratevm/src/com.oracle.graal.pointsto/src/com/oracle/graal/pointsto/api/HostVM.java
@@ -122,7 +122,7 @@ public interface HostVM {
     }
 
     @SuppressWarnings("unused")
-    default boolean platformSupported(AnalysisUniverse universe, AnnotatedElement element) {
+    default boolean platformSupported(AnnotatedElement element) {
         return true;
     }
 }

--- a/substratevm/src/com.oracle.graal.pointsto/src/com/oracle/graal/pointsto/flow/MethodTypeFlowBuilder.java
+++ b/substratevm/src/com.oracle.graal.pointsto/src/com/oracle/graal/pointsto/flow/MethodTypeFlowBuilder.java
@@ -134,6 +134,7 @@ import com.oracle.graal.pointsto.typestate.TypeState;
 
 import jdk.vm.ci.code.BytecodePosition;
 import jdk.vm.ci.common.JVMCIError;
+import jdk.vm.ci.meta.JavaConstant;
 import jdk.vm.ci.meta.JavaKind;
 
 public class MethodTypeFlowBuilder {
@@ -316,12 +317,13 @@ public class MethodTypeFlowBuilder {
     }
 
     private void registerEmbeddedRoot(ConstantNode cn) {
-        if (bb.scanningPolicy().trackConstant(bb, cn.asJavaConstant())) {
+        JavaConstant root = cn.asJavaConstant();
+        if (bb.scanningPolicy().trackConstant(bb, root)) {
             BytecodePosition position = cn.getNodeSourcePosition();
             if (position == null) {
                 position = new BytecodePosition(null, method, 0);
             }
-            bb.getUniverse().registerEmbeddedRoot(cn.asJavaConstant(), position);
+            bb.getUniverse().registerEmbeddedRoot(root, position);
         }
     }
 

--- a/substratevm/src/com.oracle.graal.pointsto/src/com/oracle/graal/pointsto/heap/HeapSnapshotVerifier.java
+++ b/substratevm/src/com.oracle.graal.pointsto/src/com/oracle/graal/pointsto/heap/HeapSnapshotVerifier.java
@@ -119,7 +119,7 @@ public class HeapSnapshotVerifier {
     public boolean verifyHeapSnapshot(CompletionExecutor executor) throws InterruptedException {
         foundMismatch = false;
         scannedObjects.reset();
-        ObjectScanner objectScanner = new ObjectScanner(bb, scannedObjects, new ScanningObserver());
+        ObjectScanner objectScanner = new ObjectScanner(bb, executor, scannedObjects, new ScanningObserver());
         executor.start();
         scanTypes(objectScanner);
         objectScanner.scanBootImageHeapRoots();

--- a/substratevm/src/com.oracle.graal.pointsto/src/com/oracle/graal/pointsto/heap/HeapSnapshotVerifier.java
+++ b/substratevm/src/com.oracle.graal.pointsto/src/com/oracle/graal/pointsto/heap/HeapSnapshotVerifier.java
@@ -46,7 +46,6 @@ import com.oracle.graal.pointsto.heap.ImageHeap.ImageHeapInstance;
 import com.oracle.graal.pointsto.heap.ImageHeap.ImageHeapObject;
 import com.oracle.graal.pointsto.meta.AnalysisField;
 import com.oracle.graal.pointsto.meta.AnalysisType;
-import com.oracle.graal.pointsto.meta.TypeData;
 import com.oracle.graal.pointsto.util.AnalysisError;
 import com.oracle.graal.pointsto.util.AnalysisFuture;
 import com.oracle.graal.pointsto.util.CompletionExecutor;
@@ -92,28 +91,28 @@ public class HeapSnapshotVerifier {
         scannedObjects = new ReusableSet();
         verbosity = Options.HeapVerifierVerbosity.getValue(bb.getOptions());
 
-        skipArrayTypes.add(scanner.getAnalysisType("java.util.concurrent.ConcurrentHashMap$Node").getArrayClass());
-        skipArrayTypes.add(scanner.getAnalysisType("java.util.HashMap$Node").getArrayClass());
-        skipArrayTypes.add(scanner.getAnalysisType("java.util.WeakHashMap$Entry").getArrayClass());
+        skipArrayTypes.add(scanner.lookupJavaType("java.util.concurrent.ConcurrentHashMap$Node").getArrayClass());
+        skipArrayTypes.add(scanner.lookupJavaType("java.util.HashMap$Node").getArrayClass());
+        skipArrayTypes.add(scanner.lookupJavaType("java.util.WeakHashMap$Entry").getArrayClass());
 
-        internalFields.add(scanner.getAnalysisField("java.util.concurrent.ConcurrentHashMap", "table"));
-        internalFields.add(scanner.getAnalysisField("java.util.concurrent.ConcurrentHashMap$Node", "next"));
-        internalFields.add(scanner.getAnalysisField("java.util.HashMap", "table"));
-        internalFields.add(scanner.getAnalysisField("java.util.HashMap$Node", "next"));
-        internalFields.add(scanner.getAnalysisField("java.util.LinkedList", "last"));
-        internalFields.add(scanner.getAnalysisField("java.util.LinkedList", "first"));
-        internalFields.add(scanner.getAnalysisField("java.util.LinkedHashMap", "head"));
-        internalFields.add(scanner.getAnalysisField("java.util.LinkedHashMap", "tail"));
-        internalFields.add(scanner.getAnalysisField("java.util.LinkedHashMap$Entry", "before"));
-        internalFields.add(scanner.getAnalysisField("java.util.LinkedHashMap$Entry", "after"));
-        internalFields.add(scanner.getAnalysisField("java.util.LinkedList$Node", "prev"));
-        internalFields.add(scanner.getAnalysisField("java.util.LinkedList$Node", "next"));
-        internalFields.add(scanner.getAnalysisField("java.util.ArrayList", "elementData"));
+        internalFields.add(scanner.lookupJavaField("java.util.concurrent.ConcurrentHashMap", "table"));
+        internalFields.add(scanner.lookupJavaField("java.util.concurrent.ConcurrentHashMap$Node", "next"));
+        internalFields.add(scanner.lookupJavaField("java.util.HashMap", "table"));
+        internalFields.add(scanner.lookupJavaField("java.util.HashMap$Node", "next"));
+        internalFields.add(scanner.lookupJavaField("java.util.LinkedList", "last"));
+        internalFields.add(scanner.lookupJavaField("java.util.LinkedList", "first"));
+        internalFields.add(scanner.lookupJavaField("java.util.LinkedHashMap", "head"));
+        internalFields.add(scanner.lookupJavaField("java.util.LinkedHashMap", "tail"));
+        internalFields.add(scanner.lookupJavaField("java.util.LinkedHashMap$Entry", "before"));
+        internalFields.add(scanner.lookupJavaField("java.util.LinkedHashMap$Entry", "after"));
+        internalFields.add(scanner.lookupJavaField("java.util.LinkedList$Node", "prev"));
+        internalFields.add(scanner.lookupJavaField("java.util.LinkedList$Node", "next"));
+        internalFields.add(scanner.lookupJavaField("java.util.ArrayList", "elementData"));
 
-        externalFields.add(scanner.getAnalysisField("java.util.concurrent.ConcurrentHashMap$Node", "key"));
-        externalFields.add(scanner.getAnalysisField("java.util.concurrent.ConcurrentHashMap$Node", "val"));
-        externalFields.add(scanner.getAnalysisField("java.util.HashMap$Node", "key"));
-        externalFields.add(scanner.getAnalysisField("java.util.HashMap$Node", "value"));
+        externalFields.add(scanner.lookupJavaField("java.util.concurrent.ConcurrentHashMap$Node", "key"));
+        externalFields.add(scanner.lookupJavaField("java.util.concurrent.ConcurrentHashMap$Node", "val"));
+        externalFields.add(scanner.lookupJavaField("java.util.HashMap$Node", "key"));
+        externalFields.add(scanner.lookupJavaField("java.util.HashMap$Node", "value"));
         // externalFields.add(scanner.getAnalysisField("java.lang.ref.Reference", "referent")); ?
     }
 
@@ -162,7 +161,7 @@ public class HeapSnapshotVerifier {
         public void forNonNullFieldValue(JavaConstant receiver, AnalysisField field, JavaConstant fieldValue, ScanReason reason) {
             if (field.isStatic()) {
                 TypeData typeData = field.getDeclaringClass().getOrComputeData();
-                AnalysisFuture<JavaConstant> fieldValueTask = typeData.getStaticFieldValueTask(field);
+                AnalysisFuture<JavaConstant> fieldValueTask = typeData.getFieldTask(field);
                 if (!fieldValueTask.isDone()) {
                     warnStaticFieldNotComputed(field, fieldValue, reason);
                     fieldValueTask.ensureDone();

--- a/substratevm/src/com.oracle.graal.pointsto/src/com/oracle/graal/pointsto/heap/HeapSnapshotVerifier.java
+++ b/substratevm/src/com.oracle.graal.pointsto/src/com/oracle/graal/pointsto/heap/HeapSnapshotVerifier.java
@@ -117,7 +117,6 @@ public class HeapSnapshotVerifier {
     }
 
     public boolean verifyHeapSnapshot(CompletionExecutor executor) throws InterruptedException {
-        scanner.disable();
         foundMismatch = false;
         scannedObjects.reset();
         executor.start();
@@ -126,7 +125,6 @@ public class HeapSnapshotVerifier {
         objectScanner.scanBootImageHeapRoots();
         executor.complete();
         executor.shutdown();
-        scanner.enable();
         return foundMismatch;
     }
 

--- a/substratevm/src/com.oracle.graal.pointsto/src/com/oracle/graal/pointsto/heap/HeapSnapshotVerifier.java
+++ b/substratevm/src/com.oracle.graal.pointsto/src/com/oracle/graal/pointsto/heap/HeapSnapshotVerifier.java
@@ -119,8 +119,8 @@ public class HeapSnapshotVerifier {
     public boolean verifyHeapSnapshot(CompletionExecutor executor) throws InterruptedException {
         foundMismatch = false;
         scannedObjects.reset();
+        ObjectScanner objectScanner = new ObjectScanner(bb, scannedObjects, new ScanningObserver());
         executor.start();
-        ObjectScanner objectScanner = new ObjectScanner(bb, null, scannedObjects, new ScanningObserver());
         scanTypes(objectScanner);
         objectScanner.scanBootImageHeapRoots();
         executor.complete();

--- a/substratevm/src/com.oracle.graal.pointsto/src/com/oracle/graal/pointsto/heap/HeapSnapshotVerifier.java
+++ b/substratevm/src/com.oracle.graal.pointsto/src/com/oracle/graal/pointsto/heap/HeapSnapshotVerifier.java
@@ -1,0 +1,235 @@
+/*
+ * Copyright (c) 2021, 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package com.oracle.graal.pointsto.heap;
+
+import static com.oracle.graal.pointsto.ObjectScanner.ScanReason;
+import static com.oracle.graal.pointsto.ObjectScanner.asString;
+
+import java.util.Objects;
+import java.util.concurrent.ExecutionException;
+
+import com.oracle.graal.pointsto.BigBang;
+import com.oracle.graal.pointsto.ObjectScanner;
+import com.oracle.graal.pointsto.ObjectScanner.ReusableSet;
+import com.oracle.graal.pointsto.ObjectScanningObserver;
+import com.oracle.graal.pointsto.heap.ImageHeap.ImageHeapArray;
+import com.oracle.graal.pointsto.heap.ImageHeap.ImageHeapInstance;
+import com.oracle.graal.pointsto.heap.ImageHeap.ImageHeapObject;
+import com.oracle.graal.pointsto.meta.AnalysisField;
+import com.oracle.graal.pointsto.meta.AnalysisType;
+import com.oracle.graal.pointsto.meta.TypeData;
+import com.oracle.graal.pointsto.util.AnalysisError;
+import com.oracle.graal.pointsto.util.AnalysisFuture;
+import com.oracle.graal.pointsto.util.CompletionExecutor;
+
+import jdk.vm.ci.meta.JavaConstant;
+
+public class HeapSnapshotVerifier {
+    protected final BigBang bb;
+    protected final ImageHeapScanner scanner;
+    protected final ImageHeap imageHeap;
+
+    private ReusableSet scannedObjects;
+    private boolean foundMismatch;
+
+    private final boolean printOnMismatch;
+
+    public HeapSnapshotVerifier(BigBang bb, ImageHeap imageHeap, ImageHeapScanner scanner) {
+        this.bb = bb;
+        this.scanner = scanner;
+        this.imageHeap = imageHeap;
+        scannedObjects = new ReusableSet();
+        printOnMismatch = ImageHeapScanner.Options.PrintOnMismatch.getValue(bb.getOptions());
+    }
+
+    public boolean verifyHeapSnapshot(CompletionExecutor executor) throws InterruptedException {
+        scanner.disable();
+        foundMismatch = false;
+        scannedObjects.reset();
+        executor.start();
+        ObjectScanner objectScanner = new ObjectScanner(bb, null, scannedObjects, new ScanningObserver());
+        scanTypes(objectScanner);
+        objectScanner.scanBootImageHeapRoots();
+        executor.complete();
+        executor.shutdown();
+        scanner.enable();
+        return foundMismatch;
+    }
+
+    protected void scanTypes(@SuppressWarnings("unused") ObjectScanner objectScanner) {
+    }
+
+    public void cleanupAfterAnalysis() {
+        scannedObjects = null;
+    }
+
+    private final class ScanningObserver implements ObjectScanningObserver {
+
+        @Override
+        public boolean forRelocatedPointerFieldValue(JavaConstant receiver, AnalysisField field, JavaConstant fieldValue, ScanReason reason) {
+            boolean result = scanner.getScanningObserver().forRelocatedPointerFieldValue(receiver, field, fieldValue, reason);
+            if (result) {
+                foundMismatch = true;
+            }
+            return result;
+        }
+
+        @Override
+        public boolean forNullFieldValue(JavaConstant receiver, AnalysisField field, ScanReason reason) {
+            boolean result = scanner.getScanningObserver().forNullFieldValue(receiver, field, reason);
+            if (result) {
+                foundMismatch = true;
+            }
+            return result;
+        }
+
+        @Override
+        public void forNonNullFieldValue(JavaConstant receiver, AnalysisField field, JavaConstant fieldValue, ScanReason reason) {
+            try {
+                if (field.isStatic()) {
+                    TypeData typeData = field.getDeclaringClass().getOrComputeData();
+                    AnalysisFuture<JavaConstant> fieldValueTask = typeData.getStaticFieldValueTask(field);
+                    if (fieldValueTask.isDone()) {
+                        JavaConstant fieldSnapshot = fieldValueTask.get();
+                        if (!Objects.equals(fieldSnapshot, fieldValue)) {
+                            warning(reason, "Value mismatch for static field %s %n snapshot: %s %n new value: %s %n",
+                                            field, fieldSnapshot, fieldValue);
+                            scanner.patchStaticField(typeData, field, fieldValue, reason).ensureDone();
+                        }
+                    } else {
+                        warning(reason, "Snapshot not yet computed for field %s %n new value: %s %n", field, fieldValue);
+                        fieldValueTask.ensureDone();
+                    }
+                } else {
+                    AnalysisFuture<ImageHeapObject> receiverTask = imageHeap.getTask(receiver);
+                    assert receiverTask != null && receiverTask.isDone() : message(reason, "Task %s for receiver %s.",
+                                    (receiverTask == null ? "is null" : "not yet executed"), receiver);
+                    ImageHeapInstance receiverObject = (ImageHeapInstance) receiverTask.get();
+                    AnalysisFuture<JavaConstant> fieldValueTask = receiverObject.getFieldTask(field);
+                    if (fieldValueTask.isDone()) {
+                        JavaConstant fieldSnapshot = fieldValueTask.get();
+                        if (!Objects.equals(fieldSnapshot, fieldValue)) {
+                            warning(reason, "Value mismatch for field %s %n snapshot: %s %n new value: %s %n",
+                                            field, fieldSnapshot, fieldValue);
+                            scanner.patchInstanceField(receiverObject, field, fieldValue, reason).ensureDone();
+                        }
+                    } else {
+                        warning(reason, "Snapshot not yet computed for field %s %n new value: %s %n", field, fieldValue);
+                        fieldValueTask.ensureDone();
+                    }
+                }
+            } catch (InterruptedException | ExecutionException e) {
+                throw AnalysisError.shouldNotReachHere(e);
+            }
+        }
+
+        @Override
+        public boolean forNullArrayElement(JavaConstant array, AnalysisType arrayType, int elementIndex, ScanReason reason) {
+            boolean result = scanner.getScanningObserver().forNullArrayElement(array, arrayType, elementIndex, reason);
+            if (result) {
+                foundMismatch = true;
+            }
+            return result;
+        }
+
+        @Override
+        public void forNonNullArrayElement(JavaConstant array, AnalysisType arrayType, JavaConstant elementValue, AnalysisType elementType, int index, ScanReason reason) {
+            try {
+                AnalysisFuture<ImageHeapObject> arrayTask = imageHeap.getTask(array);
+                assert arrayTask != null && arrayTask.isDone() : message(reason, "Task %s for array %s.",
+                                (arrayTask == null ? "is null" : "not yet executed"), array);
+                ImageHeapArray receiverObject = (ImageHeapArray) arrayTask.get();
+                JavaConstant elementSnapshot = receiverObject.getElement(index);
+                if (!Objects.equals(elementSnapshot, elementValue)) {
+                    warning(reason, "Value mismatch for array element %n snapshot: %s %n new value: %s %n", elementSnapshot, elementValue);
+                    receiverObject.setElement(index, scanner.onArrayElementReachable(array, arrayType, elementValue, index, reason));
+                }
+            } catch (InterruptedException | ExecutionException e) {
+                throw AnalysisError.shouldNotReachHere(e);
+            }
+        }
+
+        @Override
+        public void forEmbeddedRoot(JavaConstant root, ScanReason reason) {
+            AnalysisFuture<ImageHeap.ImageHeapObject> rootTask = imageHeap.getTask(root);
+            if (rootTask == null) {
+                throw error(reason, "No snapshot task found for embedded root %s %n", root);
+            } else if (rootTask.isDone()) {
+                try {
+                    JavaConstant rootSnapshot = rootTask.get().getObject();
+                    if (!Objects.equals(rootSnapshot, root)) {
+                        throw error(reason, "Value mismatch for embedded root %n snapshot: %s %n new value: %s %n", rootSnapshot, root);
+                    }
+                } catch (InterruptedException | ExecutionException e) {
+                    throw AnalysisError.shouldNotReachHere(e);
+                }
+            } else {
+                throw error(reason, "Snapshot not yet computed for embedded root %n new value: %s %n", root);
+            }
+        }
+
+        @Override
+        public void forScannedConstant(JavaConstant value, ScanReason reason) {
+            /* Make sure the value is scanned. */
+            AnalysisFuture<ImageHeapObject> task = imageHeap.getTask(value);
+            if (task == null) {
+                scanner.toImageHeapObject(value, reason);
+            }
+        }
+    }
+
+    private void warning(ScanReason reason, String format, Object... args) {
+        foundMismatch = true;
+        if (printOnMismatch) {
+            System.out.println("WARNING: " + message(reason, format, args));
+        }
+    }
+
+    private RuntimeException error(ScanReason reason, String format, Object... args) {
+        throw AnalysisError.shouldNotReachHere(message(reason, format, args));
+    }
+
+    private String message(ScanReason reason, String format, Object... args) {
+        String message = format(format, args);
+        StringBuilder objectBacktrace = new StringBuilder();
+        ObjectScanner.buildObjectBacktrace(bb, reason, objectBacktrace);
+        message += objectBacktrace;
+        return message;
+    }
+
+    private String format(String msg, Object... args) {
+        if (args != null) {
+            for (int i = 0; i < args.length; ++i) {
+                if (args[i] instanceof JavaConstant) {
+                    args[i] = asString(bb, (JavaConstant) args[i]);
+                } else if (args[i] instanceof AnalysisField) {
+                    args[i] = ((AnalysisField) args[i]).format("%H.%n");
+                }
+            }
+        }
+        return String.format(msg, args);
+    }
+
+}

--- a/substratevm/src/com.oracle.graal.pointsto/src/com/oracle/graal/pointsto/heap/ImageHeap.java
+++ b/substratevm/src/com.oracle.graal.pointsto/src/com/oracle/graal/pointsto/heap/ImageHeap.java
@@ -29,6 +29,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
+import com.oracle.graal.pointsto.ObjectScanner;
 import com.oracle.graal.pointsto.meta.AnalysisField;
 import com.oracle.graal.pointsto.meta.AnalysisType;
 import com.oracle.graal.pointsto.util.AnalysisFuture;
@@ -127,8 +128,19 @@ public class ImageHeap {
             return objectFieldValues.get(field).ensureDone();
         }
 
+        /**
+         * Return a task for transforming and snapshotting the field value, effectively a future for
+         * {@link ImageHeapScanner#onFieldValueReachable(AnalysisField, JavaConstant, JavaConstant, ObjectScanner.ScanReason)}.
+         */
         public AnalysisFuture<JavaConstant> getFieldTask(AnalysisField field) {
             return objectFieldValues.get(field);
+        }
+
+        /**
+         * Read the field value, executing the field task in this thread if not already executed.
+         */
+        public JavaConstant readField(AnalysisField field) {
+            return objectFieldValues.get(field).ensureDone();
         }
 
         public void setFieldTask(AnalysisField field, AnalysisFuture<JavaConstant> task) {
@@ -145,6 +157,10 @@ public class ImageHeap {
             this.arrayElementValues = arrayElementValues;
         }
 
+        /**
+         * Return the value of the element at the specified index as computed by
+         * {@link ImageHeapScanner#onArrayElementReachable(JavaConstant, AnalysisType, JavaConstant, int, ObjectScanner.ScanReason)}.
+         */
         public JavaConstant getElement(int idx) {
             return arrayElementValues[idx];
         }

--- a/substratevm/src/com.oracle.graal.pointsto/src/com/oracle/graal/pointsto/heap/ImageHeap.java
+++ b/substratevm/src/com.oracle.graal.pointsto/src/com/oracle/graal/pointsto/heap/ImageHeap.java
@@ -30,6 +30,7 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
 import com.oracle.graal.pointsto.ObjectScanner;
+import com.oracle.graal.pointsto.heap.value.ValueSupplier;
 import com.oracle.graal.pointsto.meta.AnalysisField;
 import com.oracle.graal.pointsto.meta.AnalysisType;
 import com.oracle.graal.pointsto.util.AnalysisFuture;
@@ -117,7 +118,7 @@ public class ImageHeap {
 
         /**
          * Return a task for transforming and snapshotting the field value, effectively a future for
-         * {@link ImageHeapScanner#onFieldValueReachable(AnalysisField, JavaConstant, JavaConstant, ObjectScanner.ScanReason)}.
+         * {@link ImageHeapScanner#onFieldValueReachable(AnalysisField, JavaConstant, ValueSupplier, ObjectScanner.ScanReason)}.
          */
         public AnalysisFuture<JavaConstant> getFieldTask(AnalysisField field) {
             return objectFieldValues[field.getPosition()];

--- a/substratevm/src/com.oracle.graal.pointsto/src/com/oracle/graal/pointsto/heap/ImageHeap.java
+++ b/substratevm/src/com.oracle.graal.pointsto/src/com/oracle/graal/pointsto/heap/ImageHeap.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright (c) 2021, 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package com.oracle.graal.pointsto.heap;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+import com.oracle.graal.pointsto.meta.AnalysisField;
+import com.oracle.graal.pointsto.meta.AnalysisType;
+import com.oracle.graal.pointsto.util.AnalysisFuture;
+
+import jdk.vm.ci.meta.JavaConstant;
+import jdk.vm.ci.meta.ResolvedJavaField;
+
+public class ImageHeap {
+
+    /** Map the original object *and* the replaced object to the HeapObject snapshot. */
+    protected ConcurrentHashMap<JavaConstant, AnalysisFuture<ImageHeapObject>> heapObjects;
+    /** Store a mapping from types to all scanned objects. */
+    protected Map<AnalysisType, Set<ImageHeapObject>> typesToObjects;
+
+    public ImageHeap() {
+        heapObjects = new ConcurrentHashMap<>();
+        typesToObjects = new ConcurrentHashMap<>();
+    }
+
+    public AnalysisFuture<ImageHeapObject> getTask(JavaConstant constant) {
+        return heapObjects.get(constant);
+    }
+
+    public ImageHeapObject get(JavaConstant constant) {
+        return getTask(constant).ensureDone();
+    }
+
+    public Set<ImageHeapObject> getObjects(AnalysisType type) {
+        return typesToObjects.getOrDefault(type, Collections.emptySet());
+    }
+
+    public boolean add(AnalysisType type, ImageHeapObject heapObj) {
+        return heapObjects(type).add(heapObj);
+    }
+
+    private Set<ImageHeapObject> heapObjects(AnalysisType type) {
+        return typesToObjects.computeIfAbsent(type, t -> Collections.newSetFromMap(new ConcurrentHashMap<>()));
+    }
+
+    /**
+     * Model for snapshotted objects. It stores the replaced object, i.e., the result of applying
+     * object replacers on the original object, and the instance field values of this object. The
+     * field values are stored as JavaConstant to also encode primitive values. ImageHeapObject are
+     * created only after an object is processed through the object replacers.
+     */
+    public static class ImageHeapObject {
+        final AnalysisType type;
+        /** Store the object, already processed by the object transformers. */
+        final JavaConstant object;
+
+        ImageHeapObject(JavaConstant object, AnalysisType type) {
+            this.object = object;
+            this.type = type;
+        }
+
+        public JavaConstant getObject() {
+            return object;
+        }
+
+        /*
+         * Equals and hascode just compare the replaced constant. Thus two HeapObject insantaces are
+         * considered equal if they snapshot the same constant, even if the instanceFieldValues are
+         * different, i.e., they were snapshotted at different times during analysis and one of them
+         * mutated. This is necessary for the removal of the old snapshotted value on forced
+         * updates. Alternativelly each AnalysisType needs a mapping from JavaConstant to HeapObject
+         * instead of just a set of HeapObject.
+         */
+
+        @Override
+        public boolean equals(Object o) {
+            // TODO ==
+            if (o instanceof ImageHeapObject) {
+                ImageHeapObject other = (ImageHeapObject) o;
+                return this.object.equals(other.object);
+            }
+            return false;
+        }
+
+        @Override
+        public int hashCode() {
+            return object.hashCode();
+        }
+    }
+
+    public static final class ImageHeapInstance extends ImageHeapObject {
+
+        /** Store original field values of the object. */
+        final Map<ResolvedJavaField, AnalysisFuture<JavaConstant>> objectFieldValues;
+
+        ImageHeapInstance(JavaConstant object, AnalysisType type, Map<ResolvedJavaField, AnalysisFuture<JavaConstant>> objectFieldValues) {
+            super(object, type);
+            this.objectFieldValues = objectFieldValues;
+        }
+
+        public JavaConstant readFieldValue(AnalysisField field) {
+            return objectFieldValues.get(field).ensureDone();
+        }
+
+        public AnalysisFuture<JavaConstant> getFieldTask(AnalysisField field) {
+            return objectFieldValues.get(field);
+        }
+
+        public void setFieldTask(AnalysisField field, AnalysisFuture<JavaConstant> task) {
+            objectFieldValues.put(field, task);
+        }
+    }
+
+    static final class ImageHeapArray extends ImageHeapObject {
+        /** Contains the already scanned array elements. */
+        private final JavaConstant[] arrayElementValues;
+
+        ImageHeapArray(JavaConstant object, AnalysisType type, JavaConstant[] arrayElementValues) {
+            super(object, type);
+            this.arrayElementValues = arrayElementValues;
+        }
+
+        public JavaConstant getElement(int idx) {
+            return arrayElementValues[idx];
+        }
+
+        public void setElement(int idx, JavaConstant value) {
+            arrayElementValues[idx] = value;
+        }
+
+        public int getLength() {
+            return arrayElementValues.length;
+        }
+    }
+
+}

--- a/substratevm/src/com.oracle.graal.pointsto/src/com/oracle/graal/pointsto/heap/ImageHeapScanner.java
+++ b/substratevm/src/com.oracle.graal.pointsto/src/com/oracle/graal/pointsto/heap/ImageHeapScanner.java
@@ -455,10 +455,6 @@ public abstract class ImageHeapScanner {
         return null;
     }
 
-    public void rescanField(Object receiver, Class<?> declaringClass, String fieldName) {
-        rescanField(receiver, ReflectionUtil.lookupField(declaringClass, fieldName));
-    }
-
     public void rescanField(Object receiver, Field reflectionField) {
         if (!enableManualRescan) {
             return;
@@ -543,7 +539,7 @@ public abstract class ImageHeapScanner {
 
     void doScan(JavaConstant constant) {
         if (constant.getJavaKind() == JavaKind.Object && constant.isNonNull()) {
-            toImageHeapObject(constant, OtherReason.SCAN);
+            getOrCreateConstantReachableTask(constant, OtherReason.SCAN);
         }
     }
 
@@ -552,7 +548,7 @@ public abstract class ImageHeapScanner {
         universe.onTypeScanned(type);
         metaAccess.lookupJavaType(java.lang.Class.class).registerAsReachable();
         /* We scan the original class here, the scanner does the replacement to DynamicHub. */
-        toImageHeapObject(asConstant(type.getJavaClass()), ObjectScanner.OtherReason.HUB);
+        getOrCreateConstantReachableTask(asConstant(type.getJavaClass()), ObjectScanner.OtherReason.HUB);
     }
 
     protected AnalysisType analysisType(Object constant) {

--- a/substratevm/src/com.oracle.graal.pointsto/src/com/oracle/graal/pointsto/heap/ImageHeapScanner.java
+++ b/substratevm/src/com.oracle.graal.pointsto/src/com/oracle/graal/pointsto/heap/ImageHeapScanner.java
@@ -94,7 +94,6 @@ public abstract class ImageHeapScanner {
     protected final SnippetReflectionProvider hostedSnippetReflection;
 
     protected ObjectScanningObserver scanningObserver;
-    protected boolean isEnabled;
     private final boolean enableManualRescan;
 
     public ImageHeapScanner(ImageHeap heap, AnalysisMetaAccess aMetaAccess, SnippetReflectionProvider aSnippetReflection,
@@ -108,20 +107,7 @@ public abstract class ImageHeapScanner {
         scanningObserver = aScanningObserver;
         hostedConstantReflection = GraalAccess.getOriginalProviders().getConstantReflection();
         hostedSnippetReflection = GraalAccess.getOriginalProviders().getSnippetReflection();
-        isEnabled = true;
         enableManualRescan = Options.EnableManualRescan.getValue(hostVM.options());
-    }
-
-    public void disable() {
-        isEnabled = false;
-    }
-
-    public void enable() {
-        isEnabled = true;
-    }
-
-    public boolean isEnabled() {
-        return isEnabled;
     }
 
     public void scanEmbeddedRoot(JavaConstant root, BytecodePosition position) {
@@ -130,6 +116,7 @@ public abstract class ImageHeapScanner {
         getOrCreateConstantReachableTask(root, new EmbeddedRootScan(position, root)).ensureDone();
     }
 
+    @SuppressWarnings("unused")
     public void scanFieldValue(AnalysisField field, JavaConstant receiver) {
         assert field.isReachable() && isValueAvailable(field);
         if (field.isStatic()) {

--- a/substratevm/src/com.oracle.graal.pointsto/src/com/oracle/graal/pointsto/heap/ImageHeapScanner.java
+++ b/substratevm/src/com.oracle.graal.pointsto/src/com/oracle/graal/pointsto/heap/ImageHeapScanner.java
@@ -1,0 +1,636 @@
+/*
+ * Copyright (c) 2021, 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package com.oracle.graal.pointsto.heap;
+
+import java.lang.reflect.Field;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+
+import org.graalvm.collections.EconomicMap;
+import org.graalvm.collections.MapCursor;
+import org.graalvm.compiler.api.replacements.SnippetReflectionProvider;
+import org.graalvm.compiler.debug.GraalError;
+import org.graalvm.compiler.options.Option;
+import org.graalvm.compiler.options.OptionKey;
+
+import com.oracle.graal.pointsto.BigBang;
+import com.oracle.graal.pointsto.ObjectScanner.ArrayScan;
+import com.oracle.graal.pointsto.ObjectScanner.EmbeddedRootScan;
+import com.oracle.graal.pointsto.ObjectScanner.FieldScan;
+import com.oracle.graal.pointsto.ObjectScanner.OtherReason;
+import com.oracle.graal.pointsto.ObjectScanner.ScanReason;
+import com.oracle.graal.pointsto.ObjectScanningObserver;
+import com.oracle.graal.pointsto.PointsToAnalysis;
+import com.oracle.graal.pointsto.api.HostVM;
+import com.oracle.graal.pointsto.heap.ImageHeap.ImageHeapArray;
+import com.oracle.graal.pointsto.heap.ImageHeap.ImageHeapInstance;
+import com.oracle.graal.pointsto.heap.ImageHeap.ImageHeapObject;
+import com.oracle.graal.pointsto.heap.value.ValueSupplier;
+import com.oracle.graal.pointsto.meta.AnalysisField;
+import com.oracle.graal.pointsto.meta.AnalysisMetaAccess;
+import com.oracle.graal.pointsto.meta.AnalysisMethod;
+import com.oracle.graal.pointsto.meta.AnalysisType;
+import com.oracle.graal.pointsto.meta.AnalysisUniverse;
+import com.oracle.graal.pointsto.meta.TypeData;
+import com.oracle.graal.pointsto.util.AnalysisError;
+import com.oracle.graal.pointsto.util.AnalysisFuture;
+import com.oracle.graal.pointsto.util.GraalAccess;
+import com.oracle.svm.util.ReflectionUtil;
+
+import jdk.vm.ci.code.BytecodePosition;
+import jdk.vm.ci.meta.Constant;
+import jdk.vm.ci.meta.ConstantReflectionProvider;
+import jdk.vm.ci.meta.JavaConstant;
+import jdk.vm.ci.meta.JavaKind;
+import jdk.vm.ci.meta.ResolvedJavaField;
+
+/**
+ * Scanning is triggered when:
+ * <ul>
+ * <li>a static final field is marked as accessed, or</li>s
+ * <li>a method that is parsed and embedded roots are discovered</li>
+ * </ul>
+ * <p>
+ * When an instance field is marked as accessed the objects of its declaring type (and all the
+ * subtypes) are re-scanned.
+ */
+public class ImageHeapScanner {
+    public static class Options {
+        @Option(help = "Enable manual rescanning of image heap objects.")//
+        public static final OptionKey<Boolean> EnableManualRescan = new OptionKey<>(true);
+
+        @Option(help = "Print warnings when verifier finds mismatch.")//
+        public static final OptionKey<Boolean> PrintOnMismatch = new OptionKey<>(false);
+    }
+
+    private final BigBang bb;
+    protected final ImageHeap imageHeap;
+    protected final AnalysisMetaAccess metaAccess;
+    protected final AnalysisUniverse universe;
+    protected final HostVM hostVM;
+
+    protected final SnippetReflectionProvider snippetReflection;
+    protected final ConstantReflectionProvider constantReflection;
+    protected final ConstantReflectionProvider hostedConstantReflection;
+    protected final SnippetReflectionProvider hostedSnippetReflection;
+    protected ObjectScanningObserver scanningObserver;
+    protected boolean isEnabled;
+    private final boolean enableManualRescan;
+
+    public ImageHeapScanner(BigBang bb, ImageHeap heap, AnalysisMetaAccess aMetaAccess,
+                    SnippetReflectionProvider aSnippetReflection, ConstantReflectionProvider aConstantReflection, ObjectScanningObserver aScanningObserver) {
+        this.bb = bb;
+        imageHeap = heap;
+        universe = aMetaAccess.getUniverse();
+        metaAccess = aMetaAccess;
+        hostVM = aMetaAccess.getUniverse().hostVM();
+        snippetReflection = aSnippetReflection;
+        constantReflection = aConstantReflection;
+        scanningObserver = aScanningObserver;
+        hostedConstantReflection = GraalAccess.getOriginalProviders().getConstantReflection();
+        hostedSnippetReflection = GraalAccess.getOriginalProviders().getSnippetReflection();
+        isEnabled = true;
+        enableManualRescan = Options.EnableManualRescan.getValue(hostVM.options());
+    }
+
+    public void disable() {
+        isEnabled = false;
+    }
+
+    public void enable() {
+        isEnabled = true;
+    }
+
+    public boolean isEnabled() {
+        return isEnabled;
+    }
+
+    public ImageHeap getImageHeap() {
+        return imageHeap;
+    }
+
+    public void scanEmbeddedRoot(JavaConstant root, BytecodePosition position) {
+        AnalysisMethod method = (AnalysisMethod) position.getMethod();
+        AnalysisType type = metaAccess.lookupJavaType(root);
+        type.registerAsReachable();
+        toImageHeapObject(root, new EmbeddedRootScan(method, position, root));
+    }
+
+    public void scanFieldValue(AnalysisField field, JavaConstant receiver) {
+        /*
+         * If this read is for constant folding then the read is not parsed yet and the field is not
+         * marked as reachable.
+         */
+        field.markReachable();
+        if (field.isStatic()) {
+            TypeData declaringClassData = field.getDeclaringClass().getOrComputeData();
+            declaringClassData.getStaticFieldValueTask(field).ensureDone();
+        } else {
+            ImageHeapObject receiverObject = getImageHeapObject(receiver);
+            if (receiverObject instanceof ImageHeapInstance) {
+                ((ImageHeapInstance) receiverObject).getFieldTask(field).ensureDone();
+            }
+        }
+    }
+
+    ImageHeapObject getImageHeapObject(Constant constant) {
+        if (constant instanceof JavaConstant) {
+            JavaConstant javaConstant = (JavaConstant) constant;
+            if (javaConstant.getJavaKind() == JavaKind.Object && javaConstant.isNonNull()) {
+                return toImageHeapObject(javaConstant);
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Computes the class initialization status and the snapshot of all static fields. This is an
+     * expensive operation and therefore done in an asynchronous task.
+     */
+    public TypeData computeTypeData(AnalysisType type) {
+        GraalError.guarantee(type.isReachable(), "TypeData is only available for reachable types");
+
+        /* Decide if the type should be initialized at build time or at run time: */
+        boolean initializeAtRunTime = initializeAtRunTime(type);
+
+        Map<ResolvedJavaField, AnalysisFuture<JavaConstant>> rawStaticFieldValues;
+        /*
+         * Snapshot all static fields. This reads the raw field value of all fields regardless of
+         * reachability status. The field value is processed when a field is marked as reachable, in
+         * onFieldReachable().
+         */
+        rawStaticFieldValues = new HashMap<>();
+        for (AnalysisField field : type.getStaticFields()) {
+            ValueSupplier<JavaConstant> rawFieldValue = readHostedFieldValue(field, null);
+            rawStaticFieldValues.put(field, new AnalysisFuture<>(() -> onFieldValueReachable(field, null, rawFieldValue, new FieldScan(field))));
+        }
+
+        return new TypeData(initializeAtRunTime, rawStaticFieldValues);
+    }
+
+    protected boolean initializeAtRunTime(@SuppressWarnings("unused") AnalysisType type) {
+        return false;
+    }
+
+    void markTypeInstantiated(AnalysisType type) {
+        if (universe.sealed() && !type.isReachable()) {
+            throw AnalysisError.shouldNotReachHere("Universe is sealed. New type reachable: " + type.toJavaName());
+        }
+        type.registerAsInHeap();
+    }
+
+    public void onFieldRead(AnalysisField field) {
+        assert field.isRead();
+        execute(() -> onFieldReadTask(field));
+    }
+
+    private void onFieldReadTask(AnalysisField field) {
+        AnalysisType declaringClass = field.getDeclaringClass();
+        if (field.isStatic()) {
+            TypeData declaringClassData = declaringClass.getOrComputeData();
+            /* Check if the value is available before accessing it. */
+            if (isValueAvailable(field)) {
+                execute(declaringClassData.getStaticFieldValueTask(field));
+            }
+        } else {
+            if (isValueAvailable(field)) {
+                onInstanceFieldRead(field, declaringClass);
+            }
+        }
+    }
+
+    private void onInstanceFieldRead(AnalysisField field, AnalysisType type) {
+        for (AnalysisType subtype : type.getSubTypes()) {
+            for (ImageHeapObject imageHeapObject : imageHeap.getObjects(subtype)) {
+                execute(((ImageHeapInstance) imageHeapObject).getFieldTask(field));
+            }
+            /* Subtypes may include this type itself. */
+            if (!subtype.equals(type)) {
+                onInstanceFieldRead(field, subtype);
+            }
+        }
+    }
+
+    AnalysisFuture<ImageHeapObject> markConstantReachable(Constant constant, ScanReason reason) {
+        if (!(constant instanceof JavaConstant)) {
+            /*
+             * The bytecode parser sometimes embeds low-level VM constants for types into the
+             * high-level graph. Since these constants are the result of type lookups, these types
+             * are already marked as reachable. Eventually, the bytecode parser should be changed to
+             * only use JavaConstant.
+             */
+            return null;
+        }
+
+        JavaConstant javaConstant = (JavaConstant) constant;
+        if (javaConstant.getJavaKind() == JavaKind.Object && javaConstant.isNonNull()) {
+            if (!hostVM.platformSupported(asObject(javaConstant).getClass())) {
+                return null;
+            }
+            return getOrCreateConstantReachableTask(javaConstant, reason);
+        }
+
+        return null;
+    }
+
+    public ImageHeapObject toImageHeapObject(JavaConstant constant) {
+        return toImageHeapObject(constant, OtherReason.SCAN);
+    }
+
+    public ImageHeapObject toImageHeapObject(JavaConstant javaConstant, ScanReason reason) {
+        assert javaConstant.getJavaKind() == JavaKind.Object && javaConstant.isNonNull();
+        return getOrCreateConstantReachableTask(javaConstant, reason).ensureDone();
+    }
+
+    public void scan(JavaConstant javaConstant, ScanReason reason) {
+        assert javaConstant.getJavaKind() == JavaKind.Object && javaConstant.isNonNull();
+        execute(getOrCreateConstantReachableTask(javaConstant, reason));
+    }
+
+    protected AnalysisFuture<ImageHeapObject> getOrCreateConstantReachableTask(JavaConstant javaConstant, ScanReason reason) {
+        ScanReason nonNullReason = Objects.requireNonNull(reason);
+        AnalysisFuture<ImageHeapObject> existingTask = imageHeap.heapObjects.get(javaConstant);
+        if (existingTask == null) {
+            /*
+             * TODO - this still true? is it ok to seal the heap?
+             *
+             * The constants can be generated at any stage, not only before/during analysis. For
+             * example `com.oracle.svm.core.graal.snippets.SubstrateAllocationSnippets.Templates.
+             * getProfilingData()` generates `AllocationProfilingData` during lowering.
+             */
+            if (universe.sealed()) {
+                throw AnalysisError.shouldNotReachHere("Universe is sealed. New constant reachable: " + javaConstant.toValueString());
+            }
+            AnalysisFuture<ImageHeapObject> newTask = new AnalysisFuture<>(() -> createImageHeapObject(javaConstant, nonNullReason));
+            existingTask = imageHeap.heapObjects.putIfAbsent(javaConstant, newTask);
+            if (existingTask == null) {
+                /*
+                 * Immediately schedule the new task. There is no need to have not-yet-reachable
+                 * ImageHeapObject.
+                 */
+                execute(newTask);
+                return newTask;
+            }
+        }
+        return existingTask;
+    }
+
+    private Optional<JavaConstant> maybeReplace(JavaConstant constant, ScanReason reason) {
+        Object unwrapped = unwrapObject(constant);
+        if (unwrapped == null) {
+            throw GraalError.shouldNotReachHere(formatReason("Could not unwrap constant", reason));
+        } else if (unwrapped instanceof ImageHeapObject) {
+            throw GraalError.shouldNotReachHere(formatReason("Double wrapping of constant. Most likely, the reachability analysis code itself is seen as reachable.", reason));
+        }
+
+        /* Run all registered object replacers. */
+        if (constant.getJavaKind() == JavaKind.Object) {
+            Object replaced = universe.replaceObject(unwrapped);
+            if (replaced != unwrapped) {
+                JavaConstant replacedConstant = universe.getSnippetReflection().forObject(replaced);
+                return Optional.of(replacedConstant);
+            }
+        }
+        return Optional.empty();
+    }
+
+    protected Object unwrapObject(JavaConstant constant) {
+        return snippetReflection.asObject(Object.class, constant);
+    }
+
+    protected ImageHeapObject createImageHeapObject(JavaConstant constant, ScanReason reason) {
+        assert constant.getJavaKind() == JavaKind.Object && !constant.isNull();
+
+        Optional<JavaConstant> replaced = maybeReplace(constant, reason);
+        if (replaced.isPresent()) {
+            /*
+             * This ensures that we have a unique ImageHeapObject for the original and replaced
+             * object. As a side effect, this runs all object transformer again on the replaced
+             * constant.
+             */
+            return toImageHeapObject(replaced.get(), reason);
+        }
+
+        if (!hostVM.platformSupported(asObject(constant).getClass())) {
+            return null;
+        }
+
+        /*
+         * Access the constant type after the replacement. Some constants may have types that should
+         * not be reachable at run time and thus are replaced.
+         */
+        AnalysisType type = metaAccess.lookupJavaType(constant);
+
+        ImageHeapObject newImageHeapObject;
+        if (type.isArray()) {
+            int length = constantReflection.readArrayLength(constant);
+            JavaConstant[] arrayElements = new JavaConstant[length];
+            ScanReason arrayReason = new ArrayScan(type, constant, reason);
+            for (int idx = 0; idx < length; idx++) {
+                final JavaConstant rawElementValue = constantReflection.readArrayElement(constant, idx);
+                arrayElements[idx] = onArrayElementReachable(constant, type, rawElementValue, idx, arrayReason);
+            }
+            newImageHeapObject = new ImageHeapArray(constant, type, arrayElements);
+            markTypeInstantiated(type);
+        } else {
+            Map<ResolvedJavaField, AnalysisFuture<JavaConstant>> instanceFieldValues = new HashMap<>();
+            /*
+             * We need to have the new ImageHeapInstance early so that we can reference it in the
+             * lambda when the field value gets reachable. But it must not be published to any other
+             * thread before all instanceFieldValues are filled in.
+             */
+            newImageHeapObject = new ImageHeapInstance(constant, type, instanceFieldValues);
+            /* We are about to query the type's fields, the type must be marked as reachable. */
+            markTypeInstantiated(type);
+            for (AnalysisField field : type.getInstanceFields(true)) {
+                ScanReason fieldReason = new FieldScan(field, constant, reason);
+                ValueSupplier<JavaConstant> rawFieldValue;
+                try {
+                    rawFieldValue = readHostedFieldValue(field, universe.toHosted(constant));
+                } catch (InternalError | TypeNotPresentException | LinkageError e) {
+                    /* Ignore missing type errors. */
+                    continue;
+                }
+                instanceFieldValues.put(field, new AnalysisFuture<>(() -> onFieldValueReachable(field, constant, rawFieldValue, fieldReason)));
+            }
+        }
+
+        /*
+         * Following all the array elements and reachable field values can be done asynchronously.
+         */
+        execute(() -> onObjectReachable(newImageHeapObject));
+        return newImageHeapObject;
+    }
+
+    JavaConstant onFieldValueReachable(AnalysisField field, JavaConstant receiver, JavaConstant fieldValue, ScanReason reason) {
+        return onFieldValueReachable(field, receiver, ValueSupplier.eagerValue(fieldValue), reason);
+    }
+
+    JavaConstant onFieldValueReachable(AnalysisField field, JavaConstant receiver, ValueSupplier<JavaConstant> rawValue, ScanReason reason) {
+        AnalysisError.guarantee(field.isReachable(), "Field value is only reachable when field is reachable " + field.format("%H.%n"));
+
+        /*
+         * Check if the field value is available. If not, trying to access it is an error. This
+         * forces the callers to only trigger the execution of the future task when the value is
+         * ready to be materialized.
+         */
+        AnalysisError.guarantee(rawValue.isAvailable(), "Value not yet available for " + field.format("%H.%n"));
+
+        /* Attempting to materialize the value before it is available may result in an error. */
+        JavaConstant transformedValue = transformFieldValue(field, receiver, rawValue.get());
+
+        if (scanningObserver != null) {
+            if (transformedValue.getJavaKind() == JavaKind.Object && hostVM.isRelocatedPointer(asObject(transformedValue))) {
+                scanningObserver.forRelocatedPointerFieldValue(receiver, field, transformedValue, reason);
+            } else if (transformedValue.isNull()) {
+                scanningObserver.forNullFieldValue(receiver, field, reason);
+            } else {
+                AnalysisFuture<ImageHeapObject> objectFuture = markConstantReachable(transformedValue, reason);
+                /* Notify the points-to analysis of the scan. */
+                if (objectFuture != null) {
+                    /* Add the transformed value to the image heap. */
+                    scanningObserver.forNonNullFieldValue(receiver, field, objectFuture.ensureDone().object, reason);
+                }
+            }
+        }
+        /* Return the transformed value, but NOT the image heap object. */
+        return transformedValue;
+    }
+
+    @SuppressWarnings("unused")
+    protected JavaConstant transformFieldValue(AnalysisField field, JavaConstant receiverConstant, JavaConstant originalValueConstant) {
+        return originalValueConstant;
+    }
+
+    protected JavaConstant onArrayElementReachable(JavaConstant array, AnalysisType arrayType, JavaConstant rawElementValue, int elementIndex, ScanReason reason) {
+        AnalysisFuture<ImageHeapObject> objectFuture = markConstantReachable(rawElementValue, reason);
+        if (scanningObserver != null && arrayType.getComponentType().getJavaKind() == JavaKind.Object) {
+            if (objectFuture == null) {
+                scanningObserver.forNullArrayElement(array, arrayType, elementIndex, reason);
+            } else {
+                ImageHeapObject element = objectFuture.ensureDone();
+                AnalysisType elementType = constantType(element.object);
+                markTypeInstantiated(elementType);
+                /* Process the array element. */
+                scanningObserver.forNonNullArrayElement(array, arrayType, element.object, elementType, elementIndex, reason);
+                return element.object;
+            }
+        }
+        return null;
+    }
+
+    void onObjectReachable(ImageHeapObject imageHeapObject) {
+        imageHeap.add(imageHeapObject.type, imageHeapObject);
+
+        markTypeInstantiated(imageHeapObject.type);
+
+        if (imageHeapObject instanceof ImageHeapInstance) {
+            ImageHeapInstance imageHeapInstance = (ImageHeapInstance) imageHeapObject;
+            for (AnalysisField field : imageHeapObject.type.getInstanceFields(true)) {
+                if (field.isReachable() && field.isRead() && isValueAvailable(field)) {
+                    execute(imageHeapInstance.getFieldTask(field));
+                }
+            }
+        }
+    }
+
+    public boolean isValueAvailable(@SuppressWarnings("unused") AnalysisField field) {
+        return true;
+    }
+
+    protected String formatReason(String message, ScanReason reason) {
+        return message + ' ' + reason;
+    }
+
+    protected ValueSupplier<JavaConstant> readHostedFieldValue(AnalysisField field, JavaConstant object) {
+        assert !field.isStatic() || !initializeAtRunTime(field.getDeclaringClass());
+        // Wrap the hosted constant into a substrate constant
+        JavaConstant value = universe.lookup(hostedConstantReflection.readFieldValue(field.wrapped, object));
+        return ValueSupplier.eagerValue(value);
+    }
+
+    protected boolean skipScanning() {
+        return false;
+    }
+
+    public void rescanRoot(Field reflectionField) {
+        if (!enableManualRescan) {
+            return;
+        }
+        if (skipScanning()) {
+            return;
+        }
+        AnalysisType type = metaAccess.lookupJavaType(reflectionField.getDeclaringClass());
+        if (type.isReachable()) {
+            AnalysisField field = metaAccess.lookupJavaField(reflectionField);
+            JavaConstant fieldValue = readHostedFieldValue(field, null).get();
+            TypeData typeData = field.getDeclaringClass().getOrComputeData();
+            AnalysisFuture<JavaConstant> fieldTask = patchStaticField(typeData, field, fieldValue, OtherReason.RESCAN);
+            if (field.isRead()) {
+                rescanCollectionElements(asObject(fieldTask.ensureDone()));
+            }
+        }
+    }
+
+    public void rescanField(Object receiver, Class<?> declaringClass, String fieldName) {
+        rescanField(receiver, ReflectionUtil.lookupField(declaringClass, fieldName));
+    }
+
+    public void rescanField(Object receiver, Field reflectionField) {
+        if (!enableManualRescan) {
+            return;
+        }
+        if (skipScanning()) {
+            return;
+        }
+        AnalysisType type = metaAccess.lookupJavaType(reflectionField.getDeclaringClass());
+        if (type.isReachable()) {
+            AnalysisField field = metaAccess.lookupJavaField(reflectionField);
+            assert !field.isStatic();
+            JavaConstant receiverConstant = asConstant(receiver);
+            Optional<JavaConstant> replaced = maybeReplace(receiverConstant, OtherReason.RESCAN);
+            if (replaced.isPresent()) {
+                receiverConstant = replaced.get();
+            }
+            JavaConstant fieldValue = readHostedFieldValue(field, universe.toHosted(receiverConstant)).get();
+            if (fieldValue != null) {
+                ImageHeapInstance receiverObject = (ImageHeapInstance) getImageHeapObject(receiverConstant);
+                AnalysisFuture<JavaConstant> fieldTask = patchInstanceField(receiverObject, field, fieldValue, OtherReason.RESCAN);
+                if (field.isRead()) {
+                    rescanCollectionElements(asObject(fieldTask.ensureDone()));
+                }
+            }
+        }
+    }
+
+    protected AnalysisFuture<JavaConstant> patchStaticField(TypeData typeData, AnalysisField field, JavaConstant fieldValue, ScanReason reason) {
+        AnalysisFuture<JavaConstant> task = new AnalysisFuture<>(() -> onFieldValueReachable(field, null, fieldValue, reason));
+        typeData.setStaticFieldValueTask(field, task);
+        return task;
+    }
+
+    protected AnalysisFuture<JavaConstant> patchInstanceField(ImageHeapInstance receiverObject, AnalysisField field, JavaConstant fieldValue, ScanReason reason) {
+        AnalysisFuture<JavaConstant> task = new AnalysisFuture<>(() -> onFieldValueReachable(field, receiverObject.object, fieldValue, reason));
+        receiverObject.setFieldTask(field, task);
+        return task;
+    }
+
+    /** Trigger rescanning of constants. */
+    public void rescanObject(Object object) {
+        if (!enableManualRescan) {
+            return;
+        }
+        if (skipScanning()) {
+            return;
+        }
+        if (object == null) {
+            return;
+        }
+        doScan(asConstant(object));
+        rescanCollectionElements(object);
+    }
+
+    private void rescanCollectionElements(Object object) {
+        if (object instanceof Object[]) {
+            Object[] array = (Object[]) object;
+            for (Object element : array) {
+                doScan(asConstant(element));
+            }
+        } else if (object instanceof Collection) {
+            Collection<?> collection = (Collection<?>) object;
+            collection.forEach(e -> doScan(asConstant(e)));
+        } else if (object instanceof Map) {
+            Map<?, ?> map = (Map<?, ?>) object;
+            map.forEach((k, v) -> {
+                doScan(asConstant(k));
+                doScan(asConstant(v));
+            });
+        } else if (object instanceof EconomicMap) {
+            rescanEconomicMap((EconomicMap<?, ?>) object);
+        }
+    }
+
+    protected void rescanEconomicMap(EconomicMap<?, ?> object) {
+        MapCursor<?, ?> cursor = object.getEntries();
+        while (cursor.advance()) {
+            doScan(asConstant(cursor.getKey()));
+            doScan(asConstant(cursor.getValue()));
+        }
+    }
+
+    void doScan(JavaConstant constant) {
+        if (constant.getJavaKind() == JavaKind.Object && constant.isNonNull()) {
+            toImageHeapObject(constant, OtherReason.SCAN);
+        }
+    }
+
+    public void scanHub(AnalysisType type) {
+        /* Initialize dynamic hub metadata before scanning it. */
+        bb.onTypeScanned(type);
+        metaAccess.lookupJavaType(java.lang.Class.class).registerAsReachable();
+        /* We scan the original class here, the scanner does the replacement to DynamicHub. */
+        createImageHeapObject(asConstant(type.getJavaClass()), OtherReason.HUB);
+    }
+
+    protected AnalysisType analysisType(Object constant) {
+        return metaAccess.lookupJavaType(constant.getClass());
+    }
+
+    protected AnalysisType constantType(JavaConstant constant) {
+        return metaAccess.lookupJavaType(constant);
+    }
+
+    protected Object asObject(JavaConstant constant) {
+        return snippetReflection.asObject(Object.class, constant);
+    }
+
+    public JavaConstant asConstant(Object object) {
+        return snippetReflection.forObject(object);
+    }
+
+    public void cleanupAfterAnalysis() {
+        scanningObserver = null;
+        imageHeap.heapObjects = null;
+        imageHeap.typesToObjects = null;
+    }
+
+    public ObjectScanningObserver getScanningObserver() {
+        return scanningObserver;
+    }
+
+    public void execute(AnalysisFuture<?> future) {
+        if (future.isDone()) {
+            return;
+        }
+        ((PointsToAnalysis) universe.getBigbang()).postTask(debug -> future.run());
+    }
+
+    public void execute(Runnable task) {
+        ((PointsToAnalysis) universe.getBigbang()).postTask(debug -> task.run());
+    }
+}

--- a/substratevm/src/com.oracle.graal.pointsto/src/com/oracle/graal/pointsto/heap/TypeData.java
+++ b/substratevm/src/com.oracle.graal.pointsto/src/com/oracle/graal/pointsto/heap/TypeData.java
@@ -27,6 +27,7 @@ package com.oracle.graal.pointsto.heap;
 import java.util.Map;
 
 import com.oracle.graal.pointsto.ObjectScanner;
+import com.oracle.graal.pointsto.heap.value.ValueSupplier;
 import com.oracle.graal.pointsto.meta.AnalysisField;
 import com.oracle.graal.pointsto.meta.AnalysisType;
 import com.oracle.graal.pointsto.util.AnalysisFuture;
@@ -46,7 +47,7 @@ public final class TypeData {
     /**
      * The raw values of all static fields, regardless of field reachability status. Evaluating the
      * {@link AnalysisFuture} runs
-     * {@link ImageHeapScanner#onFieldValueReachable(AnalysisField, JavaConstant, JavaConstant, ObjectScanner.ScanReason)}
+     * {@link ImageHeapScanner#onFieldValueReachable(AnalysisField, JavaConstant, ValueSupplier, ObjectScanner.ScanReason)}
      * adds the result to the image heap}.
      */
     final Map<ResolvedJavaField, AnalysisFuture<JavaConstant>> staticFieldValues;
@@ -62,7 +63,7 @@ public final class TypeData {
 
     /**
      * Return a task for transforming and snapshotting the field value, effectively a future for
-     * {@link ImageHeapScanner#onFieldValueReachable(AnalysisField, JavaConstant, JavaConstant, ObjectScanner.ScanReason)}.
+     * {@link ImageHeapScanner#onFieldValueReachable(AnalysisField, JavaConstant, ValueSupplier, ObjectScanner.ScanReason)}.
      */
     public AnalysisFuture<JavaConstant> getFieldTask(AnalysisField field) {
         return staticFieldValues.get(field);

--- a/substratevm/src/com.oracle.graal.pointsto/src/com/oracle/graal/pointsto/heap/value/EagerValueSupplier.java
+++ b/substratevm/src/com.oracle.graal.pointsto/src/com/oracle/graal/pointsto/heap/value/EagerValueSupplier.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2021, 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package com.oracle.graal.pointsto.heap.value;
+
+public final class EagerValueSupplier<V> implements ValueSupplier<V> {
+
+    private final V value;
+
+    EagerValueSupplier(V value) {
+        this.value = value;
+    }
+
+    @Override
+    public boolean isAvailable() {
+        return true;
+    }
+
+    @Override
+    public V get() {
+        return value;
+    }
+}

--- a/substratevm/src/com.oracle.graal.pointsto/src/com/oracle/graal/pointsto/heap/value/LazyValueSupplier.java
+++ b/substratevm/src/com.oracle.graal.pointsto/src/com/oracle/graal/pointsto/heap/value/LazyValueSupplier.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2021, 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package com.oracle.graal.pointsto.heap.value;
+
+import java.util.function.Supplier;
+
+import com.oracle.graal.pointsto.util.AnalysisError;
+
+public final class LazyValueSupplier<V> implements ValueSupplier<V> {
+
+    private final Supplier<V> valueSupplier;
+    private final Supplier<Boolean> isAvailable;
+
+    LazyValueSupplier(Supplier<V> valueSupplier, Supplier<Boolean> isAvailable) {
+        this.valueSupplier = valueSupplier;
+        this.isAvailable = isAvailable;
+    }
+
+    @Override
+    public boolean isAvailable() {
+        return isAvailable.get();
+    }
+
+    @Override
+    public V get() {
+        AnalysisError.guarantee(isAvailable(), "Value is not yet available.");
+        return valueSupplier.get();
+    }
+}

--- a/substratevm/src/com.oracle.graal.pointsto/src/com/oracle/graal/pointsto/heap/value/ValueSupplier.java
+++ b/substratevm/src/com.oracle.graal.pointsto/src/com/oracle/graal/pointsto/heap/value/ValueSupplier.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2021, 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package com.oracle.graal.pointsto.heap.value;
+
+import java.util.function.Supplier;
+
+/**
+ * Interface for accessing hosted heap values. It provides mechanisms for accessing hosted heap
+ * values either eagerly or lazily.
+ * <p/>
+ * Eager heap values are objects whose state doesn't change during heap snapshotting. Their value is
+ * immediately available.
+ * <p/>
+ * Lazy heap values are objects whose state can change during heap snapshotting, therefore reading
+ * the actual value is delayed. Instead, both a value supplier and an availability supplier are
+ * installed. The implementation guarantees that the value is indeed available, by checking the
+ * availability supplier, before it attempts to retrieve it.
+ */
+public interface ValueSupplier<V> {
+
+    static <V> ValueSupplier<V> eagerValue(V value) {
+        return new EagerValueSupplier<>(value);
+    }
+
+    static <V> ValueSupplier<V> lazyValue(Supplier<V> valueSupplier, Supplier<Boolean> isAvailable) {
+        return new LazyValueSupplier<>(valueSupplier, isAvailable);
+    }
+
+    /** Checks if the value is available. */
+    boolean isAvailable();
+
+    /**
+     * Retrieves the value, if available. Attempting to access a value before it is available
+     * results in error.
+     */
+    V get();
+}

--- a/substratevm/src/com.oracle.graal.pointsto/src/com/oracle/graal/pointsto/infrastructure/UniverseMetaAccess.java
+++ b/substratevm/src/com.oracle.graal.pointsto/src/com/oracle/graal/pointsto/infrastructure/UniverseMetaAccess.java
@@ -52,7 +52,7 @@ public class UniverseMetaAccess implements WrappedMetaAccess {
             return universe.lookup(wrapped.lookupJavaType(clazz));
         }
     };
-    private final Universe universe;
+    protected final Universe universe;
     private final MetaAccessProvider wrapped;
 
     public UniverseMetaAccess(Universe universe, MetaAccessProvider wrapped) {

--- a/substratevm/src/com.oracle.graal.pointsto/src/com/oracle/graal/pointsto/meta/AnalysisField.java
+++ b/substratevm/src/com.oracle.graal.pointsto/src/com/oracle/graal/pointsto/meta/AnalysisField.java
@@ -101,6 +101,7 @@ public class AnalysisField implements ResolvedJavaField, OriginalFieldProvider {
 
     private final AnalysisType declaringClass;
     private final AnalysisType fieldType;
+    private final boolean isStatic;
 
     public AnalysisField(AnalysisUniverse universe, ResolvedJavaField wrappedField) {
         assert !wrappedField.isInternal();
@@ -111,6 +112,7 @@ public class AnalysisField implements ResolvedJavaField, OriginalFieldProvider {
 
         this.wrapped = wrappedField;
         this.id = universe.nextFieldId.getAndIncrement();
+        this.isStatic = Modifier.isStatic(this.getModifiers());
 
         boolean trackAccessChain = PointstoOptions.TrackAccessChain.getValue(universe.hostVM().options());
         readBy = trackAccessChain ? new ConcurrentHashMap<>() : null;
@@ -476,7 +478,7 @@ public class AnalysisField implements ResolvedJavaField, OriginalFieldProvider {
 
     @Override
     public boolean isStatic() {
-        return Modifier.isStatic(this.getModifiers());
+        return isStatic;
     }
 
     @Override

--- a/substratevm/src/com.oracle.graal.pointsto/src/com/oracle/graal/pointsto/meta/AnalysisMetaAccess.java
+++ b/substratevm/src/com.oracle.graal.pointsto/src/com/oracle/graal/pointsto/meta/AnalysisMetaAccess.java
@@ -57,7 +57,7 @@ public class AnalysisMetaAccess extends UniverseMetaAccess {
         if (result != null) {
             return Optional.of(result);
         }
-        result = ((AnalysisUniverse) getUniverse()).optionalLookup(getWrapped().lookupJavaType(clazz));
+        result = getUniverse().optionalLookup(getWrapped().lookupJavaType(clazz));
         return Optional.ofNullable(result);
     }
 
@@ -85,4 +85,10 @@ public class AnalysisMetaAccess extends UniverseMetaAccess {
     public int getArrayBaseOffset(JavaKind elementKind) {
         throw shouldNotReachHere();
     }
+
+    @Override
+    public AnalysisUniverse getUniverse() {
+        return (AnalysisUniverse) universe;
+    }
+
 }

--- a/substratevm/src/com.oracle.graal.pointsto/src/com/oracle/graal/pointsto/meta/AnalysisType.java
+++ b/substratevm/src/com.oracle.graal.pointsto/src/com/oracle/graal/pointsto/meta/AnalysisType.java
@@ -52,6 +52,7 @@ import com.oracle.graal.pointsto.constraints.UnsupportedFeatureException;
 import com.oracle.graal.pointsto.flow.AllInstantiatedTypeFlow;
 import com.oracle.graal.pointsto.flow.context.object.AnalysisObject;
 import com.oracle.graal.pointsto.flow.context.object.ConstantContextSensitiveObject;
+import com.oracle.graal.pointsto.heap.TypeData;
 import com.oracle.graal.pointsto.infrastructure.OriginalClassProvider;
 import com.oracle.graal.pointsto.infrastructure.WrappedJavaType;
 import com.oracle.graal.pointsto.typestate.TypeState;

--- a/substratevm/src/com.oracle.graal.pointsto/src/com/oracle/graal/pointsto/meta/AnalysisType.java
+++ b/substratevm/src/com.oracle.graal.pointsto/src/com/oracle/graal/pointsto/meta/AnalysisType.java
@@ -1085,6 +1085,10 @@ public class AnalysisType implements WrappedJavaType, OriginalClassProvider, Com
         return universe.lookup(wrapped.getHostClass());
     }
 
+    AnalysisUniverse getUniverse() {
+        return universe;
+    }
+
     @Override
     public int compareTo(AnalysisType other) {
         return Integer.compare(this.id, other.id);

--- a/substratevm/src/com.oracle.graal.pointsto/src/com/oracle/graal/pointsto/meta/AnalysisType.java
+++ b/substratevm/src/com.oracle.graal.pointsto/src/com/oracle/graal/pointsto/meta/AnalysisType.java
@@ -25,7 +25,6 @@
 package com.oracle.graal.pointsto.meta;
 
 import java.lang.annotation.Annotation;
-import java.lang.reflect.Modifier;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -410,7 +409,7 @@ public class AnalysisType implements WrappedJavaType, OriginalClassProvider, Com
     public boolean registerAsInHeap() {
         registerAsReachable();
         if (AtomicUtils.atomicMark(isInHeap)) {
-            registerAsInstantiated(UsageKind.InHeap);
+            universe.onTypeInstantiated(this, UsageKind.InHeap);
             return true;
         }
         return false;
@@ -422,27 +421,10 @@ public class AnalysisType implements WrappedJavaType, OriginalClassProvider, Com
     public boolean registerAsAllocated(Node node) {
         registerAsReachable();
         if (AtomicUtils.atomicMark(isAllocated)) {
-            registerAsInstantiated(UsageKind.Allocated);
+            universe.onTypeInstantiated(this, UsageKind.Allocated);
             return true;
         }
         return false;
-    }
-
-    /** Register the type as instantiated with all its super types. */
-    private void registerAsInstantiated(UsageKind usageKind) {
-        assert isAllocated.get() || isInHeap.get();
-        assert isArray() || (isInstanceClass() && !Modifier.isAbstract(getModifiers())) : this;
-        universe.hostVM.checkForbidden(this, usageKind);
-
-        PointsToAnalysis bb = ((PointsToAnalysis) universe.getBigbang());
-        TypeState typeState = TypeState.forExactType(bb, this, true);
-        TypeState typeStateNonNull = TypeState.forExactType(bb, this, false);
-
-        /* Register the instantiated type with its super types. */
-        forAllSuperTypes(t -> {
-            t.instantiatedTypes.addState(bb, typeState);
-            t.instantiatedTypesNonNull.addState(bb, typeStateNonNull);
-        });
     }
 
     /**
@@ -504,7 +486,7 @@ public class AnalysisType implements WrappedJavaType, OriginalClassProvider, Com
      * reachable directly, but also through java.lang.GenericDeclaration, so it will be processed
      * twice.
      */
-    private void forAllSuperTypes(Consumer<AnalysisType> superTypeConsumer) {
+    public void forAllSuperTypes(Consumer<AnalysisType> superTypeConsumer) {
         forAllSuperTypes(superTypeConsumer, true);
     }
 
@@ -1057,6 +1039,14 @@ public class AnalysisType implements WrappedJavaType, OriginalClassProvider, Com
          * will not be linked.
          */
         return wrapped.isLinked();
+    }
+
+    public boolean isInHeap() {
+        return isInHeap.get();
+    }
+
+    public boolean isAllocated() {
+        return isAllocated.get();
     }
 
     @Override

--- a/substratevm/src/com.oracle.graal.pointsto/src/com/oracle/graal/pointsto/meta/AnalysisUniverse.java
+++ b/substratevm/src/com.oracle.graal.pointsto/src/com/oracle/graal/pointsto/meta/AnalysisUniverse.java
@@ -674,6 +674,10 @@ public class AnalysisUniverse implements Universe {
         return objectClass;
     }
 
+    public void onFieldAccessed(AnalysisField field) {
+        bb.onFieldAccessed(field);
+    }
+
     public SubstitutionProcessor getSubstitutions() {
         return substitutions;
     }

--- a/substratevm/src/com.oracle.graal.pointsto/src/com/oracle/graal/pointsto/meta/AnalysisUniverse.java
+++ b/substratevm/src/com.oracle.graal.pointsto/src/com/oracle/graal/pointsto/meta/AnalysisUniverse.java
@@ -46,6 +46,8 @@ import com.oracle.graal.pointsto.AnalysisPolicy;
 import com.oracle.graal.pointsto.BigBang;
 import com.oracle.graal.pointsto.api.HostVM;
 import com.oracle.graal.pointsto.constraints.UnsupportedFeatureException;
+import com.oracle.graal.pointsto.heap.HeapSnapshotVerifier;
+import com.oracle.graal.pointsto.heap.ImageHeapScanner;
 import com.oracle.graal.pointsto.infrastructure.AnalysisConstantPool;
 import com.oracle.graal.pointsto.infrastructure.SubstitutionProcessor;
 import com.oracle.graal.pointsto.infrastructure.Universe;
@@ -116,6 +118,8 @@ public class AnalysisUniverse implements Universe {
     private AnalysisType cloneableClass;
     private final JavaKind wordKind;
     private AnalysisPolicy analysisPolicy;
+    private ImageHeapScanner heapScanner;
+    private HeapSnapshotVerifier heapVerifier;
     private BigBang bb;
 
     public JavaKind getWordKind() {
@@ -521,6 +525,7 @@ public class AnalysisUniverse implements Universe {
      * Register an embedded root, i.e., a JavaConstant embedded in a Graal graph via a ConstantNode.
      */
     public void registerEmbeddedRoot(JavaConstant root, BytecodePosition position) {
+        this.heapScanner.scanEmbeddedRoot(root, position);
         this.embeddedRoots.put(root, position);
     }
 
@@ -699,4 +704,23 @@ public class AnalysisUniverse implements Universe {
         this.bb = bb;
     }
 
+    public BigBang getBigbang() {
+        return bb;
+    }
+
+    public void setHeapScanner(ImageHeapScanner heapScanner) {
+        this.heapScanner = heapScanner;
+    }
+
+    public ImageHeapScanner getHeapScanner() {
+        return heapScanner;
+    }
+
+    public void setHeapVerifier(HeapSnapshotVerifier heapVerifier) {
+        this.heapVerifier = heapVerifier;
+    }
+
+    public HeapSnapshotVerifier getHeapVerifier() {
+        return heapVerifier;
+    }
 }

--- a/substratevm/src/com.oracle.graal.pointsto/src/com/oracle/graal/pointsto/meta/AnalysisUniverse.java
+++ b/substratevm/src/com.oracle.graal.pointsto/src/com/oracle/graal/pointsto/meta/AnalysisUniverse.java
@@ -489,7 +489,7 @@ public class AnalysisUniverse implements Universe {
         if (constant == null) {
             return null;
         } else if (constant.getJavaKind().isObject() && !constant.isNull()) {
-            return originalSnippetReflection.forObject(getSnippetReflection().asObject(Object.class, constant));
+            return originalSnippetReflection.forObject(snippetReflection.asObject(Object.class, constant));
         } else {
             return constant;
         }

--- a/substratevm/src/com.oracle.graal.pointsto/src/com/oracle/graal/pointsto/meta/AnalysisUniverse.java
+++ b/substratevm/src/com.oracle.graal.pointsto/src/com/oracle/graal/pointsto/meta/AnalysisUniverse.java
@@ -52,6 +52,7 @@ import com.oracle.graal.pointsto.infrastructure.Universe;
 import com.oracle.graal.pointsto.infrastructure.WrappedConstantPool;
 import com.oracle.graal.pointsto.infrastructure.WrappedJavaType;
 import com.oracle.graal.pointsto.infrastructure.WrappedSignature;
+import com.oracle.graal.pointsto.meta.AnalysisType.UsageKind;
 import com.oracle.graal.pointsto.util.AnalysisError;
 
 import jdk.vm.ci.code.BytecodePosition;
@@ -678,6 +679,10 @@ public class AnalysisUniverse implements Universe {
         bb.onFieldAccessed(field);
     }
 
+    public void onTypeInstantiated(AnalysisType type, UsageKind usage) {
+        bb.onTypeInstantiated(type, usage);
+    }
+
     public SubstitutionProcessor getSubstitutions() {
         return substitutions;
     }
@@ -694,7 +699,4 @@ public class AnalysisUniverse implements Universe {
         this.bb = bb;
     }
 
-    public BigBang getBigbang() {
-        return bb;
-    }
 }

--- a/substratevm/src/com.oracle.graal.pointsto/src/com/oracle/graal/pointsto/meta/AnalysisUniverse.java
+++ b/substratevm/src/com.oracle.graal.pointsto/src/com/oracle/graal/pointsto/meta/AnalysisUniverse.java
@@ -688,6 +688,10 @@ public class AnalysisUniverse implements Universe {
         bb.onTypeInstantiated(type, usage);
     }
 
+    public void onTypeScanned(AnalysisType type) {
+        bb.onTypeScanned(type);
+    }
+
     public SubstitutionProcessor getSubstitutions() {
         return substitutions;
     }

--- a/substratevm/src/com.oracle.graal.pointsto/src/com/oracle/graal/pointsto/meta/AnalysisUniverse.java
+++ b/substratevm/src/com.oracle.graal.pointsto/src/com/oracle/graal/pointsto/meta/AnalysisUniverse.java
@@ -210,7 +210,7 @@ public class AnalysisUniverse implements Universe {
 
     @SuppressFBWarnings(value = {"ES_COMPARING_STRINGS_WITH_EQ"}, justification = "Bug in findbugs")
     private AnalysisType createType(ResolvedJavaType type) {
-        if (!hostVM.platformSupported(this, type)) {
+        if (!hostVM.platformSupported(type)) {
             throw new UnsupportedFeatureException("type is not available in this platform: " + type.toJavaName(true));
         }
         if (sealed && !type.isArray()) {
@@ -382,7 +382,7 @@ public class AnalysisUniverse implements Universe {
     }
 
     private AnalysisField createField(ResolvedJavaField field) {
-        if (!hostVM.platformSupported(this, field)) {
+        if (!hostVM.platformSupported(field)) {
             throw new UnsupportedFeatureException("field is not available in this platform: " + field.format("%H.%n"));
         }
         if (sealed) {
@@ -425,7 +425,7 @@ public class AnalysisUniverse implements Universe {
     }
 
     private AnalysisMethod createMethod(ResolvedJavaMethod method) {
-        if (!hostVM.platformSupported(this, method)) {
+        if (!hostVM.platformSupported(method)) {
             throw new UnsupportedFeatureException("Method " + method.format("%H.%n(%p)" + " is not available in this platform."));
         }
         if (sealed) {
@@ -439,7 +439,7 @@ public class AnalysisUniverse implements Universe {
     public AnalysisMethod[] lookup(JavaMethod[] inputs) {
         List<AnalysisMethod> result = new ArrayList<>(inputs.length);
         for (JavaMethod method : inputs) {
-            if (hostVM.platformSupported(this, (ResolvedJavaMethod) method)) {
+            if (hostVM.platformSupported((ResolvedJavaMethod) method)) {
                 AnalysisMethod aMethod = lookup(method);
                 if (aMethod != null) {
                     result.add(aMethod);

--- a/substratevm/src/com.oracle.graal.pointsto/src/com/oracle/graal/pointsto/meta/HostedProviders.java
+++ b/substratevm/src/com.oracle.graal.pointsto/src/com/oracle/graal/pointsto/meta/HostedProviders.java
@@ -37,12 +37,15 @@ import org.graalvm.compiler.nodes.spi.StampProvider;
 import org.graalvm.compiler.phases.util.Providers;
 import org.graalvm.compiler.word.WordTypes;
 
+import com.oracle.graal.pointsto.PointsToAnalysis;
+
 import jdk.vm.ci.code.CodeCacheProvider;
 import jdk.vm.ci.meta.ConstantReflectionProvider;
 import jdk.vm.ci.meta.MetaAccessProvider;
 
 public class HostedProviders extends Providers {
 
+    private PointsToAnalysis bigBang;
     private GraphBuilderConfiguration.Plugins graphBuilderPlugins;
 
     public HostedProviders(MetaAccessProvider metaAccess, CodeCacheProvider codeCache, ConstantReflectionProvider constantReflection, ConstantFieldProvider constantFieldProvider,
@@ -58,6 +61,14 @@ public class HostedProviders extends Providers {
 
     public void setGraphBuilderPlugins(GraphBuilderConfiguration.Plugins graphBuilderPlugins) {
         this.graphBuilderPlugins = graphBuilderPlugins;
+    }
+
+    public void setBigBang(PointsToAnalysis bigBang) {
+        this.bigBang = bigBang;
+    }
+
+    public PointsToAnalysis getBigBang() {
+        return bigBang;
     }
 
     @Override

--- a/substratevm/src/com.oracle.graal.pointsto/src/com/oracle/graal/pointsto/meta/TypeData.java
+++ b/substratevm/src/com.oracle.graal.pointsto/src/com/oracle/graal/pointsto/meta/TypeData.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2021, 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package com.oracle.graal.pointsto.meta;
+
+import java.util.Map;
+
+import com.oracle.graal.pointsto.util.AnalysisFuture;
+
+import jdk.vm.ci.meta.JavaConstant;
+import jdk.vm.ci.meta.ResolvedJavaField;
+
+/**
+ * Additional data for a {@link AnalysisType type} that is only available for types that are marked
+ * as reachable. Computed lazily once the type is seen as reachable.
+ */
+public final class TypeData {
+    /** The class initialization state: initialize the class at build time or at run time. */
+    final boolean initializeAtRunTime;
+    /**
+     * The raw values of all static fields, regardless of field reachability status. Evaluating the
+     * {@link AnalysisFuture} runs
+     * com.oracle.graal.pointsto.heap.ImageHeapScanner#onFieldValueReachable adds the result to the
+     * image heap}.
+     */
+    final Map<ResolvedJavaField, AnalysisFuture<JavaConstant>> staticFieldValues;
+
+    public TypeData(boolean initializeAtRunTime, Map<ResolvedJavaField, AnalysisFuture<JavaConstant>> staticFieldValues) {
+        this.initializeAtRunTime = initializeAtRunTime;
+        this.staticFieldValues = staticFieldValues;
+    }
+
+    public boolean initializeAtRunTime() {
+        return initializeAtRunTime;
+    }
+
+    public AnalysisFuture<JavaConstant> getStaticFieldValueTask(AnalysisField field) {
+        return staticFieldValues.get(field);
+    }
+
+    public JavaConstant readStaticFieldValue(AnalysisField field) {
+        return staticFieldValues.get(field).ensureDone();
+    }
+
+    public void setStaticFieldValueTask(AnalysisField field, AnalysisFuture<JavaConstant> task) {
+        staticFieldValues.put(field, task);
+    }
+
+}

--- a/substratevm/src/com.oracle.graal.pointsto/src/com/oracle/graal/pointsto/reports/AnalysisHeapHistogramPrinter.java
+++ b/substratevm/src/com.oracle.graal.pointsto/src/com/oracle/graal/pointsto/reports/AnalysisHeapHistogramPrinter.java
@@ -91,23 +91,26 @@ public final class AnalysisHeapHistogramPrinter extends ObjectScanner {
         }
 
         @Override
-        public void forRelocatedPointerFieldValue(JavaConstant receiver, AnalysisField field, JavaConstant fieldValue) {
+        public boolean forRelocatedPointerFieldValue(JavaConstant receiver, AnalysisField field, JavaConstant fieldValue, ScanReason reason) {
+            return false;
         }
 
         @Override
-        public void forNullFieldValue(JavaConstant receiver, AnalysisField field) {
+        public boolean forNullFieldValue(JavaConstant receiver, AnalysisField field, ScanReason reason) {
+            return false;
         }
 
         @Override
-        public void forNonNullFieldValue(JavaConstant receiver, AnalysisField field, JavaConstant fieldValue) {
+        public void forNonNullFieldValue(JavaConstant receiver, AnalysisField field, JavaConstant fieldValue, ScanReason reason) {
         }
 
         @Override
-        public void forNullArrayElement(JavaConstant array, AnalysisType arrayType, int index) {
+        public boolean forNullArrayElement(JavaConstant array, AnalysisType arrayType, int index, ScanReason reason) {
+            return false;
         }
 
         @Override
-        public void forNonNullArrayElement(JavaConstant array, AnalysisType arrayType, JavaConstant elementConstant, AnalysisType elementType, int index) {
+        public void forNonNullArrayElement(JavaConstant array, AnalysisType arrayType, JavaConstant elementConstant, AnalysisType elementType, int index, ScanReason reason) {
         }
     }
 }

--- a/substratevm/src/com.oracle.graal.pointsto/src/com/oracle/graal/pointsto/reports/AnalysisHeapHistogramPrinter.java
+++ b/substratevm/src/com.oracle.graal.pointsto/src/com/oracle/graal/pointsto/reports/AnalysisHeapHistogramPrinter.java
@@ -101,7 +101,8 @@ public final class AnalysisHeapHistogramPrinter extends ObjectScanner {
         }
 
         @Override
-        public void forNonNullFieldValue(JavaConstant receiver, AnalysisField field, JavaConstant fieldValue, ScanReason reason) {
+        public boolean forNonNullFieldValue(JavaConstant receiver, AnalysisField field, JavaConstant fieldValue, ScanReason reason) {
+            return false;
         }
 
         @Override
@@ -110,7 +111,8 @@ public final class AnalysisHeapHistogramPrinter extends ObjectScanner {
         }
 
         @Override
-        public void forNonNullArrayElement(JavaConstant array, AnalysisType arrayType, JavaConstant elementConstant, AnalysisType elementType, int index, ScanReason reason) {
+        public boolean forNonNullArrayElement(JavaConstant array, AnalysisType arrayType, JavaConstant elementConstant, AnalysisType elementType, int index, ScanReason reason) {
+            return false;
         }
     }
 }

--- a/substratevm/src/com.oracle.graal.pointsto/src/com/oracle/graal/pointsto/reports/ObjectTreePrinter.java
+++ b/substratevm/src/com.oracle.graal.pointsto/src/com/oracle/graal/pointsto/reports/ObjectTreePrinter.java
@@ -339,11 +339,11 @@ public final class ObjectTreePrinter extends ObjectScanner {
         }
 
         @Override
-        public void forNonNullFieldValue(JavaConstant receiver, AnalysisField field, JavaConstant fieldValue, ScanReason reason) {
+        public boolean forNonNullFieldValue(JavaConstant receiver, AnalysisField field, JavaConstant fieldValue, ScanReason reason) {
 
             if (receiver == null) {
                 // static field
-                return;
+                return false;
             }
 
             if (constantToNode.containsKey(receiver) && constantToNode.containsKey(fieldValue)) {
@@ -351,6 +351,7 @@ public final class ObjectTreePrinter extends ObjectScanner {
                 ObjectNodeBase valueNode = constantToNode.get(fieldValue);
                 receiverNode.addField(field, valueNode);
             }
+            return true;
         }
 
         @Override
@@ -363,12 +364,14 @@ public final class ObjectTreePrinter extends ObjectScanner {
         }
 
         @Override
-        public void forNonNullArrayElement(JavaConstant array, AnalysisType arrayType, JavaConstant elementConstant, AnalysisType elementType, int index, ScanReason reason) {
+        public boolean forNonNullArrayElement(JavaConstant array, AnalysisType arrayType, JavaConstant elementConstant, AnalysisType elementType, int index, ScanReason reason) {
             if (constantToNode.containsKey(array) && constantToNode.containsKey(elementConstant)) {
                 ArrayObjectNode arrayNode = (ArrayObjectNode) constantToNode.get(array);
                 ObjectNodeBase valueNode = constantToNode.get(elementConstant);
                 arrayNode.addElement(index, valueNode);
+                return true;
             }
+            return false;
         }
 
         @Override

--- a/substratevm/src/com.oracle.graal.pointsto/src/com/oracle/graal/pointsto/reports/ObjectTreePrinter.java
+++ b/substratevm/src/com.oracle.graal.pointsto/src/com/oracle/graal/pointsto/reports/ObjectTreePrinter.java
@@ -320,24 +320,26 @@ public final class ObjectTreePrinter extends ObjectScanner {
         }
 
         @Override
-        public void forRelocatedPointerFieldValue(JavaConstant receiver, AnalysisField field, JavaConstant fieldValue) {
+        public boolean forRelocatedPointerFieldValue(JavaConstant receiver, AnalysisField field, JavaConstant fieldValue, ScanReason reason) {
+            return false;
         }
 
         @Override
-        public void forNullFieldValue(JavaConstant receiver, AnalysisField field) {
+        public boolean forNullFieldValue(JavaConstant receiver, AnalysisField field, ScanReason reason) {
             if (receiver == null) {
                 // static field
-                return;
+                return false;
             }
 
             assert constantToNode.containsKey(receiver);
 
             ObjectNode receiverNode = (ObjectNode) constantToNode.get(receiver);
             receiverNode.addField(field, ObjectNodeBase.forNull());
+            return true;
         }
 
         @Override
-        public void forNonNullFieldValue(JavaConstant receiver, AnalysisField field, JavaConstant fieldValue) {
+        public void forNonNullFieldValue(JavaConstant receiver, AnalysisField field, JavaConstant fieldValue, ScanReason reason) {
 
             if (receiver == null) {
                 // static field
@@ -352,15 +354,16 @@ public final class ObjectTreePrinter extends ObjectScanner {
         }
 
         @Override
-        public void forNullArrayElement(JavaConstant array, AnalysisType arrayType, int index) {
+        public boolean forNullArrayElement(JavaConstant array, AnalysisType arrayType, int index, ScanReason reason) {
             assert constantToNode.containsKey(array);
 
             ArrayObjectNode arrayNode = (ArrayObjectNode) constantToNode.get(array);
             arrayNode.addElement(index, ObjectNodeBase.forNull());
+            return true;
         }
 
         @Override
-        public void forNonNullArrayElement(JavaConstant array, AnalysisType arrayType, JavaConstant elementConstant, AnalysisType elementType, int index) {
+        public void forNonNullArrayElement(JavaConstant array, AnalysisType arrayType, JavaConstant elementConstant, AnalysisType elementType, int index, ScanReason reason) {
             if (constantToNode.containsKey(array) && constantToNode.containsKey(elementConstant)) {
                 ArrayObjectNode arrayNode = (ArrayObjectNode) constantToNode.get(array);
                 ObjectNodeBase valueNode = constantToNode.get(elementConstant);
@@ -380,8 +383,8 @@ public final class ObjectTreePrinter extends ObjectScanner {
                     } else {
                         node = ObjectNodeBase.fromConstant(bb, scannedValue);
                     }
-                } else if (reason instanceof MethodScan) {
-                    ResolvedJavaMethod method = ((MethodScan) reason).getMethod();
+                } else if (reason instanceof EmbeddedRootScan) {
+                    ResolvedJavaMethod method = ((EmbeddedRootScan) reason).getMethod();
                     node = ObjectNodeBase.fromConstant(bb, scannedValue, new RootSource(method));
                 } else {
                     node = ObjectNodeBase.fromConstant(bb, scannedValue);

--- a/substratevm/src/com.oracle.graal.pointsto/src/com/oracle/graal/pointsto/reports/ReportUtils.java
+++ b/substratevm/src/com.oracle.graal.pointsto/src/com/oracle/graal/pointsto/reports/ReportUtils.java
@@ -62,7 +62,7 @@ public class ReportUtils {
     static final Comparator<AnalysisField> fieldComparator = Comparator.comparing(f -> f.format("%H.%n"));
     static final Comparator<InvokeInfo> invokeInfoComparator = Comparator.comparing(i -> i.getTargetMethod().format("%H.%n(%p)"));
     static final Comparator<BytecodePosition> positionMethodComparator = Comparator.comparing(pos -> pos.getMethod().format("%H.%n(%p)"));
-    static final Comparator<BytecodePosition> positionComparator = positionMethodComparator.thenComparing(pos -> pos.getBCI());
+    public static final Comparator<BytecodePosition> positionComparator = positionMethodComparator.thenComparing(pos -> pos.getBCI());
 
     public static Path report(String description, String path, String name, String extension, Consumer<PrintWriter> reporter) {
         return report(description, path, name, extension, reporter, true);

--- a/substratevm/src/com.oracle.graal.pointsto/src/com/oracle/graal/pointsto/util/AnalysisFuture.java
+++ b/substratevm/src/com.oracle.graal.pointsto/src/com/oracle/graal/pointsto/util/AnalysisFuture.java
@@ -67,4 +67,12 @@ public class AnalysisFuture<V> extends FutureTask<V> {
         }
     }
 
+    public V guardedGet() {
+        try {
+            return get();
+        } catch (InterruptedException | ExecutionException e) {
+            throw AnalysisError.shouldNotReachHere(e);
+        }
+    }
+
 }

--- a/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/PosixSunSecuritySubstitutions.java
+++ b/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/PosixSunSecuritySubstitutions.java
@@ -58,7 +58,11 @@ class NativeSecureRandomFilesCloser implements Feature {
     }
 
     private static void registerShutdownHook(@SuppressWarnings("unused") DuringAnalysisAccess access) {
-        RuntimeSupport.getRuntimeSupport().addTearDownHook(new NativeSecureRandomFilesCloserShutdownHook());
+        NativeSecureRandomFilesCloserShutdownHook hook = new NativeSecureRandomFilesCloserShutdownHook();
+        RuntimeSupport.getRuntimeSupport().addTearDownHook(hook);
+        // TODO just rescanning the tearDownHooks should be enough
+        access.rescanObject(RuntimeSupport.getRuntimeSupport());
+        access.rescanObject(hook);
     }
 }
 

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/annotate/RecomputeFieldValue.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/annotate/RecomputeFieldValue.java
@@ -110,11 +110,49 @@ public @interface RecomputeFieldValue {
         Custom,
     }
 
+    enum ValueAvailability {
+        DuringAnalysis,
+        AfterAnalysis,
+        AfterCompilation
+    }
+
+    interface CustomFieldValueProvider {
+
+        /**
+         * When is the value for this custom computation available? By default, it is assumed that
+         * the value is available {@link ValueAvailability#DuringAnalysis during analysis}.
+         */
+        default ValueAvailability valueAvailability() {
+            return ValueAvailability.DuringAnalysis;
+        }
+
+        /** Return true if value is available during analysis, false otherwise. */
+        default boolean isAvailableDuringAnalysis() {
+            return valueAvailability() == ValueAvailability.DuringAnalysis;
+        }
+
+        /**
+         * Return true if value is available only after analysis, i.e., it depends on data computed
+         * by the analysis (such as field offsets), false otherwise.
+         */
+        default boolean isAvailableAfterAnalysis() {
+            return valueAvailability() == ValueAvailability.AfterAnalysis;
+        }
+
+        /**
+         * Return true if value is available only after compilation, i.e., it depends on data
+         * computed during compilation, false otherwise.
+         */
+        default boolean isAvailableAfterCompilation() {
+            return valueAvailability() == ValueAvailability.AfterCompilation;
+        }
+    }
+
     /**
      * Custom recomputation of field values. A class implementing this interface must have a
      * no-argument constructor, which is used to instantiate it before invoking {@link #compute}.
      */
-    interface CustomFieldValueComputer {
+    interface CustomFieldValueComputer extends CustomFieldValueProvider {
         /**
          * Computes the new field value. This method can already be invoked during the analysis,
          * especially when it computes the value of an object field that needs to be visited.
@@ -140,7 +178,7 @@ public @interface RecomputeFieldValue {
      * original value, but also requires the original field to be present, e.g., it cannot be use
      * for {@link Inject injected fields}.
      */
-    interface CustomFieldValueTransformer {
+    interface CustomFieldValueTransformer extends CustomFieldValueProvider {
         /**
          * Computes the new field value. This method can already be invoked during the analysis,
          * especially when it computes the value of an object field that needs to be visited.

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/graal/snippets/SubstrateAllocationSnippets.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/graal/snippets/SubstrateAllocationSnippets.java
@@ -77,6 +77,7 @@ import org.graalvm.word.WordFactory;
 import com.oracle.svm.core.SubstrateOptions;
 import com.oracle.svm.core.allocationprofile.AllocationCounter;
 import com.oracle.svm.core.allocationprofile.AllocationSite;
+import com.oracle.svm.core.annotate.UnknownObjectField;
 import com.oracle.svm.core.config.ConfigurationValues;
 import com.oracle.svm.core.graal.meta.SubstrateForeignCallsProvider;
 import com.oracle.svm.core.graal.nodes.NewStoredContinuationNode;
@@ -384,7 +385,7 @@ public abstract class SubstrateAllocationSnippets extends AllocationSnippets {
 
     public abstract static class Templates extends SubstrateTemplates {
         protected final AllocationSnippetCounters snippetCounters;
-        private final AllocationProfilingData profilingData;
+        @UnknownObjectField(types = {AllocationProfilingData.class}) private AllocationProfilingData profilingData;
 
         private final SnippetInfo allocateInstance;
         private final SnippetInfo allocateArray;

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/hub/AnnotationTypeSupport.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/hub/AnnotationTypeSupport.java
@@ -43,14 +43,17 @@ public class AnnotationTypeSupport {
     private Map<Class<? extends Annotation>, AnnotationType> annotationTypeMap = new HashMap<>();
 
     @Platforms(Platform.HOSTED_ONLY.class)
-    public void createInstance(Class<? extends Annotation> annotationClass) {
-        annotationTypeMap.putIfAbsent(annotationClass, AnnotationType.getInstance(annotationClass));
+    public boolean createInstance(Class<? extends Annotation> annotationClass) {
+        return annotationTypeMap.putIfAbsent(annotationClass, AnnotationType.getInstance(annotationClass)) == null;
     }
 
     public AnnotationType getInstance(Class<? extends Annotation> annotationClass) {
         return annotationTypeMap.get(annotationClass);
     }
 
+    public Map<Class<? extends Annotation>, AnnotationType> getAnnotationTypeMap() {
+        return annotationTypeMap;
+    }
 }
 
 @TargetClass(className = "sun.reflect.annotation.AnnotationType")

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/hub/DynamicHub.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/hub/DynamicHub.java
@@ -424,8 +424,10 @@ public final class DynamicHub implements JavaKind.FormatWithToString, AnnotatedE
     }
 
     @Platforms(Platform.HOSTED_ONLY.class)
-    public void setAnnotationsEncoding(Object annotationsEncoding) {
+    public boolean setAnnotationsEncoding(Object annotationsEncoding) {
+        boolean result = this.annotationsEncoding != annotationsEncoding;
         this.annotationsEncoding = annotationsEncoding;
+        return result;
     }
 
     @Platforms(Platform.HOSTED_ONLY.class)

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/SecuritySubstitutions.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/SecuritySubstitutions.java
@@ -658,6 +658,13 @@ final class Target_sun_security_ssl_SunJSSE {
 
 @TargetClass(className = "sun.security.jca.Providers")
 final class Target_sun_security_jca_Providers {
+    /*
+     * TODO The computation for providerList relies on repeated scans and assumes that eventually
+     * SecurityServicesFeature.usedProviders contains all used providers. That's why caching is also
+     * disabled. When the field is read too early is going to clean all providers, since none is yet
+     * found as used. With the new heap scanning there is no repeated scanning of the field.
+     */
+    // @UnknownObjectField isValidForAnalysis = false
     @Alias//
     @RecomputeFieldValue(kind = RecomputeFieldValue.Kind.Custom, declClass = ProviderListTransformer.class, disableCaching = true)//
     private static ProviderList providerList;

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/VarHandleFeature.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/VarHandleFeature.java
@@ -222,6 +222,11 @@ class VarHandleInfo {
 
 class VarHandleFieldOffsetComputer implements RecomputeFieldValue.CustomFieldValueComputer {
     @Override
+    public RecomputeFieldValue.ValueAvailability valueAvailability() {
+        return RecomputeFieldValue.ValueAvailability.AfterAnalysis;
+    }
+
+    @Override
     public Object compute(MetaAccessProvider metaAccess, ResolvedJavaField original, ResolvedJavaField annotated, Object varHandle) {
         Field field = ImageSingletons.lookup(VarHandleFeature.class).findVarHandleField(varHandle);
         SharedField sField = (SharedField) metaAccess.lookupJavaField(field);

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/meta/ReadableJavaField.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/meta/ReadableJavaField.java
@@ -33,13 +33,23 @@ public interface ReadableJavaField extends ResolvedJavaField {
 
     static JavaConstant readFieldValue(MetaAccessProvider metaAccess, ConstantReflectionProvider originalConstantReflection, ResolvedJavaField javaField, JavaConstant javaConstant) {
         if (javaField instanceof ReadableJavaField) {
-            return ((ReadableJavaField) javaField).readValue(metaAccess, javaConstant);
+            ReadableJavaField readableField = (ReadableJavaField) javaField;
+            assert readableField.isValueAvailable();
+            return readableField.readValue(metaAccess, javaConstant);
         } else {
             return originalConstantReflection.readFieldValue(javaField, javaConstant);
         }
     }
 
     JavaConstant readValue(MetaAccessProvider metaAccess, JavaConstant receiver);
+
+    default boolean isValueAvailableDuringAnalysis() {
+        return true;
+    }
+
+    default boolean isValueAvailable() {
+        return true;
+    }
 
     boolean allowConstantFolding();
 

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/meta/SharedField.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/meta/SharedField.java
@@ -52,6 +52,8 @@ public interface SharedField extends ResolvedJavaField {
 
     boolean isAccessed();
 
+    boolean isReachable();
+
     boolean isWritten();
 
     JavaKind getStorageKind();

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/util/ImageHeapMap.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/util/ImageHeapMap.java
@@ -112,6 +112,7 @@ final class ImageHeapMapFeature implements Feature {
         for (HostedImageHeapMap<?, ?> hostedImageHeapMap : allInstances) {
             if (needsUpdate(hostedImageHeapMap)) {
                 update(hostedImageHeapMap);
+                access.rescanObject(hostedImageHeapMap.runtimeMap);
                 access.requireAnalysisIteration();
             }
         }

--- a/substratevm/src/com.oracle.svm.graal/src/com/oracle/svm/graal/GraalSubstitutions.java
+++ b/substratevm/src/com.oracle.svm.graal/src/com/oracle/svm/graal/GraalSubstitutions.java
@@ -72,7 +72,6 @@ import com.oracle.svm.core.annotate.RecomputeFieldValue.Kind;
 import com.oracle.svm.core.annotate.Substitute;
 import com.oracle.svm.core.annotate.TargetClass;
 import com.oracle.svm.core.config.ConfigurationValues;
-import com.oracle.svm.core.hub.DynamicHub;
 import com.oracle.svm.core.log.Log;
 import com.oracle.svm.core.option.HostedOptionValues;
 import com.oracle.svm.core.util.VMError;
@@ -314,7 +313,7 @@ final class Target_org_graalvm_compiler_graph_NodeClass {
     @SuppressWarnings("unlikely-arg-type")
     @SuppressFBWarnings(value = {"GC_UNRELATED_TYPES"}, justification = "Class is DynamicHub")
     public static NodeClass<?> get(Class<?> clazz) {
-        NodeClass<?> nodeClass = GraalSupport.get().nodeClasses.get(DynamicHub.fromClass(clazz));
+        NodeClass<?> nodeClass = GraalSupport.get().nodeClasses.get(clazz);
         if (nodeClass == null) {
             throw VMError.shouldNotReachHere("Unknown node class: " + clazz.getName() + "\n");
         }
@@ -338,7 +337,7 @@ final class Target_org_graalvm_compiler_lir_LIRInstructionClass {
     @SuppressWarnings("unlikely-arg-type")
     @SuppressFBWarnings(value = {"GC_UNRELATED_TYPES"}, justification = "Class is DynamicHub")
     public static LIRInstructionClass<?> get(Class<? extends LIRInstruction> clazz) {
-        LIRInstructionClass<?> instructionClass = GraalSupport.get().instructionClasses.get(DynamicHub.fromClass(clazz));
+        LIRInstructionClass<?> instructionClass = GraalSupport.get().instructionClasses.get(clazz);
         if (instructionClass == null) {
             throw VMError.shouldNotReachHere("Unknown instruction class: " + clazz.getName() + "\n");
         }
@@ -353,7 +352,7 @@ final class Target_org_graalvm_compiler_lir_CompositeValueClass {
     @SuppressWarnings("unlikely-arg-type")
     @SuppressFBWarnings(value = {"GC_UNRELATED_TYPES"}, justification = "Class is DynamicHub")
     public static CompositeValueClass<?> get(Class<? extends CompositeValue> clazz) {
-        CompositeValueClass<?> compositeValueClass = GraalSupport.get().compositeValueClasses.get(DynamicHub.fromClass(clazz));
+        CompositeValueClass<?> compositeValueClass = GraalSupport.get().compositeValueClasses.get(clazz);
         if (compositeValueClass == null) {
             throw VMError.shouldNotReachHere("Unknown composite value class: " + clazz.getName() + "\n");
         }

--- a/substratevm/src/com.oracle.svm.graal/src/com/oracle/svm/graal/GraalSupport.java
+++ b/substratevm/src/com.oracle.svm.graal/src/com/oracle/svm/graal/GraalSupport.java
@@ -79,6 +79,7 @@ import com.oracle.svm.core.graal.code.SubstrateBackendFactory;
 import com.oracle.svm.core.graal.meta.RuntimeConfiguration;
 import com.oracle.svm.core.graal.meta.SharedRuntimeMethod;
 import com.oracle.svm.core.option.RuntimeOptionValues;
+import com.oracle.svm.core.util.ImageHeapMap;
 import com.oracle.svm.graal.meta.SubstrateMethod;
 import com.oracle.svm.hosted.FeatureImpl.DuringAnalysisAccessImpl;
 
@@ -100,13 +101,13 @@ public class GraalSupport {
     private Object[] graphObjects;
     private NodeClass<?>[] graphNodeTypes;
 
-    public final Map<Class<?>, NodeClass<?>> nodeClasses = new HashMap<>();
-    public final Map<Class<?>, LIRInstructionClass<?>> instructionClasses = new HashMap<>();
-    public final Map<Class<?>, CompositeValueClass<?>> compositeValueClasses = new HashMap<>();
+    public final EconomicMap<Class<?>, NodeClass<?>> nodeClasses = ImageHeapMap.create();
+    public final EconomicMap<Class<?>, LIRInstructionClass<?>> instructionClasses = ImageHeapMap.create();
+    public final EconomicMap<Class<?>, CompositeValueClass<?>> compositeValueClasses = ImageHeapMap.create();
     public HashMap<Class<? extends NodeMatchRules>, EconomicMap<Class<? extends Node>, List<MatchStatement>>> matchRuleRegistry;
 
-    protected Map<Class<?>, BasePhase.BasePhaseStatistics> basePhaseStatistics;
-    protected Map<Class<?>, LIRPhase.LIRPhaseStatistics> lirPhaseStatistics;
+    protected EconomicMap<Class<?>, BasePhase.BasePhaseStatistics> basePhaseStatistics;
+    protected EconomicMap<Class<?>, LIRPhase.LIRPhaseStatistics> lirPhaseStatistics;
     protected Function<Providers, SubstrateBackend> runtimeBackendProvider;
 
     protected final GlobalMetrics metricValues = new GlobalMetrics();
@@ -229,8 +230,8 @@ public class GraalSupport {
 
     @Platforms(Platform.HOSTED_ONLY.class)
     public static void allocatePhaseStatisticsCache() {
-        GraalSupport.get().basePhaseStatistics = new HashMap<>();
-        GraalSupport.get().lirPhaseStatistics = new HashMap<>();
+        GraalSupport.get().basePhaseStatistics = ImageHeapMap.create();
+        GraalSupport.get().lirPhaseStatistics = ImageHeapMap.create();
     }
 
     /* Invoked once for every class that is reachable in the native image. */
@@ -249,7 +250,7 @@ public class GraalSupport {
         }
     }
 
-    private static <S> void registerStatistics(Class<?> phaseSubClass, Map<Class<?>, S> cache, S newStatistics, DuringAnalysisAccessImpl access) {
+    private static <S> void registerStatistics(Class<?> phaseSubClass, EconomicMap<Class<?>, S> cache, S newStatistics, DuringAnalysisAccessImpl access) {
         assert !cache.containsKey(phaseSubClass);
 
         cache.put(phaseSubClass, newStatistics);

--- a/substratevm/src/com.oracle.svm.graal/src/com/oracle/svm/graal/GraalSupport.java
+++ b/substratevm/src/com.oracle.svm.graal/src/com/oracle/svm/graal/GraalSupport.java
@@ -27,6 +27,7 @@ package com.oracle.svm.graal;
 import static org.graalvm.word.LocationIdentity.ANY_LOCATION;
 
 import java.io.PrintStream;
+import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -68,6 +69,7 @@ import org.graalvm.nativeimage.Platform;
 import org.graalvm.nativeimage.Platforms;
 import org.graalvm.nativeimage.hosted.Feature.CompilationAccess;
 import org.graalvm.nativeimage.hosted.Feature.DuringAnalysisAccess;
+import org.graalvm.nativeimage.hosted.Feature.FeatureAccess;
 import org.graalvm.word.Pointer;
 import org.graalvm.word.WordFactory;
 
@@ -82,6 +84,7 @@ import com.oracle.svm.core.option.RuntimeOptionValues;
 import com.oracle.svm.core.util.ImageHeapMap;
 import com.oracle.svm.graal.meta.SubstrateMethod;
 import com.oracle.svm.hosted.FeatureImpl.DuringAnalysisAccessImpl;
+import com.oracle.svm.util.ReflectionUtil;
 
 /**
  * Holds data that is pre-computed during native image generation and accessed at run time during a
@@ -114,6 +117,11 @@ public class GraalSupport {
     protected final List<DebugHandlersFactory> debugHandlersFactories = new ArrayList<>();
     protected final DiagnosticsOutputDirectory outputDirectory = new DiagnosticsOutputDirectory(RuntimeOptionValues.singleton());
     protected final Map<ExceptionAction, Integer> compilationProblemsPerAction = new EnumMap<>(ExceptionAction.class);
+
+    private static final Field graphEncodingField = ReflectionUtil.lookupField(GraalSupport.class, "graphEncoding");
+    private static final Field graphObjectsField = ReflectionUtil.lookupField(GraalSupport.class, "graphObjects");
+    private static final Field graphNodeTypesField = ReflectionUtil.lookupField(GraalSupport.class, "graphNodeTypes");
+    private static final Field methodsToCompileField = ReflectionUtil.lookupField(GraalSupport.class, "methodsToCompile");
 
     private static final CGlobalData<Pointer> nextIsolateId = CGlobalDataFactory.createWord((Pointer) WordFactory.unsigned(1L));
 
@@ -189,36 +197,48 @@ public class GraalSupport {
     }
 
     @Platforms(Platform.HOSTED_ONLY.class)
-    public static boolean setMethodsToCompile(SubstrateMethod[] methodsToCompile) {
+    public static boolean setMethodsToCompile(DuringAnalysisAccessImpl config, SubstrateMethod[] methodsToCompile) {
         boolean result = false;
-        if (!Arrays.equals(get().methodsToCompile, methodsToCompile)) {
-            get().methodsToCompile = methodsToCompile;
+        GraalSupport support = get();
+        if (!Arrays.equals(support.methodsToCompile, methodsToCompile)) {
+            support.methodsToCompile = methodsToCompile;
+            GraalSupport.rescan(support, config, methodsToCompileField);
             result = true;
         }
         return result;
     }
 
     @Platforms(Platform.HOSTED_ONLY.class)
-    public static boolean setGraphEncoding(byte[] graphEncoding, Object[] graphObjects, NodeClass<?>[] graphNodeTypes) {
-        if (get().graphObjects == null && graphObjects.length == 0) {
+    public static boolean setGraphEncoding(FeatureAccess a, byte[] graphEncoding, Object[] graphObjects, NodeClass<?>[] graphNodeTypes) {
+        GraalSupport support = get();
+        if (support.graphObjects == null && graphObjects.length == 0) {
             assert graphEncoding.length == 0;
             assert graphNodeTypes.length == 0;
             return false;
         }
         boolean result = false;
-        if (!Arrays.equals(get().graphEncoding, graphEncoding)) {
-            get().graphEncoding = graphEncoding;
+        if (!Arrays.equals(support.graphEncoding, graphEncoding)) {
+            support.graphEncoding = graphEncoding;
+            GraalSupport.rescan(support, a, graphEncodingField);
             result = true;
         }
-        if (!Arrays.deepEquals(get().graphObjects, graphObjects)) {
-            get().graphObjects = graphObjects;
+        if (!Arrays.deepEquals(support.graphObjects, graphObjects)) {
+            support.graphObjects = graphObjects;
+            GraalSupport.rescan(support, a, graphObjectsField);
             result = true;
         }
-        if (!Arrays.equals(get().graphNodeTypes, graphNodeTypes)) {
-            get().graphNodeTypes = graphNodeTypes;
+        if (!Arrays.equals(support.graphNodeTypes, graphNodeTypes)) {
+            support.graphNodeTypes = graphNodeTypes;
+            GraalSupport.rescan(support, a, graphNodeTypesField);
             result = true;
         }
         return result;
+    }
+
+    private static void rescan(GraalSupport support, FeatureAccess a, Field field) {
+        if (a instanceof DuringAnalysisAccessImpl) {
+            ((DuringAnalysisAccessImpl) a).rescanField(support, field);
+        }
     }
 
     @Platforms(Platform.HOSTED_ONLY.class)
@@ -240,12 +260,11 @@ public class GraalSupport {
         DuringAnalysisAccessImpl access = (DuringAnalysisAccessImpl) a;
 
         if (!Modifier.isAbstract(newlyReachableClass.getModifiers())) {
+            GraalSupport support = GraalSupport.get();
             if (BasePhase.class.isAssignableFrom(newlyReachableClass)) {
-                registerStatistics(newlyReachableClass, GraalSupport.get().basePhaseStatistics, new BasePhase.BasePhaseStatistics(newlyReachableClass), access);
-
+                registerStatistics(newlyReachableClass, support.basePhaseStatistics, new BasePhase.BasePhaseStatistics(newlyReachableClass), access);
             } else if (LIRPhase.class.isAssignableFrom(newlyReachableClass)) {
-                registerStatistics(newlyReachableClass, GraalSupport.get().lirPhaseStatistics, new LIRPhase.LIRPhaseStatistics(newlyReachableClass), access);
-
+                registerStatistics(newlyReachableClass, support.lirPhaseStatistics, new LIRPhase.LIRPhaseStatistics(newlyReachableClass), access);
             }
         }
     }

--- a/substratevm/src/com.oracle.svm.graal/src/com/oracle/svm/graal/hosted/FieldsOffsetsFeature.java
+++ b/substratevm/src/com.oracle.svm.graal/src/com/oracle/svm/graal/hosted/FieldsOffsetsFeature.java
@@ -30,6 +30,7 @@ import java.util.IdentityHashMap;
 import java.util.Map;
 import java.util.function.Function;
 
+import org.graalvm.collections.EconomicMap;
 import org.graalvm.compiler.core.common.FieldIntrospection;
 import org.graalvm.compiler.core.common.Fields;
 import org.graalvm.compiler.graph.Edges;
@@ -168,8 +169,8 @@ public class FieldsOffsetsFeature implements Feature {
         }
     }
 
-    private static <R extends FieldIntrospection<?>> void registerClass(Class<?> clazz, Map<Class<?>, R> registry, Function<Class<?>, R> lookup, boolean excludeAbstract,
-                    DuringAnalysisAccessImpl access) {
+    private static <R extends FieldIntrospection<?>> void registerClass(Class<?> clazz, EconomicMap<Class<?>, R> registry,
+                    Function<Class<?>, R> lookup, boolean excludeAbstract, DuringAnalysisAccessImpl access) {
         assert !registry.containsKey(clazz);
 
         if (!excludeAbstract || !Modifier.isAbstract(clazz.getModifiers())) {
@@ -247,7 +248,7 @@ public class FieldsOffsetsFeature implements Feature {
 
     @Override
     public void afterCompilation(AfterCompilationAccess access) {
-        access.registerAsImmutable(GraalSupport.get().nodeClasses.values(), o -> true);
-        access.registerAsImmutable(GraalSupport.get().instructionClasses.values(), o -> true);
+        access.registerAsImmutable(GraalSupport.get().nodeClasses.getValues(), o -> true);
+        access.registerAsImmutable(GraalSupport.get().instructionClasses.getValues(), o -> true);
     }
 }

--- a/substratevm/src/com.oracle.svm.graal/src/com/oracle/svm/graal/hosted/FieldsOffsetsFeature.java
+++ b/substratevm/src/com.oracle.svm.graal/src/com/oracle/svm/graal/hosted/FieldsOffsetsFeature.java
@@ -73,6 +73,11 @@ public class FieldsOffsetsFeature implements Feature {
 
     abstract static class IterationMaskRecomputation implements RecomputeFieldValue.CustomFieldValueComputer {
         @Override
+        public RecomputeFieldValue.ValueAvailability valueAvailability() {
+            return RecomputeFieldValue.ValueAvailability.AfterAnalysis;
+        }
+
+        @Override
         public Object compute(MetaAccessProvider metaAccess, ResolvedJavaField original, ResolvedJavaField annotated, Object receiver) {
             Edges edges = getEdges((NodeClass<?>) receiver);
             FieldsOffsetsReplacement replacement = FieldsOffsetsFeature.getReplacements().get(edges.getOffsets());

--- a/substratevm/src/com.oracle.svm.graal/src/com/oracle/svm/graal/hosted/FieldsOffsetsFeature.java
+++ b/substratevm/src/com.oracle.svm.graal/src/com/oracle/svm/graal/hosted/FieldsOffsetsFeature.java
@@ -163,14 +163,13 @@ public class FieldsOffsetsFeature implements Feature {
     private static void classReachabilityListener(DuringAnalysisAccess a, Class<?> newlyReachableClass) {
         DuringAnalysisAccessImpl access = (DuringAnalysisAccessImpl) a;
 
+        GraalSupport support = GraalSupport.get();
         if (Node.class.isAssignableFrom(newlyReachableClass) && newlyReachableClass != Node.class) {
-            FieldsOffsetsFeature.<NodeClass<?>> registerClass(newlyReachableClass, GraalSupport.get().nodeClasses, NodeClass::get, false, access);
-
+            FieldsOffsetsFeature.registerClass(newlyReachableClass, support.nodeClasses, NodeClass::get, false, access);
         } else if (LIRInstruction.class.isAssignableFrom(newlyReachableClass) && newlyReachableClass != LIRInstruction.class) {
-            FieldsOffsetsFeature.<LIRInstructionClass<?>> registerClass(newlyReachableClass, GraalSupport.get().instructionClasses, LIRInstructionClass::get, true, access);
-
+            FieldsOffsetsFeature.registerClass(newlyReachableClass, support.instructionClasses, LIRInstructionClass::get, true, access);
         } else if (CompositeValue.class.isAssignableFrom(newlyReachableClass) && newlyReachableClass != CompositeValue.class) {
-            FieldsOffsetsFeature.<CompositeValueClass<?>> registerClass(newlyReachableClass, GraalSupport.get().compositeValueClasses, CompositeValueClass::get, true, access);
+            FieldsOffsetsFeature.registerClass(newlyReachableClass, support.compositeValueClasses, CompositeValueClass::get, true, access);
         }
     }
 

--- a/substratevm/src/com.oracle.svm.graal/src/com/oracle/svm/graal/hosted/GraalFeature.java
+++ b/substratevm/src/com.oracle.svm.graal/src/com/oracle/svm/graal/hosted/GraalFeature.java
@@ -338,7 +338,7 @@ public final class GraalFeature implements Feature {
             ImageSingletons.add(RuntimeGraalSetup.class, new SubstrateRuntimeGraalSetup());
         }
         GraalProviderObjectReplacements providerReplacements = ImageSingletons.lookup(RuntimeGraalSetup.class).getProviderObjectReplacements(aMetaAccess);
-        objectReplacer = new GraalObjectReplacer(config.getUniverse(), aMetaAccess, providerReplacements);
+        objectReplacer = new GraalObjectReplacer(config, config.getUniverse(), aMetaAccess, providerReplacements);
         config.registerObjectReplacer(objectReplacer);
 
         config.registerClassReachabilityListener(GraalSupport::registerPhaseStatistics);

--- a/substratevm/src/com.oracle.svm.graal/src/com/oracle/svm/graal/hosted/GraalFeature.java
+++ b/substratevm/src/com.oracle.svm.graal/src/com/oracle/svm/graal/hosted/GraalFeature.java
@@ -493,7 +493,7 @@ public final class GraalFeature implements Feature {
         for (CallTreeNode node : methods.values()) {
             methodsToCompileArr[idx++] = objectReplacer.createMethod(node.implementationMethod);
         }
-        if (GraalSupport.setMethodsToCompile(methodsToCompileArr)) {
+        if (GraalSupport.setMethodsToCompile(config, methodsToCompileArr)) {
             config.requireAnalysisIteration();
         }
 
@@ -503,7 +503,7 @@ public final class GraalFeature implements Feature {
         for (NodeClass<?> nodeClass : nodeClasses) {
             metaAccess.lookupJavaType(nodeClass.getClazz()).registerAsAllocated(null);
         }
-        if (GraalSupport.setGraphEncoding(graphEncoder.getEncoding(), graphEncoder.getObjects(), nodeClasses)) {
+        if (GraalSupport.setGraphEncoding(config, graphEncoder.getEncoding(), graphEncoder.getObjects(), nodeClasses)) {
             config.requireAnalysisIteration();
         }
 
@@ -727,7 +727,7 @@ public final class GraalFeature implements Feature {
         }
 
         ProgressReporter.singleton().setGraphEncodingByteLength(graphEncoder.getEncoding().length);
-        GraalSupport.setGraphEncoding(graphEncoder.getEncoding(), graphEncoder.getObjects(), graphEncoder.getNodeClasses());
+        GraalSupport.setGraphEncoding(config, graphEncoder.getEncoding(), graphEncoder.getObjects(), graphEncoder.getNodeClasses());
 
         objectReplacer.updateDataDuringAnalysis((AnalysisMetaAccess) hMetaAccess.getWrapped());
     }

--- a/substratevm/src/com.oracle.svm.graal/src/com/oracle/svm/graal/hosted/GraalFeature.java
+++ b/substratevm/src/com.oracle.svm.graal/src/com/oracle/svm/graal/hosted/GraalFeature.java
@@ -888,7 +888,7 @@ public final class GraalFeature implements Feature {
         CompilationAccessImpl config = (CompilationAccessImpl) a;
 
         HostedMetaAccess hMetaAccess = config.getMetaAccess();
-        HostedUniverse hUniverse = (HostedUniverse) hMetaAccess.getUniverse();
+        HostedUniverse hUniverse = hMetaAccess.getUniverse();
         objectReplacer.updateSubstrateDataAfterCompilation(hUniverse, config.getProviders().getConstantFieldProvider());
 
         objectReplacer.registerImmutableObjects(config);
@@ -900,7 +900,7 @@ public final class GraalFeature implements Feature {
     public void afterHeapLayout(AfterHeapLayoutAccess a) {
         AfterHeapLayoutAccessImpl config = (AfterHeapLayoutAccessImpl) a;
         HostedMetaAccess hMetaAccess = config.getMetaAccess();
-        HostedUniverse hUniverse = (HostedUniverse) hMetaAccess.getUniverse();
+        HostedUniverse hUniverse = hMetaAccess.getUniverse();
         objectReplacer.updateSubstrateDataAfterHeapLayout(hUniverse);
     }
 }

--- a/substratevm/src/com.oracle.svm.graal/src/com/oracle/svm/graal/meta/SubstrateField.java
+++ b/substratevm/src/com.oracle.svm.graal/src/com/oracle/svm/graal/meta/SubstrateField.java
@@ -28,7 +28,6 @@ import static com.oracle.svm.core.util.VMError.unimplemented;
 
 import java.lang.annotation.Annotation;
 
-import com.oracle.svm.core.util.VMError;
 import org.graalvm.nativeimage.Platform;
 import org.graalvm.nativeimage.Platforms;
 
@@ -38,6 +37,7 @@ import com.oracle.svm.core.hub.AnnotationsEncoding;
 import com.oracle.svm.core.meta.DirectSubstrateObjectConstant;
 import com.oracle.svm.core.meta.SharedField;
 import com.oracle.svm.core.util.HostedStringDeduplication;
+import com.oracle.svm.core.util.VMError;
 import com.oracle.truffle.api.nodes.Node.Child;
 import com.oracle.truffle.api.nodes.Node.Children;
 import com.oracle.truffle.api.nodes.NodeCloneable;
@@ -115,6 +115,11 @@ public class SubstrateField implements SharedField {
     @Override
     public boolean isAccessed() {
         return isAccessed;
+    }
+
+    @Override
+    public boolean isReachable() {
+        return isAccessed || isWritten;
     }
 
     @Override

--- a/substratevm/src/com.oracle.svm.graal/src/com/oracle/svm/graal/meta/SubstrateRuntimeConfigurationBuilder.java
+++ b/substratevm/src/com.oracle.svm.graal/src/com/oracle/svm/graal/meta/SubstrateRuntimeConfigurationBuilder.java
@@ -75,7 +75,7 @@ public class SubstrateRuntimeConfigurationBuilder extends SharedRuntimeConfigura
 
     @Override
     protected ConstantFieldProvider createConstantFieldProvider(Providers p) {
-        return new AnalysisConstantFieldProvider(aUniverse, (AnalysisMetaAccess) p.getMetaAccess(), (AnalysisConstantReflectionProvider) p.getConstantReflection(), classInitializationSupport);
+        return new AnalysisConstantFieldProvider(aUniverse, (AnalysisMetaAccess) p.getMetaAccess(), classInitializationSupport);
     }
 
     @Override

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/FeatureImpl.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/FeatureImpl.java
@@ -81,6 +81,7 @@ import com.oracle.svm.hosted.meta.HostedMetaAccess;
 import com.oracle.svm.hosted.meta.HostedType;
 import com.oracle.svm.hosted.meta.HostedUniverse;
 import com.oracle.svm.hosted.option.HostedOptionProvider;
+import com.oracle.svm.util.ReflectionUtil;
 import com.oracle.svm.util.UnsafePartitionKind;
 
 import jdk.vm.ci.meta.JavaConstant;
@@ -245,6 +246,35 @@ public class FeatureImpl {
         Set<AnalysisMethod> reachableMethodOverrides(AnalysisMethod baseMethod) {
             return AnalysisUniverse.getMethodImplementations(getBigBang(), baseMethod, true);
         }
+
+        public void rescanObject(Object obj) {
+            getUniverse().getHeapScanner().rescanObject(obj);
+        }
+
+        public void rescanField(Object receiver, Field field) {
+            getUniverse().getHeapScanner().rescanField(receiver, field);
+        }
+
+        public void rescanField(Object receiver, Class<?> declaringClass, String fieldName) {
+            rescanField(receiver, ReflectionUtil.lookupField(declaringClass, fieldName));
+        }
+
+        public void rescanField(Object receiver, String className, String fieldName) {
+            rescanField(receiver, getImageClassLoader().findClassOrFail(className), fieldName);
+        }
+
+        public void rescanRoot(Field field) {
+            getUniverse().getHeapScanner().rescanRoot(field);
+        }
+
+        public void rescanRoot(Class<?> declaringClass, String fieldName) {
+            rescanRoot(ReflectionUtil.lookupField(declaringClass, fieldName));
+        }
+
+        public void rescanRoot(String declaringClassName, String fieldName) {
+            rescanRoot(getImageClassLoader().findClassOrFail(declaringClassName), fieldName);
+        }
+
     }
 
     public static class DuringSetupAccessImpl extends AnalysisAccessBase implements Feature.DuringSetupAccess {

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/FeatureImpl.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/FeatureImpl.java
@@ -255,26 +255,17 @@ public class FeatureImpl {
             getUniverse().getHeapScanner().rescanField(receiver, field);
         }
 
-        public void rescanField(Object receiver, Class<?> declaringClass, String fieldName) {
-            rescanField(receiver, ReflectionUtil.lookupField(declaringClass, fieldName));
-        }
-
-        public void rescanField(Object receiver, String className, String fieldName) {
-            rescanField(receiver, getImageClassLoader().findClassOrFail(className), fieldName);
-        }
-
         public Object rescanRoot(Field field) {
             return getUniverse().getHeapScanner().rescanRoot(field);
         }
 
-        public Object rescanRoot(Class<?> declaringClass, String fieldName) {
-            return rescanRoot(ReflectionUtil.lookupField(declaringClass, fieldName));
+        public Field findField(String declaringClassName, String fieldName) {
+            return findField(imageClassLoader.findClassOrFail(declaringClassName), fieldName);
         }
 
-        public Object rescanRoot(String declaringClassName, String fieldName) {
-            return rescanRoot(getImageClassLoader().findClassOrFail(declaringClassName), fieldName);
+        public Field findField(Class<?> declaringClass, String fieldName) {
+            return ReflectionUtil.lookupField(declaringClass, fieldName);
         }
-
     }
 
     public static class DuringSetupAccessImpl extends AnalysisAccessBase implements Feature.DuringSetupAccess {

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/FeatureImpl.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/FeatureImpl.java
@@ -348,7 +348,7 @@ public class FeatureImpl {
             if (!aField.isUnsafeAccessed()) {
                 /* Register the field as unsafe accessed. */
                 aField.registerAsAccessed();
-                aField.registerAsUnsafeAccessed(bb.getUniverse());
+                aField.registerAsUnsafeAccessed();
                 /* Force the update of registered unsafe loads and stores. */
                 bb.forceUnsafeUpdate(aField);
                 return true;
@@ -374,7 +374,7 @@ public class FeatureImpl {
             if (!aField.isUnsafeAccessed()) {
                 /* Register the field as unsafe accessed. */
                 aField.registerAsAccessed();
-                aField.registerAsUnsafeAccessed(bb.getUniverse(), partitionKind);
+                aField.registerAsUnsafeAccessed(partitionKind);
                 /* Force the update of registered unsafe loads and stores. */
                 bb.forceUnsafeUpdate(aField);
             }

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/FeatureImpl.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/FeatureImpl.java
@@ -263,16 +263,16 @@ public class FeatureImpl {
             rescanField(receiver, getImageClassLoader().findClassOrFail(className), fieldName);
         }
 
-        public void rescanRoot(Field field) {
-            getUniverse().getHeapScanner().rescanRoot(field);
+        public Object rescanRoot(Field field) {
+            return getUniverse().getHeapScanner().rescanRoot(field);
         }
 
-        public void rescanRoot(Class<?> declaringClass, String fieldName) {
-            rescanRoot(ReflectionUtil.lookupField(declaringClass, fieldName));
+        public Object rescanRoot(Class<?> declaringClass, String fieldName) {
+            return rescanRoot(ReflectionUtil.lookupField(declaringClass, fieldName));
         }
 
-        public void rescanRoot(String declaringClassName, String fieldName) {
-            rescanRoot(getImageClassLoader().findClassOrFail(declaringClassName), fieldName);
+        public Object rescanRoot(String declaringClassName, String fieldName) {
+            return rescanRoot(getImageClassLoader().findClassOrFail(declaringClassName), fieldName);
         }
 
     }

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/HostedConfiguration.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/HostedConfiguration.java
@@ -133,8 +133,8 @@ public class HostedConfiguration {
     }
 
     public SVMHost createHostVM(OptionValues options, ClassLoader classLoader, ClassInitializationSupport classInitializationSupport,
-                    UnsafeAutomaticSubstitutionProcessor automaticSubstitutions, Platform platform) {
-        return new SVMHost(options, classLoader, classInitializationSupport, automaticSubstitutions, platform);
+                    UnsafeAutomaticSubstitutionProcessor automaticSubstitutions, Platform platform, SnippetReflectionProvider originalSnippetReflection) {
+        return new SVMHost(options, classLoader, classInitializationSupport, automaticSubstitutions, platform, originalSnippetReflection);
     }
 
     public CompileQueue createCompileQueue(DebugContext debug, FeatureHandler featureHandler, HostedUniverse hostedUniverse,

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/ImageClassLoader.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/ImageClassLoader.java
@@ -281,8 +281,12 @@ public final class ImageClassLoader {
         }
     }
 
-    Class<?> forName(String name) throws ClassNotFoundException {
-        return Class.forName(name, false, classLoaderSupport.getClassLoader());
+    public Class<?> forName(String className) throws ClassNotFoundException {
+        return forName(className, false);
+    }
+
+    public Class<?> forName(String className, boolean initialize) throws ClassNotFoundException {
+        return Class.forName(className, initialize, classLoaderSupport.getClassLoader());
     }
 
     public Class<?> forName(String className, Object module) throws ClassNotFoundException {

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/LoggingFeature.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/LoggingFeature.java
@@ -24,6 +24,7 @@
  */
 package com.oracle.svm.hosted;
 
+import java.lang.reflect.Field;
 import java.util.logging.LogManager;
 
 import org.graalvm.compiler.options.Option;
@@ -35,6 +36,7 @@ import com.oracle.svm.core.annotate.AutomaticFeature;
 import com.oracle.svm.core.option.HostedOptionKey;
 import com.oracle.svm.core.util.VMError;
 import com.oracle.svm.hosted.FeatureImpl.DuringAnalysisAccessImpl;
+import com.oracle.svm.hosted.FeatureImpl.DuringSetupAccessImpl;
 
 @AutomaticFeature
 public class LoggingFeature implements Feature {
@@ -51,6 +53,8 @@ public class LoggingFeature implements Feature {
 
     private boolean reflectionConfigured = false;
 
+    private Field loggersField;
+
     @Override
     public boolean isInConfiguration(IsInConfigurationAccess access) {
         return LoggingFeature.Options.EnableLoggingFeature.getValue();
@@ -60,13 +64,14 @@ public class LoggingFeature implements Feature {
     public void duringSetup(DuringSetupAccess access) {
         /* Ensure that the log manager is initialized and the initial configuration is read. */
         LogManager.getLogManager();
+        loggersField = ((DuringSetupAccessImpl) access).findField("sun.util.logging.PlatformLogger", "loggers");
     }
 
     @Override
     public void duringAnalysis(DuringAnalysisAccess a) {
         DuringAnalysisAccessImpl access = (DuringAnalysisAccessImpl) a;
 
-        access.rescanRoot("sun.util.logging.PlatformLogger", "loggers");
+        access.rescanRoot(loggersField);
 
         if (!reflectionConfigured && access.getMetaAccess().optionalLookupJavaType(java.util.logging.Logger.class).isPresent()) {
             registerForReflection(java.util.logging.ConsoleHandler.class);

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/LoggingFeature.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/LoggingFeature.java
@@ -66,6 +66,8 @@ public class LoggingFeature implements Feature {
     public void duringAnalysis(DuringAnalysisAccess a) {
         DuringAnalysisAccessImpl access = (DuringAnalysisAccessImpl) a;
 
+        access.rescanRoot("sun.util.logging.PlatformLogger", "loggers");
+
         if (!reflectionConfigured && access.getMetaAccess().optionalLookupJavaType(java.util.logging.Logger.class).isPresent()) {
             registerForReflection(java.util.logging.ConsoleHandler.class);
             registerForReflection(java.util.logging.SimpleFormatter.class);

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/NativeImageGenerator.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/NativeImageGenerator.java
@@ -874,7 +874,7 @@ public class NativeImageGenerator {
         SubstitutionProcessor aSubstitutions = createAnalysisSubstitutionProcessor(originalMetaAccess, originalSnippetReflection, cEnumProcessor, automaticSubstitutions,
                         annotationSubstitutions, additionalSubstitutions);
 
-        SVMHost hostVM = HostedConfiguration.instance().createHostVM(options, loader.getClassLoader(), classInitializationSupport, automaticSubstitutions, loader.platform);
+        SVMHost hostVM = HostedConfiguration.instance().createHostVM(options, loader.getClassLoader(), classInitializationSupport, automaticSubstitutions, loader.platform, originalSnippetReflection);
 
         automaticSubstitutions.init(loader, originalMetaAccess);
         AnalysisPolicy analysisPolicy = PointstoOptions.AllocationSiteSensitiveHeap.getValue(options) ? new BytecodeSensitiveAnalysisPolicy(options)

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/NativeImageGenerator.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/NativeImageGenerator.java
@@ -842,7 +842,7 @@ public class NativeImageGenerator {
                 /* Create the HeapScanner and install it into the universe. */
                 ImageHeap imageHeap = new ImageHeap();
                 AnalysisObjectScanningObserver aScanningObserver = new AnalysisObjectScanningObserver(bb);
-                ImageHeapScanner heapScanner = new SVMImageHeapScanner(bb, imageHeap, loader, aMetaAccess, aSnippetReflection, aConstantReflection, aScanningObserver);
+                ImageHeapScanner heapScanner = new SVMImageHeapScanner(imageHeap, loader, aMetaAccess, aSnippetReflection, aConstantReflection, aScanningObserver);
                 aUniverse.setHeapScanner(heapScanner);
                 HeapSnapshotVerifier heapVerifier = new SVMImageHeapVerifier(bb, imageHeap, heapScanner);
                 aUniverse.setHeapVerifier(heapVerifier);

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/ResourcesFeature.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/ResourcesFeature.java
@@ -268,6 +268,7 @@ public final class ResourcesFeature implements Feature {
         ImageSingletons.lookup(ClassLoaderSupport.class).collectResources(collector);
 
         resourcePatternWorkSet.clear();
+        // access.rescanObject(ImageSingletons.lookup(Resources.ResourcesSupport.class).hostedResources);
     }
 
     private ResourcePattern[] compilePatterns(Set<String> patterns) {

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/ServiceLoaderFeature.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/ServiceLoaderFeature.java
@@ -363,6 +363,7 @@ public class ServiceLoaderFeature implements Feature {
             debugContext.log("ServiceLoaderFeature: registerResource: " + serviceResourceLocation);
         }
         Resources.registerResource(null, serviceResourceLocation, new ByteArrayInputStream(newResourceValue.toString().getBytes(StandardCharsets.UTF_8)));
+        // access.rescanObject(ImageSingletons.lookup(Resources.ResourcesSupport.class).hostedResources);
 
         /* Ensure that the static analysis runs again for the new implementation classes. */
         access.requireAnalysisIteration();

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/ameta/AnalysisConstantFieldProvider.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/ameta/AnalysisConstantFieldProvider.java
@@ -42,14 +42,11 @@ import jdk.vm.ci.meta.ResolvedJavaField;
 public class AnalysisConstantFieldProvider extends SharedConstantFieldProvider {
     private final AnalysisUniverse universe;
     private final AnalysisMetaAccess metaAccess;
-    private final AnalysisConstantReflectionProvider constantReflection;
 
-    public AnalysisConstantFieldProvider(AnalysisUniverse universe, AnalysisMetaAccess metaAccess, AnalysisConstantReflectionProvider constantReflection,
-                    ClassInitializationSupport classInitializationSupport) {
+    public AnalysisConstantFieldProvider(AnalysisUniverse universe, AnalysisMetaAccess metaAccess, ClassInitializationSupport classInitializationSupport) {
         super(metaAccess, classInitializationSupport);
         this.universe = universe;
         this.metaAccess = metaAccess;
-        this.constantReflection = constantReflection;
     }
 
     @Override
@@ -63,7 +60,7 @@ public class AnalysisConstantFieldProvider extends SharedConstantFieldProvider {
             if (readableField.allowConstantFolding()) {
                 JavaConstant fieldValue = readableField.readValue(metaAccess, universe.toHosted(analysisTool.getReceiver()));
                 if (fieldValue != null) {
-                    return analysisTool.foldConstant(constantReflection.interceptValue(f, universe.lookup(fieldValue)));
+                    return analysisTool.foldConstant(AnalysisConstantReflectionProvider.interceptValue(universe, f, universe.lookup(fieldValue)));
                 }
             }
             return null;

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/ameta/AnalysisConstantReflectionProvider.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/ameta/AnalysisConstantReflectionProvider.java
@@ -33,7 +33,6 @@ import org.graalvm.nativeimage.Platform;
 import org.graalvm.nativeimage.Platforms;
 import org.graalvm.word.WordBase;
 
-import com.oracle.graal.pointsto.heap.ImageHeapScanner;
 import com.oracle.graal.pointsto.meta.AnalysisField;
 import com.oracle.graal.pointsto.meta.AnalysisType;
 import com.oracle.graal.pointsto.meta.AnalysisUniverse;
@@ -105,14 +104,6 @@ public class AnalysisConstantReflectionProvider extends SharedConstantReflection
 
         if (!BuildPhaseProvider.isAnalysisFinished()) {
             field.markReachable();
-        }
-
-        if (!BuildPhaseProvider.isAnalysisFinished() && field.getJavaKind() == JavaKind.Object && field.isRead()) {
-            /* Make sure the field value is scanned. */
-            ImageHeapScanner scanner = universe.getHeapScanner();
-            if (scanner.isEnabled()) {
-                scanner.scanFieldValue(field, receiver);
-            }
         }
 
         return result;

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/analysis/NativeImagePointsToAnalysis.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/analysis/NativeImagePointsToAnalysis.java
@@ -62,7 +62,7 @@ public class NativeImagePointsToAnalysis extends PointsToAnalysis implements Inf
         super(options, universe, providers, universe.hostVM(), executor, heartbeatCallback, new SubstrateUnsupportedFeatures(), SubstrateOptions.parseOnce());
         this.annotationSubstitutionProcessor = annotationSubstitutionProcessor;
 
-        dynamicHubInitializer = new DynamicHubInitializer(universe, metaAccess, unsupportedFeatures, providers.getConstantReflection());
+        dynamicHubInitializer = new DynamicHubInitializer(metaAccess, unsupportedFeatures, providers.getConstantReflection());
         unknownFieldHandler = new PointsToUnknownFieldHandler(metaAccess);
         callChecker = new CallChecker();
     }

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/analysis/NativeImagePointsToAnalysis.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/analysis/NativeImagePointsToAnalysis.java
@@ -60,7 +60,7 @@ public class NativeImagePointsToAnalysis extends PointsToAnalysis implements Inf
 
     public NativeImagePointsToAnalysis(OptionValues options, AnalysisUniverse universe, HostedProviders providers, AnnotationSubstitutionProcessor annotationSubstitutionProcessor,
                     ForkJoinPool executor, Runnable heartbeatCallback, UnsupportedFeatures unsupportedFeatures) {
-        super(options, universe, providers, universe.hostVM(), executor, heartbeatCallback, new SubstrateUnsupportedFeatures(), SubstrateOptions.parseOnce());
+        super(options, universe, providers, universe.hostVM(), executor, heartbeatCallback, unsupportedFeatures, SubstrateOptions.parseOnce());
         this.annotationSubstitutionProcessor = annotationSubstitutionProcessor;
 
         dynamicHubInitializer = new DynamicHubInitializer(metaAccess, unsupportedFeatures, providers.getConstantReflection());

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/analysis/NativeImagePointsToAnalysis.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/analysis/NativeImagePointsToAnalysis.java
@@ -29,8 +29,6 @@ import java.util.concurrent.ForkJoinPool;
 import org.graalvm.compiler.graph.NodeSourcePosition;
 import org.graalvm.compiler.options.OptionValues;
 
-import com.oracle.graal.pointsto.ObjectScanner;
-import com.oracle.graal.pointsto.ObjectScanner.ScanReason;
 import com.oracle.graal.pointsto.PointsToAnalysis;
 import com.oracle.graal.pointsto.constraints.UnsupportedFeatures;
 import com.oracle.graal.pointsto.flow.MethodTypeFlow;
@@ -42,13 +40,11 @@ import com.oracle.graal.pointsto.meta.AnalysisUniverse;
 import com.oracle.graal.pointsto.meta.HostedProviders;
 import com.oracle.svm.core.SubstrateOptions;
 import com.oracle.svm.core.graal.meta.SubstrateReplacements;
-import com.oracle.svm.core.meta.SubstrateObjectConstant;
 import com.oracle.svm.hosted.HostedConfiguration;
 import com.oracle.svm.hosted.SVMHost;
 import com.oracle.svm.hosted.meta.HostedType;
 import com.oracle.svm.hosted.substitute.AnnotationSubstitutionProcessor;
 
-import jdk.vm.ci.meta.JavaConstant;
 import jdk.vm.ci.meta.ResolvedJavaType;
 
 public class NativeImagePointsToAnalysis extends PointsToAnalysis implements Inflation {
@@ -79,14 +75,6 @@ public class NativeImagePointsToAnalysis extends PointsToAnalysis implements Inf
     }
 
     @Override
-    protected void checkObjectGraph(ObjectScanner objectScanner) {
-        universe.getTypes().stream().filter(AnalysisType::isReachable).forEach(dynamicHubInitializer::initializeMetaData);
-
-        /* Scan hubs of all types that end up in the native image. */
-        universe.getTypes().stream().filter(AnalysisType::isReachable).forEach(type -> scanHub(objectScanner, type));
-    }
-
-    @Override
     public SVMHost getHostVM() {
         return (SVMHost) hostVM;
     }
@@ -113,10 +101,9 @@ public class NativeImagePointsToAnalysis extends PointsToAnalysis implements Inf
         unknownFieldHandler.handleUnknownValueField(field);
     }
 
-    private void scanHub(ObjectScanner objectScanner, AnalysisType type) {
-        SVMHost svmHost = (SVMHost) hostVM;
-        JavaConstant hubConstant = SubstrateObjectConstant.forObject(svmHost.dynamicHub(type));
-        objectScanner.scanConstant(hubConstant, ScanReason.HUB);
+    @Override
+    public void onTypeScanned(AnalysisType type) {
+        dynamicHubInitializer.initializeMetaData(universe.getHeapScanner(), type);
     }
 
     public static ResolvedJavaType toWrappedType(ResolvedJavaType type) {

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/analysis/PointsToUnknownFieldHandler.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/analysis/PointsToUnknownFieldHandler.java
@@ -29,11 +29,12 @@ import com.oracle.graal.pointsto.flow.TypeFlow;
 import com.oracle.graal.pointsto.meta.AnalysisField;
 import com.oracle.graal.pointsto.meta.AnalysisMetaAccess;
 import com.oracle.graal.pointsto.meta.AnalysisType;
+
 import jdk.vm.ci.meta.JavaKind;
 
 public class PointsToUnknownFieldHandler extends UnknownFieldHandler {
-    public PointsToUnknownFieldHandler(AnalysisMetaAccess metaAccess) {
-        super(metaAccess);
+    public PointsToUnknownFieldHandler(BigBang bb, AnalysisMetaAccess metaAccess) {
+        super(bb, metaAccess);
     }
 
     /**
@@ -41,7 +42,7 @@ public class PointsToUnknownFieldHandler extends UnknownFieldHandler {
      * code. It can have multiple declared types provided via annotation.
      */
     @Override
-    protected void handleUnknownObjectField(BigBang bb, AnalysisField aField, AnalysisType... declaredTypes) {
+    protected void handleUnknownObjectField(AnalysisField aField, AnalysisType... declaredTypes) {
         NativeImagePointsToAnalysis analysis = (NativeImagePointsToAnalysis) bb;
         assert aField.getJavaKind() == JavaKind.Object;
 

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/analysis/heap/SVMImageHeapScanner.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/analysis/heap/SVMImageHeapScanner.java
@@ -27,7 +27,6 @@ package com.oracle.svm.hosted.analysis.heap;
 import org.graalvm.collections.EconomicMap;
 import org.graalvm.compiler.api.replacements.SnippetReflectionProvider;
 
-import com.oracle.graal.pointsto.BigBang;
 import com.oracle.graal.pointsto.ObjectScanner.ScanReason;
 import com.oracle.graal.pointsto.ObjectScanningObserver;
 import com.oracle.graal.pointsto.heap.ImageHeap;
@@ -51,17 +50,24 @@ import jdk.vm.ci.meta.JavaConstant;
 
 public class SVMImageHeapScanner extends ImageHeapScanner {
 
+    private final ImageClassLoader loader;
     protected HostedMetaAccess hostedMetaAccess;
     private final Class<?> economicMapImpl;
 
-    public SVMImageHeapScanner(BigBang bb, ImageHeap imageHeap, ImageClassLoader loader, AnalysisMetaAccess metaAccess, SnippetReflectionProvider snippetReflection,
-                    ConstantReflectionProvider constantReflection, ObjectScanningObserver aScanningObserver) {
-        super(bb, imageHeap, metaAccess, snippetReflection, constantReflection, aScanningObserver);
-        this.economicMapImpl = loader.findClassOrFail("org.graalvm.collections.EconomicMapImpl");
+    public SVMImageHeapScanner(ImageHeap imageHeap, ImageClassLoader loader, AnalysisMetaAccess metaAccess,
+                    SnippetReflectionProvider snippetReflection, ConstantReflectionProvider aConstantReflection, ObjectScanningObserver aScanningObserver) {
+        super(imageHeap, metaAccess, snippetReflection, aConstantReflection, aScanningObserver);
+        this.loader = loader;
+        this.economicMapImpl = this.loader.findClassOrFail("org.graalvm.collections.EconomicMapImpl");
     }
 
     public void setHostedMetaAccess(HostedMetaAccess hostedMetaAccess) {
         this.hostedMetaAccess = hostedMetaAccess;
+    }
+
+    @Override
+    protected Class<?> getClass(String className) {
+        return loader.findClassOrFail(className);
     }
 
     @Override

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/analysis/heap/SVMImageHeapScanner.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/analysis/heap/SVMImageHeapScanner.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright (c) 2021, 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package com.oracle.svm.hosted.analysis.heap;
+
+import org.graalvm.collections.EconomicMap;
+import org.graalvm.compiler.api.replacements.SnippetReflectionProvider;
+
+import com.oracle.graal.pointsto.BigBang;
+import com.oracle.graal.pointsto.ObjectScanner.ScanReason;
+import com.oracle.graal.pointsto.ObjectScanningObserver;
+import com.oracle.graal.pointsto.heap.ImageHeap;
+import com.oracle.graal.pointsto.heap.ImageHeapScanner;
+import com.oracle.graal.pointsto.heap.value.ValueSupplier;
+import com.oracle.graal.pointsto.meta.AnalysisField;
+import com.oracle.graal.pointsto.meta.AnalysisMetaAccess;
+import com.oracle.graal.pointsto.meta.AnalysisType;
+import com.oracle.graal.pointsto.util.AnalysisFuture;
+import com.oracle.svm.core.BuildPhaseProvider;
+import com.oracle.svm.core.meta.ReadableJavaField;
+import com.oracle.svm.core.meta.SubstrateObjectConstant;
+import com.oracle.svm.core.util.VMError;
+import com.oracle.svm.hosted.ImageClassLoader;
+import com.oracle.svm.hosted.SVMHost;
+import com.oracle.svm.hosted.ameta.AnalysisConstantReflectionProvider;
+import com.oracle.svm.hosted.meta.HostedMetaAccess;
+
+import jdk.vm.ci.meta.ConstantReflectionProvider;
+import jdk.vm.ci.meta.JavaConstant;
+
+public class SVMImageHeapScanner extends ImageHeapScanner {
+
+    protected HostedMetaAccess hostedMetaAccess;
+    private final Class<?> economicMapImpl;
+
+    public SVMImageHeapScanner(BigBang bb, ImageHeap imageHeap, ImageClassLoader loader, AnalysisMetaAccess metaAccess, SnippetReflectionProvider snippetReflection,
+                    ConstantReflectionProvider constantReflection, ObjectScanningObserver aScanningObserver) {
+        super(bb, imageHeap, metaAccess, snippetReflection, constantReflection, aScanningObserver);
+        this.economicMapImpl = loader.findClassOrFail("org.graalvm.collections.EconomicMapImpl");
+    }
+
+    public void setHostedMetaAccess(HostedMetaAccess hostedMetaAccess) {
+        this.hostedMetaAccess = hostedMetaAccess;
+    }
+
+    @Override
+    protected boolean initializeAtRunTime(AnalysisType type) {
+        return ((SVMHost) hostVM).getClassInitializationSupport().shouldInitializeAtRuntime(type);
+    }
+
+    @Override
+    protected AnalysisFuture<ImageHeap.ImageHeapObject> getOrCreateConstantReachableTask(JavaConstant javaConstant, ScanReason reason) {
+        VMError.guarantee(javaConstant instanceof SubstrateObjectConstant, "Not a substrate constant " + javaConstant);
+        return super.getOrCreateConstantReachableTask(javaConstant, reason);
+    }
+
+    @Override
+    protected Object unwrapObject(JavaConstant constant) {
+        /*
+         * Unwrap the original object from the constant. Unlike HostedSnippetReflectionProvider this
+         * will just return the wrapped object, without any transformation. This is important during
+         * scanning: when scanning a java.lang.Class it will be replaced by a DynamicHub which is
+         * then actually scanned. The HostedSnippetReflectionProvider returns the original Class for
+         * a DynamicHub, which would lead to a deadlock during scanning.
+         */
+        return SubstrateObjectConstant.asObject(Object.class, constant);
+    }
+
+    @Override
+    public boolean isValueAvailable(AnalysisField field) {
+        if (field.wrapped instanceof ReadableJavaField) {
+            ReadableJavaField readableField = (ReadableJavaField) field.wrapped;
+            return readableField.isValueAvailable();
+        }
+        return super.isValueAvailable(field);
+    }
+
+    @Override
+    protected ValueSupplier<JavaConstant> readHostedFieldValue(AnalysisField field, JavaConstant object) {
+        if (field.isStatic() && initializeAtRunTime(field.getDeclaringClass())) {
+            return ValueSupplier.eagerValue(AnalysisConstantReflectionProvider.readUninitializedStaticValue(field));
+        }
+
+        if (field.wrapped instanceof ReadableJavaField) {
+            ReadableJavaField readableField = (ReadableJavaField) field.wrapped;
+            if (readableField.isValueAvailableDuringAnalysis()) {
+                /* Materialize and return the value. */
+                JavaConstant value = universe.lookup(readableField.readValue(metaAccess, object));
+                return ValueSupplier.eagerValue(value);
+            } else {
+                /*
+                 * Return a lazy value. This applies to RecomputeFieldValue.Kind.FieldOffset and
+                 * RecomputeFieldValue.Kind.Custom. The value becomes available during hosted
+                 * universe building and is installed by calling
+                 * ComputedValueField.processSubstrate() or by ComputedValueField.readValue().
+                 * Attempts to materialize the value earlier will result in an error.
+                 */
+                return ValueSupplier.lazyValue(() -> universe.lookup(readableField.readValue(hostedMetaAccess, object)),
+                                readableField::isValueAvailable);
+            }
+        }
+        return super.readHostedFieldValue(field, object);
+    }
+
+    @Override
+    protected JavaConstant transformFieldValue(AnalysisField field, JavaConstant receiverConstant, JavaConstant originalValueConstant) {
+        return AnalysisConstantReflectionProvider.interceptValue(universe, field, originalValueConstant);
+    }
+
+    @Override
+    protected boolean skipScanning() {
+        return BuildPhaseProvider.isAnalysisFinished();
+    }
+
+    @Override
+    protected void rescanEconomicMap(EconomicMap<?, ?> map) {
+        super.rescanEconomicMap(map);
+        /* Make sure any EconomicMapImpl$CollisionLink objects are scanned. */
+        if (map.getClass() == economicMapImpl) {
+            rescanField(map, economicMapImpl, "entries");
+            rescanField(map, economicMapImpl, "hashArray");
+        }
+
+    }
+}

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/analysis/heap/SVMImageHeapVerifier.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/analysis/heap/SVMImageHeapVerifier.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2021, 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package com.oracle.svm.hosted.analysis.heap;
+
+import com.oracle.graal.pointsto.BigBang;
+import com.oracle.graal.pointsto.ObjectScanner;
+import com.oracle.graal.pointsto.heap.HeapSnapshotVerifier;
+import com.oracle.graal.pointsto.heap.ImageHeap;
+import com.oracle.graal.pointsto.heap.ImageHeapScanner;
+import com.oracle.graal.pointsto.meta.AnalysisType;
+import com.oracle.svm.core.meta.SubstrateObjectConstant;
+import com.oracle.svm.hosted.SVMHost;
+
+import jdk.vm.ci.meta.JavaConstant;
+
+public class SVMImageHeapVerifier extends HeapSnapshotVerifier {
+    public SVMImageHeapVerifier(BigBang bb, ImageHeap imageHeap, ImageHeapScanner scanner) {
+        super(bb, imageHeap, scanner);
+    }
+
+    @Override
+    protected void scanTypes(ObjectScanner objectScanner) {
+        SVMHost svmHost = (SVMHost) bb.getHostVM();
+        bb.getUniverse().getTypes().stream().filter(AnalysisType::isReachable).forEach(bb::onTypeScanned);
+
+        bb.getUniverse().getTypes().stream().filter(AnalysisType::isReachable).forEach(t -> scanHub(svmHost, objectScanner, t));
+    }
+
+    private static void scanHub(SVMHost svmHost, ObjectScanner objectScanner, AnalysisType type) {
+        JavaConstant hubConstant = SubstrateObjectConstant.forObject(svmHost.dynamicHub(type));
+        objectScanner.scanConstant(hubConstant, ObjectScanner.OtherReason.HUB);
+    }
+
+}

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/annotation/AnnotationSupport.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/annotation/AnnotationSupport.java
@@ -211,7 +211,7 @@ public class AnnotationSupport extends CustomSubstitution<AnnotationSubstitution
 
     @Override
     public ResolvedJavaMethod lookup(ResolvedJavaMethod method) {
-        if (isConstantAnnotationType(method.getDeclaringClass())) {
+        if (isConstantAnnotationType(method.getDeclaringClass()) && !method.getName().equals("proxyClassLookup")) {
             AnnotationSubstitutionType declaringClass = getSubstitution(method.getDeclaringClass());
             AnnotationSubstitutionMethod result = declaringClass.getSubstitutionMethod(method);
             assert result != null && result.original.equals(method);
@@ -236,6 +236,9 @@ public class AnnotationSupport extends CustomSubstitution<AnnotationSubstitution
             for (ResolvedJavaMethod originalMethod : type.getDeclaredMethods()) {
                 AnnotationSubstitutionMethod substitutionMethod;
                 String methodName = canonicalMethodName(originalMethod);
+                if (methodName.equals("proxyClassLookup")) {
+                    continue;
+                }
                 if (methodName.equals("equals")) {
                     substitutionMethod = new AnnotationEqualsMethod(originalMethod);
                 } else if (methodName.equals("hashCode")) {

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/classinitialization/ClassInitializationFeature.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/classinitialization/ClassInitializationFeature.java
@@ -299,7 +299,9 @@ public class ClassInitializationFeature implements GraalFeature {
                                     provenSafe.add(c);
                                     ClassInitializationInfo initializationInfo = type.getClassInitializer() == null ? ClassInitializationInfo.NO_INITIALIZER_INFO_SINGLETON
                                                     : ClassInitializationInfo.INITIALIZED_INFO_SINGLETON;
-                                    ((SVMHost) universe.hostVM()).dynamicHub(type).setClassInitializationInfo(initializationInfo);
+                                    DynamicHub hub = ((SVMHost) universe.hostVM()).dynamicHub(type);
+                                    hub.setClassInitializationInfo(initializationInfo);
+                                    universe.getHeapScanner().rescanField(hub, DynamicHub.class, "classInitializationInfo");
                                 }
                             }
                         });
@@ -324,6 +326,9 @@ public class ClassInitializationFeature implements GraalFeature {
             info = type.getClassInitializer() == null ? ClassInitializationInfo.NO_INITIALIZER_INFO_SINGLETON : ClassInitializationInfo.INITIALIZED_INFO_SINGLETON;
         }
         hub.setClassInitializationInfo(info);
+        // TODO rescanning the hub here should not be necessary
+        universe.getHeapScanner().scanHub(type);
+        universe.getHeapScanner().rescanField(hub, DynamicHub.class, "classInitializationInfo");
     }
 
     private static ClassInitializationInfo buildRuntimeInitializationInfo(FeatureImpl.DuringAnalysisAccessImpl access, AnalysisType type) {

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/code/FactoryMethodSupport.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/code/FactoryMethodSupport.java
@@ -67,7 +67,7 @@ public class FactoryMethodSupport {
             hUniverse = null;
             aMetaAccess = (AnalysisMetaAccess) metaAccess;
         }
-        AnalysisUniverse aUniverse = (AnalysisUniverse) aMetaAccess.getUniverse();
+        AnalysisUniverse aUniverse = aMetaAccess.getUniverse();
         MetaAccessProvider unwrappedMetaAccess = aMetaAccess.getWrapped();
 
         AnalysisMethod aConstructor = constructor instanceof HostedMethod ? ((HostedMethod) constructor).getWrapped() : (AnalysisMethod) constructor;

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/image/NativeImageCodeCache.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/image/NativeImageCodeCache.java
@@ -173,7 +173,7 @@ public abstract class NativeImageCodeCache {
         for (DataSection.Data data : dataSection) {
             if (data instanceof SubstrateDataBuilder.ObjectData) {
                 JavaConstant constant = ((SubstrateDataBuilder.ObjectData) data).getConstant();
-                addConstantToHeap(constant);
+                addConstantToHeap(constant, "data section");
             }
         }
         for (CompilationResult compilationResult : compilations.values()) {
@@ -191,10 +191,6 @@ public abstract class NativeImageCodeCache {
         }
     }
 
-    private void addConstantToHeap(Constant constant) {
-        addConstantToHeap(constant, null);
-    }
-
     private void addConstantToHeap(Constant constant, Object reason) {
         Object obj = SubstrateObjectConstant.asObject(constant);
 
@@ -203,7 +199,7 @@ public abstract class NativeImageCodeCache {
                             (reason != null ? " Method: " + reason : ""));
         }
 
-        imageHeap.addObject(obj, false, constantReasons.get(constant));
+        imageHeap.addObject(obj, false, reason != null ? reason : constantReasons.get(constant));
     }
 
     protected int getConstantsSize() {

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/jdk/JDKRegistrations.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/jdk/JDKRegistrations.java
@@ -69,5 +69,8 @@ class JDKRegistrations extends JNIRegistrationUtil implements GraalFeature {
          * members and do not allow instantiation.
          */
         rerunClassInit(a, "java.lang.ApplicationShutdownHooks", "java.io.DeleteOnExitHook");
+
+        /* Trigger initialization of java.net.URLConnection.fileNameMap. */
+        java.net.URLConnection.getFileNameMap();
     }
 }

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/jdk/localization/LocalizationFeature.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/jdk/localization/LocalizationFeature.java
@@ -89,6 +89,7 @@ import com.oracle.svm.util.ReflectionUtil;
 import jdk.vm.ci.meta.ResolvedJavaField;
 import jdk.vm.ci.meta.ResolvedJavaMethod;
 import jdk.vm.ci.meta.ResolvedJavaType;
+import sun.util.locale.LocaleObjectCache;
 import sun.util.locale.provider.LocaleProviderAdapter;
 import sun.util.locale.provider.ResourceBundleBasedAdapter;
 import sun.util.resources.LocaleData;
@@ -321,14 +322,14 @@ public abstract class LocalizationFeature implements Feature {
             scanLocaleCache(access, "sun.util.locale.BaseLocale", "CACHE");
             scanLocaleCache(access, "java.util.Locale", "LOCALECACHE");
         }
+        scanLocaleCache(access, "java.util.ResourceBundle$Control", "CANDIDATES_CACHE");
     }
 
     private static void scanLocaleCache(DuringAnalysisAccessImpl access, String localeClassName, String cacheFieldName) {
-        access.rescanRoot(localeClassName, cacheFieldName);
-        // Object localeCache = access.rescanRoot(localeClassName, cacheFieldName);
-        // Object localeCacheMap = ReflectionUtil.readField(LocaleObjectCache.class, "map",
-        // localeCache);
-        // access.rescanObject(localeCacheMap);
+        Object localeCache = access.rescanRoot(localeClassName, cacheFieldName);
+        if (localeCache != null) {
+            access.rescanField(localeCache, LocaleObjectCache.class, "map");
+        }
     }
 
     @Override

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/meta/HostedField.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/meta/HostedField.java
@@ -104,6 +104,11 @@ public class HostedField implements OriginalFieldProvider, SharedField, Comparab
         return wrapped.isAccessed();
     }
 
+    @Override
+    public boolean isReachable() {
+        return wrapped.isReachable();
+    }
+
     public boolean isRead() {
         return wrapped.isRead();
     }

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/meta/HostedMetaAccess.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/meta/HostedMetaAccess.java
@@ -63,7 +63,7 @@ public class HostedMetaAccess extends UniverseMetaAccess {
         if (!analysisType.isPresent()) {
             return Optional.empty();
         }
-        result = ((HostedUniverse) getUniverse()).optionalLookup(analysisType.get());
+        result = getUniverse().optionalLookup(analysisType.get());
         return Optional.ofNullable(result);
     }
 
@@ -80,7 +80,7 @@ public class HostedMetaAccess extends UniverseMetaAccess {
     }
 
     public HostedMethod optionalLookupJavaMethod(Executable reflectionMethod) {
-        return ((HostedUniverse) getUniverse()).optionalLookup(getWrapped().lookupJavaMethod(reflectionMethod));
+        return getUniverse().optionalLookup(getWrapped().lookupJavaMethod(reflectionMethod));
     }
 
     @Override
@@ -89,7 +89,7 @@ public class HostedMetaAccess extends UniverseMetaAccess {
     }
 
     public HostedField optionalLookupJavaField(Field reflectionField) {
-        return ((HostedUniverse) getUniverse()).optionalLookup(getWrapped().lookupJavaField(reflectionField));
+        return getUniverse().optionalLookup(getWrapped().lookupJavaField(reflectionField));
     }
 
     @Override
@@ -120,5 +120,10 @@ public class HostedMetaAccess extends UniverseMetaAccess {
     @Override
     public int getArrayIndexScale(JavaKind elementKind) {
         return getObjectLayout().getArrayIndexScale(elementKind);
+    }
+
+    @Override
+    public HostedUniverse getUniverse() {
+        return (HostedUniverse) universe;
     }
 }

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/snippets/SubstrateGraphBuilderPlugins.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/snippets/SubstrateGraphBuilderPlugins.java
@@ -94,10 +94,8 @@ import org.graalvm.word.Pointer;
 import org.graalvm.word.PointerBase;
 import org.graalvm.word.UnsignedWord;
 
-import com.oracle.graal.pointsto.infrastructure.UniverseMetaAccess;
 import com.oracle.graal.pointsto.meta.AnalysisField;
 import com.oracle.graal.pointsto.meta.AnalysisType;
-import com.oracle.graal.pointsto.meta.AnalysisUniverse;
 import com.oracle.graal.pointsto.nodes.UnsafePartitionLoadNode;
 import com.oracle.graal.pointsto.nodes.UnsafePartitionStoreNode;
 import com.oracle.svm.core.FrameAccess;
@@ -528,8 +526,7 @@ public class SubstrateGraphBuilderPlugins {
     private static void registerAsUnsafeAccessed(MetaAccessProvider metaAccess, Field field) {
         AnalysisField targetField = (AnalysisField) metaAccess.lookupJavaField(field);
         targetField.registerAsAccessed();
-        AnalysisUniverse universe = (AnalysisUniverse) ((UniverseMetaAccess) metaAccess).getUniverse();
-        targetField.registerAsUnsafeAccessed(universe);
+        targetField.registerAsUnsafeAccessed();
     }
 
     private static void registerObjectPlugins(InvocationPlugins plugins) {

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/substitute/AnnotationSubstitutionProcessor.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/substitute/AnnotationSubstitutionProcessor.java
@@ -249,7 +249,7 @@ public class AnnotationSubstitutionProcessor extends SubstitutionProcessor {
                         targetFieldDeclaringType.registerAsReachable();
                         AnalysisField targetField = bb.getMetaAccess().lookupJavaField(cvField.getTargetField());
                         targetField.registerAsAccessed();
-                        targetField.registerAsUnsafeAccessed(bb.getUniverse());
+                        targetField.registerAsUnsafeAccessed();
                         break;
                 }
             }

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/substitute/AnnotationSubstitutionProcessor.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/substitute/AnnotationSubstitutionProcessor.java
@@ -864,7 +864,7 @@ public class AnnotationSubstitutionProcessor extends SubstitutionProcessor {
             targetName = recomputeAnnotation.name();
             isFinal = recomputeAnnotation.isFinal();
             disableCaching = recomputeAnnotation.disableCaching();
-            guarantee(!isFinal || ComputedValueField.isFinalValid(kind), "@%s with %s can never be final during analysis: unset isFinal in the annotation on %s",
+            guarantee(!isFinal || !ComputedValueField.isOffsetRecomputation(kind), "@%s with %s can never be final during analysis: unset isFinal in the annotation on %s",
                             RecomputeFieldValue.class.getSimpleName(), kind, annotated);
             guarantee(!isFinal || !disableCaching, "@%s can not be final if caching is disabled: unset isFinal in the annotation on %s",
                             RecomputeFieldValue.class.getSimpleName(), kind, annotated);

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/substitute/ComputedValueField.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/substitute/ComputedValueField.java
@@ -24,6 +24,9 @@
  */
 package com.oracle.svm.hosted.substitute;
 
+import static com.oracle.svm.core.annotate.RecomputeFieldValue.Kind.AtomicFieldUpdaterOffset;
+import static com.oracle.svm.core.annotate.RecomputeFieldValue.Kind.FieldOffset;
+import static com.oracle.svm.core.annotate.RecomputeFieldValue.Kind.TranslateFieldOffset;
 import static com.oracle.svm.core.util.VMError.guarantee;
 import static com.oracle.svm.core.util.VMError.shouldNotReachHere;
 
@@ -46,8 +49,10 @@ import com.oracle.graal.pointsto.infrastructure.OriginalFieldProvider;
 import com.oracle.graal.pointsto.meta.AnalysisField;
 import com.oracle.graal.pointsto.meta.AnalysisMetaAccess;
 import com.oracle.graal.pointsto.util.GraalAccess;
+import com.oracle.svm.core.BuildPhaseProvider;
 import com.oracle.svm.core.annotate.RecomputeFieldValue;
 import com.oracle.svm.core.annotate.RecomputeFieldValue.CustomFieldValueComputer;
+import com.oracle.svm.core.annotate.RecomputeFieldValue.CustomFieldValueProvider;
 import com.oracle.svm.core.annotate.RecomputeFieldValue.CustomFieldValueTransformer;
 import com.oracle.svm.core.config.ConfigurationValues;
 import com.oracle.svm.core.meta.ReadableJavaField;
@@ -76,14 +81,18 @@ import sun.misc.Unsafe;
 public class ComputedValueField implements ReadableJavaField, OriginalFieldProvider, ComputedValue {
 
     private static final Unsafe UNSAFE = GraalUnsafeAccess.getUnsafe();
+    private static final EnumSet<?> offsetComputationKinds = EnumSet.of(FieldOffset, TranslateFieldOffset, AtomicFieldUpdaterOffset);
     private final ResolvedJavaField original;
     private final ResolvedJavaField annotated;
 
     private final RecomputeFieldValue.Kind kind;
     private final Class<?> targetClass;
     private final Field targetField;
+    private final CustomFieldValueProvider customValueProvider;
     private final boolean isFinal;
     private final boolean disableCaching;
+    private final boolean isCustomValueAvailableDuringAnalysis;
+    private final boolean isOffsetField;
 
     private JavaConstant constantValue;
 
@@ -94,6 +103,10 @@ public class ComputedValueField implements ReadableJavaField, OriginalFieldProvi
      */
     private JavaConstant valueCacheNullKey;
     private final ReentrantReadWriteLock valueCacheLock = new ReentrantReadWriteLock();
+
+    public ComputedValueField(ResolvedJavaField original, ResolvedJavaField annotated, RecomputeFieldValue.Kind kind, Class<?> targetClass, String targetName, boolean isFinal) {
+        this(original, annotated, kind, targetClass, targetName, isFinal, false);
+    }
 
     public ComputedValueField(ResolvedJavaField original, ResolvedJavaField annotated, RecomputeFieldValue.Kind kind, Class<?> targetClass, String targetName, boolean isFinal,
                     boolean disableCaching) {
@@ -106,7 +119,10 @@ public class ComputedValueField implements ReadableJavaField, OriginalFieldProvi
         this.targetClass = targetClass;
         this.isFinal = isFinal;
         this.disableCaching = disableCaching;
+        this.isOffsetField = isOffsetRecomputation(kind);
 
+        boolean customValueAvailableDuringAnalysis = true;
+        CustomFieldValueProvider customProvider = null;
         Field f = null;
         switch (kind) {
             case Reset:
@@ -119,20 +135,44 @@ public class ComputedValueField implements ReadableJavaField, OriginalFieldProvi
                     throw shouldNotReachHere("could not find target field " + targetClass.getName() + "." + targetName + " for alias " + annotated.format("%H.%n"));
                 }
                 break;
+            case Custom:
+                try {
+                    Constructor<?>[] constructors = targetClass.getDeclaredConstructors();
+                    if (constructors.length != 1) {
+                        throw UserError.abort("The custom field value computer class %s has more than one constructor", targetClass.getName());
+                    }
+                    Constructor<?> constructor = constructors[0];
+
+                    Object[] constructorArgs = new Object[constructor.getParameterCount()];
+                    for (int i = 0; i < constructorArgs.length; i++) {
+                        constructorArgs[i] = configurationValue(constructor.getParameterTypes()[i]);
+                    }
+                    constructor.setAccessible(true);
+                    customProvider = (CustomFieldValueProvider) constructor.newInstance(constructorArgs);
+                    customValueAvailableDuringAnalysis = customProvider.isAvailableDuringAnalysis();
+                } catch (InvocationTargetException | InstantiationException | IllegalAccessException ex) {
+                    throw shouldNotReachHere("Error creating custom field value computer for alias " + annotated.format("%H.%n"), ex);
+                }
         }
-        guarantee(!isFinal || isFinalValid(kind));
+        guarantee(!isFinal || !isOffsetField);
+        this.isCustomValueAvailableDuringAnalysis = customValueAvailableDuringAnalysis;
         this.targetField = f;
+        this.customValueProvider = customProvider;
         this.valueCache = EconomicMap.create();
     }
 
-    public ComputedValueField(ResolvedJavaField original, ResolvedJavaField annotated, RecomputeFieldValue.Kind kind, Class<?> targetClass, String targetName, boolean isFinal) {
-        this(original, annotated, kind, targetClass, targetName, isFinal, false);
+    public static boolean isOffsetRecomputation(RecomputeFieldValue.Kind kind) {
+        return offsetComputationKinds.contains(kind);
     }
 
-    public static boolean isFinalValid(RecomputeFieldValue.Kind kind) {
-        EnumSet<RecomputeFieldValue.Kind> finalIllegal = EnumSet.of(RecomputeFieldValue.Kind.FieldOffset,
-                        RecomputeFieldValue.Kind.TranslateFieldOffset, RecomputeFieldValue.Kind.AtomicFieldUpdaterOffset);
-        return !finalIllegal.contains(kind);
+    @Override
+    public boolean isValueAvailableDuringAnalysis() {
+        return isCustomValueAvailableDuringAnalysis && !isOffsetField;
+    }
+
+    @Override
+    public boolean isValueAvailable() {
+        return constantValue != null || BuildPhaseProvider.isAnalysisFinished() || isValueAvailableDuringAnalysis();
     }
 
     public ResolvedJavaField getAnnotated() {
@@ -292,43 +332,26 @@ public class ComputedValueField implements ReadableJavaField, OriginalFieldProvi
                 result = translateFieldOffset(metaAccess, receiver, targetClass);
                 break;
             case Custom:
-                try {
-                    Constructor<?>[] constructors = targetClass.getDeclaredConstructors();
-                    if (constructors.length != 1) {
-                        throw UserError.abort("The custom field value computer class %s has more than one constructor", targetClass.getName());
-                    }
-                    Constructor<?> constructor = constructors[0];
-
-                    Object[] constructorArgs = new Object[constructor.getParameterCount()];
-                    for (int i = 0; i < constructorArgs.length; i++) {
-                        constructorArgs[i] = configurationValue(constructor.getParameterTypes()[i]);
-                    }
-                    constructor.setAccessible(true);
-                    Object instance = constructor.newInstance(constructorArgs);
-
-                    Object receiverValue = receiver == null ? null : originalSnippetReflection.asObject(Object.class, receiver);
-                    Object newValue;
-                    if (instance instanceof CustomFieldValueComputer) {
-                        newValue = ((CustomFieldValueComputer) instance).compute(metaAccess, original, annotated, receiverValue);
-                    } else if (instance instanceof CustomFieldValueTransformer) {
-                        JavaConstant originalValueConstant = ReadableJavaField.readFieldValue(metaAccess, GraalAccess.getOriginalProviders().getConstantReflection(), original, receiver);
-                        Object originalValue;
-                        if (originalValueConstant.getJavaKind().isPrimitive()) {
-                            originalValue = originalValueConstant.asBoxedPrimitive();
-                        } else {
-                            originalValue = originalSnippetReflection.asObject(Object.class, originalValueConstant);
-                        }
-                        newValue = ((CustomFieldValueTransformer) instance).transform(metaAccess, original, annotated, receiverValue, originalValue);
+                Object receiverValue = receiver == null ? null : originalSnippetReflection.asObject(Object.class, receiver);
+                Object newValue;
+                if (customValueProvider instanceof CustomFieldValueComputer) {
+                    newValue = ((CustomFieldValueComputer) customValueProvider).compute(metaAccess, original, annotated, receiverValue);
+                } else if (customValueProvider instanceof CustomFieldValueTransformer) {
+                    JavaConstant originalValueConstant = ReadableJavaField.readFieldValue(metaAccess, GraalAccess.getOriginalProviders().getConstantReflection(), original, receiver);
+                    Object originalValue;
+                    if (originalValueConstant.getJavaKind().isPrimitive()) {
+                        originalValue = originalValueConstant.asBoxedPrimitive();
                     } else {
-                        throw UserError.abort("The custom field value computer class %s does not implement %s or %s", targetClass.getName(),
-                                        CustomFieldValueComputer.class.getSimpleName(), CustomFieldValueTransformer.class.getSimpleName());
+                        originalValue = originalSnippetReflection.asObject(Object.class, originalValueConstant);
                     }
-
-                    result = originalSnippetReflection.forBoxed(annotated.getJavaKind(), newValue);
-                    assert result.getJavaKind() == annotated.getJavaKind();
-                } catch (InvocationTargetException | InstantiationException | IllegalAccessException ex) {
-                    throw shouldNotReachHere("Error performing field recomputation for alias " + annotated.format("%H.%n"), ex);
+                    newValue = ((CustomFieldValueTransformer) customValueProvider).transform(metaAccess, original, annotated, receiverValue, originalValue);
+                } else {
+                    throw UserError.abort("The custom field value computer class %s does not implement %s or %s", targetClass.getName(),
+                                    CustomFieldValueComputer.class.getSimpleName(), CustomFieldValueTransformer.class.getSimpleName());
                 }
+
+                result = originalSnippetReflection.forBoxed(annotated.getJavaKind(), newValue);
+                assert result.getJavaKind() == annotated.getJavaKind();
                 break;
             default:
                 throw shouldNotReachHere("Field recomputation of kind " + kind + " for field " + original.format("%H.%n") +

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/substitute/ComputedValueField.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/substitute/ComputedValueField.java
@@ -225,6 +225,13 @@ public class ComputedValueField implements ReadableJavaField, OriginalFieldProvi
         return original.isSynthetic();
     }
 
+    /*
+     * TODO remove this method
+     * 
+     * It is a catch-all method in case we forgot to register some of the target fields as accessed.
+     * AnnotationSubstitutionProcessor.processComputedValueFields() also registers the target fields
+     * of the automatic re-computation as unsafe accessed.
+     */
     public void processAnalysis(AnalysisMetaAccess aMetaAccess) {
         switch (kind) {
             case FieldOffset:

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/substitute/SubstitutionReflectivityFilter.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/substitute/SubstitutionReflectivityFilter.java
@@ -46,7 +46,7 @@ public class SubstitutionReflectivityFilter {
     public static boolean shouldExclude(Class<?> classObj, AnalysisMetaAccess metaAccess, AnalysisUniverse universe) {
         try {
             ResolvedJavaType analysisClass = metaAccess.lookupJavaType(classObj);
-            if (!universe.hostVM().platformSupported(universe, analysisClass)) {
+            if (!universe.hostVM().platformSupported(analysisClass)) {
                 return true;
             } else if (analysisClass.isAnnotationPresent(Delete.class)) {
                 return true; // accesses would fail at runtime
@@ -60,7 +60,7 @@ public class SubstitutionReflectivityFilter {
     public static boolean shouldExclude(Executable method, AnalysisMetaAccess metaAccess, AnalysisUniverse universe) {
         try {
             AnalysisMethod aMethod = metaAccess.lookupJavaMethod(method);
-            if (!universe.hostVM().platformSupported(universe, aMethod)) {
+            if (!universe.hostVM().platformSupported(aMethod)) {
                 return true;
             } else if (aMethod.isAnnotationPresent(Delete.class)) {
                 return true; // accesses would fail at runtime
@@ -83,7 +83,7 @@ public class SubstitutionReflectivityFilter {
     public static boolean shouldExclude(Field field, AnalysisMetaAccess metaAccess, AnalysisUniverse universe) {
         try {
             AnalysisField aField = metaAccess.lookupJavaField(field);
-            if (!universe.hostVM().platformSupported(universe, aField)) {
+            if (!universe.hostVM().platformSupported(aField)) {
                 return true;
             }
             if (aField.isAnnotationPresent(Delete.class)) {

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/thread/VMThreadMTFeature.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/thread/VMThreadMTFeature.java
@@ -60,6 +60,7 @@ import com.oracle.svm.core.threadlocal.VMThreadLocalInfo;
 import com.oracle.svm.core.threadlocal.VMThreadLocalInfos;
 import com.oracle.svm.core.threadlocal.VMThreadLocalMTSupport;
 import com.oracle.svm.core.util.VMError;
+import com.oracle.svm.hosted.FeatureImpl.DuringAnalysisAccessImpl;
 
 import jdk.vm.ci.code.MemoryBarriers;
 import jdk.vm.ci.meta.ResolvedJavaMethod;
@@ -226,13 +227,15 @@ public class VMThreadMTFeature implements GraalFeature {
     }
 
     @Override
-    public void duringAnalysis(DuringAnalysisAccess access) {
+    public void duringAnalysis(DuringAnalysisAccess a) {
         /*
          * Update during analysis so that the static analysis sees all infos. After analysis only
          * the order is going to change.
          */
         if (VMThreadLocalInfos.setInfos(threadLocalCollector.threadLocals.values())) {
-            access.requireAnalysisIteration();
+            a.requireAnalysisIteration();
+            DuringAnalysisAccessImpl access = (DuringAnalysisAccessImpl) a;
+            access.rescanField(ImageSingletons.lookup(VMThreadLocalInfos.class), VMThreadLocalInfos.class, "infos");
         }
     }
 

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/thread/VMThreadSTFeature.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/thread/VMThreadSTFeature.java
@@ -56,6 +56,7 @@ import com.oracle.svm.core.threadlocal.FastThreadLocalWord;
 import com.oracle.svm.core.threadlocal.VMThreadLocalInfo;
 import com.oracle.svm.core.threadlocal.VMThreadLocalInfos;
 import com.oracle.svm.core.threadlocal.VMThreadLocalSTSupport;
+import com.oracle.svm.hosted.FeatureImpl.DuringAnalysisAccessImpl;
 
 import jdk.vm.ci.meta.JavaKind;
 import jdk.vm.ci.meta.ResolvedJavaMethod;
@@ -205,13 +206,15 @@ public class VMThreadSTFeature implements GraalFeature {
     }
 
     @Override
-    public void duringAnalysis(DuringAnalysisAccess access) {
+    public void duringAnalysis(DuringAnalysisAccess a) {
         /*
          * Update during analysis so that the static analysis sees all infos. After analysis only
          * the order is going to change.
          */
         if (VMThreadLocalInfos.setInfos(threadLocalCollector.threadLocals.values())) {
-            access.requireAnalysisIteration();
+            a.requireAnalysisIteration();
+            DuringAnalysisAccessImpl access = (DuringAnalysisAccessImpl) a;
+            access.rescanField(ImageSingletons.lookup(VMThreadLocalInfos.class), VMThreadLocalInfos.class, "infos");
         }
     }
 

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/thread/VMThreadSTFeature.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/thread/VMThreadSTFeature.java
@@ -24,6 +24,7 @@
  */
 package com.oracle.svm.hosted.thread;
 
+import java.lang.reflect.Field;
 import java.util.List;
 
 import org.graalvm.compiler.api.replacements.SnippetReflectionProvider;
@@ -56,6 +57,7 @@ import com.oracle.svm.core.threadlocal.FastThreadLocalWord;
 import com.oracle.svm.core.threadlocal.VMThreadLocalInfo;
 import com.oracle.svm.core.threadlocal.VMThreadLocalInfos;
 import com.oracle.svm.core.threadlocal.VMThreadLocalSTSupport;
+import com.oracle.svm.hosted.FeatureImpl;
 import com.oracle.svm.hosted.FeatureImpl.DuringAnalysisAccessImpl;
 
 import jdk.vm.ci.meta.JavaKind;
@@ -69,6 +71,7 @@ import jdk.vm.ci.meta.ResolvedJavaMethod;
 public class VMThreadSTFeature implements GraalFeature {
 
     private final VMThreadLocalCollector threadLocalCollector = new VMThreadLocalCollector();
+    private Field infosField;
 
     @Override
     public boolean isInConfiguration(IsInConfigurationAccess access) {
@@ -79,6 +82,7 @@ public class VMThreadSTFeature implements GraalFeature {
     public void duringSetup(DuringSetupAccess config) {
         ImageSingletons.add(VMThreadLocalSTSupport.class, new VMThreadLocalSTSupport());
         config.registerObjectReplacer(threadLocalCollector);
+        infosField = ((FeatureImpl.DuringSetupAccessImpl) config).findField(VMThreadLocalInfos.class, "infos");
     }
 
     /**
@@ -214,7 +218,7 @@ public class VMThreadSTFeature implements GraalFeature {
         if (VMThreadLocalInfos.setInfos(threadLocalCollector.threadLocals.values())) {
             a.requireAnalysisIteration();
             DuringAnalysisAccessImpl access = (DuringAnalysisAccessImpl) a;
-            access.rescanField(ImageSingletons.lookup(VMThreadLocalInfos.class), VMThreadLocalInfos.class, "infos");
+            access.rescanField(ImageSingletons.lookup(VMThreadLocalInfos.class), infosField);
         }
     }
 

--- a/substratevm/src/com.oracle.svm.jfr/src/com/oracle/svm/jfr/JfrFeature.java
+++ b/substratevm/src/com.oracle.svm.jfr/src/com/oracle/svm/jfr/JfrFeature.java
@@ -49,6 +49,7 @@ import com.oracle.svm.core.thread.ThreadListenerFeature;
 import com.oracle.svm.core.thread.ThreadListenerSupport;
 import com.oracle.svm.core.util.VMError;
 import com.oracle.svm.hosted.FeatureImpl;
+import com.oracle.svm.hosted.FeatureImpl.DuringAnalysisAccessImpl;
 import com.oracle.svm.jfr.traceid.JfrTraceId;
 import com.oracle.svm.jfr.traceid.JfrTraceIdEpoch;
 import com.oracle.svm.jfr.traceid.JfrTraceIdMap;
@@ -174,7 +175,8 @@ public class JfrFeature implements Feature {
     }
 
     @Override
-    public void duringAnalysis(DuringAnalysisAccess access) {
+    public void duringAnalysis(DuringAnalysisAccess a) {
+        DuringAnalysisAccessImpl access = (DuringAnalysisAccessImpl) a;
         Class<?> eventClass = access.findClassByName("jdk.internal.event.Event");
         if (eventClass != null && access.isReachable(eventClass)) {
             Set<Class<?>> s = access.reachableSubtypes(eventClass);
@@ -187,6 +189,7 @@ public class JfrFeature implements Feature {
                 try {
                     Field f = c.getDeclaredField("eventHandler");
                     RuntimeReflection.register(f);
+                    access.rescanRoot(c, "eventHandler");
                 } catch (Exception e) {
                     throw VMError.shouldNotReachHere("Unable to register eventHandler for: " + c.getCanonicalName(), e);
                 }

--- a/substratevm/src/com.oracle.svm.jfr/src/com/oracle/svm/jfr/JfrFeature.java
+++ b/substratevm/src/com.oracle.svm.jfr/src/com/oracle/svm/jfr/JfrFeature.java
@@ -189,7 +189,7 @@ public class JfrFeature implements Feature {
                 try {
                     Field f = c.getDeclaredField("eventHandler");
                     RuntimeReflection.register(f);
-                    access.rescanRoot(c, "eventHandler");
+                    access.rescanRoot(f);
                 } catch (Exception e) {
                     throw VMError.shouldNotReachHere("Unable to register eventHandler for: " + c.getCanonicalName(), e);
                 }

--- a/substratevm/src/com.oracle.svm.jni/src/com/oracle/svm/jni/access/JNIAccessFeature.java
+++ b/substratevm/src/com.oracle.svm.jni/src/com/oracle/svm/jni/access/JNIAccessFeature.java
@@ -281,7 +281,7 @@ public class JNIAccessFeature implements Feature {
         }
         JNIAccessibleClass jniClass = addClass(method.getDeclaringClass(), access);
         JNIAccessibleMethodDescriptor descriptor = JNIAccessibleMethodDescriptor.of(method);
-        jniClass.addMethodIfAbsent(descriptor, d -> {
+        jniClass.addMethodIfAbsent(access, descriptor, d -> {
             MetaAccessProvider wrappedMetaAccess = access.getMetaAccess().getWrapped();
 
             JNIJavaCallWrapperMethod varargsCallWrapper = new JNIJavaCallWrapperMethod(method, CallVariant.VARARGS, false, wrappedMetaAccess, nativeLibraries);
@@ -318,7 +318,7 @@ public class JNIAccessFeature implements Feature {
         }
         JNIAccessibleClass jniClass = addClass(reflField.getDeclaringClass(), access);
         AnalysisField field = access.getMetaAccess().lookupJavaField(reflField);
-        jniClass.addFieldIfAbsent(field.getName(), name -> new JNIAccessibleField(jniClass, name, field.getJavaKind(), field.getModifiers()));
+        jniClass.addFieldIfAbsent(access, field.getName(), name -> new JNIAccessibleField(jniClass, name, field.getJavaKind(), field.getModifiers()));
         field.registerAsJNIAccessed();
         field.registerAsRead(null);
         if (writable) {

--- a/substratevm/src/com.oracle.svm.jni/src/com/oracle/svm/jni/access/JNIAccessibleClass.java
+++ b/substratevm/src/com.oracle.svm.jni/src/com/oracle/svm/jni/access/JNIAccessibleClass.java
@@ -34,6 +34,7 @@ import org.graalvm.nativeimage.Platforms;
 
 import com.oracle.svm.core.util.ImageHeapMap;
 import com.oracle.svm.hosted.FeatureImpl;
+import com.oracle.svm.util.ReflectionUtil;
 
 import jdk.vm.ci.meta.MetaUtil;
 
@@ -72,7 +73,7 @@ public final class JNIAccessibleClass {
         }
         if (!fields.containsKey(name)) {
             fields.put(name, mappingFunction.apply(name));
-            access.rescanField(this, JNIAccessibleClass.class, "fields");
+            access.rescanField(this, ReflectionUtil.lookupField(JNIAccessibleClass.class, "fields"));
         }
     }
 
@@ -83,7 +84,7 @@ public final class JNIAccessibleClass {
         }
         if (!methods.containsKey(descriptor)) {
             methods.put(descriptor, mappingFunction.apply(descriptor));
-            access.rescanField(this, JNIAccessibleClass.class, "methods");
+            access.rescanField(this, ReflectionUtil.lookupField(JNIAccessibleClass.class, "methods"));
         }
     }
 

--- a/substratevm/src/com.oracle.svm.jni/src/com/oracle/svm/jni/access/JNIAccessibleClass.java
+++ b/substratevm/src/com.oracle.svm.jni/src/com/oracle/svm/jni/access/JNIAccessibleClass.java
@@ -33,6 +33,7 @@ import org.graalvm.nativeimage.Platform.HOSTED_ONLY;
 import org.graalvm.nativeimage.Platforms;
 
 import com.oracle.svm.core.util.ImageHeapMap;
+import com.oracle.svm.hosted.FeatureImpl;
 
 import jdk.vm.ci.meta.MetaUtil;
 
@@ -65,22 +66,24 @@ public final class JNIAccessibleClass {
     }
 
     @Platforms(HOSTED_ONLY.class)
-    void addFieldIfAbsent(String name, Function<String, JNIAccessibleField> mappingFunction) {
+    void addFieldIfAbsent(FeatureImpl.DuringAnalysisAccessImpl access, String name, Function<String, JNIAccessibleField> mappingFunction) {
         if (fields == null) {
             fields = ImageHeapMap.create();
         }
         if (!fields.containsKey(name)) {
             fields.put(name, mappingFunction.apply(name));
+            access.rescanField(this, JNIAccessibleClass.class, "fields");
         }
     }
 
     @Platforms(HOSTED_ONLY.class)
-    void addMethodIfAbsent(JNIAccessibleMethodDescriptor descriptor, Function<JNIAccessibleMethodDescriptor, JNIAccessibleMethod> mappingFunction) {
+    void addMethodIfAbsent(FeatureImpl.DuringAnalysisAccessImpl access, JNIAccessibleMethodDescriptor descriptor, Function<JNIAccessibleMethodDescriptor, JNIAccessibleMethod> mappingFunction) {
         if (methods == null) {
             methods = ImageHeapMap.create();
         }
         if (!methods.containsKey(descriptor)) {
             methods.put(descriptor, mappingFunction.apply(descriptor));
+            access.rescanField(this, JNIAccessibleClass.class, "methods");
         }
     }
 

--- a/substratevm/src/com.oracle.svm.jni/src/com/oracle/svm/jni/access/JNINativeLinkage.java
+++ b/substratevm/src/com.oracle.svm.jni/src/com/oracle/svm/jni/access/JNINativeLinkage.java
@@ -28,6 +28,7 @@ import org.graalvm.nativeimage.c.function.CFunctionPointer;
 import org.graalvm.word.PointerBase;
 import org.graalvm.word.WordFactory;
 
+import com.oracle.graal.pointsto.BigBang;
 import com.oracle.svm.core.c.CGlobalData;
 import com.oracle.svm.core.c.CGlobalDataFactory;
 import com.oracle.svm.core.graal.code.CGlobalDataInfo;
@@ -85,11 +86,12 @@ public final class JNINativeLinkage {
         return (PlatformNativeLibrarySupport.singleton().isBuiltinPkgNative(this.getShortName()));
     }
 
-    public CGlobalDataInfo getBuiltInAddress() {
+    public CGlobalDataInfo getBuiltInAddress(BigBang bb) {
         assert this.isBuiltInFunction();
         if (builtInAddress == null) {
             CGlobalData<CFunctionPointer> linkage = CGlobalDataFactory.forSymbol(this.getShortName());
             builtInAddress = CGlobalDataFeature.singleton().registerAsAccessedOrGet(linkage);
+            bb.getUniverse().getHeapScanner().rescanField(this, JNINativeLinkage.class, "builtInAddress");
         }
         return builtInAddress;
     }

--- a/substratevm/src/com.oracle.svm.jni/src/com/oracle/svm/jni/access/JNINativeLinkage.java
+++ b/substratevm/src/com.oracle.svm.jni/src/com/oracle/svm/jni/access/JNINativeLinkage.java
@@ -24,6 +24,10 @@
  */
 package com.oracle.svm.jni.access;
 
+//Checkstyle: allow reflection
+
+import java.lang.reflect.Field;
+
 import org.graalvm.nativeimage.c.function.CFunctionPointer;
 import org.graalvm.word.PointerBase;
 import org.graalvm.word.WordFactory;
@@ -35,6 +39,7 @@ import com.oracle.svm.core.graal.code.CGlobalDataInfo;
 import com.oracle.svm.core.jdk.NativeLibrarySupport;
 import com.oracle.svm.core.jdk.PlatformNativeLibrarySupport;
 import com.oracle.svm.hosted.c.CGlobalDataFeature;
+import com.oracle.svm.util.ReflectionUtil;
 
 import jdk.vm.ci.meta.JavaType;
 import jdk.vm.ci.meta.MetaUtil;
@@ -91,7 +96,8 @@ public final class JNINativeLinkage {
         if (builtInAddress == null) {
             CGlobalData<CFunctionPointer> linkage = CGlobalDataFactory.forSymbol(this.getShortName());
             builtInAddress = CGlobalDataFeature.singleton().registerAsAccessedOrGet(linkage);
-            bb.getUniverse().getHeapScanner().rescanField(this, JNINativeLinkage.class, "builtInAddress");
+            Field jniNativeLinkageBuiltInAddressField = ReflectionUtil.lookupField(JNINativeLinkage.class, "builtInAddress");
+            bb.getUniverse().getHeapScanner().rescanField(this, jniNativeLinkageBuiltInAddressField);
         }
         return builtInAddress;
     }

--- a/substratevm/src/com.oracle.svm.jni/src/com/oracle/svm/jni/hosted/JNICallTrampolineMethod.java
+++ b/substratevm/src/com.oracle.svm.jni/src/com/oracle/svm/jni/hosted/JNICallTrampolineMethod.java
@@ -139,7 +139,7 @@ public class JNICallTrampolineMethod extends CustomSubstitutionMethod {
 
     private int getFieldOffset(HostedProviders providers) {
         HostedMetaAccess metaAccess = (HostedMetaAccess) providers.getMetaAccess();
-        HostedUniverse universe = (HostedUniverse) metaAccess.getUniverse();
+        HostedUniverse universe = metaAccess.getUniverse();
         AnalysisUniverse analysisUniverse = universe.getBigBang().getUniverse();
         HostedField hostedField = universe.lookup(analysisUniverse.lookup(callWrapperField));
         assert hostedField.hasLocation();

--- a/substratevm/src/com.oracle.svm.jni/src/com/oracle/svm/jni/hosted/JNINativeCallWrapperMethod.java
+++ b/substratevm/src/com.oracle.svm.jni/src/com/oracle/svm/jni/hosted/JNINativeCallWrapperMethod.java
@@ -113,7 +113,7 @@ class JNINativeCallWrapperMethod extends CustomSubstitutionMethod {
 
         ValueNode callAddress;
         if (linkage.isBuiltInFunction()) {
-            callAddress = kit.unique(new CGlobalDataLoadAddressNode(linkage.getBuiltInAddress()));
+            callAddress = kit.unique(new CGlobalDataLoadAddressNode(linkage.getBuiltInAddress(providers.getBigBang())));
         } else {
             callAddress = kit.nativeCallAddress(kit.createObject(linkage));
         }

--- a/substratevm/src/com.oracle.svm.reflect/src/com/oracle/svm/reflect/hosted/FieldOffsetComputer.java
+++ b/substratevm/src/com.oracle.svm.reflect/src/com/oracle/svm/reflect/hosted/FieldOffsetComputer.java
@@ -28,6 +28,7 @@ package com.oracle.svm.reflect.hosted;
 
 import java.lang.reflect.Field;
 
+import com.oracle.svm.core.annotate.RecomputeFieldValue;
 import com.oracle.svm.core.annotate.RecomputeFieldValue.CustomFieldValueComputer;
 import com.oracle.svm.core.util.VMError;
 import com.oracle.svm.hosted.meta.HostedField;
@@ -37,6 +38,11 @@ import jdk.vm.ci.meta.MetaAccessProvider;
 import jdk.vm.ci.meta.ResolvedJavaField;
 
 public class FieldOffsetComputer implements CustomFieldValueComputer {
+
+    @Override
+    public RecomputeFieldValue.ValueAvailability valueAvailability() {
+        return RecomputeFieldValue.ValueAvailability.AfterAnalysis;
+    }
 
     @Override
     public Object compute(MetaAccessProvider metaAccess, ResolvedJavaField original, ResolvedJavaField annotated, Object receiver) {

--- a/substratevm/src/com.oracle.svm.reflect/src/com/oracle/svm/reflect/hosted/ReflectionDataBuilder.java
+++ b/substratevm/src/com.oracle.svm.reflect/src/com/oracle/svm/reflect/hosted/ReflectionDataBuilder.java
@@ -51,10 +51,10 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
-import com.oracle.svm.core.jdk.SealedClassSupport;
 import org.graalvm.compiler.debug.GraalError;
 import org.graalvm.nativeimage.ImageSingletons;
 import org.graalvm.nativeimage.hosted.Feature.DuringAnalysisAccess;
+import org.graalvm.nativeimage.hosted.Feature.DuringSetupAccess;
 import org.graalvm.nativeimage.impl.ConfigurationCondition;
 import org.graalvm.nativeimage.impl.RuntimeReflectionSupport;
 import org.graalvm.util.GuardedAnnotationAccess;
@@ -67,11 +67,13 @@ import com.oracle.svm.core.hub.AnnotationTypeSupport;
 import com.oracle.svm.core.hub.ClassForNameSupport;
 import com.oracle.svm.core.hub.DynamicHub;
 import com.oracle.svm.core.jdk.RecordSupport;
+import com.oracle.svm.core.jdk.SealedClassSupport;
 import com.oracle.svm.core.jdk.proxy.DynamicProxyRegistry;
 import com.oracle.svm.core.util.UserError;
 import com.oracle.svm.core.util.VMError;
 import com.oracle.svm.hosted.ConditionalConfigurationRegistry;
 import com.oracle.svm.hosted.FeatureImpl.DuringAnalysisAccessImpl;
+import com.oracle.svm.hosted.FeatureImpl.DuringSetupAccessImpl;
 import com.oracle.svm.hosted.FeatureImpl.FeatureAccessImpl;
 import com.oracle.svm.hosted.annotation.AnnotationSubstitutionType;
 import com.oracle.svm.hosted.substitute.SubstitutionReflectivityFilter;
@@ -107,6 +109,9 @@ public class ReflectionDataBuilder extends ConditionalConfigurationRegistry impl
     private final Map<Class<?>, Set<Member>> annotationMembers = new HashMap<>();
 
     private final ReflectionDataAccessors accessors;
+
+    private static Field annotationTypeMapField;
+    private static Field dynamicHubReflectionDataField;
 
     public ReflectionDataBuilder(FeatureAccessImpl access) {
         arrayReflectionData = getArrayReflectionData();
@@ -196,6 +201,12 @@ public class ReflectionDataBuilder extends ConditionalConfigurationRegistry impl
         if (sealed) {
             throw UserError.abort("Too late to add classes, methods, and fields for reflective access. Registration must happen in a Feature before the analysis has finished.");
         }
+    }
+
+    protected void duringSetup(DuringSetupAccess a) {
+        DuringSetupAccessImpl access = (DuringSetupAccessImpl) a;
+        annotationTypeMapField = access.findField(AnnotationTypeSupport.class, "annotationTypeMap");
+        dynamicHubReflectionDataField = access.findField(DynamicHub.class, "rd");
     }
 
     protected void duringAnalysis(DuringAnalysisAccess a) {
@@ -446,7 +457,7 @@ public class ReflectionDataBuilder extends ConditionalConfigurationRegistry impl
              */
             AnnotationTypeSupport annotationTypeSupport = ImageSingletons.lookup(AnnotationTypeSupport.class);
             if (annotationTypeSupport.createInstance((Class<? extends Annotation>) type)) {
-                access.rescanField(annotationTypeSupport, AnnotationTypeSupport.class, "annotationTypeMap");
+                access.rescanField(annotationTypeSupport, annotationTypeMapField);
             }
             ImageSingletons.lookup(DynamicProxyRegistry.class).addProxyClass(type);
 
@@ -565,7 +576,7 @@ public class ReflectionDataBuilder extends ConditionalConfigurationRegistry impl
                             buildRecordComponents(clazz, access));
         }
         hub.setReflectionData(reflectionData);
-        access.rescanField(hub, DynamicHub.class, "rd");
+        access.rescanField(hub, dynamicHubReflectionDataField);
 
         if (type.isAnnotation()) {
             /*

--- a/substratevm/src/com.oracle.svm.reflect/src/com/oracle/svm/reflect/hosted/ReflectionDataBuilder.java
+++ b/substratevm/src/com.oracle.svm.reflect/src/com/oracle/svm/reflect/hosted/ReflectionDataBuilder.java
@@ -411,6 +411,7 @@ public class ReflectionDataBuilder extends ConditionalConfigurationRegistry impl
                 access.requireAnalysisIteration();
             }
             ClassForNameSupport.registerClass(clazz);
+            // access.rescanObject(annotationTypeSupport.getAnnotationTypeMap());
         } else if (type instanceof TypeVariable<?>) {
             for (Type bound : ((TypeVariable<?>) type).getBounds()) {
                 makeTypeReachable(access, bound);
@@ -443,7 +444,10 @@ public class ReflectionDataBuilder extends ConditionalConfigurationRegistry impl
              * Parsing annotation data in reflection classes requires being able to instantiate all
              * annotation types at runtime.
              */
-            ImageSingletons.lookup(AnnotationTypeSupport.class).createInstance((Class<? extends Annotation>) type);
+            AnnotationTypeSupport annotationTypeSupport = ImageSingletons.lookup(AnnotationTypeSupport.class);
+            if (annotationTypeSupport.createInstance((Class<? extends Annotation>) type)) {
+                access.rescanField(annotationTypeSupport, AnnotationTypeSupport.class, "annotationTypeMap");
+            }
             ImageSingletons.lookup(DynamicProxyRegistry.class).addProxyClass(type);
 
             Annotation annotation = (Annotation) value;
@@ -507,6 +511,7 @@ public class ReflectionDataBuilder extends ConditionalConfigurationRegistry impl
 
         if (reflectionClasses.contains(clazz)) {
             ClassForNameSupport.registerClass(clazz);
+            // access.rescanObject(ImageSingletons.lookup(ClassForNameSupport.class).registeredClasses);
         }
 
         /*
@@ -560,6 +565,7 @@ public class ReflectionDataBuilder extends ConditionalConfigurationRegistry impl
                             buildRecordComponents(clazz, access));
         }
         hub.setReflectionData(reflectionData);
+        access.rescanField(hub, DynamicHub.class, "rd");
 
         if (type.isAnnotation()) {
             /*

--- a/substratevm/src/com.oracle.svm.reflect/src/com/oracle/svm/reflect/hosted/ReflectionFeature.java
+++ b/substratevm/src/com.oracle.svm.reflect/src/com/oracle/svm/reflect/hosted/ReflectionFeature.java
@@ -188,6 +188,7 @@ public class ReflectionFeature implements GraalFeature {
 
         loader = access.getImageClassLoader();
         annotationSubstitutions = ((Inflation) access.getBigBang()).getAnnotationSubstitutionProcessor();
+        reflectionData.duringSetup(access);
     }
 
     @Override

--- a/substratevm/src/com.oracle.svm.reflect/src/com/oracle/svm/reflect/hosted/ReflectionObjectReplacer.java
+++ b/substratevm/src/com.oracle.svm.reflect/src/com/oracle/svm/reflect/hosted/ReflectionObjectReplacer.java
@@ -41,7 +41,6 @@ import org.graalvm.util.GuardedAnnotationAccess;
 import com.oracle.graal.pointsto.meta.AnalysisField;
 import com.oracle.graal.pointsto.meta.AnalysisMetaAccess;
 import com.oracle.graal.pointsto.meta.AnalysisType;
-import com.oracle.graal.pointsto.meta.AnalysisUniverse;
 import com.oracle.svm.core.annotate.Delete;
 
 import sun.reflect.generics.repository.AbstractRepository;
@@ -115,7 +114,7 @@ public class ReflectionObjectReplacer implements Function<Object, Object> {
 
                     if (!analysisField.isUnsafeAccessed()) {
                         analysisField.registerAsAccessed();
-                        analysisField.registerAsUnsafeAccessed((AnalysisUniverse) metaAccess.getUniverse());
+                        analysisField.registerAsUnsafeAccessed();
                     }
                 }
             }

--- a/substratevm/src/com.oracle.svm.reflect/src/com/oracle/svm/reflect/hosted/ReflectionObjectReplacer.java
+++ b/substratevm/src/com.oracle.svm.reflect/src/com/oracle/svm/reflect/hosted/ReflectionObjectReplacer.java
@@ -49,6 +49,7 @@ import sun.reflect.generics.repository.ConstructorRepository;
 import sun.reflect.generics.repository.FieldRepository;
 import sun.reflect.generics.repository.GenericDeclRepository;
 import sun.reflect.generics.repository.MethodRepository;
+import sun.reflect.generics.scope.AbstractScope;
 
 public class ReflectionObjectReplacer implements Function<Object, Object> {
     private final AnalysisMetaAccess metaAccess;
@@ -79,7 +80,8 @@ public class ReflectionObjectReplacer implements Function<Object, Object> {
 
     @Override
     public Object apply(Object original) {
-        if (original instanceof AccessibleObject || original instanceof Parameter || original instanceof AbstractRepository) {
+        if (original instanceof AccessibleObject || original instanceof Parameter ||
+                        original instanceof AbstractRepository || original instanceof AbstractScope) {
             if (scanned.add(new Identity(original))) {
                 scan(original);
             }
@@ -180,6 +182,23 @@ public class ReflectionObjectReplacer implements Function<Object, Object> {
             ClassRepository classRepository = (ClassRepository) original;
             classRepository.getSuperclass();
             classRepository.getSuperInterfaces();
+        }
+        if (original instanceof AbstractScope) {
+            AbstractScope<?> abstractScope = (AbstractScope<?>) original;
+            /*
+             * Lookup a type variable in the scope to trigger creation of
+             * sun.reflect.generics.scope.AbstractScope.enclosingScope. The looked-up value is not
+             * important, we just want to trigger creation of lazy internal state. The same eager
+             * initialization is triggered by
+             * sun.reflect.generics.repository.MethodRepository.getReturnType() called above,
+             * however if the AbstractScope is seen first by the heap scanner then a `null` value
+             * will be snapshotted for the `enclosingScope`.
+             */
+            try {
+                abstractScope.lookup("");
+            } catch (UnsatisfiedLinkError | NoClassDefFoundError e) {
+                // The lookup calls Class.getEnclosingClass() which may fail.
+            }
         }
     }
 }

--- a/substratevm/src/com.oracle.svm.reflect/src/com/oracle/svm/reflect/proxy/hosted/DynamicProxyFeature.java
+++ b/substratevm/src/com.oracle.svm.reflect/src/com/oracle/svm/reflect/proxy/hosted/DynamicProxyFeature.java
@@ -24,6 +24,9 @@
  */
 package com.oracle.svm.reflect.proxy.hosted;
 
+// Checkstyle: allow reflection
+
+import java.lang.reflect.Field;
 import java.util.Collections;
 import java.util.List;
 
@@ -48,6 +51,7 @@ import com.oracle.svm.reflect.proxy.DynamicProxySupport;
 @AutomaticFeature
 public final class DynamicProxyFeature implements Feature {
     private int loadedConfigurations;
+    private Field proxyCacheField;
 
     @Override
     public List<Class<? extends Feature>> getRequiredFeatures() {
@@ -68,6 +72,8 @@ public final class DynamicProxyFeature implements Feature {
         loadedConfigurations = ConfigurationParserUtils.parseAndRegisterConfigurations(parser, imageClassLoader, "dynamic proxy",
                         ConfigurationFiles.Options.DynamicProxyConfigurationFiles, ConfigurationFiles.Options.DynamicProxyConfigurationResources,
                         ConfigurationFile.DYNAMIC_PROXY.getFileName());
+
+        proxyCacheField = access.findField(DynamicProxySupport.class, "proxyCache");
     }
 
     private static ProxyRegistry proxyRegistry() {
@@ -82,7 +88,7 @@ public final class DynamicProxyFeature implements Feature {
     @Override
     public void duringAnalysis(DuringAnalysisAccess a) {
         DuringAnalysisAccessImpl access = (DuringAnalysisAccessImpl) a;
-        access.rescanField(ImageSingletons.lookup(DynamicProxyRegistry.class), DynamicProxySupport.class, "proxyCache");
+        access.rescanField(ImageSingletons.lookup(DynamicProxyRegistry.class), proxyCacheField);
         proxyRegistry().flushConditionalConfiguration(a);
     }
 

--- a/substratevm/src/com.oracle.svm.reflect/src/com/oracle/svm/reflect/proxy/hosted/DynamicProxyFeature.java
+++ b/substratevm/src/com.oracle.svm.reflect/src/com/oracle/svm/reflect/proxy/hosted/DynamicProxyFeature.java
@@ -37,6 +37,7 @@ import com.oracle.svm.core.configure.ProxyConfigurationParser;
 import com.oracle.svm.core.jdk.proxy.DynamicProxyRegistry;
 import com.oracle.svm.hosted.ConfigurationTypeResolver;
 import com.oracle.svm.hosted.FallbackFeature;
+import com.oracle.svm.hosted.FeatureImpl.DuringAnalysisAccessImpl;
 import com.oracle.svm.hosted.FeatureImpl.DuringSetupAccessImpl;
 import com.oracle.svm.hosted.ImageClassLoader;
 import com.oracle.svm.hosted.NativeImageOptions;
@@ -79,8 +80,10 @@ public final class DynamicProxyFeature implements Feature {
     }
 
     @Override
-    public void duringAnalysis(DuringAnalysisAccess access) {
-        proxyRegistry().flushConditionalConfiguration(access);
+    public void duringAnalysis(DuringAnalysisAccess a) {
+        DuringAnalysisAccessImpl access = (DuringAnalysisAccessImpl) a;
+        access.rescanField(ImageSingletons.lookup(DynamicProxyRegistry.class), DynamicProxySupport.class, "proxyCache");
+        proxyRegistry().flushConditionalConfiguration(a);
     }
 
     @Override

--- a/substratevm/src/com.oracle.svm.reflect/src/com/oracle/svm/reflect/serialize/hosted/SerializationFeature.java
+++ b/substratevm/src/com.oracle.svm.reflect/src/com/oracle/svm/reflect/serialize/hosted/SerializationFeature.java
@@ -99,6 +99,14 @@ public class SerializationFeature implements Feature {
     @Override
     public void beforeAnalysis(BeforeAnalysisAccess access) {
         serializationBuilder.flushConditionalConfiguration(access);
+
+        try {
+            ImageClassLoader loader = ((FeatureImpl.BeforeAnalysisAccessImpl) access).getImageClassLoader();
+            /* Ensure SharedSecrets.javaObjectInputStreamAccess is initialized before scanning. */
+            loader.forName("java.io.ObjectInputStream", true);
+        } catch (ClassNotFoundException e) {
+            VMError.shouldNotReachHere(e);
+        }
     }
 
     @Override

--- a/substratevm/src/com.oracle.svm.truffle.tck/src/com/oracle/svm/truffle/tck/WhiteListParser.java
+++ b/substratevm/src/com.oracle.svm.truffle.tck/src/com/oracle/svm/truffle/tck/WhiteListParser.java
@@ -192,12 +192,12 @@ final class WhiteListParser extends ConfigurationParser {
     private void verifySupportedOnActivePlatform(Class<?> clz) throws UnsupportedPlatformException {
         AnalysisUniverse universe = bb.getUniverse();
         Package pkg = clz.getPackage();
-        if (pkg != null && !universe.hostVM().platformSupported(universe, pkg)) {
+        if (pkg != null && !universe.hostVM().platformSupported(pkg)) {
             throw new UnsupportedPlatformException(clz.getPackage());
         }
         Class<?> current = clz;
         do {
-            if (!universe.hostVM().platformSupported(universe, current)) {
+            if (!universe.hostVM().platformSupported(current)) {
                 throw new UnsupportedPlatformException(current);
             }
             current = current.getEnclosingClass();

--- a/substratevm/src/com.oracle.svm.truffle/src/com/oracle/svm/truffle/TruffleBaseFeature.java
+++ b/substratevm/src/com.oracle.svm.truffle/src/com/oracle/svm/truffle/TruffleBaseFeature.java
@@ -352,6 +352,8 @@ public final class TruffleBaseFeature implements com.oracle.svm.core.graal.Graal
     public void duringAnalysis(DuringAnalysisAccess a) {
         DuringAnalysisAccessImpl access = (DuringAnalysisAccessImpl) a;
 
+        StaticObjectSupport.duringAnalysis(a);
+
         for (Class<?> clazz : a.reachableSubtypes(com.oracle.truffle.api.nodes.Node.class)) {
             registerUnsafeAccess(a, clazz.asSubclass(com.oracle.truffle.api.nodes.Node.class));
 
@@ -373,9 +375,9 @@ public final class TruffleBaseFeature implements com.oracle.svm.core.graal.Graal
         // access.rescanRoot("com.oracle.truffle.api.library.LibraryFactory$ResolvedDispatch",
         // "CACHE");
         access.rescanRoot("com.oracle.truffle.object.DefaultLayout$LayoutInfo", "LAYOUT_INFO_MAP");
-        access.rescanRoot("com.oracle.truffle.polyglot.PolyglotEngineImpl", "ENGINES");
-        // access.rescanRoot("com.oracle.truffle.api.TruffleLogger$LoggerCache", "INSTANCE");
         access.rescanRoot("com.oracle.truffle.object.DefaultLayout", "LAYOUT_MAP");
+        // access.rescanRoot("com.oracle.truffle.polyglot.PolyglotEngineImpl", "ENGINES");
+        // access.rescanRoot("com.oracle.truffle.api.TruffleLogger$LoggerCache", "INSTANCE");
 
         // Object instance = access.rescanRoot("com.oracle.truffle.api.TruffleLogger$LoggerCache",
         // "INSTANCE");

--- a/substratevm/src/com.oracle.svm.truffle/src/com/oracle/svm/truffle/TruffleBaseFeature.java
+++ b/substratevm/src/com.oracle.svm.truffle/src/com/oracle/svm/truffle/TruffleBaseFeature.java
@@ -354,8 +354,8 @@ public final class TruffleBaseFeature implements com.oracle.svm.core.graal.Graal
 
         StaticObjectSupport.duringAnalysis(a);
 
-        for (Class<?> clazz : a.reachableSubtypes(com.oracle.truffle.api.nodes.Node.class)) {
-            registerUnsafeAccess(a, clazz.asSubclass(com.oracle.truffle.api.nodes.Node.class));
+        for (Class<?> clazz : access.reachableSubtypes(com.oracle.truffle.api.nodes.Node.class)) {
+            registerUnsafeAccess(access, clazz.asSubclass(com.oracle.truffle.api.nodes.Node.class));
 
             AnalysisType type = access.getMetaAccess().lookupJavaType(clazz);
             if (type.isInstantiated()) {

--- a/substratevm/src/com.oracle.svm.truffle/src/com/oracle/svm/truffle/TruffleBaseFeature.java
+++ b/substratevm/src/com.oracle.svm.truffle/src/com/oracle/svm/truffle/TruffleBaseFeature.java
@@ -727,6 +727,11 @@ final class Target_com_oracle_truffle_api_staticobject_ArrayBasedShapeGenerator 
         }
 
         @Override
+        public RecomputeFieldValue.ValueAvailability valueAvailability() {
+            return RecomputeFieldValue.ValueAvailability.AfterAnalysis;
+        }
+
+        @Override
         public Object transform(MetaAccessProvider metaAccess, ResolvedJavaField original, ResolvedJavaField annotated,
                         Object receiver, Object originalValue) {
             Class<?> generatedStorageClass = ReflectionUtil.readField(SHAPE_GENERATOR, "generatedStorageClass",

--- a/substratevm/src/com.oracle.svm.truffle/src/com/oracle/svm/truffle/TruffleFeature.java
+++ b/substratevm/src/com.oracle.svm.truffle/src/com/oracle/svm/truffle/TruffleFeature.java
@@ -373,12 +373,6 @@ public class TruffleFeature implements com.oracle.svm.core.graal.GraalFeature {
         }
     }
 
-    @Override
-    public void duringAnalysis(DuringAnalysisAccess a) {
-        FeatureImpl.DuringAnalysisAccessImpl access = (FeatureImpl.DuringAnalysisAccessImpl) a;
-        access.rescanRoot("com.oracle.truffle.polyglot.PolyglotEngineImpl", "ENGINES");
-    }
-
     static class TruffleParsingInlineInvokePlugin implements InlineInvokePlugin {
 
         private final SVMHost hostVM;

--- a/substratevm/src/com.oracle.svm.truffle/src/com/oracle/svm/truffle/TruffleFeature.java
+++ b/substratevm/src/com.oracle.svm.truffle/src/com/oracle/svm/truffle/TruffleFeature.java
@@ -364,6 +364,19 @@ public class TruffleFeature implements com.oracle.svm.core.graal.GraalFeature {
          */
         TruffleBaseFeature.invokeStaticMethod("com.oracle.truffle.polyglot.PolyglotEngineImpl", "resetFallbackEngine", Collections.emptyList());
         TruffleBaseFeature.preInitializeEngine();
+
+        try {
+            /* Ensure org.graalvm.polyglot.io.IOHelper.IMPL is initialized. */
+            ((FeatureImpl.BeforeAnalysisAccessImpl) access).getImageClassLoader().forName("org.graalvm.polyglot.io.IOHelper", true);
+        } catch (ClassNotFoundException e) {
+            throw VMError.shouldNotReachHere(e);
+        }
+    }
+
+    @Override
+    public void duringAnalysis(DuringAnalysisAccess a) {
+        FeatureImpl.DuringAnalysisAccessImpl access = (FeatureImpl.DuringAnalysisAccessImpl) a;
+        access.rescanRoot("com.oracle.truffle.polyglot.PolyglotEngineImpl", "ENGINES");
     }
 
     static class TruffleParsingInlineInvokePlugin implements InlineInvokePlugin {


### PR DESCRIPTION
Scan the image heap during analysis, concurrently with type flow propagation, to avoid scanning from roots multiple times. This eliminates the `(objects)` image build phase, i.e., the old, repeated scanning from roots, and it should improve the image build time for images with large heaps.