### PR TITLE
Fix sulong build in github actions.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -146,15 +146,6 @@ jobs:
     - name: Build GraalVM and run gate
       env: ${{ matrix.env }}
       run: |
-        if [[ "${PRIMARY}" == "vm" || "${PRIMARY}" == "sulong" ]]
-        then
-          # workaround issue in cmake 3.22: downgrade to 3.21.4
-          wget --no-verbose https://github.com/Kitware/CMake/releases/download/v3.21.4/cmake-3.21.4-linux-x86_64.tar.gz
-          tar -xzf cmake-3.21.4-linux-x86_64.tar.gz
-          export PATH=$(pwd)/cmake-3.21.4-linux-x86_64/bin:$PATH
-          cmake --version
-        fi
-
         if [[ ${GATE} == *style* ]]
         then
           export ECLIPSE_TAR=eclipse.tar.gz

--- a/sulong/mx.sulong/suite.py
+++ b/sulong/mx.sulong/suite.py
@@ -755,28 +755,19 @@ suite = {
     "com.oracle.truffle.llvm.libraries.bitcode.libcxx" : {
       "subDir" : "projects",
       "vpath" : True,
-      "sourceDir" : "<path:sdk:LLVM_ORG_SRC>/llvm",
+      "sourceDir" : "<path:sdk:LLVM_ORG_SRC>/runtimes",
       "class" : "CMakeNinjaProject",
       # NinjaBuildTask uses only 1 job otherwise
       "max_jobs" : "8",
-      "ninja_targets" : ["<lib:c++abi>", "<lib:c++>"],
+      "ninja_targets" : ["cxxabi", "cxx"],
       "ninja_install_targets" : ["install-cxxabi", "install-cxx"],
       "results" : ["native"],
       "cmakeConfig" : {
-        "LLVM_ENABLE_PROJECTS" : "libcxx;libcxxabi",
-        "LLVM_INCLUDE_DOCS" : "NO",
-        "LLVM_INCLUDE_BENCHMARKS": "NO",
-        "LLVM_TARGETS_TO_BUILD" : "X86",
+        "LLVM_ENABLE_RUNTIMES" : "libcxx;libcxxabi",
         "LIBCXXABI_INCLUDE_TESTS": "NO",
-        "LIBCXXABI_LINK_TESTS_WITH_SHARED_LIBCXX" : "YES",
-        "LIBCXXABI_LIBCXX_INCLUDES" : "<path:sdk:LLVM_ORG_SRC>/libcxx/include",
-        "LIBCXXABI_LIBCXX_PATH" : "<path:sdk:LLVM_ORG_SRC>/libcxx",
         "LIBCXXABI_ENABLE_STATIC" : "NO",
         "LIBCXX_INCLUDE_BENCHMARKS": "NO",
         "LIBCXX_INCLUDE_TESTS": "NO",
-        # using "default" will choose the in-tree version libc++abi and add a build dependency
-        # from libc++ to libc++abi
-        "LIBCXX_CXX_ABI" : "default",
         "LIBCXX_ENABLE_STATIC" : "NO",
         "LIBCXX_ENABLE_EXPERIMENTAL_LIBRARY" : "NO",
         "CMAKE_C_COMPILER" : "<path:SULONG_BOOTSTRAP_TOOLCHAIN_NO_HOME>/bin/clang",

--- a/sulong/mx.sulong/suite.py
+++ b/sulong/mx.sulong/suite.py
@@ -773,6 +773,9 @@ suite = {
         "CMAKE_C_COMPILER" : "<path:SULONG_BOOTSTRAP_TOOLCHAIN_NO_HOME>/bin/clang",
         "CMAKE_CXX_COMPILER" : "<path:SULONG_BOOTSTRAP_TOOLCHAIN_NO_HOME>/bin/clang++",
         "CMAKE_INSTALL_PREFIX" : "native",
+        # workaround for build problem with cmake >=3.22
+        # see https://lists.llvm.org/pipermail/llvm-dev/2021-December/154144.html
+        "CMAKE_BUILD_WITH_INSTALL_RPATH" : "YES",
       },
       "buildDependencies" : [
         "sdk:LLVM_ORG_SRC",


### PR DESCRIPTION
Looks like the update to CMake 3.22.0 broke the LLVM CMake build. Building libc++ and libc++abi individually still seems to work.