### PR TITLE
[GR-36532] Improve debug info log output

### DIFF
--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/DebugInfoBase.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/DebugInfoBase.java
@@ -374,7 +374,7 @@ public abstract class DebugInfoBase {
         Range subRange = new Range(stringTable, subRangeMethodEntry, lo, hi, line, primaryRange, isInline, caller);
         classEntry.indexSubRange(subRange);
         try (DebugContext.Scope s = debugContext.scope("Subranges")) {
-            debugContext.log(DebugContext.VERBOSE_LEVEL, "SubRange %s.%s %s %s:%d 0x%x, 0x%x]",
+            debugContext.log(DebugContext.DETAILED_LEVEL, "SubRange %s.%s %s %s:%d 0x%x, 0x%x]",
                             ownerType.toJavaName(), methodName, filePath, fileName, line, lo, hi);
         }
         return subRange;

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/Range.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/Range.java
@@ -277,7 +277,7 @@ public class Range {
         if (next == null) {
             return;
         }
-        debugContext.log(DebugContext.INFO_LEVEL, "Merge subranges [0x%x, 0x%x] %s", lo, hi, getFullMethodNameWithParams());
+        debugContext.log(DebugContext.DETAILED_LEVEL, "Merge subranges [0x%x, 0x%x] %s", lo, hi, getFullMethodNameWithParams());
         /* merge siblings together if possible, reparenting children to the merged node */
         while (next != null) {
             next = next.maybeMergeSibling(debugContext);
@@ -297,7 +297,7 @@ public class Range {
      */
     private Range maybeMergeSibling(DebugContext debugContext) {
         Range sibling = getSiblingCallee();
-        debugContext.log(DebugContext.INFO_LEVEL, "Merge subrange (maybe) [0x%x, 0x%x] %s", lo, hi, getFullMethodNameWithParams());
+        debugContext.log(DebugContext.DETAILED_LEVEL, "Merge subrange (maybe) [0x%x, 0x%x] %s", lo, hi, getFullMethodNameWithParams());
         if (sibling == null) {
             /* all child nodes at this level have been merged */
             return null;
@@ -334,7 +334,7 @@ public class Range {
                         lo, hi, getFullMethodNameWithParams(), sibling.getLo(), sibling.getHi(), sibling.getFullMethodNameWithParams());
         assert this.isInlined == sibling.isInlined : String.format("change in inlined [0x%x,0x%x] %s %s [0x%x,0x%x] %s %s",
                         lo, hi, getFullMethodNameWithParams(), Boolean.valueOf(this.isInlined), sibling.lo, sibling.hi, sibling.getFullMethodNameWithParams(), Boolean.valueOf(sibling.isInlined));
-        debugContext.log(DebugContext.INFO_LEVEL, "Combining [0x%x, 0x%x] %s into [0x%x, 0x%x] %s", sibling.lo, sibling.hi, sibling.getFullMethodName(), lo, hi, getFullMethodNameWithParams());
+        debugContext.log(DebugContext.DETAILED_LEVEL, "Combining [0x%x, 0x%x] %s into [0x%x, 0x%x] %s", sibling.lo, sibling.hi, sibling.getFullMethodName(), lo, hi, getFullMethodNameWithParams());
         this.hi = sibling.hi;
         this.siblingCallee = sibling.siblingCallee;
     }
@@ -342,7 +342,7 @@ public class Range {
     private void reparentChildren(DebugContext debugContext, Range sibling) {
         Range siblingNext = sibling.getFirstCallee();
         while (siblingNext != null) {
-            debugContext.log(DebugContext.INFO_LEVEL, "Reparenting [0x%x, 0x%x] %s to [0x%x, 0x%x] %s", siblingNext.lo, siblingNext.hi, siblingNext.getFullMethodName(), lo, hi,
+            debugContext.log(DebugContext.DETAILED_LEVEL, "Reparenting [0x%x, 0x%x] %s to [0x%x, 0x%x] %s", siblingNext.lo, siblingNext.hi, siblingNext.getFullMethodName(), lo, hi,
                             getFullMethodNameWithParams());
             siblingNext.caller = this;
             Range newSiblingNext = siblingNext.siblingCallee;

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/StructureTypeEntry.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/StructureTypeEntry.java
@@ -64,7 +64,7 @@ public abstract class StructureTypeEntry extends TypeEntry {
         int fieldSize = debugFieldInfo.size();
         int fieldoffset = debugFieldInfo.offset();
         int fieldModifiers = debugFieldInfo.modifiers();
-        debugContext.log("typename %s adding %s field %s type %s size %s at offset %d\n",
+        debugContext.log("typename %s adding %s field %s type %s size %s at offset 0x%x\n",
                         typeName, memberModifiers(fieldModifiers), fieldName, valueTypeName, fieldSize, fieldoffset);
         TypeEntry valueType = debugInfoBase.lookupTypeEntry(valueTypeName);
         /*

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debuginfo/DebugInfoProvider.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debuginfo/DebugInfoProvider.java
@@ -47,7 +47,7 @@ public interface DebugInfoProvider {
     int oopCompressShift();
 
     /**
-     * Mask delecting low order bits used for tagging oops.
+     * Mask selecting low order bits used for tagging oops.
      */
     int oopTagsMask();
 

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/image/NativeImageDebugInfoProvider.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/image/NativeImageDebugInfoProvider.java
@@ -1228,7 +1228,7 @@ class NativeImageDebugInfoProvider implements DebugInfoProvider {
         @SuppressWarnings("try")
         @Override
         public void debugContext(Consumer<DebugContext> action) {
-            try (DebugContext.Scope s = debugContext.scope("DebugCodeInfo", provenance)) {
+            try (DebugContext.Scope s = debugContext.scope("DebugDataInfo", provenance)) {
                 action.accept(debugContext);
             } catch (Throwable e) {
                 throw debugContext.handle(e);


### PR DESCRIPTION
This trivial fix improves the quality of debug info log output

- Log info for compiled code subranges is moved from level VERBOSE to DETAILED. 
- Log info for heap object/primitive data is moved from level VERBOSE to DETAILED and generated under log context id DebugDataInfo instead of the current DebugCodeInfo.

Subrange messages constitute about 3/4 of the log output for a normal image build when log pattern DebugCodeInfo is passed. Data info messages produce much less output but separating them from code info messages is appropriate since info about heap objects is needed much less often than code info.
