### PR TITLE
Implementation of Safepoint events

### DIFF
--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/JfrEvent.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/JfrEvent.java
@@ -49,7 +49,9 @@ public enum JfrEvent {
     GCPhasePauseLevel1Event("jdk.GCPhasePauseLevel1"),
     GCPhasePauseLevel2Event("jdk.GCPhasePauseLevel2"),
     GCPhasePauseLevel3Event("jdk.GCPhasePauseLevel3"),
-    GCPhasePauseLevel4Event("jdk.GCPhasePauseLevel4");
+    GCPhasePauseLevel4Event("jdk.GCPhasePauseLevel4"),
+    SafepointBegin("jdk.SafepointBegin"),
+    SafepointEnd("jdk.SafepointEnd");
 
     private final long id;
 

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/JfrTicks.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/JfrTicks.java
@@ -44,8 +44,12 @@ public final class JfrTicks {
 
     @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
     public static long elapsedTicks() {
-        assert initialTicks > 0;
-        return System.nanoTime() - initialTicks;
+        if (HasJfrSupport.get()) {
+            assert initialTicks > 0;
+            return System.nanoTime() - initialTicks;
+        } else {
+            return 0;
+        }
     }
 
     public static long getTicksFrequency() {

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/events/SafepointBeginEvent.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/events/SafepointBeginEvent.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2022, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2022, Red Hat Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package com.oracle.svm.core.jfr.events;
+
+import com.oracle.svm.core.annotate.Uninterruptible;
+import com.oracle.svm.core.jfr.JfrEvent;
+import com.oracle.svm.core.jfr.HasJfrSupport;
+import com.oracle.svm.core.jfr.JfrNativeEventWriter;
+import com.oracle.svm.core.jfr.JfrNativeEventWriterData;
+import com.oracle.svm.core.jfr.JfrNativeEventWriterDataAccess;
+import com.oracle.svm.core.jfr.JfrTicks;
+import com.oracle.svm.core.jfr.SubstrateJVM;
+
+import org.graalvm.nativeimage.StackValue;
+import org.graalvm.word.UnsignedWord;
+
+public class SafepointBeginEvent {
+    @Uninterruptible(reason = "Accesses a JFR buffer.")
+    public static void emit(UnsignedWord safepointId, int numOfThreads, long startTicks) {
+        if (!HasJfrSupport.get()) {
+            return;
+        }
+
+        if (SubstrateJVM.isRecording() && SubstrateJVM.get().isEnabled(JfrEvent.SafepointBegin)) {
+            JfrNativeEventWriterData data = StackValue.get(JfrNativeEventWriterData.class);
+            JfrNativeEventWriterDataAccess.initializeThreadLocalNativeBuffer(data);
+
+            JfrNativeEventWriter.beginEventWrite(data, false);
+            JfrNativeEventWriter.putLong(data, JfrEvent.SafepointBegin.getId());
+            JfrNativeEventWriter.putLong(data, startTicks);
+            JfrNativeEventWriter.putLong(data, JfrTicks.elapsedTicks() - startTicks);
+            JfrNativeEventWriter.putEventThread(data);
+            JfrNativeEventWriter.putLong(data, safepointId.rawValue());
+            JfrNativeEventWriter.putInt(data, numOfThreads);
+            JfrNativeEventWriter.putInt(data, 0); // jniCriticalThreadCount
+            JfrNativeEventWriter.endEventWrite(data, false);
+        }
+    }
+}

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/events/SafepointEndEvent.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/events/SafepointEndEvent.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2022, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2022, Red Hat Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package com.oracle.svm.core.jfr.events;
+
+import com.oracle.svm.core.annotate.Uninterruptible;
+import com.oracle.svm.core.jfr.JfrEvent;
+import com.oracle.svm.core.jfr.HasJfrSupport;
+import com.oracle.svm.core.jfr.JfrNativeEventWriter;
+import com.oracle.svm.core.jfr.JfrNativeEventWriterData;
+import com.oracle.svm.core.jfr.JfrNativeEventWriterDataAccess;
+import com.oracle.svm.core.jfr.JfrTicks;
+import com.oracle.svm.core.jfr.SubstrateJVM;
+
+import org.graalvm.nativeimage.StackValue;
+import org.graalvm.word.UnsignedWord;
+
+public class SafepointEndEvent {
+    @Uninterruptible(reason = "Accesses a JFR buffer.")
+    public static void emit(UnsignedWord safepointId, long startTick) {
+        if (!HasJfrSupport.get()) {
+            return;
+        }
+
+        if (SubstrateJVM.isRecording() && SubstrateJVM.get().isEnabled(JfrEvent.SafepointEnd)) {
+            JfrNativeEventWriterData data = StackValue.get(JfrNativeEventWriterData.class);
+            JfrNativeEventWriterDataAccess.initializeThreadLocalNativeBuffer(data);
+
+            JfrNativeEventWriter.beginEventWrite(data, false);
+            JfrNativeEventWriter.putLong(data, JfrEvent.SafepointEnd.getId());
+            JfrNativeEventWriter.putLong(data, startTick);
+            JfrNativeEventWriter.putLong(data, JfrTicks.elapsedTicks() - startTick);
+            JfrNativeEventWriter.putEventThread(data);
+            JfrNativeEventWriter.putLong(data, safepointId.rawValue());
+            JfrNativeEventWriter.endEventWrite(data, false);
+        }
+    }
+}

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/thread/Safepoint.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/thread/Safepoint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -57,6 +57,9 @@ import com.oracle.svm.core.annotate.Uninterruptible;
 import com.oracle.svm.core.graal.nodes.KillMemoryNode;
 import com.oracle.svm.core.heap.Heap;
 import com.oracle.svm.core.jdk.UninterruptibleUtils;
+import com.oracle.svm.core.jfr.JfrTicks;
+import com.oracle.svm.core.jfr.events.SafepointBeginEvent;
+import com.oracle.svm.core.jfr.events.SafepointEndEvent;
 import com.oracle.svm.core.log.Log;
 import com.oracle.svm.core.nodes.CFunctionEpilogueNode;
 import com.oracle.svm.core.nodes.CFunctionPrologueNode;
@@ -612,6 +615,7 @@ public final class Safepoint {
         protected boolean freeze(String reason) {
             assert SubstrateOptions.MultiThreaded.getValue() : "Should only freeze for a safepoint when multi-threaded.";
             assert VMOperationControl.mayExecuteVmOperations();
+            long startTicks = JfrTicks.elapsedTicks();
 
             /* the current thread may already own the lock for non-safepoint reasons */
             boolean lock = !VMThreads.THREAD_MUTEX.isOwner();
@@ -624,11 +628,12 @@ public final class Safepoint {
             Statistics.setStartNanos();
             ImageSingletons.lookup(Heap.class).prepareForSafepoint();
             safepointState = SYNCHRONIZING;
-            requestSafepoints(reason);
+            int numOfThreads = requestSafepoints(reason);
             waitForSafepoints(reason);
             Statistics.setFrozenNanos();
             safepointState = AT_SAFEPOINT;
             safepointId = safepointId.add(1);
+            SafepointBeginEvent.emit(getSafepointId(), numOfThreads, startTicks);
             return lock;
         }
 
@@ -637,9 +642,10 @@ public final class Safepoint {
         protected void thaw(String reason, boolean unlock) {
             assert SubstrateOptions.MultiThreaded.getValue() : "Should only thaw from a safepoint when multi-threaded.";
             assert VMOperationControl.mayExecuteVmOperations();
-
+            long startTicks = JfrTicks.elapsedTicks();
             safepointState = NOT_AT_SAFEPOINT;
             releaseSafepoints(reason);
+            SafepointEndEvent.emit(getSafepointId(), startTicks);
             ImageSingletons.lookup(Heap.class).endSafepoint();
             Statistics.setThawedNanos();
             requestingThread = WordFactory.nullPointer();
@@ -657,12 +663,14 @@ public final class Safepoint {
         }
 
         /** Send each of the threads (except myself) a request to come to a safepoint. */
-        private static void requestSafepoints(String reason) {
+        private static int requestSafepoints(String reason) {
             VMThreads.THREAD_MUTEX.assertIsOwner("Must hold mutex while requesting a safepoint.");
             final Log trace = Log.noopLog().string("[Safepoint.Master.requestSafepoints:  reason: ").string(reason);
+            int numOfThreads = 0;
 
             // Walk the threads list and ask each thread (except myself) to come to a safepoint.
             for (IsolateThread vmThread = VMThreads.firstThread(); vmThread.isNonNull(); vmThread = VMThreads.nextThread(vmThread)) {
+                numOfThreads++;
                 if (isMyself(vmThread)) {
                     continue;
                 }
@@ -677,6 +685,7 @@ public final class Safepoint {
                 trace.string(" with requests: ").signed(Statistics.getRequested());
             }
             trace.string("]").newline();
+            return numOfThreads;
         }
 
         /**


### PR DESCRIPTION
Add implementation of Safepoint event that provides safepoint latency information.

e.g. 

```
jdk.SafepointBegin {
  startTime = 15:43:26.488
  duration = 4.315 us
  safepointId = 2
  totalThreadCount = 5
  jniCriticalThreadCount = 0
  eventThread = "main" (javaThreadId = 1)
}

jdk.SafepointEnd {
  startTime = 15:43:26.490
  duration = 0.318 us
  safepointId = 2
  eventThread = "main" (javaThreadId = 1)
}


```
