### PR TITLE
[GR-35274] Restore missing param type names in method signatures in debug log statements

### DIFF
--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/Range.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/Range.java
@@ -87,7 +87,7 @@ public class Range {
         }
         this.methodEntry = methodEntry;
         this.fullMethodName = isInline ? stringTable.uniqueDebugString(constructClassAndMethodName()) : stringTable.uniqueString(constructClassAndMethodName());
-        this.fullMethodNameWithParams = stringTable.uniqueString(constructClassAndMethodNameWithParams());
+        this.fullMethodNameWithParams = constructClassAndMethodNameWithParams();
         this.lo = lo;
         this.hi = hi;
         this.line = line;
@@ -181,8 +181,13 @@ public class Range {
         }
         builder.append(getMethodName());
         if (includeParams) {
-            builder.append('(');
-            builder.append(String.join(", ", methodEntry.paramNames));
+            builder.append("(");
+            String prefix = "";
+            for (TypeEntry t : methodEntry.paramTypes) {
+                builder.append(prefix);
+                builder.append(t.getTypeName());
+                prefix = ", ";
+            }
             builder.append(')');
         }
         if (includeReturnType) {


### PR DESCRIPTION
This PR fixes an error introduced during refactoring of the debug types info code (GR-31277). Full method names used in log statements are supposed to list the method param type names in the signature. The are currently listing the method parameter names (which at present are empty strings).
