### PR TITLE
Fix library paths for native library reporterchelper

### DIFF
--- a/substratevm/mx.substratevm/suite.py
+++ b/substratevm/mx.substratevm/suite.py
@@ -1556,8 +1556,13 @@ suite = {
             "native" : True,
             "platformDependent" : True,
             "description" : "SubstrateVM support libraries for the GraalVM",
+            "platforms" : [
+                "linux-amd64",
+                "darwin-amd64",
+                "windows-amd64",
+            ],
             "layout" : {
-                "svm/builder/lib/" : ["dependency:com.oracle.svm.native.reporterchelper"],
+                "builder/clibraries/<os>-<arch>/" : ["dependency:com.oracle.svm.native.reporterchelper"],
             },
             "maven" : False,
         },

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/reporting/ProgressReporterCHelper.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/reporting/ProgressReporterCHelper.java
@@ -29,6 +29,9 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
+import jdk.vm.ci.hotspot.HotSpotJVMCIRuntime;
+import org.graalvm.compiler.hotspot.GraalHotSpotVMConfig;
+import org.graalvm.compiler.hotspot.HotSpotGraalCompiler;
 import org.graalvm.compiler.serviceprovider.JavaVersionUtil;
 
 import com.oracle.svm.hosted.image.AbstractImage.NativeImageKind;
@@ -45,7 +48,10 @@ public final class ProgressReporterCHelper {
         if (JavaVersionUtil.JAVA_SPEC <= 8) {
             return; // TODO: remove as part of JDK8 removal (GR-35238).
         }
-        Path libRSSHelperPath = Paths.get(System.getProperty("java.home"), "lib", "svm", "builder", "lib", "libreporterchelper" + NativeImageKind.SHARED_LIBRARY.getFilenameSuffix());
+        HotSpotGraalCompiler compiler = (HotSpotGraalCompiler) HotSpotJVMCIRuntime.runtime().getCompiler();
+        GraalHotSpotVMConfig vmConfig = compiler.getGraalRuntime().getVMConfig();
+        Path libRSSHelperPath = Paths.get(System.getProperty("java.home"), "lib", "builder", "clibraries", vmConfig.osName + "-" + vmConfig.osArch,
+                        "libreporterchelper" + NativeImageKind.SHARED_LIBRARY.getFilenameSuffix());
         if (Files.exists(libRSSHelperPath)) {
             System.load(libRSSHelperPath.toString());
         }


### PR DESCRIPTION
A new native shared library `reporterchelper` was introduced in https://github.com/oracle/graal/commit/e04a9cd21653bfc5c44c3dc2702b86085216de71 

However its location doesn't seem to be consistent with the location of other native libraries:

Under windows the location seems to be wrong, as it ends up under `/bin/`, and I would expect peakRSS to not work under windoes given that GraalVM [tries to load the library from `lib/svm/builder/lib/`](https://github.com/oracle/graal/blob/6fbf945cdd53fa0370f9c36a59058d912e3f6194/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/reporting/ProgressReporterCHelper.java#L48):
```
$ find -name "*chelper*" 
./lib/svm/clibraries/windows-amd64/libchelper.lib
./lib/svm/builder/clibraries/windows-amd64/libchelper.lib
./bin/svm/builder/lib/reporterchelper.dll
```

Under linux things look OK, but the library location is not platform dependent:
```
$ find -name "*chelper*"                    
./lib/svm/clibraries/linux-amd64/liblibchelper.a
./lib/svm/builder/clibraries/linux-amd64/liblibchelper.a
./lib/svm/builder/lib/libreporterchelper.so
```