### PR TITLE
Remove agent filters for calls from lambda classes.

### DIFF
--- a/substratevm/src/com.oracle.svm.configure/src/com/oracle/svm/configure/trace/AccessAdvisor.java
+++ b/substratevm/src/com.oracle.svm.configure/src/com/oracle/svm/configure/trace/AccessAdvisor.java
@@ -68,6 +68,10 @@ public final class AccessAdvisor {
         internalCallerFilter.addOrGetChildren("java.lang.**", RuleNode.Inclusion.Exclude);
         // The agent should not filter calls from native libraries.
         internalCallerFilter.addOrGetChildren("java.lang.ClassLoader$NativeLibrary", RuleNode.Inclusion.Include);
+        // The agent should not filter calls from lambdas.
+        internalCallerFilter.addOrGetChildren("java.lang.invoke.LambdaMetafactory", RuleNode.Inclusion.Include);
+        internalCallerFilter.addOrGetChildren("java.lang.invoke.InnerClassLambdaMetafactory", RuleNode.Inclusion.Include);
+        internalCallerFilter.addOrGetChildren("java.lang.invoke.InnerClassLambdaMetafactory$1", RuleNode.Inclusion.Include);
         internalCallerFilter.addOrGetChildren("java.math.**", RuleNode.Inclusion.Exclude);
         internalCallerFilter.addOrGetChildren("java.net.**", RuleNode.Inclusion.Exclude);
         internalCallerFilter.addOrGetChildren("java.nio.**", RuleNode.Inclusion.Exclude);


### PR DESCRIPTION
Some benchmarks from the renaissance suite are using reflection calls from lambda classes. In this case, the caller class is java.lang.invoke.LambdaMetafactory and will be filtered.

Reproducer:
`mx --java-home $JAVA_HOME --env ni-ce benchmark renaissance-native-image:dotty -- --jvm=native-image --jvm-config=default-ce`