### PR TITLE
[GR-36446] Fix static field printing when isolates are enabled and test printing in debuginfotest with gdb 11.0+

### DIFF
--- a/substratevm/mx.substratevm/testhello.py
+++ b/substratevm/mx.substratevm/testhello.py
@@ -149,8 +149,8 @@ def test():
     # range of major.minor versions
     # for now we use an env setting
     print("Found gdb version %s.%s"%(major, minor))
-    # can_print_data = major > 10 or (major == 10 and minor > 1)
-    can_print_data = False
+    # printing does not always work on gdb 10.x or earlier
+    can_print_data = major > 10
     if os.environ.get('GDB_CAN_PRINT', '') == 'True':
         can_print_data = True
 

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/image/NativeImageDebugInfoProvider.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/image/NativeImageDebugInfoProvider.java
@@ -119,8 +119,8 @@ class NativeImageDebugInfoProvider implements DebugInfoProvider {
         this.pointerSize = ConfigurationValues.getTarget().wordSize;
         this.referenceAlignment = getObjectLayout().getAlignment();
         /* Offsets need to be adjusted relative to the heap base plus partition-specific offset. */
-        primitiveStartOffset = (int) primitiveFields.getOffset();
-        referenceStartOffset = (int) objectFields.getOffset();
+        primitiveStartOffset = (int) primitiveFields.getAddress();
+        referenceStartOffset = (int) objectFields.getAddress();
     }
 
     @Override


### PR DESCRIPTION
This is a fix for the problem reported in issue #4224.

The fix also enables printing of objects, including those reachable via a static field, under mx debuginfotest when gdb with version 11.0 or greater is in the path. Issue #4224 was not found until recently because the test was disabled due to a bug in gdb 10.x.
