### PR TITLE
Remove hosted annotations from getAnnotations method

### DIFF
--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/hub/AnnotationsEncoding.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/hub/AnnotationsEncoding.java
@@ -29,6 +29,7 @@ import com.oracle.svm.core.util.VMError;
 import java.lang.annotation.Annotation;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
@@ -120,6 +121,7 @@ public final class AnnotationsEncoding {
     }
 
     public static Object encodeAnnotations(Set<Annotation> allAnnotations, Set<Annotation> declaredAnnotations) {
+        filterHostedAnnotations(allAnnotations);
         if (allAnnotations == null || allAnnotations.isEmpty()) {
             return null;
         }
@@ -145,5 +147,11 @@ public final class AnnotationsEncoding {
         System.arraycopy(tail.toArray(new Annotation[0]), 0, encoding, position, tail.size());
 
         return new AnnotationsEncoding(encoding, position);
+    }
+
+    public static void filterHostedAnnotations(Collection<Annotation> annotations) {
+        if (annotations != null) {
+            annotations.removeIf(annotation -> annotation.toString().contains("com.oracle.svm.core.annotate"));
+        }
     }
 }

--- a/substratevm/src/com.oracle.svm.reflect/src/com/oracle/svm/reflect/target/Target_java_lang_reflect_Executable.java
+++ b/substratevm/src/com.oracle.svm.reflect/src/com/oracle/svm/reflect/target/Target_java_lang_reflect_Executable.java
@@ -43,6 +43,7 @@ import com.oracle.svm.core.annotate.RecomputeFieldValue.CustomFieldValueComputer
 import com.oracle.svm.core.annotate.RecomputeFieldValue.Kind;
 import com.oracle.svm.core.annotate.Substitute;
 import com.oracle.svm.core.annotate.TargetClass;
+import com.oracle.svm.core.hub.AnnotationsEncoding;
 import com.oracle.svm.core.option.SubstrateOptionsParser;
 import com.oracle.svm.core.util.VMError;
 import com.oracle.svm.hosted.NativeImageOptions;
@@ -136,6 +137,8 @@ public final class Target_java_lang_reflect_Executable {
                                     holder.getAnnotationBytes(),
                                     new Target_jdk_internal_reflect_ConstantPool(),
                                     holder.getDeclaringClass());
+
+                    AnnotationsEncoding.filterHostedAnnotations(declAnnos.values());
                     declaredAnnotations = declAnnos;
                 }
             }


### PR DESCRIPTION
Methods such as `Class.getAnnotations` or `Method.getAnnotations` will return the list of all annotations for specific element. In our case, the list will contain hosted annotations such as `Substitute`, `TargetElement`, `TargetClass`... This PR filters those annotations before the calls happen.