### PR TITLE
Adding the "Towards a polyglot framework for factorized ML" paper

### DIFF
--- a/docs/Publications.md
+++ b/docs/Publications.md
@@ -57,6 +57,11 @@ SPLASH 2012, October 19-26, Tucson, AZ
 
 ## Truffle Papers
 
+### 2021
+- David Justo, Shaoqing Yi, Lukas Stadler, Nadia Polikarpova, Arun Kumar
+[**Towards a polyglot framework for factorized ML**](https://dl.acm.org/doi/abs/10.14778/3476311.3476372)
+In _Proceedings of the VLDB Endowment 14, Issue 12 (VLDB 2021 Industry Track)_
+
 ### 2020
 
 - Fabio Niephaus, Patrick Rein, Jakob Edding, Jonas Hering, Bastian König, Kolya Opahle, Nico Scordialo, Robert Hirschfeld


### PR DESCRIPTION
Hi all, I saw that in [this](https://www.graalvm.org/community/publications/) page that you all accept PRs to include research work done with GraalVM.
I'm sending this PR to include some work that I started during my internship at OracleLabs in the summer of 2019. Thanks!

I also noticed that the publications [page](https://www.graalvm.org/community/publications/) hasn't been updated in some time. Will it be updated again anytime soon with the contents of this README? I noticed that the 2020 papers don't show up, for example. Thanks again!

Also tagging @lukasstadler, who was involved in this work :-) 