### PR TITLE
Use movi to set FP registers to zero on AArch64

### DIFF
--- a/compiler/src/org.graalvm.compiler.lir.aarch64/src/org/graalvm/compiler/lir/aarch64/AArch64MathCopySignOp.java
+++ b/compiler/src/org.graalvm.compiler.lir.aarch64/src/org/graalvm/compiler/lir/aarch64/AArch64MathCopySignOp.java
@@ -63,7 +63,7 @@ public final class AArch64MathCopySignOp extends AArch64LIRInstruction {
         Register signReg = asRegister(sign);
 
         int size = result.getPlatformKind().getSizeInBytes() * Byte.SIZE;
-        masm.fmov(size, resultReg, 0);
+        masm.neon.moviVI(ASIMDSize.HalfReg, resultReg, 0);
         masm.fneg(size, resultReg, resultReg);
         masm.neon.bslVVV(ASIMDSize.HalfReg, resultReg, signReg, magnitudeReg);
     }

--- a/compiler/src/org.graalvm.compiler.lir.aarch64/src/org/graalvm/compiler/lir/aarch64/AArch64MathSignumOp.java
+++ b/compiler/src/org.graalvm.compiler.lir.aarch64/src/org/graalvm/compiler/lir/aarch64/AArch64MathSignumOp.java
@@ -66,7 +66,7 @@ public final class AArch64MathSignumOp extends AArch64LIRInstruction {
         Register floatScratch = asRegister(scratch);
 
         int size = result.getPlatformKind().getSizeInBytes() * Byte.SIZE;
-        masm.fmov(size, floatScratch, 0.0d);
+        masm.neon.moviVI(ASIMDSize.HalfReg, floatScratch, 0);
         masm.neon.facgtSSS(ElementSize.fromKind(result.getPlatformKind()), resultReg, inputReg, floatScratch);
         masm.neon.ushrSSI(ElementSize.DoubleWord, resultReg, resultReg, 1);
         masm.fmov(size, floatScratch, 1.0d);

--- a/compiler/src/org.graalvm.compiler.lir.aarch64/src/org/graalvm/compiler/lir/aarch64/AArch64Move.java
+++ b/compiler/src/org.graalvm.compiler.lir.aarch64/src/org/graalvm/compiler/lir/aarch64/AArch64Move.java
@@ -612,7 +612,11 @@ public class AArch64Move {
                 break;
             case Float:
                 if (AArch64MacroAssembler.isFloatImmediate(input.asFloat()) && result.getRegisterCategory().equals(SIMD)) {
-                    masm.fmov(32, result, input.asFloat());
+                    if (input.asFloat() == 0.0) {
+                        masm.neon.moviVI(AArch64ASIMDAssembler.ASIMDSize.HalfReg, result, 0);
+                    } else {
+                        masm.fmov(32, result, input.asFloat());
+                    }
                 } else if (result.getRegisterCategory().equals(CPU)) {
                     masm.mov(result, Float.floatToRawIntBits(input.asFloat()));
                 } else {
@@ -625,7 +629,11 @@ public class AArch64Move {
                 break;
             case Double:
                 if (AArch64MacroAssembler.isDoubleImmediate(input.asDouble()) && result.getRegisterCategory().equals(SIMD)) {
-                    masm.fmov(64, result, input.asDouble());
+                    if (input.asDouble() == 0.0) {
+                        masm.neon.moviVI(AArch64ASIMDAssembler.ASIMDSize.HalfReg, result, 0);
+                    } else {
+                        masm.fmov(64, result, input.asDouble());
+                    }
                 } else if (result.getRegisterCategory().equals(CPU)) {
                     masm.mov(result, Double.doubleToRawLongBits(input.asDouble()));
                 } else {


### PR DESCRIPTION
Changes made to replace "fmov" instructions with a constant "0.0"
with "movi" instructions on AArch64. The "movi" instructions are faster and
therefore the recommended instruction.

It is worthy of note that this change has already been
implemented in OpenJDK.

More details are on the OpenJDK patch here:
https://github.com/openjdk/jdk/pull/3322