### PR TITLE
[WIP] Adds debuginfo size to native-image output

### DIFF
--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/NativeImageGenerator.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/NativeImageGenerator.java
@@ -672,7 +672,7 @@ public class NativeImageGenerator {
                 featureHandler.forEachFeature(feature -> feature.afterImageWrite(afterConfig));
             }
             reporter.printCreationEnd(imageTimer, writeTimer, image.getImageSize(), bb.getUniverse(), heap.getObjectCount(), image.getImageHeapSize(), codeCache.getCodeCacheSize(),
-                            codeCache.getCompilations().size());
+                            codeCache.getCompilations().size(), image.getDebugInfoSize());
             if (SubstrateOptions.BuildOutputBreakdowns.getValue()) {
                 ProgressReporter.singleton().printBreakdowns(compileQueue.getCompilationTasks(), image.getHeap().getObjects());
             }

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/image/AbstractImage.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/image/AbstractImage.java
@@ -47,6 +47,7 @@ public abstract class AbstractImage {
     protected final NativeImageCodeCache codeCache;
     protected final List<HostedMethod> entryPoints;
     protected int resultingImageSize; // for statistical output
+    protected int debugInfoSize; // for statistical output
 
     public enum NativeImageKind {
         SHARED_LIBRARY(false) {
@@ -113,6 +114,10 @@ public abstract class AbstractImage {
 
     public int getImageSize() {
         return resultingImageSize;
+    }
+
+    public int getDebugInfoSize() {
+        return debugInfoSize;
     }
 
     public NativeLibraries getNativeLibs() {

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/image/NativeImage.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/image/NativeImage.java
@@ -179,6 +179,12 @@ public abstract class NativeImage extends AbstractImage {
             throw shouldNotReachHere(ex);
         }
         resultingImageSize = (int) outputFile.toFile().length();
+        debugInfoSize = 0;
+        for (Element e : objectFile.getElements()) {
+            if (e.getName().contains(".debug")) {
+                debugInfoSize += e.getMemSize(objectFile.getDecisionsByElement());
+            }
+        }
         if (NativeImageOptions.PrintImageElementSizes.getValue()) {
             for (Element e : objectFile.getElements()) {
                 System.out.printf("PrintImageElementSizes:  size: %15d  name: %s\n", e.getMemSize(objectFile.getDecisionsByElement()), e.getElementName());

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/reporting/ProgressReporter.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/reporting/ProgressReporter.java
@@ -328,7 +328,7 @@ public class ProgressReporter {
     }
 
     public void printCreationEnd(Timer creationTimer, Timer writeTimer, int imageSize, AnalysisUniverse universe, int numHeapObjects, long imageHeapSize, int codeCacheSize,
-                    int numCompilations) {
+                    int numCompilations, int debugInfoSize) {
         printStageEnd(creationTimer.getTotalTime() + writeTimer.getTotalTime());
         String total = bytesToHuman("%4.2f", imageSize);
         l().a("%9s in total (%2.2f%% for ", total, codeCacheSize / (double) imageSize * 100).doclink("code area", "#glossary-code-area")
@@ -336,6 +336,10 @@ public class ProgressReporter {
         l().a("%9s in code size: %,8d compilation units", bytesToHuman("%4.2f", codeCacheSize), numCompilations).flushln();
         long numInstantiatedClasses = universe.getTypes().stream().filter(t -> t.isInstantiated()).count();
         l().a("%9s in heap size: %,8d classes and %,d objects", bytesToHuman("%4.2f", imageHeapSize), numInstantiatedClasses, numHeapObjects).flushln();
+        if (debugInfoSize > 0) {
+            // TODO print number of DIEs etc.
+            l().a("%9s in debugInfo size", bytesToHuman("%4.2f", debugInfoSize)).flushln();
+        }
         if (debugInfoTimer != null) {
             String debugInfoTime = String.format("%.1fs", millisToSeconds(debugInfoTimer.getTotalTime()));
             l().dim().a("%9s for generating debug info", debugInfoTime).reset().flushln();


### PR DESCRIPTION
@fniephaus this is a draft implementation that outputs the debuginfo size along with the other stats.

It uses the objectfile sections' names to aggregate the sizes of those containing `.debug` in their name.
This should work for both linux:

.debug  | This  section holds information for symbolic debugging. The contents are  unspecified. All section names with the prefix .debug hold information  for symbolic debugging. The contents of these sections are unspecified.
-- | --

Source: https://refspecs.linuxfoundation.org/LSB_5.0.0/LSB-Core-generic/LSB-Core-generic/specialsections.html

and windows:
> The .debug section is used in object files to contain compiler-generated debug information and in image files to contain all of the debug information that is generated. This section describes the packaging of debug information in object and image files.

Source: https://docs.microsoft.com/en-us/windows/win32/debug/pe-format#the-debug-section

WDYT?