### PR TITLE
Substitute `ClassLoader.createOrGetClassLoaderValueMap` in order to make `Module.defineModule0` work with XLST

### DIFF
--- a/substratevm/src/com.oracle.svm.core.jdk11/src/com/oracle/svm/core/jdk11/Target_java_lang_ClassLoader_JDK11OrLater.java
+++ b/substratevm/src/com.oracle.svm.core.jdk11/src/com/oracle/svm/core/jdk11/Target_java_lang_ClassLoader_JDK11OrLater.java
@@ -46,7 +46,22 @@ public final class Target_java_lang_ClassLoader_JDK11OrLater {
      */
     @Alias @RecomputeFieldValue(kind = RecomputeFieldValue.Kind.NewInstance, declClass = ConcurrentHashMap.class)//
     @TargetElement(onlyWith = JDK11OrLater.class)//
-    ConcurrentHashMap<?, ?> classLoaderValueMap;
+    volatile ConcurrentHashMap<?, ?> classLoaderValueMap;
+
+    @Substitute
+    ConcurrentHashMap<?, ?> createOrGetClassLoaderValueMap() {
+        ConcurrentHashMap<?, ?> result = classLoaderValueMap;
+        if (result == null) {
+            // Checkstyle: allow synchronization
+            synchronized (this) {
+                result = classLoaderValueMap;
+                if (result == null) {
+                    classLoaderValueMap = result = new ConcurrentHashMap<>();
+                }
+            }
+        }
+        return result;
+    }
 
     @Alias
     @TargetElement(onlyWith = JDK11OrLater.class)

--- a/substratevm/src/com.oracle.svm.core.jdk11/src/com/oracle/svm/core/jdk11/Target_java_lang_ClassLoader_JDK11OrLater.java
+++ b/substratevm/src/com.oracle.svm.core.jdk11/src/com/oracle/svm/core/jdk11/Target_java_lang_ClassLoader_JDK11OrLater.java
@@ -30,6 +30,7 @@ import com.oracle.svm.core.annotate.Substitute;
 import com.oracle.svm.core.annotate.TargetClass;
 import com.oracle.svm.core.annotate.TargetElement;
 import com.oracle.svm.core.jdk.JDK11OrLater;
+import com.oracle.svm.core.jdk.JDK17OrLater;
 import com.oracle.svm.core.util.LazyFinalReference;
 
 import java.util.concurrent.ConcurrentHashMap;
@@ -49,6 +50,7 @@ public final class Target_java_lang_ClassLoader_JDK11OrLater {
     volatile ConcurrentHashMap<?, ?> classLoaderValueMap;
 
     @Substitute
+    @TargetElement(onlyWith = JDK17OrLater.class)//
     ConcurrentHashMap<?, ?> createOrGetClassLoaderValueMap() {
         ConcurrentHashMap<?, ?> result = classLoaderValueMap;
         if (result == null) {


### PR DESCRIPTION
This PR addresses a part of #3811.

`ClassLoader.createOrGetClassLoaderValueMap` is invoked by `Module.defineModule0` in this case, and inititalizes the `classLoaderValueMap` in an atomic way. The JDK implementation uses `Unsafe` to get-or-set the field, so this PR introduces a substitution that will bypass a call to `Unsafe.objectFieldOffset`.

Our implementation of `Unsafe.objectFieldOffset` substitution currently uses reflection to fetch the offset of a field. If a field is filtered by JDK's reflection filters, that invocation will throw.