### PR TITLE
Fix: scala-dotty benchmark

### DIFF
--- a/substratevm/mx.substratevm/mx_substratevm_benchmark.py
+++ b/substratevm/mx.substratevm/mx_substratevm_benchmark.py
@@ -94,6 +94,9 @@ _RENAISSANCE_EXTRA_IMAGE_BUILD_ARGS = {
                             '--allow-incomplete-classpath',
                             '--report-unsupported-elements-at-runtime'
                           ],
+    'dotty'             : [
+                            '-H:+AllowJRTFileSystem'
+                          ]
 }
 
 _renaissance_config = {

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/PlatformNativeLibrarySupport.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/PlatformNativeLibrarySupport.java
@@ -67,6 +67,7 @@ public abstract class PlatformNativeLibrarySupport {
                     "jdk_internal_org",
                     "jdk_internal_misc",
                     "jdk_internal_util",
+                    "jdk_internal_jimage",
                     "jdk_net",
                     "sun_invoke",
                     "sun_launcher",

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/jdk/JRTFeature.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/jdk/JRTFeature.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2021, 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package com.oracle.svm.hosted.jdk;
+
+import org.graalvm.nativeimage.hosted.Feature;
+
+import com.oracle.svm.core.annotate.AutomaticFeature;
+import com.oracle.svm.hosted.FeatureImpl;
+
+@AutomaticFeature
+public class JRTFeature implements Feature {
+
+    @Override
+    public void beforeAnalysis(BeforeAnalysisAccess access) {
+        access.registerReachabilityHandler(duringAnalysisAccess -> {
+            FeatureImpl.BeforeAnalysisAccessImpl beforeAnalysisAccess = (FeatureImpl.BeforeAnalysisAccessImpl) access;
+            beforeAnalysisAccess.getNativeLibraries().addStaticJniLibrary("jimage");
+            beforeAnalysisAccess.getNativeLibraries().addDynamicNonJniLibrary("stdc++");
+        }, access.findClassByName("jdk.internal.jimage.NativeImageBuffer"));
+    }
+}


### PR DESCRIPTION
The problem was that the `scala-dotty` benchmark uses the `JRT` file system and, the `JRT` file system didn't work because jimage lib was in the image.