### PR TITLE
[GR-36201] Avoid control chars in new build output to dumb terminals

### DIFF
--- a/substratevm/mx.substratevm/mx_substratevm.py
+++ b/substratevm/mx.substratevm/mx_substratevm.py
@@ -241,6 +241,9 @@ def native_image_context(common_args=None, hosted_assertions=True, native_image_
     common_args = [] if common_args is None else common_args
     base_args = ['--no-fallback', '-H:+EnforceMaxRuntimeCompileMethods']
     base_args += ['-H:Path=' + svmbuild_dir()]
+    # avoid escape sequences in output to dumb terminals (or emacs)
+    if os.getenv("TERM") == "dumb":
+        base_args += ["-H:-BuildOutputColorful", "-H:-BuildOutputProgress"]
     if mx.get_opts().verbose:
         base_args += ['--verbose']
     if mx.get_opts().very_verbose:

--- a/substratevm/mx.substratevm/mx_substratevm.py
+++ b/substratevm/mx.substratevm/mx_substratevm.py
@@ -241,9 +241,6 @@ def native_image_context(common_args=None, hosted_assertions=True, native_image_
     common_args = [] if common_args is None else common_args
     base_args = ['--no-fallback', '-H:+EnforceMaxRuntimeCompileMethods']
     base_args += ['-H:Path=' + svmbuild_dir()]
-    # avoid escape sequences in output to dumb terminals (or emacs)
-    if os.getenv("TERM") == "dumb":
-        base_args += ["-H:-BuildOutputColorful", "-H:-BuildOutputProgress"]
     if mx.get_opts().verbose:
         base_args += ['--verbose']
     if mx.get_opts().very_verbose:

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/ProgressReporter.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/ProgressReporter.java
@@ -77,8 +77,7 @@ public class ProgressReporter {
     private static final int CHARACTERS_PER_LINE;
     private static final int PROGRESS_BAR_START = 30;
     private static final boolean IS_CI = System.console() == null || System.getenv("CI") != null;
-    boolean IS_DUMB_TERM = "dumb".equals(System.getenv("TERM"));
-
+    private static final boolean IS_DUMB_TERM = isDumbTerm();
     private static final int MAX_NUM_FEATURES = 50;
     private static final int MAX_NUM_BREAKDOWN = 10;
     private static final String CODE_BREAKDOWN_TITLE = String.format("Top %d packages in code area:", MAX_NUM_BREAKDOWN);
@@ -135,6 +134,11 @@ public class ProgressReporter {
 
     static {
         CHARACTERS_PER_LINE = IS_CI ? ProgressReporterCHelper.MAX_CHARACTERS_PER_LINE : ProgressReporterCHelper.getTerminalWindowColumnsClamped();
+    }
+
+    private final static boolean isDumbTerm() {
+        String term = System.getenv("TERM");
+        return (term == null || term.equals("") || term.equals("dumb") || term.equals("unknown"));
     }
 
     public static ProgressReporter singleton() {

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/ProgressReporter.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/ProgressReporter.java
@@ -77,6 +77,7 @@ public class ProgressReporter {
     private static final int CHARACTERS_PER_LINE;
     private static final int PROGRESS_BAR_START = 30;
     private static final boolean IS_CI = System.console() == null || System.getenv("CI") != null;
+    boolean IS_DUMB_TERM = "dumb".equals(System.getenv("TERM"));
 
     private static final int MAX_NUM_FEATURES = 50;
     private static final int MAX_NUM_BREAKDOWN = 10;
@@ -148,12 +149,12 @@ public class ProgressReporter {
             Timer.disablePrinting();
         }
         usePrefix = SubstrateOptions.BuildOutputPrefix.getValue(options);
-        boolean enableColors = !IS_CI && OS.getCurrent() != OS.WINDOWS;
+        boolean enableColors = !IS_DUMB_TERM && !IS_CI && OS.getCurrent() != OS.WINDOWS;
         if (SubstrateOptions.BuildOutputColorful.hasBeenSet(options)) {
             enableColors = SubstrateOptions.BuildOutputColorful.getValue(options);
         }
         boolean loggingDisabled = DebugOptions.Log.getValue(options) == null;
-        boolean enableProgress = !IS_CI && loggingDisabled;
+        boolean enableProgress = !IS_DUMB_TERM && !IS_CI && loggingDisabled;
         if (SubstrateOptions.BuildOutputProgress.hasBeenSet(options)) {
             enableProgress = SubstrateOptions.BuildOutputProgress.getValue(options);
         }


### PR DESCRIPTION
The new build output is wonderful except when you are running your build inside a dumb terminal (i.e. a shell inside emacs). The control sequences posted to the tty just make a mess of the output so it looks like this:


    $ mx debuginfotest
    . . .
    ================================================================================
    ^[]8;;https://www.graalvm.org/native-image^[\GraalVM Native Image^[]8;;^[\: Generating 'hello.hello'...
    ================================================================================
    [1/7] ^[]8;;https://github.com/oracle/graal/blob/master/docs/reference-manual/native-image/BuildOutput.md#stage-initializing^[\Initializing^[]8;;^[\...                                            (5.3s @ 0.27GB)
     ^[]8;;https://github.com/oracle/graal/blob/master/docs/reference-manual/native-image/BuildOutput.md#glossary-version-info^[\Version info^[]8;;^[\: 'GraalVM dev Java 11 CE'
    . . .

This patch modifies the native image build command definded in mx_substrate.py to detect a dumb terminal and disable the build options that generate control sequences, resulting in output like this:

    $ mx debuginfotest
    . . .
    ================================================================================
    GraalVM Native Image: Generating 'hello.hello'...
    ================================================================================
    [1/7] Initializing...                                            (5.8s @ 0.28GB)
     Version info: 'GraalVM dev Java 11 CE'
    . . .
