### PR TITLE
[GR-35277] Fix merging of debug info subranges and make debuginfotest more resiliant to JDK changes

### DIFF
--- a/substratevm/mx.substratevm/testhello.py
+++ b/substratevm/mx.substratevm/testhello.py
@@ -513,64 +513,37 @@ def test():
     checker = Checker('ptype info func nline', rexp)
     checker.check(exec_string)
 
-    # list inlineMee and inlineMoo and check that the listing maps to the inlined code instead of the actual code,
+    # list inlineIs and inlineA and check that the listing maps to the inlined code instead of the actual code,
     # although not ideal this is how GDB treats inlined code in C/C++ as well
-    rexp = [r"115%sSystem\.out\.println\(\"This is a cow\"\);"%spaces_pattern]
-    checker = Checker('list inlineMee', rexp)
-    checker.check(execute("list inlineMee"))
-    checker = Checker('list inlineMoo', rexp)
-    checker.check(execute("list inlineMoo"))
+    rexp = [r"130%snoInlineTest\(\);"%spaces_pattern]
+    checker = Checker('list inlineIs', rexp)
+    checker.check(execute("list inlineIs"))
+    checker = Checker('list inlineA', rexp)
+    checker.check(execute("list inlineA"))
 
     execute("delete breakpoints")
     # Set breakpoint at inlined method and step through its nested inline methods
-    exec_string = execute("break hello.Hello::inlineMee")
-    rexp = r"Breakpoint %s at %s: hello\.Hello::inlineMee\. \(3 locations\)"%(digits_pattern, address_pattern)
-    checker = Checker('break inlineMee', rexp)
+    exec_string = execute("break hello.Hello::inlineIs")
+    rexp = r"Breakpoint %s at %s: file hello/Hello\.java, line 130\."%(digits_pattern, address_pattern)
+    checker = Checker('break inlineIs', rexp)
     checker.check(exec_string, skip_fails=False)
-
-    exec_string = execute("info break 4")
-    # The breakpoint will be set to the inlined code instead of the actual code,
-    # although not ideal this is how GDB treats inlined code in C/C++ as well
-    rexp = [r"4.1%sy%s%s in hello\.Hello::inlineMee at hello/Hello\.java:115"%(spaces_pattern, spaces_pattern, address_pattern),
-            r"4.2%sy%s%s in hello\.Hello::inlineMee at hello/Hello\.java:115"%(spaces_pattern, spaces_pattern, address_pattern),
-            r"4.3%sy%s%s in hello\.Hello::inlineMee at hello/Hello\.java:115"%(spaces_pattern, spaces_pattern, address_pattern)]
-    checker = Checker('info break inlineMee', rexp)
-    checker.check(exec_string)
 
     execute("continue")
     exec_string = execute("list")
-    rexp = [r"110%sinlineMoo\(\);"%spaces_pattern]
-    checker = Checker('hit break at inlineMee', rexp)
+    rexp = [r"125%sinlineA\(\);"%spaces_pattern]
+    checker = Checker('hit break at inlineIs', rexp)
     checker.check(exec_string, skip_fails=False)
     execute("step")
     exec_string = execute("list")
-    rexp = [r"115%sSystem\.out\.println\(\"This is a cow\"\);"%spaces_pattern]
-    checker = Checker('step in inlineMee', rexp)
+    rexp = [r"130%snoInlineTest\(\);"%spaces_pattern]
+    checker = Checker('step in inlineA', rexp)
     checker.check(exec_string, skip_fails=False)
     exec_string = execute("backtrace 4")
-    rexp = [r"#0%shello\.Hello::inlineMoo \(\) at hello/Hello\.java:115"%spaces_pattern,
-            r"#1%shello\.Hello::inlineMee \(\) at hello/Hello\.java:110"%spaces_pattern,
-            r"#2%shello\.Hello::noInlineFoo\(void\) \(\) at hello/Hello\.java:100"%spaces_pattern,
-            r"#3%s%s in hello\.Hello::main\(java\.lang\.String\[\] \*\) \(\) at hello/Hello\.java:91"%(spaces_pattern, address_pattern)]
+    rexp = [r"#0%shello\.Hello::inlineA \(\) at hello/Hello\.java:130"%spaces_pattern,
+            r"#1%shello\.Hello::inlineIs \(\) at hello/Hello\.java:125"%spaces_pattern,
+            r"#2%shello\.Hello::noInlineThis\(void\) \(\) at hello/Hello\.java:120"%spaces_pattern,
+            r"#3%s%s in hello\.Hello::main\(java\.lang\.String\[\] \*\) \(\) at hello/Hello\.java:93"%(spaces_pattern, address_pattern)]
     checker = Checker('backtrace inlineMee', rexp)
-    checker.check(exec_string, skip_fails=False)
-
-    execute("continue")
-    exec_string = execute("list")
-    rexp = [r"110%sinlineMoo\(\);"%spaces_pattern]
-    checker = Checker('hit break at inlineMee', rexp)
-    checker.check(exec_string, skip_fails=False)
-    execute("step")
-    exec_string = execute("list")
-    rexp = [r"115%sSystem\.out\.println\(\"This is a cow\"\);"%spaces_pattern]
-    checker = Checker('step in inlineMee', rexp)
-    checker.check(exec_string, skip_fails=False)
-    exec_string = execute("backtrace 4")
-    rexp = [r"#0%shello\.Hello::inlineMoo \(\) at hello/Hello\.java:115"%spaces_pattern,
-            r"#1%shello\.Hello::inlineMee \(\) at hello/Hello\.java:110"%spaces_pattern,
-            r"#2%shello\.Hello::inlineCallChain \(\) at hello/Hello\.java:105"%spaces_pattern,
-            r"#3%shello\.Hello::main\(java\.lang\.String\[\] \*\) \(\) at hello/Hello\.java:92"%spaces_pattern]
-    checker = Checker('backtrace inlineMee 2', rexp)
     checker.check(exec_string, skip_fails=False)
 
     execute("delete breakpoints")

--- a/substratevm/mx.substratevm/testhello.py
+++ b/substratevm/mx.substratevm/testhello.py
@@ -298,17 +298,6 @@ def test():
     checker = Checker("info func greet", rexp)
     checker.check(exec_string)
 
-    # look up PrintStream.println methods
-    # expect "All functions matching regular expression "java.io.PrintStream.println":"
-    # expect ""
-    # expect "File java.base/java/io/PrintStream.java:"
-    # expect "      void java.io.PrintStream::println(java.lang.Object *);"
-    # expect "      void java.io.PrintStream::println(java.lang.String *);"
-    exec_string = execute("info func java.io.PrintStream::println")
-    rexp = r"%svoid java.io.PrintStream::println\(java\.lang\.String \*\)"%maybe_spaces_pattern
-    checker = Checker("info func java.io.PrintStream::println", rexp)
-    checker.check(exec_string)
-
     # step into method call
     execute("step")
 
@@ -541,7 +530,8 @@ def test():
     checker = Checker('ptype hello.Hello', rexp)
     checker.check(exec_string, skip_fails=False)
 
-    # list methods matching regural expression "nlined", inline methods are not listed
+    # list methods matching regural expression "nline", inline methods are not listed because they lack a definition
+    # (this is true for C/C++ as well)
     exec_string = execute("info func nline")
     rexp = [r"All functions matching regular expression \"nline\":",
             r"File hello/Hello\.java:",

--- a/substratevm/mx.substratevm/testhello.py
+++ b/substratevm/mx.substratevm/testhello.py
@@ -567,6 +567,21 @@ def test():
     checker.check(exec_string, skip_fails=False)
 
     execute("delete breakpoints")
+    # Set breakpoint at method with inline and not-inlined invocation in same line
+    exec_string = execute("break hello.Hello::inlineFrom")
+    rexp = r"Breakpoint %s at %s: hello\.Hello::inlineFrom\. \(4 locations\)"%(digits_pattern, address_pattern)
+    checker = Checker('break inlineFrom', rexp)
+    checker.check(exec_string, skip_fails=False)
+
+    exec_string = execute("info break 6")
+    rexp = [r"6.1%sy%s%s in hello\.Hello::inlineFrom at hello/Hello\.java:140"%(spaces_pattern, spaces_pattern, address_pattern),
+            r"6.2%sy%s%s in hello\.Hello::inlineFrom at hello/Hello\.java:177"%(spaces_pattern, spaces_pattern, address_pattern),
+            r"6.3%sy%s%s in hello\.Hello::inlineFrom at hello/Hello\.java:160"%(spaces_pattern, spaces_pattern, address_pattern),
+            r"6.4%sy%s%s in hello\.Hello::inlineFrom at hello/Hello\.java:177"%(spaces_pattern, spaces_pattern, address_pattern)]
+    checker = Checker('info break inlineFrom', rexp)
+    checker.check(exec_string)
+
+    execute("delete breakpoints")
     exec_string = execute("break Hello.java:155")
     rexp = r"Breakpoint %s at %s: file hello/Hello\.java, line 155\."%(digits_pattern, address_pattern)
     checker = Checker('break Hello.java:155', rexp)

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/Range.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/Range.java
@@ -306,6 +306,13 @@ public class Range {
             /* cannot merge callers with different line numbers, move on. */
             return sibling;
         }
+        if (isLeaf() != sibling.isLeaf()) {
+            /*
+             * cannot merge leafs with non-leafs as that results in them becoming non-leafs and not
+             * getting proper line info
+             */
+            return sibling;
+        }
         /* splice out the sibling from the chain and update this one to include it. */
         unlink(debugContext, sibling);
         /* relocate the siblings children to this node. */

--- a/substratevm/src/com.oracle.svm.test/src/hello/Hello.java
+++ b/substratevm/src/com.oracle.svm.test/src/hello/Hello.java
@@ -137,7 +137,9 @@ public class Hello {
 
     @AlwaysInline("For testing purposes")
     private static void inlineFrom() {
-        noInlineHere(5);
+        //@formatter:off
+        noInlineHere(5); inlineTailRecursion(1); // These two calls are purposely placed on the same line!!!
+        //@formatter:on
         inlineHere(5);
         inlineTailRecursion(5);
     }


### PR DESCRIPTION
* Stops merging leaf subranges with non-leaf ones.

  As we are generating line info only for leaf ranges, merging a leaf range with a non-leaf one results in not generating line info for the former (previously leaf) range.

* Substitutes or removes tests relying on standard library PrintStream.

**Note**: This PR is based on 4550c69898bf6c0eec11e4965f86b66b25396268 instead of `master` to avoid the AssertionError introduced by https://github.com/oracle/graal/commit/ee638aadb6201aa713e44c4865858a84f856d06e and reported in #4018 so that it can be tested without getting the AssertionError.

Closes: #4036