### PR TITLE
Fix debuginfotest gate

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -79,12 +79,10 @@ jobs:
               JDK: "labsjdk-ce-17"
               GATE: "build,debuginfotest"
               PRIMARY: "substratevm"
-              GHA_EXPECTED_FAILURE: true # temporarily marked as expected failure due to #4018 / GR-35118
           - env:
               JDK: "labsjdk-ce-11"
               GATE: "build,debuginfotest"
               PRIMARY: "substratevm"
-              GHA_EXPECTED_FAILURE: true # temporarily marked as expected failure due to #4018 / GR-35118
           - env:
               JDK: "labsjdk-ce-11"
               GATE: "hellomodule"

--- a/substratevm/mx.substratevm/testhello.py
+++ b/substratevm/mx.substratevm/testhello.py
@@ -574,78 +574,78 @@ def test():
     checker.check(exec_string, skip_fails=False)
 
     exec_string = execute("info break 6")
-    rexp = [r"6.1%sy%s%s in hello\.Hello::inlineFrom at hello/Hello\.java:140"%(spaces_pattern, spaces_pattern, address_pattern),
-            r"6.2%sy%s%s in hello\.Hello::inlineFrom at hello/Hello\.java:177"%(spaces_pattern, spaces_pattern, address_pattern),
-            r"6.3%sy%s%s in hello\.Hello::inlineFrom at hello/Hello\.java:160"%(spaces_pattern, spaces_pattern, address_pattern),
-            r"6.4%sy%s%s in hello\.Hello::inlineFrom at hello/Hello\.java:177"%(spaces_pattern, spaces_pattern, address_pattern)]
+    rexp = [r"6.1%sy%s%s in hello\.Hello::inlineFrom at hello/Hello\.java:141"%(spaces_pattern, spaces_pattern, address_pattern),
+            r"6.2%sy%s%s in hello\.Hello::inlineFrom at hello/Hello\.java:179"%(spaces_pattern, spaces_pattern, address_pattern),
+            r"6.3%sy%s%s in hello\.Hello::inlineFrom at hello/Hello\.java:162"%(spaces_pattern, spaces_pattern, address_pattern),
+            r"6.4%sy%s%s in hello\.Hello::inlineFrom at hello/Hello\.java:179"%(spaces_pattern, spaces_pattern, address_pattern)]
     checker = Checker('info break inlineFrom', rexp)
     checker.check(exec_string)
 
     execute("delete breakpoints")
-    exec_string = execute("break Hello.java:155")
-    rexp = r"Breakpoint %s at %s: file hello/Hello\.java, line 155\."%(digits_pattern, address_pattern)
-    checker = Checker('break Hello.java:155', rexp)
+    exec_string = execute("break Hello.java:157")
+    rexp = r"Breakpoint %s at %s: file hello/Hello\.java, line 157\."%(digits_pattern, address_pattern)
+    checker = Checker('break Hello.java:157', rexp)
     checker.check(exec_string)
 
     execute("continue 5")
     exec_string = execute("backtrace 14")
-    rexp = [r"#0%shello\.Hello::inlineMixTo \(\) at hello/Hello\.java:155"%(spaces_pattern),
-            r"#1%shello\.Hello::noInlineHere\(int\) \(\) at hello/Hello\.java:147"%(spaces_pattern),
-            r"#2%s%s in hello\.Hello::inlineMixTo \(\) at hello/Hello\.java:153"%(spaces_pattern, address_pattern),
-            r"#3%shello\.Hello::noInlineHere\(int\) \(\) at hello/Hello\.java:147"%(spaces_pattern),
-            r"#4%s%s in hello\.Hello::inlineMixTo \(\) at hello/Hello\.java:153"%(spaces_pattern, address_pattern),
-            r"#5%shello\.Hello::noInlineHere\(int\) \(\) at hello/Hello\.java:147"%(spaces_pattern),
-            r"#6%s%s in hello\.Hello::inlineMixTo \(\) at hello/Hello\.java:153"%(spaces_pattern, address_pattern),
-            r"#7%shello\.Hello::noInlineHere\(int\) \(\) at hello/Hello\.java:147"%(spaces_pattern),
-            r"#8%s%s in hello\.Hello::inlineMixTo \(\) at hello/Hello\.java:153"%(spaces_pattern, address_pattern),
-            r"#9%shello\.Hello::noInlineHere\(int\) \(\) at hello/Hello\.java:147"%(spaces_pattern),
-            r"#10%s%s in hello\.Hello::inlineMixTo \(\) at hello/Hello\.java:153"%(spaces_pattern, address_pattern),
-            r"#11%shello\.Hello::noInlineHere\(int\) \(\) at hello/Hello\.java:147"%(spaces_pattern),
-            r"#12%s%s in hello\.Hello::inlineFrom \(\) at hello/Hello\.java:140"%(spaces_pattern, address_pattern),
+    rexp = [r"#0%shello\.Hello::inlineMixTo \(\) at hello/Hello\.java:157"%(spaces_pattern),
+            r"#1%shello\.Hello::noInlineHere\(int\) \(\) at hello/Hello\.java:149"%(spaces_pattern),
+            r"#2%s%s in hello\.Hello::inlineMixTo \(\) at hello/Hello\.java:155"%(spaces_pattern, address_pattern),
+            r"#3%shello\.Hello::noInlineHere\(int\) \(\) at hello/Hello\.java:149"%(spaces_pattern),
+            r"#4%s%s in hello\.Hello::inlineMixTo \(\) at hello/Hello\.java:155"%(spaces_pattern, address_pattern),
+            r"#5%shello\.Hello::noInlineHere\(int\) \(\) at hello/Hello\.java:149"%(spaces_pattern),
+            r"#6%s%s in hello\.Hello::inlineMixTo \(\) at hello/Hello\.java:155"%(spaces_pattern, address_pattern),
+            r"#7%shello\.Hello::noInlineHere\(int\) \(\) at hello/Hello\.java:149"%(spaces_pattern),
+            r"#8%s%s in hello\.Hello::inlineMixTo \(\) at hello/Hello\.java:155"%(spaces_pattern, address_pattern),
+            r"#9%shello\.Hello::noInlineHere\(int\) \(\) at hello/Hello\.java:149"%(spaces_pattern),
+            r"#10%s%s in hello\.Hello::inlineMixTo \(\) at hello/Hello\.java:155"%(spaces_pattern, address_pattern),
+            r"#11%shello\.Hello::noInlineHere\(int\) \(\) at hello/Hello\.java:149"%(spaces_pattern),
+            r"#12%s%s in hello\.Hello::inlineFrom \(\) at hello/Hello\.java:141"%(spaces_pattern, address_pattern),
             r"#13%shello\.Hello::main\(java\.lang\.String\[\] \*\) \(\) at hello/Hello\.java:94"%(spaces_pattern)]
     checker = Checker('backtrace in recursive inlineMixTo', rexp)
     checker.check(exec_string, skip_fails=False)
 
     execute("delete breakpoints")
-    exec_string = execute("break Hello.java:168")
-    rexp = r"Breakpoint %s at %s: Hello\.java:168\. \(2 locations\)"%(digits_pattern, address_pattern)
-    checker = Checker('break Hello.java:168', rexp)
+    exec_string = execute("break Hello.java:170")
+    rexp = r"Breakpoint %s at %s: Hello\.java:170\. \(2 locations\)"%(digits_pattern, address_pattern)
+    checker = Checker('break Hello.java:170', rexp)
     checker.check(exec_string)
 
-    execute("continue 5")
+    execute("continue")
     exec_string = execute("backtrace 14")
-    rexp = [r"#0%shello\.Hello::inlineTo\(int\) \(\) at hello/Hello\.java:168"%(spaces_pattern),
-            r"#1%s%s in hello\.Hello::inlineHere \(\) at hello/Hello\.java:160"%(spaces_pattern, address_pattern),
-            r"#2%shello\.Hello::inlineTo\(int\) \(\) at hello/Hello\.java:166"%(spaces_pattern),
-            r"#3%s%s in hello\.Hello::inlineHere \(\) at hello/Hello\.java:160"%(spaces_pattern, address_pattern),
-            r"#4%shello\.Hello::inlineTo\(int\) \(\) at hello/Hello\.java:166"%(spaces_pattern),
-            r"#5%s%s in hello\.Hello::inlineHere \(\) at hello/Hello\.java:160"%(spaces_pattern, address_pattern),
-            r"#6%shello\.Hello::inlineTo\(int\) \(\) at hello/Hello\.java:166"%(spaces_pattern),
-            r"#7%s%s in hello\.Hello::inlineHere \(\) at hello/Hello\.java:160"%(spaces_pattern, address_pattern),
-            r"#8%shello\.Hello::inlineTo\(int\) \(\) at hello/Hello\.java:166"%(spaces_pattern),
-            r"#9%s%s in hello\.Hello::inlineHere \(\) at hello/Hello\.java:160"%(spaces_pattern, address_pattern),
-            r"#10%shello\.Hello::inlineTo \(\) at hello/Hello\.java:166"%(spaces_pattern),
-            r"#11%shello\.Hello::inlineHere \(\) at hello/Hello\.java:160"%(spaces_pattern),
-            r"#12%shello\.Hello::inlineFrom \(\) at hello/Hello\.java:141"%(spaces_pattern),
+    rexp = [r"#0%shello\.Hello::inlineTo\(int\) \(\) at hello/Hello\.java:170"%(spaces_pattern),
+            r"#1%s%s in hello\.Hello::inlineHere \(\) at hello/Hello\.java:162"%(spaces_pattern, address_pattern),
+            r"#2%shello\.Hello::inlineTo\(int\) \(\) at hello/Hello\.java:168"%(spaces_pattern),
+            r"#3%s%s in hello\.Hello::inlineHere \(\) at hello/Hello\.java:162"%(spaces_pattern, address_pattern),
+            r"#4%shello\.Hello::inlineTo\(int\) \(\) at hello/Hello\.java:168"%(spaces_pattern),
+            r"#5%s%s in hello\.Hello::inlineHere \(\) at hello/Hello\.java:162"%(spaces_pattern, address_pattern),
+            r"#6%shello\.Hello::inlineTo\(int\) \(\) at hello/Hello\.java:168"%(spaces_pattern),
+            r"#7%s%s in hello\.Hello::inlineHere \(\) at hello/Hello\.java:162"%(spaces_pattern, address_pattern),
+            r"#8%shello\.Hello::inlineTo\(int\) \(\) at hello/Hello\.java:168"%(spaces_pattern),
+            r"#9%s%s in hello\.Hello::inlineHere \(\) at hello/Hello\.java:162"%(spaces_pattern, address_pattern),
+            r"#10%shello\.Hello::inlineTo \(\) at hello/Hello\.java:168"%(spaces_pattern),
+            r"#11%shello\.Hello::inlineHere \(\) at hello/Hello\.java:162"%(spaces_pattern),
+            r"#12%shello\.Hello::inlineFrom \(\) at hello/Hello\.java:143"%(spaces_pattern),
             r"#13%shello\.Hello::main\(java\.lang\.String\[\] \*\) \(\) at hello/Hello\.java:94"%(spaces_pattern)]
     checker = Checker('backtrace in recursive inlineTo', rexp)
     checker.check(exec_string, skip_fails=False)
 
     execute("delete breakpoints")
-    exec_string = execute("break Hello.java:174")
-    rexp = r"Breakpoint %s at %s: file hello/Hello\.java, line 174\."%(digits_pattern, address_pattern)
-    checker = Checker('break Hello.java:174', rexp)
+    exec_string = execute("break Hello.java:176")
+    rexp = r"Breakpoint %s at %s: file hello/Hello\.java, line 176\."%(digits_pattern, address_pattern)
+    checker = Checker('break Hello.java:176', rexp)
     checker.check(exec_string)
 
     execute("continue 5")
     exec_string = execute("backtrace 8")
-    rexp = [r"#0%shello\.Hello::inlineTailRecursion\(int\) \(\) at hello/Hello\.java:174"%(spaces_pattern),
-            r"#1%s%s in hello\.Hello::inlineTailRecursion\(int\) \(\) at hello/Hello\.java:177"%(spaces_pattern, address_pattern),
-            r"#2%s%s in hello\.Hello::inlineTailRecursion\(int\) \(\) at hello/Hello\.java:177"%(spaces_pattern, address_pattern),
-            r"#3%s%s in hello\.Hello::inlineTailRecursion\(int\) \(\) at hello/Hello\.java:177"%(spaces_pattern, address_pattern),
-            r"#4%s%s in hello\.Hello::inlineTailRecursion\(int\) \(\) at hello/Hello\.java:177"%(spaces_pattern, address_pattern),
-            r"#5%s%s in hello\.Hello::inlineTailRecursion \(\) at hello/Hello\.java:177"%(spaces_pattern, address_pattern),
-            r"#6%shello\.Hello::inlineFrom \(\) at hello/Hello\.java:142"%(spaces_pattern),
+    rexp = [r"#0%shello\.Hello::inlineTailRecursion\(int\) \(\) at hello/Hello\.java:176"%(spaces_pattern),
+            r"#1%s%s in hello\.Hello::inlineTailRecursion\(int\) \(\) at hello/Hello\.java:179"%(spaces_pattern, address_pattern),
+            r"#2%s%s in hello\.Hello::inlineTailRecursion\(int\) \(\) at hello/Hello\.java:179"%(spaces_pattern, address_pattern),
+            r"#3%s%s in hello\.Hello::inlineTailRecursion\(int\) \(\) at hello/Hello\.java:179"%(spaces_pattern, address_pattern),
+            r"#4%s%s in hello\.Hello::inlineTailRecursion\(int\) \(\) at hello/Hello\.java:179"%(spaces_pattern, address_pattern),
+            r"#5%s%s in hello\.Hello::inlineTailRecursion \(\) at hello/Hello\.java:179"%(spaces_pattern, address_pattern),
+            r"#6%shello\.Hello::inlineFrom \(\) at hello/Hello\.java:144"%(spaces_pattern),
             r"#7%shello\.Hello::main\(java\.lang\.String\[\] \*\) \(\) at hello/Hello\.java:94"%(spaces_pattern)]
     checker = Checker('backtrace in recursive inlineTo', rexp)
     checker.check(exec_string, skip_fails=False)

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/ClassEntry.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/ClassEntry.java
@@ -292,14 +292,18 @@ public class ClassEntry extends StructureTypeEntry {
         debugContext.log("typename %s adding %s method %s %s(%s)\n",
                         typeName, memberModifiers(modifiers), resultTypeName, methodName, formatParams(paramTypes, paramNames));
         TypeEntry resultType = debugInfoBase.lookupTypeEntry(resultTypeName);
-        TypeEntry[] paramTypeArray = new TypeEntry[paramCount];
-        String[] paramNameArray = new String[paramCount];
-        int idx = 0;
-        for (String paramTypeName : paramTypes) {
-            TypeEntry paramType = debugInfoBase.lookupTypeEntry(TypeEntry.canonicalize(paramTypeName));
-            paramTypeArray[idx++] = paramType;
+        TypeEntry[] paramTypeArray = null;
+        String[] paramNameArray = null;
+        if (paramCount != 0) {
+            paramTypeArray = new TypeEntry[paramCount];
+            paramNameArray = new String[paramCount];
+            int idx = 0;
+            for (String paramTypeName : paramTypes) {
+                TypeEntry paramType = debugInfoBase.lookupTypeEntry(TypeEntry.canonicalize(paramTypeName));
+                paramTypeArray[idx++] = paramType;
+            }
+            paramNameArray = paramNames.toArray(paramNameArray);
         }
-        paramNameArray = paramNames.toArray(paramNameArray);
         /*
          * n.b. the method file may differ from the owning class file when the method is a
          * substitution

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/MethodEntry.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/MethodEntry.java
@@ -31,8 +31,8 @@ import com.oracle.objectfile.debuginfo.DebugInfoProvider.DebugLineInfo;
 import com.oracle.objectfile.debuginfo.DebugInfoProvider.DebugMethodInfo;
 
 public class MethodEntry extends MemberEntry {
-    final TypeEntry[] paramTypes;
-    final String[] paramNames;
+    private final TypeEntry[] paramTypes;
+    private final String[] paramNames;
     static final int DEOPT = 1 << 0;
     static final int IN_RANGE = 1 << 1;
     static final int INLINED = 1 << 2;

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/Range.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/Range.java
@@ -182,11 +182,14 @@ public class Range {
         builder.append(getMethodName());
         if (includeParams) {
             builder.append("(");
-            String prefix = "";
-            for (TypeEntry t : methodEntry.paramTypes) {
-                builder.append(prefix);
-                builder.append(t.getTypeName());
-                prefix = ", ";
+            TypeEntry[] paramTypes = methodEntry.getParamTypes();
+            if (paramTypes != null) {
+                String prefix = "";
+                for (TypeEntry t : paramTypes) {
+                    builder.append(prefix);
+                    builder.append(t.getTypeName());
+                    prefix = ", ";
+                }
             }
             builder.append(')');
         }

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfInfoSectionImpl.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfInfoSectionImpl.java
@@ -737,6 +737,9 @@ public class DwarfInfoSectionImpl extends DwarfSectionImpl {
         if (!Modifier.isStatic(method.getModifiers())) {
             pos = writeMethodParameterDeclaration(context, "this", classEntry.getTypeName(), true, isSpecification, buffer, pos);
         }
+        if (method.getParamTypes() == null) {
+            return pos;
+        }
         for (TypeEntry paramType : method.getParamTypes()) {
             String paramTypeName = paramType.getTypeName();
             String paramName = uniqueDebugString("");

--- a/substratevm/src/com.oracle.svm.jni/src/com/oracle/svm/jni/JNIJavaCallTrampolines.java
+++ b/substratevm/src/com.oracle.svm.jni/src/com/oracle/svm/jni/JNIJavaCallTrampolines.java
@@ -41,6 +41,9 @@ public final class JNIJavaCallTrampolines {
         return metaAccess.lookupJavaType(JNIJavaCallWrappers.class).getDeclaredConstructors()[0].getConstantPool();
     }
 
+    private JNIJavaCallTrampolines() {
+    }
+
     public static String getTrampolineName(CallVariant variant, boolean nonVirtual) {
         StringBuilder name = new StringBuilder(48);
         if (variant == CallVariant.VARARGS) {
@@ -59,7 +62,21 @@ public final class JNIJavaCallTrampolines {
         return name.toString();
     }
 
-    private JNIJavaCallTrampolines() {
+    public static boolean isNonVirtual(String trampolineName) {
+        return trampolineName.endsWith("NonvirtualJavaCallTrampoline");
+    }
+
+    public static CallVariant getVariant(String trampolineName) {
+        if (trampolineName.startsWith("varargs")) {
+            return CallVariant.VARARGS;
+        }
+        if (trampolineName.startsWith("array")) {
+            return CallVariant.ARRAY;
+        }
+        if (trampolineName.startsWith("valist")) {
+            return CallVariant.VA_LIST;
+        }
+        throw VMError.shouldNotReachHere();
     }
 
     private native void varargsJavaCallTrampoline();

--- a/substratevm/src/com.oracle.svm.jni/src/com/oracle/svm/jni/JNIJavaCallTrampolines.java
+++ b/substratevm/src/com.oracle.svm.jni/src/com/oracle/svm/jni/JNIJavaCallTrampolines.java
@@ -24,21 +24,53 @@
  */
 package com.oracle.svm.jni;
 
-import com.oracle.svm.jni.hosted.JNICallTrampolineMethod;
+import com.oracle.svm.core.util.VMError;
+import com.oracle.svm.jni.hosted.JNIJavaCallWrapperMethod;
+import com.oracle.svm.jni.hosted.JNIJavaCallWrapperMethod.CallVariant;
 
 import jdk.vm.ci.meta.ConstantPool;
 import jdk.vm.ci.meta.MetaAccessProvider;
 
 /**
- * Holder class for generated {@link JNICallTrampolineMethod} code.
+ * Holder class for generated {@link JNIJavaCallWrapperMethod} code.
  */
-public final class JNIJavaCallWrappers {
+public final class JNIJavaCallTrampolines {
     public static ConstantPool getConstantPool(MetaAccessProvider metaAccess) {
         // Each generated call wrapper needs an actual constant pool, so we provide our
         // private constructor's
         return metaAccess.lookupJavaType(JNIJavaCallWrappers.class).getDeclaredConstructors()[0].getConstantPool();
     }
 
-    private JNIJavaCallWrappers() {
+    public static String getTrampolineName(CallVariant variant, boolean nonVirtual) {
+        StringBuilder name = new StringBuilder(48);
+        if (variant == CallVariant.VARARGS) {
+            name.append("varargs");
+        } else if (variant == CallVariant.ARRAY) {
+            name.append("array");
+        } else if (variant == CallVariant.VA_LIST) {
+            name.append("valist");
+        } else {
+            throw VMError.shouldNotReachHere();
+        }
+        if (nonVirtual) {
+            name.append("Nonvirtual");
+        }
+        name.append("JavaCallTrampoline");
+        return name.toString();
     }
+
+    private JNIJavaCallTrampolines() {
+    }
+
+    private native void varargsJavaCallTrampoline();
+
+    private native void arrayJavaCallTrampoline();
+
+    private native void valistJavaCallTrampoline();
+
+    private native void varargsNonvirtualJavaCallTrampoline();
+
+    private native void arrayNonvirtualJavaCallTrampoline();
+
+    private native void valistNonvirtualJavaCallTrampoline();
 }

--- a/substratevm/src/com.oracle.svm.jni/src/com/oracle/svm/jni/JNIJavaCallTrampolines.java
+++ b/substratevm/src/com.oracle.svm.jni/src/com/oracle/svm/jni/JNIJavaCallTrampolines.java
@@ -28,18 +28,10 @@ import com.oracle.svm.core.util.VMError;
 import com.oracle.svm.jni.hosted.JNIJavaCallWrapperMethod;
 import com.oracle.svm.jni.hosted.JNIJavaCallWrapperMethod.CallVariant;
 
-import jdk.vm.ci.meta.ConstantPool;
-import jdk.vm.ci.meta.MetaAccessProvider;
-
 /**
  * Holder class for generated {@link JNIJavaCallWrapperMethod} code.
  */
 public final class JNIJavaCallTrampolines {
-    public static ConstantPool getConstantPool(MetaAccessProvider metaAccess) {
-        // Each generated call wrapper needs an actual constant pool, so we provide our
-        // private constructor's
-        return metaAccess.lookupJavaType(JNIJavaCallWrappers.class).getDeclaredConstructors()[0].getConstantPool();
-    }
 
     private JNIJavaCallTrampolines() {
     }

--- a/substratevm/src/com.oracle.svm.jni/src/com/oracle/svm/jni/JNIJavaCallWrappers.java
+++ b/substratevm/src/com.oracle.svm.jni/src/com/oracle/svm/jni/JNIJavaCallWrappers.java
@@ -30,7 +30,6 @@ import com.oracle.svm.jni.hosted.JNIJavaCallWrapperMethod.CallVariant;
 
 import jdk.vm.ci.meta.ConstantPool;
 import jdk.vm.ci.meta.MetaAccessProvider;
-import jdk.vm.ci.meta.ResolvedJavaMethod;
 
 /**
  * Holder class for generated {@link JNIJavaCallWrapperMethod} code.
@@ -42,7 +41,7 @@ public final class JNIJavaCallWrappers {
         return metaAccess.lookupJavaType(JNIJavaCallWrappers.class).getDeclaredConstructors()[0].getConstantPool();
     }
 
-    public static ResolvedJavaMethod lookupJavaCallTrampoline(MetaAccessProvider metaAccess, CallVariant variant, boolean nonVirtual) {
+    public static String getTrampolineName(CallVariant variant, boolean nonVirtual) {
         StringBuilder name = new StringBuilder(48);
         if (variant == CallVariant.VARARGS) {
             name.append("varargs");
@@ -57,11 +56,7 @@ public final class JNIJavaCallWrappers {
             name.append("Nonvirtual");
         }
         name.append("JavaCallTrampoline");
-        try {
-            return metaAccess.lookupJavaMethod(JNIJavaCallWrappers.class.getDeclaredMethod(name.toString()));
-        } catch (NoSuchMethodException e) {
-            throw VMError.shouldNotReachHere(e);
-        }
+        return name.toString();
     }
 
     private JNIJavaCallWrappers() {

--- a/substratevm/src/com.oracle.svm.jni/src/com/oracle/svm/jni/access/JNIAccessFeature.java
+++ b/substratevm/src/com.oracle.svm.jni/src/com/oracle/svm/jni/access/JNIAccessFeature.java
@@ -189,30 +189,30 @@ public class JNIAccessFeature implements Feature {
         ResolvedJavaField field = JNIAccessibleMethod.getCallWrapperField(metaAccess.getWrapped(), variant, nonVirtual);
         access.getUniverse().lookup(field.getDeclaringClass()).registerAsReachable();
         access.registerAsAccessed(access.getUniverse().lookup(field));
-        String trampolineName = JNIJavaCallTrampolines.getTrampolineName(variant, nonVirtual);
-        Method reflectionMethod = ReflectionUtil.lookupMethod(JNIJavaCallTrampolines.class, trampolineName);
+        String name = JNIJavaCallTrampolines.getTrampolineName(variant, nonVirtual);
+        Method method = ReflectionUtil.lookupMethod(JNIJavaCallTrampolines.class, name);
         // Look up the java method to ensure a JNICallTrampolineMethod gets created for it through
         // com.oracle.svm.jni.hosted.JNINativeCallWrapperSubstitutionProcessor.lookup
-        AnalysisMethod trampoline = metaAccess.lookupJavaMethod(reflectionMethod);
+        AnalysisMethod trampoline = metaAccess.lookupJavaMethod(method);
         access.registerAsCompiled(trampoline);
     }
 
     public JNICallTrampolineMethod getCallTrampolineMethod(CallVariant variant, boolean nonVirtual) {
-        String trampolineName = JNIJavaCallTrampolines.getTrampolineName(variant, nonVirtual);
-        return getCallTrampolineMethod(trampolineName);
+        String name = JNIJavaCallTrampolines.getTrampolineName(variant, nonVirtual);
+        return getCallTrampolineMethod(name);
     }
 
     public JNICallTrampolineMethod getCallTrampolineMethod(String javaTrampolineName) {
-        JNICallTrampolineMethod jniCallTrampolineMethod = trampolineMethods.get(javaTrampolineName);
-        assert jniCallTrampolineMethod != null;
-        return jniCallTrampolineMethod;
+        JNICallTrampolineMethod trampoline = trampolineMethods.get(javaTrampolineName);
+        assert trampoline != null;
+        return trampoline;
     }
 
     public JNICallTrampolineMethod getOrCreateCallTrampolineMethod(DuringSetupAccessImpl access, String trampolineName) {
-        JNICallTrampolineMethod jniCallTrampolineMethod = trampolineMethods.get(trampolineName);
+        JNICallTrampolineMethod trampoline = trampolineMethods.get(trampolineName);
 
-        if (jniCallTrampolineMethod != null) {
-            return jniCallTrampolineMethod;
+        if (trampoline != null) {
+            return trampoline;
         }
 
         MetaAccessProvider wrappedMetaAccess = access.getMetaAccess().getWrapped();
@@ -222,7 +222,7 @@ public class JNIAccessFeature implements Feature {
         // Use wrapped MetaAccess to avoid infinite recursion through
         // com.oracle.svm.jni.hosted.JNINativeCallWrapperSubstitutionProcessor.lookup
         ResolvedJavaMethod method = wrappedMetaAccess.lookupJavaMethod(reflectionMethod);
-        JNICallTrampolineMethod trampoline = new JNICallTrampolineMethod(method, field, nonVirtual);
+        trampoline = new JNICallTrampolineMethod(method, field, nonVirtual);
         trampolineMethods.put(trampolineName, trampoline);
         return trampoline;
     }

--- a/substratevm/src/com.oracle.svm.jni/src/com/oracle/svm/jni/hosted/JNICallWrapperFeature.java
+++ b/substratevm/src/com.oracle.svm.jni/src/com/oracle/svm/jni/hosted/JNICallWrapperFeature.java
@@ -74,6 +74,6 @@ class JNICallWrapperFeature implements Feature {
     @Override
     public void duringSetup(DuringSetupAccess access) {
         DuringSetupAccessImpl config = (DuringSetupAccessImpl) access;
-        config.registerNativeSubstitutionProcessor(new JNINativeCallWrapperSubstitutionProcessor());
+        config.registerNativeSubstitutionProcessor(new JNINativeCallWrapperSubstitutionProcessor(config));
     }
 }


### PR DESCRIPTION
* Fix line numbers in debuginfotest (broke with https://github.com/oracle/graal/pull/4046/commits/cd0790a2dc2f9596cc401530b89bcffbf62e6d8d#diff-105ea9ecbf6b46cbee13172668e206702bfb7927851d2033614b06ce9cef6fabR140-R142)
* Don't create JNINativeCallWrapperMethods for JNICallTrampolineMethods
* Optimize debug info generation by not allocating two 0-sized arrays per method with no arguments   

Closes: #4018