### PR TITLE
Don't prepend resource URLs with '/'

### DIFF
--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/Resources.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/Resources.java
@@ -141,7 +141,7 @@ public final class Resources {
     private static URL createURL(String moduleName, String resourceName, int index) {
         try {
             String refPart = index != 0 ? '#' + Integer.toString(index) : "";
-            return new URL(JavaNetSubstitutions.RESOURCE_PROTOCOL, moduleName, -1, '/' + resourceName + refPart);
+            return new URL(JavaNetSubstitutions.RESOURCE_PROTOCOL, moduleName, -1, resourceName + refPart);
         } catch (MalformedURLException ex) {
             throw new IllegalStateException(ex);
         }

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/resources/ResourceURLConnection.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/resources/ResourceURLConnection.java
@@ -44,6 +44,10 @@ public class ResourceURLConnection extends URLConnection {
         super(url);
     }
 
+    private static String resolveName(String resourceName) {
+        return resourceName.startsWith("/") ? resourceName.substring(1) : resourceName;
+    }
+
     @Override
     public void connect() {
         if (connected) {
@@ -54,10 +58,7 @@ public class ResourceURLConnection extends URLConnection {
         String urlHost = url.getHost();
         String hostNameOrNull = urlHost != null && !urlHost.isEmpty() ? urlHost : null;
         String urlPath = url.getPath();
-        if (urlPath.isEmpty()) {
-            throw new IllegalArgumentException("Empty URL path not allowed in " + JavaNetSubstitutions.RESOURCE_PROTOCOL + " URL");
-        }
-        String resourceName = urlPath.substring(1);
+        String resourceName = resolveName(urlPath);
         ResourceStorageEntry entry = Resources.get(hostNameOrNull, Resources.toCanonicalForm(resourceName));
         if (entry != null) {
             List<byte[]> bytes = entry.getData();


### PR DESCRIPTION
In PR #4281 resource URLs started being prefixed with '/', which results
in failures to retrieve the resource in some cases.
E.g. https://github.com/quarkusio/quarkus/issues/23604