### PR TITLE
Fix: finagle-chirper and finagle-http benchmarks on renaissance 0.13.0.

### DIFF
--- a/java-benchmarks/mx.java-benchmarks/mx_java_benchmarks.py
+++ b/java-benchmarks/mx.java-benchmarks/mx_java_benchmarks.py
@@ -1924,6 +1924,16 @@ class RenaissanceBenchmarkSuite(mx_benchmark.JavaBenchmarkSuite, mx_benchmark.Av
             else:
                 return ["-r", str(iterations)] + remaining
 
+    def vmArgs(self, bmSuiteArgs):
+        vm_args = super(RenaissanceBenchmarkSuite, self).vmArgs(bmSuiteArgs)
+        # The --add-opens flag will be available in the next Renaissance release (> 0.13.0).
+        if java_home_jdk().javaCompliance > '16' and self.version() in ["0.9.0", "0.10.0", "0.11.0", "0.12.0",
+                                                                        "0.13.0"]:
+            vm_args += ["--add-opens", "java.management/sun.management=ALL-UNNAMED"]
+            vm_args += ["--add-opens", "java.management/sun.management.counter=ALL-UNNAMED"]
+            vm_args += ["--add-opens", "java.management/sun.management.counter.perf=ALL-UNNAMED"]
+        return vm_args
+
     def createCommandLineArgs(self, benchmarks, bmSuiteArgs):
         benchArg = ""
         if benchmarks is None:

--- a/substratevm/src/com.oracle.svm.configure/src/com/oracle/svm/configure/trace/AccessAdvisor.java
+++ b/substratevm/src/com.oracle.svm.configure/src/com/oracle/svm/configure/trace/AccessAdvisor.java
@@ -66,7 +66,7 @@ public final class AccessAdvisor {
         internalCallerFilter.addOrGetChildren("com.sun.nio.zipfs.**", RuleNode.Inclusion.Exclude);
         internalCallerFilter.addOrGetChildren("java.io.**", RuleNode.Inclusion.Exclude);
         internalCallerFilter.addOrGetChildren("java.lang.**", RuleNode.Inclusion.Exclude);
-        // The agent should not filter calls from native libraries.
+        // The agent should not filter calls from native libraries (JDK11).
         internalCallerFilter.addOrGetChildren("java.lang.ClassLoader$NativeLibrary", RuleNode.Inclusion.Include);
         internalCallerFilter.addOrGetChildren("java.math.**", RuleNode.Inclusion.Exclude);
         internalCallerFilter.addOrGetChildren("java.net.**", RuleNode.Inclusion.Exclude);
@@ -79,6 +79,8 @@ public final class AccessAdvisor {
         internalCallerFilter.addOrGetChildren("javax.net.**", RuleNode.Inclusion.Exclude);
         internalCallerFilter.addOrGetChildren("javax.tools.**", RuleNode.Inclusion.Exclude);
         internalCallerFilter.addOrGetChildren("jdk.internal.**", RuleNode.Inclusion.Exclude);
+        // The agent should not filter calls from native libraries (JDK17).
+        internalCallerFilter.addOrGetChildren("jdk.internal.loader.NativeLibraries$NativeLibraryImpl", RuleNode.Inclusion.Include);
         internalCallerFilter.addOrGetChildren("jdk.jfr.**", RuleNode.Inclusion.Exclude);
         internalCallerFilter.addOrGetChildren("jdk.net.**", RuleNode.Inclusion.Exclude);
         internalCallerFilter.addOrGetChildren("jdk.nio.**", RuleNode.Inclusion.Exclude);

--- a/vm/mx.vm/mx_vm_benchmark.py
+++ b/vm/mx.vm/mx_vm_benchmark.py
@@ -124,7 +124,7 @@ class NativeImageVM(GraalVm):
             self.bmSuite = bm_suite
             self.benchmark_suite_name = bm_suite.benchSuiteName(args) if len(inspect.getargspec(bm_suite.benchSuiteName).args) > 1 else bm_suite.benchSuiteName() # pylint: disable=deprecated-method
             self.benchmark_name = bm_suite.benchmarkName()
-            self.executable, self.classpath_arguments, self.system_properties, cmd_line_image_run_args = NativeImageVM.extract_benchmark_arguments(args)
+            self.executable, self.classpath_arguments, self.system_properties, self.vm_args, cmd_line_image_run_args = NativeImageVM.extract_benchmark_arguments(args)
             self.extra_image_build_arguments = bm_suite.extra_image_build_argument(self.benchmark_name, args)
             # use list() to create fresh copies to safeguard against accidental modification
             self.image_run_args = bm_suite.extra_run_arg(self.benchmark_name, args, list(cmd_line_image_run_args))
@@ -178,6 +178,7 @@ class NativeImageVM(GraalVm):
             mx.log_deprecation("Ignoring NativeImageVM custom configuration! Use named configuration instead.")
             mx.warn("Ignoring: {}".format(kwargs))
 
+        self.vm_args = None
         self.pgo_aot_inline = False
         self.pgo_instrumented_iterations = 0
         self.pgo_context_sensitive = True
@@ -277,11 +278,12 @@ class NativeImageVM(GraalVm):
             basis. In the future we can convert this from a failure into a warning.
             :return: a list of args supported by native image.
         """
-        return ['-D', '-Xmx', '-Xmn', '-XX:-PrintGC', '-XX:+PrintGC']
+        return ['-D', '-Xmx', '-Xmn', '-XX:-PrintGC', '-XX:+PrintGC', '--add-opens', '--add-modules', '--add-exports',
+                '--add-reads']
 
     _VM_OPTS_SPACE_SEPARATED_ARG = ['-mp', '-modulepath', '-limitmods', '-addmods', '-upgrademodulepath', '-m',
                                     '--module-path', '--limit-modules', '--add-modules', '--upgrade-module-path',
-                                    '--module', '--module-source-path', '--add-exports', '--add-reads',
+                                    '--module', '--module-source-path', '--add-exports', '--add-opens', '--add-reads',
                                     '--patch-module', '--boot-class-path', '--source-path', '-cp', '-classpath']
 
     @staticmethod
@@ -329,10 +331,15 @@ class NativeImageVM(GraalVm):
                 if not any(vm_arg.startswith(elem) for elem in NativeImageVM.supported_vm_arg_prefixes()):
                     mx.abort('Unsupported argument ' + vm_arg + '.' +
                              ' Currently supported argument prefixes are: ' + str(NativeImageVM.supported_vm_arg_prefixes()))
-                image_vm_args.append(vm_arg)
-                i += 1
+                if vm_arg in NativeImageVM._VM_OPTS_SPACE_SEPARATED_ARG:
+                    image_vm_args.append(vm_args[i])
+                    image_vm_args.append(vm_args[i + 1])
+                    i += 2
+                else:
+                    image_vm_args.append(vm_arg)
+                    i += 1
 
-        return executable, classpath_arguments, system_properties, image_vm_args + image_run_args
+        return executable, classpath_arguments, system_properties, image_vm_args, image_run_args
 
     class Stages:
         def __init__(self, config, bench_out, bench_err, is_gate, non_zero_is_fatal, cwd):
@@ -644,6 +651,9 @@ class NativeImageVM(GraalVm):
         hotspot_vm_args = ['-ea', '-esa'] if self.is_gate and not config.skip_agent_assertions else []
         hotspot_run_args = []
         hotspot_vm_args += ['-agentlib:native-image-agent=config-output-dir=' + str(config.config_dir), '-XX:-UseJVMCINativeLibrary']
+
+        if config.vm_args is not None:
+            hotspot_vm_args += config.vm_args
 
         if self.hotspot_pgo:
             hotspot_vm_args += ['-Dgraal.PGOInstrument=' + profile_path]


### PR DESCRIPTION
This PR is solving a problem with `finagle-chirper` and `finagle-http` benchmarks.

Exception:

> java.lang.ExceptionInInitializerError
> The following benchmarks failed: finagle-chirper
> 	at com.twitter.finagle.server.ListeningStackServer$$anon$1.<init>(ListeningStackServer.scala:41)
> 	at com.twitter.finagle.server.ListeningStackServer$class.serve(ListeningStackServer.scala:39)
> 	at com.twitter.finagle.Http$Server.superServe(Http.scala:670)
> 	at com.twitter.finagle.Http$Server.serve(Http.scala:683)
> 	at com.twitter.finagle.Http$.serve(Http.scala:690)
> 	at com.twitter.finagle.Server$class.serve(Server.scala:131)
> 	at com.twitter.finagle.Http$.serve(Http.scala:48)
> 	at com.twitter.finagle.Server$class.serve(Server.scala:135)
> 	at com.twitter.finagle.Http$.serve(Http.scala:48)
> 	at org.renaissance.twitter.finagle.FinagleChirper.setUpBeforeAll(FinagleChirper.scala:430)
> 	at org.renaissance.harness.ExecutionDriver.executeBenchmark(ExecutionDriver.java:44)
> 	at org.renaissance.harness.RenaissanceSuite$$anonfun$runBenchmarks$1.apply(RenaissanceSuite.scala:118)
> 	at org.renaissance.harness.RenaissanceSuite$$anonfun$runBenchmarks$1.apply(RenaissanceSuite.scala:113)
> 	at scala.collection.mutable.ResizableArray$class.foreach(ResizableArray.scala:59)
> 	at scala.collection.mutable.ArrayBuffer.foreach(ArrayBuffer.scala:48)
> 	at org.renaissance.harness.RenaissanceSuite$.runBenchmarks(RenaissanceSuite.scala:113)
> 	at org.renaissance.harness.RenaissanceSuite$.main(RenaissanceSuite.scala:94)
> 	at org.renaissance.harness.RenaissanceSuite.main(RenaissanceSuite.scala)
> 	at java.lang.reflect.Method.invoke(Method.java:568)
> 	at org.renaissance.core.Launcher.launchHarnessClass(Launcher.java:37)
> 	at org.renaissance.core.Launcher.main(Launcher.java:25)
> Caused by: java.lang.NoSuchMethodException: sun.management.VMManagementImpl.getInternalCounters(java.lang.String)
> 	at java.lang.Class.getMethod(DynamicHub.java:1142)
> 	at com.twitter.jvm.Hotspot.reflMethod$Method2(Hotspot.scala:59)
> 	at com.twitter.jvm.Hotspot.com$twitter$jvm$Hotspot$$counters(Hotspot.scala:59)
> 	at com.twitter.jvm.Hotspot.metaspaceUsage(Hotspot.scala:196)
> 	at com.twitter.jvm.JvmStats$.register(JvmStats.scala:106)
> 	at com.twitter.finagle.Init$.<init>(Init.scala:58)
> 	at com.twitter.finagle.Init$.<clinit>(Init.scala)

Command to reproduce:
`mx --java-home /path/to/labsjdk17 --env ni-ce benchmark renaissance-native-image:finagle-chirper -- --jvm=native-image --jvm-config=default-ce`
`mx --java-home /path/to/labsjdk17 --env ni-ce benchmark renaissance-native-image:finagle-http -- --jvm=native-image --jvm-config=default-ce`