### PR TITLE
Fix fstat call in darwin-aarch64.

### DIFF
--- a/compiler/mx.compiler/suite.py
+++ b/compiler/mx.compiler/suite.py
@@ -2219,7 +2219,7 @@ suite = {
         ],
         "exports" : [
           "* to com.oracle.graal.graal_enterprise,org.graalvm.nativeimage.pointsto,org.graalvm.nativeimage.builder,org.graalvm.nativeimage.llvm,com.oracle.svm.svm_enterprise,org.graalvm.nativeimage.base",
-          "org.graalvm.compiler.core.common            to jdk.internal.vm.compiler.management,org.graalvm.nativeimage.agent.tracing",
+          "org.graalvm.compiler.core.common            to jdk.internal.vm.compiler.management,org.graalvm.nativeimage.agent.tracing,org.graalvm.nativeimage.objectfile",
           "org.graalvm.compiler.debug                  to jdk.internal.vm.compiler.management,org.graalvm.nativeimage.objectfile",
           "org.graalvm.compiler.hotspot                to jdk.internal.vm.compiler.management",
           "org.graalvm.compiler.nodes.graphbuilderconf to org.graalvm.nativeimage.driver",

--- a/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/PosixStat.java
+++ b/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/PosixStat.java
@@ -45,7 +45,7 @@ public final class PosixStat {
             result = LinuxStat.fstat64(fd, stat);
         } else if (Platform.includedIn(Platform.DARWIN.class)) {
             DarwinStat.stat stat = StackValue.get(DarwinStat.stat.class);
-            result = DarwinStat.fstat(fd, stat);
+            result = DarwinStat.fstat_aarch64(fd, stat);
         } else {
             throw VMError.shouldNotReachHere("Unsupported platform");
         }

--- a/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/headers/darwin/DarwinStat.java
+++ b/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/headers/darwin/DarwinStat.java
@@ -24,6 +24,9 @@
  */
 package com.oracle.svm.core.posix.headers.darwin;
 
+import com.oracle.svm.core.util.VMError;
+import org.graalvm.nativeimage.Platform;
+import org.graalvm.nativeimage.Platforms;
 import org.graalvm.nativeimage.c.CContext;
 import org.graalvm.nativeimage.c.function.CFunction;
 import org.graalvm.nativeimage.c.struct.CField;
@@ -53,10 +56,42 @@ public class DarwinStat {
     }
 
     @CFunction("fstat$INODE64")
-    public static native int fstat(int fd, stat buf);
+    @Platforms({Platform.DARWIN_AMD64.class})
+    public static native int fstat_amd64(int fd, stat buf);
+
+    @CFunction("fstat")
+    @Platforms({Platform.DARWIN_AARCH64.class})
+    public static native int fstat_aarch64(int fd, stat buf);
+
+    @Platforms(Platform.DARWIN.class)
+    public static int fstat(int fd, stat buf) {
+        if (Platform.includedIn(Platform.AMD64.class)) {
+            return fstat_amd64(fd, buf);
+        } else if (Platform.includedIn(Platform.AARCH64.class)) {
+            return fstat_aarch64(fd, buf);
+        } else {
+            throw VMError.shouldNotReachHere();
+        }
+    }
 
     public static class NoTransitions {
         @CFunction(value = "fstat$INODE64", transition = CFunction.Transition.NO_TRANSITION)
-        public static native int fstat(int fd, stat buf);
+        @Platforms({Platform.DARWIN_AMD64.class})
+        public static native int fstat_amd64(int fd, stat buf);
+
+        @CFunction(value = "fstat", transition = CFunction.Transition.NO_TRANSITION)
+        @Platforms({Platform.DARWIN_AARCH64.class})
+        public static native int fstat_aarch64(int fd, stat buf);
+
+        @Platforms(Platform.DARWIN.class)
+        public static int fstat(int fd, stat buf) {
+            if (Platform.includedIn(Platform.AMD64.class)) {
+                return fstat_amd64(fd, buf);
+            } else if (Platform.includedIn(Platform.AARCH64.class)) {
+                return fstat_aarch64(fd, buf);
+            } else {
+                throw VMError.shouldNotReachHere();
+            }
+        }
     }
 }

--- a/substratevm/src/com.oracle.svm.truffle.nfi.posix/src/com/oracle/svm/truffle/nfi/posix/PosixTruffleNFIFeature.java
+++ b/substratevm/src/com.oracle.svm.truffle.nfi.posix/src/com/oracle/svm/truffle/nfi/posix/PosixTruffleNFIFeature.java
@@ -95,6 +95,7 @@ final class PosixTruffleNFISupport extends TruffleNFISupport {
         return PosixLibC.strdup(src);
     }
 
+    @Platforms(Platform.LINUX.class)
     private static PointerBase dlmopen(Lmid_t lmid, String filename, int mode) {
         try (CTypeConversion.CCharPointerHolder pathPin = CTypeConversion.toCString(filename)) {
             CCharPointer pathPtr = pathPin.get();
@@ -105,6 +106,7 @@ final class PosixTruffleNFISupport extends TruffleNFISupport {
     /**
      * A single linking namespace is created lazily and registered on the NFI context instance.
      */
+    @Platforms(Platform.LINUX.class)
     private static PointerBase loadLibraryInNamespace(long nativeContext, String name, int mode) {
         assert (mode & isolatedNamespaceFlag) == 0;
         Target_com_oracle_truffle_nfi_backend_libffi_LibFFIContextLinux context = SubstrateUtil.cast(getContext(nativeContext), Target_com_oracle_truffle_nfi_backend_libffi_LibFFIContextLinux.class);


### PR DESCRIPTION
Looks like `fstat` and some other system calls don't have `$INODE64` suffix on aarch64 anymore, even if `_DARWIN_USE_64_BIT_INODE` is given, since they're only for a backward-compatible issue which only happens on Intel platform.

This PR is to fix the failure on darwin-aarch64.

<details>
  <summary>Failed test</summary>
  
  ```
# yyc @ Yichens-M1 in ~/IdeaProjects/graal/graal/substratevm on git:master o [17:08:52] 
$ mx native-unittest --regex ImageInfoTest 
========================================================================================================================
GraalVM Native Image: Generating 'com.oracle.svm.junit.svmjunitrunner'...
========================================================================================================================
[1/7] Initializing...                                                                                   (18.4s @ 0.21GB)
 Version info: 'GraalVM dev Java 17 CE'
 4 user-provided feature(s)
  - com.oracle.svm.configure.config.SignatureUtilFeature
  - com.oracle.svm.junit.JUnitFeature
  - com.oracle.svm.test.NativeImageResourceFileSystemProviderTest$RegisterResourceFeature
  - com.oracle.svm.test.SerializationRegistrationTestFeature
[2/7] Performing analysis...  [******]                                                                  (58.2s @ 0.69GB)
   3,823 (78.60%) of  4,864 classes reachable
   4,844 (61.95%) of  7,819 fields reachable
  17,933 (48.66%) of 36,851 methods reachable
      49 classes,    55 fields, and   622 methods registered for reflection
      58 classes,    60 fields, and    51 methods registered for JNI access
[3/7] Building universe...                                                                               (3.8s @ 1.12GB)
[4/7] Parsing methods...      [**]                                                                       (2.9s @ 2.62GB)
[5/7] Inlining methods...     [****]                                                                     (4.5s @ 1.37GB)
[6/7] Compiling methods...    [*****]                                                                   (31.3s @ 2.35GB)
[7/7] Creating image...Fatal error: java.lang.RuntimeException: There was an error linking the native image: Linker command exited with 1

Linker command executed:
/usr/bin/cc -Wl,-U,___darwin_check_fd_set_overflow -Wl,-no_compact_unwind -Wl,-exported_symbols_list -Wl,/var/folders/yc/q5xjr0614bl08972dyxfjmmm0000gn/T/SVM-6025001424348589003/exported_symbols.list -Wl,-x -arch arm64 -o /Users/yyc/IdeaProjects/graal/graal/substratevm/svmbuild/darwin-aarch64/junit/tmp9zKWLO/com.oracle.svm.junit.svmjunitrunner com.oracle.svm.junit.svmjunitrunner.o /Users/yyc/IdeaProjects/graal/graal/sdk/mxbuild/darwin-aarch64/GRAALVM_CEE4649546_JAVA17/graalvm-cee4649546-java17-22.1.0-dev/lib/svm/clibraries/darwin-aarch64/liblibchelper.a /Users/yyc/IdeaProjects/graal/graal/sdk/mxbuild/darwin-aarch64/GRAALVM_CEE4649546_JAVA17/graalvm-cee4649546-java17-22.1.0-dev/lib/libnet.a /Users/yyc/IdeaProjects/graal/graal/sdk/mxbuild/darwin-aarch64/GRAALVM_CEE4649546_JAVA17/graalvm-cee4649546-java17-22.1.0-dev/lib/svm/clibraries/darwin-aarch64/libdarwin.a /Users/yyc/IdeaProjects/graal/graal/sdk/mxbuild/darwin-aarch64/GRAALVM_CEE4649546_JAVA17/graalvm-cee4649546-java17-22.1.0-dev/lib/libnio.a /Users/yyc/IdeaProjects/graal/graal/sdk/mxbuild/darwin-aarch64/GRAALVM_CEE4649546_JAVA17/graalvm-cee4649546-java17-22.1.0-dev/lib/libjava.a /Users/yyc/IdeaProjects/graal/graal/sdk/mxbuild/darwin-aarch64/GRAALVM_CEE4649546_JAVA17/graalvm-cee4649546-java17-22.1.0-dev/lib/libfdlibm.a /Users/yyc/IdeaProjects/graal/graal/sdk/mxbuild/darwin-aarch64/GRAALVM_CEE4649546_JAVA17/graalvm-cee4649546-java17-22.1.0-dev/lib/libzip.a /Users/yyc/IdeaProjects/graal/graal/sdk/mxbuild/darwin-aarch64/GRAALVM_CEE4649546_JAVA17/graalvm-cee4649546-java17-22.1.0-dev/lib/svm/clibraries/darwin-aarch64/libjvm.a -v -L/var/folders/yc/q5xjr0614bl08972dyxfjmmm0000gn/T/SVM-6025001424348589003 -L/Users/yyc/IdeaProjects/graal/graal/sdk/mxbuild/darwin-aarch64/GRAALVM_CEE4649546_JAVA17/graalvm-cee4649546-java17-22.1.0-dev/lib -L/Users/yyc/IdeaProjects/graal/graal/sdk/mxbuild/darwin-aarch64/GRAALVM_CEE4649546_JAVA17/graalvm-cee4649546-java17-22.1.0-dev/lib/svm/clibraries/darwin-aarch64 -lz -Wl,-framework,Foundation -lpthread -ldl

Linker command output:
Apple clang version 13.0.0 (clang-1300.0.29.3)
Target: arm64-apple-darwin20.6.0
Thread model: posix
InstalledDir: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin
 "/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/ld" -demangle -lto_library /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/libLTO.dylib -dynamic -arch arm64 -platform_version macos 11.0.0 12.0 -syslibroot /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk -o /Users/yyc/IdeaProjects/graal/graal/substratevm/svmbuild/darwin-aarch64/junit/tmp9zKWLO/com.oracle.svm.junit.svmjunitrunner -L/var/folders/yc/q5xjr0614bl08972dyxfjmmm0000gn/T/SVM-6025001424348589003 -L/Users/yyc/IdeaProjects/graal/graal/sdk/mxbuild/darwin-aarch64/GRAALVM_CEE4649546_JAVA17/graalvm-cee4649546-java17-22.1.0-dev/lib -L/Users/yyc/IdeaProjects/graal/graal/sdk/mxbuild/darwin-aarch64/GRAALVM_CEE4649546_JAVA17/graalvm-cee4649546-java17-22.1.0-dev/lib/svm/clibraries/darwin-aarch64 -L/usr/local/lib -U ___darwin_check_fd_set_overflow -no_compact_unwind -exported_symbols_list /var/folders/yc/q5xjr0614bl08972dyxfjmmm0000gn/T/SVM-6025001424348589003/exported_symbols.list -x com.oracle.svm.junit.svmjunitrunner.o /Users/yyc/IdeaProjects/graal/graal/sdk/mxbuild/darwin-aarch64/GRAALVM_CEE4649546_JAVA17/graalvm-cee4649546-java17-22.1.0-dev/lib/svm/clibraries/darwin-aarch64/liblibchelper.a /Users/yyc/IdeaProjects/graal/graal/sdk/mxbuild/darwin-aarch64/GRAALVM_CEE4649546_JAVA17/graalvm-cee4649546-java17-22.1.0-dev/lib/libnet.a /Users/yyc/IdeaProjects/graal/graal/sdk/mxbuild/darwin-aarch64/GRAALVM_CEE4649546_JAVA17/graalvm-cee4649546-java17-22.1.0-dev/lib/svm/clibraries/darwin-aarch64/libdarwin.a /Users/yyc/IdeaProjects/graal/graal/sdk/mxbuild/darwin-aarch64/GRAALVM_CEE4649546_JAVA17/graalvm-cee4649546-java17-22.1.0-dev/lib/libnio.a /Users/yyc/IdeaProjects/graal/graal/sdk/mxbuild/darwin-aarch64/GRAALVM_CEE4649546_JAVA17/graalvm-cee4649546-java17-22.1.0-dev/lib/libjava.a /Users/yyc/IdeaProjects/graal/graal/sdk/mxbuild/darwin-aarch64/GRAALVM_CEE4649546_JAVA17/graalvm-cee4649546-java17-22.1.0-dev/lib/libfdlibm.a /Users/yyc/IdeaProjects/graal/graal/sdk/mxbuild/darwin-aarch64/GRAALVM_CEE4649546_JAVA17/graalvm-cee4649546-java17-22.1.0-dev/lib/libzip.a /Users/yyc/IdeaProjects/graal/graal/sdk/mxbuild/darwin-aarch64/GRAALVM_CEE4649546_JAVA17/graalvm-cee4649546-java17-22.1.0-dev/lib/svm/clibraries/darwin-aarch64/libjvm.a -lz -framework Foundation -lpthread -ldl -lSystem /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/13.0.0/lib/darwin/libclang_rt.osx.a
Undefined symbols for architecture arm64:
  "_fstat$INODE64", referenced from:
      ___svm_version_info in com.oracle.svm.junit.svmjunitrunner.o
ld: symbol(s) not found for architecture arm64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
        at com.oracle.svm.hosted.image.NativeImageViaCC.handleLinkerFailure(NativeImageViaCC.java:505)
        at com.oracle.svm.hosted.image.NativeImageViaCC.write(NativeImageViaCC.java:452)
        at com.oracle.svm.hosted.NativeImageGenerator.doRun(NativeImageGenerator.java:674)
        at com.oracle.svm.hosted.NativeImageGenerator.run(NativeImageGenerator.java:495)
        at com.oracle.svm.hosted.NativeImageGeneratorRunner.buildImage(NativeImageGeneratorRunner.java:424)
        at com.oracle.svm.hosted.NativeImageGeneratorRunner.build(NativeImageGeneratorRunner.java:580)
        at com.oracle.svm.hosted.NativeImageGeneratorRunner.main(NativeImageGeneratorRunner.java:127)
        at com.oracle.svm.hosted.NativeImageGeneratorRunner$JDK9Plus.main(NativeImageGeneratorRunner.java:610)
------------------------------------------------------------------------------------------------------------------------
                      5.7s (4.2% of total time) in 24 GCs | Peak RSS: 3.30GB | CPU load: ~358.64%
------------------------------------------------------------------------------------------------------------------------
Produced artifacts:
 /Users/yyc/IdeaProjects/graal/graal/substratevm/svmbuild/darwin-aarch64/junit/tmp9zKWLO/com.oracle.svm.junit.svmjunitrunner.build_artifacts.txt
========================================================================================================================
Failed generating 'com.oracle.svm.junit.svmjunitrunner' after 2m 14s.
Error: Image build request failed with exit status 1

  ```
</details>

Ref: #2666