### PR TITLE
Only clear out native array entry if it's virtual.

### DIFF
--- a/compiler/src/org.graalvm.compiler.truffle.compiler/src/org/graalvm/compiler/truffle/compiler/nodes/frame/VirtualFrameSetNode.java
+++ b/compiler/src/org.graalvm.compiler.truffle.compiler/src/org/graalvm/compiler/truffle/compiler/nodes/frame/VirtualFrameSetNode.java
@@ -93,7 +93,9 @@ public final class VirtualFrameSetNode extends VirtualFrameAccessorNode implemen
                         if (valueKind == JavaKind.Object) {
                             // clear out native entry
                             ValueNode primitiveAlias = tool.getAlias(frame.getPrimitiveArray(type));
-                            tool.setVirtualEntry((VirtualObjectNode) primitiveAlias, frameSlotIndex, ConstantNode.defaultForKind(JavaKind.Long, graph()), JavaKind.Long, -1);
+                            if (primitiveAlias instanceof VirtualObjectNode) {
+                                tool.setVirtualEntry((VirtualObjectNode) primitiveAlias, frameSlotIndex, ConstantNode.defaultForKind(JavaKind.Long, graph()), JavaKind.Long, -1);
+                            }
                         }
                         tool.delete();
                         return;


### PR DESCRIPTION
@lukasstadler We started seeing a [compilation issue](#4123) after def50a7810dd841e0536a3ca11e46a188b943d74 was added. I don't really understand the PEA code all that well, but I looked at the diff of changes and think adding this guard is sufficient to fix the problem. But, please evaluate on your own and see if you've come up with the same conclusion. The last thing I want to do is gloss over a bigger issue in the compiler. Feel free to close this PR out in favor of something else, too, or reword the commit message. I just wanted something concrete here to center the discussion.

Fixes #4213.