### PR TITLE
Bump mx version for substratevm

### DIFF
--- a/substratevm/mx.substratevm/suite.py
+++ b/substratevm/mx.substratevm/suite.py
@@ -1,6 +1,6 @@
 # pylint: disable=line-too-long
 suite = {
-    "mxversion": "5.310.0",
+    "mxversion": "5.315.0",
     "name": "substratevm",
     "version" : "22.0.0",
     "release" : False,


### PR DESCRIPTION
4609007cba98c4d02738170401c55900b001c97f breaks builds with mx 5.310.0 due to
its dependency on
https://github.com/graalvm/mx/commit/2a364eec1736fb0c858703491bd30605526cb2ea