### PR TITLE
array filling for counted loop

### DIFF
--- a/compiler/src/org.graalvm.compiler.core.common/src/org/graalvm/compiler/core/common/GraalOptions.java
+++ b/compiler/src/org.graalvm.compiler.core.common/src/org/graalvm/compiler/core/common/GraalOptions.java
@@ -122,6 +122,9 @@ public final class GraalOptions {
                    "dominate the back edge of a loop.", type = OptionType.Debug)
     public static final OptionKey<Boolean> LoopPredicationMainPath = new OptionKey<>(true);
 
+    @Option(help = "Convert array fill counted loop to stub call", type = OptionType.Debug)
+    public static final OptionKey<Boolean> OptimizeFill = new OptionKey<>(true);
+
     // debugging settings
     @Option(help = "", type = OptionType.Debug)
     public static final OptionKey<Boolean> ZapStackOnMethodEntry = new OptionKey<>(false);

--- a/compiler/src/org.graalvm.compiler.core/src/org/graalvm/compiler/core/phases/HighTier.java
+++ b/compiler/src/org.graalvm.compiler.core/src/org/graalvm/compiler/core/phases/HighTier.java
@@ -29,6 +29,7 @@ import static org.graalvm.compiler.core.common.GraalOptions.LoopPeeling;
 import static org.graalvm.compiler.core.common.GraalOptions.LoopUnswitch;
 import static org.graalvm.compiler.core.common.GraalOptions.OptConvertDeoptsToGuards;
 import static org.graalvm.compiler.core.common.GraalOptions.OptReadElimination;
+import static org.graalvm.compiler.core.common.GraalOptions.OptimizeFill;
 import static org.graalvm.compiler.core.common.GraalOptions.PartialEscapeAnalysis;
 import static org.graalvm.compiler.phases.common.DeadCodeEliminationPhase.Optionality.Optional;
 
@@ -93,6 +94,10 @@ public class HighTier extends BaseTier<HighTierContext> {
 
         if (ConditionalElimination.getValue(options)) {
             appendPhase(new IterativeConditionalEliminationPhase(canonicalizer, false));
+        }
+
+        if (OptimizeFill.getValue(options)) {
+            appendPhase(new IntrinsifyArrayFillPhase());
         }
 
         LoopPolicies loopPolicies = createLoopPolicies(options);

--- a/compiler/src/org.graalvm.compiler.hotspot.test/src/org/graalvm/compiler/hotspot/test/ArrayFillTest.java
+++ b/compiler/src/org.graalvm.compiler.hotspot.test/src/org/graalvm/compiler/hotspot/test/ArrayFillTest.java
@@ -1,0 +1,546 @@
+/*
+ * Copyright (c) 2022, Alibaba Group Holding Limited. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+package org.graalvm.compiler.hotspot.test;
+
+import org.graalvm.compiler.core.common.cfg.Loop;
+import org.graalvm.compiler.core.common.spi.ForeignCallDescriptor;
+import org.graalvm.compiler.core.test.GraalCompilerTest;
+import org.graalvm.compiler.graph.iterators.NodeIterable;
+import org.graalvm.compiler.hotspot.replacements.arraycopy.HotSpotArrayFillSnippets;
+import org.graalvm.compiler.nodes.StructuredGraph;
+import org.graalvm.compiler.nodes.cfg.Block;
+import org.graalvm.compiler.nodes.extended.ForeignCallNode;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class ArrayFillTest extends GraalCompilerTest {
+    private static boolean isFillCallDescriptor(ForeignCallDescriptor descriptor) {
+        return descriptor == HotSpotArrayFillSnippets.ARRAYOF_JBYTE_FILL_CALL ||
+                descriptor == HotSpotArrayFillSnippets.ARRAYOF_JINT_FILL_CALL ||
+                descriptor == HotSpotArrayFillSnippets.ARRAYOF_JSHORT_FILL_CALL ||
+                descriptor == HotSpotArrayFillSnippets.JINT_FILL_CALL ||
+                descriptor == HotSpotArrayFillSnippets.JBYTE_FILL_CALL ||
+                descriptor == HotSpotArrayFillSnippets.JSHORT_FILL_CALL;
+    }
+
+    public int[] int_fill1() {
+        int[] arr = new int[300];
+        for (int i = 0; i < arr.length; i++) {
+            arr[i] = 1024;
+        }
+        if (arr[0] != 1024 || arr[arr.length - 1] != 1024) {
+            throw new RuntimeException("Wrong optimization");
+        }
+        return arr;
+    }
+
+    public int[] int_fill2() {
+        int[] arr = new int[300];
+        Arrays.fill(arr, 1234);
+        if (arr[0] != 1024 || arr[arr.length - 1] != 1024) {
+            throw new RuntimeException("Wrong optimization");
+        }
+        return arr;
+    }
+
+    public int[] int_fill3() {
+        int[] arr = new int[300];
+        for (int i = 0; i < 100; i++) {
+            arr[i] = 1024;
+        }
+        if (arr[0] != 1024 || arr[100] != 0) {
+            throw new RuntimeException("Wrong optimization");
+        }
+        return arr;
+    }
+
+    public int[] int_fill4() {
+        int[] arr = new int[300];
+        Arrays.fill(arr, arr.length);
+        if (arr[0] != 1024 || arr[arr.length - 1] != 1024) {
+            throw new RuntimeException("Wrong optimization");
+        }
+        return arr;
+    }
+
+    public int[] int_fill5() {
+        int[] arr = new int[300];
+        for (int i = 3; i < arr.length; i++) {
+            arr[i] = 1024;
+        }
+        if (arr[0] != 0 || arr[1] != 0 || arr[2] != 0 || arr[3] != 1024) {
+            throw new RuntimeException("Wrong optimization");
+        }
+        return arr;
+    }
+
+    public int[] int_fill6() {
+        int[] arr = new int[300];
+        for (int i = 3; i < 100; i++) {
+            arr[i] = 1024;
+        }
+        if (arr[0] != 0 || arr[1] != 0 || arr[2] != 0 || arr[3] != 1024 || arr[99] != 1024) {
+            throw new RuntimeException("Wrong optimization");
+        }
+        return arr;
+    }
+
+    public int[] no_int_fill1() {
+        int[] arr = new int[300];
+        for (int i = 0; i < arr.length; i++) {
+            if (i % 2 == 0) {
+                // interference...
+                i++;
+            }
+            arr[i] = 1024;
+        }
+        return arr;
+    }
+
+    public int[] no_int_fill2() {
+        int[] arr = new int[300];
+        for (int i = 0; i < arr.length; i += 2) {
+            arr[i] = 1024;
+        }
+        return arr;
+    }
+
+    public int[] no_int_fill3() {
+        int[] arr = new int[300];
+        for (int i = 0; i < arr.length; i += 2) {
+            arr[i] = i * 2;
+        }
+        return arr;
+    }
+
+    public int[] no_int_fill4() {
+        int[] arr = new int[300];
+        int k = 0;
+        for (int i = 0; i < arr.length; i += 2) {
+            arr[k] = 1;
+            k++;
+        }
+        return arr;
+    }
+
+    public int[] no_int_fill5() {
+        int[] arr = new int[300];
+        int k = 0;
+        for (int i = 0; i < arr.length; i += arr.length) {
+            arr[k] = 1;
+        }
+        return arr;
+    }
+
+    public short[] short_fill1() {
+        short[] arr = new short[300];
+        for (int i = 0; i < arr.length; i++) {
+            arr[i] = 1024;
+        }
+        if (arr[0] != 1024 || arr[arr.length - 1] != 1024) {
+            throw new RuntimeException("Wrong optimization");
+        }
+        return arr;
+    }
+
+    public short[] short_fill2() {
+        short[] arr = new short[300];
+        Arrays.fill(arr, (short) 1234);
+        if (arr[0] != 1024 || arr[arr.length - 1] != 1024) {
+            throw new RuntimeException("Wrong optimization");
+        }
+        return arr;
+    }
+
+    public short[] short_fill3() {
+        short[] arr = new short[300];
+        for (int i = 0; i < 100; i++) {
+            arr[i] = 1024;
+        }
+        if (arr[0] != 1024 || arr[100] != 0) {
+            throw new RuntimeException("Wrong optimization");
+        }
+        return arr;
+    }
+
+    public short[] short_fill4() {
+        short[] arr = new short[300];
+        Arrays.fill(arr, (short) arr.length);
+        if (arr[0] != 1024 || arr[arr.length - 1] != 1024) {
+            throw new RuntimeException("Wrong optimization");
+        }
+        return arr;
+    }
+
+    public short[] short_fill5() {
+        short[] arr = new short[300];
+        for (int i = 3; i < arr.length; i++) {
+            arr[i] = 1024;
+        }
+        if (arr[0] != 0 || arr[1] != 0 || arr[2] != 0 || arr[3] != 1024) {
+            throw new RuntimeException("Wrong optimization");
+        }
+        return arr;
+    }
+
+    public short[] short_fill6() {
+        short[] arr = new short[300];
+        for (int i = 3; i < 100; i++) {
+            arr[i] = 1024;
+        }
+        if (arr[0] != 0 || arr[1] != 0 || arr[2] != 0 || arr[3] != 1024 || arr[99] != 1024) {
+            throw new RuntimeException("Wrong optimization");
+        }
+        return arr;
+    }
+
+    public short[] no_short_fill1() {
+        short[] arr = new short[300];
+        for (int i = 0; i < arr.length; i++) {
+            if (i % 2 == 0) {
+                // interference...
+                i++;
+            }
+            arr[i] = 1024;
+        }
+        return arr;
+    }
+
+    public short[] no_short_fill2() {
+        short[] arr = new short[300];
+        for (int i = 0; i < arr.length; i += 2) {
+            arr[i] = 1024;
+        }
+        return arr;
+    }
+
+    public short[] no_short_fill3() {
+        short[] arr = new short[300];
+        for (int i = 0; i < arr.length; i += 2) {
+            arr[i] = (short) (i * 2);
+        }
+        return arr;
+    }
+
+    public short[] no_short_fill4() {
+        short[] arr = new short[300];
+        int k = 0;
+        for (int i = 0; i < arr.length; i += 2) {
+            arr[k] = 1;
+            k++;
+        }
+        return arr;
+    }
+
+    public short[] no_short_fill5() {
+        short[] arr = new short[300];
+        int k = 0;
+        for (int i = 0; i < arr.length; i += arr.length) {
+            arr[k] = 1;
+        }
+        return arr;
+    }
+
+    public byte[] byte_fill1() {
+        byte[] arr = new byte[300];
+        for (int i = 0; i < arr.length; i++) {
+            arr[i] = 120;
+        }
+        if (arr[0] != 120 || arr[arr.length - 1] != 120) {
+            throw new RuntimeException("Wrong optimization");
+        }
+        return arr;
+    }
+
+    public byte[] byte_fill2() {
+        byte[] arr = new byte[300];
+        Arrays.fill(arr, (byte) 120);
+        if (arr[0] != 120 || arr[arr.length - 1] != 120) {
+            throw new RuntimeException("Wrong optimization");
+        }
+        return arr;
+    }
+
+    public byte[] byte_fill3() {
+        byte[] arr = new byte[300];
+        for (int i = 0; i < 100; i++) {
+            arr[i] = 120;
+        }
+        if (arr[0] != 120 || arr[100] != 0) {
+            throw new RuntimeException("Wrong optimization");
+        }
+        return arr;
+    }
+
+    public byte[] byte_fill4() {
+        byte[] arr = new byte[300];
+        Arrays.fill(arr, (byte) arr.length);
+        if (arr[0] != 120 || arr[arr.length - 1] != 120) {
+            throw new RuntimeException("Wrong optimization");
+        }
+        return arr;
+    }
+
+    public byte[] byte_fill5() {
+        byte[] arr = new byte[300];
+        for (int i = 3; i < arr.length; i++) {
+            arr[i] = 120;
+        }
+        if (arr[0] != 0 || arr[1] != 0 || arr[2] != 0 || arr[3] != 120) {
+            throw new RuntimeException("Wrong optimization");
+        }
+        return arr;
+    }
+
+    public byte[] byte_fill6() {
+        byte[] arr = new byte[300];
+        for (int i = 3; i < 100; i++) {
+            arr[i] = 120;
+        }
+        if (arr[0] != 0 || arr[1] != 0 || arr[2] != 0 || arr[3] != 120 || arr[99] != 120) {
+            throw new RuntimeException("Wrong optimization");
+        }
+        return arr;
+    }
+
+    public byte[] no_byte_fill1() {
+        byte[] arr = new byte[300];
+        for (int i = 0; i < arr.length; i++) {
+            if (i % 2 == 0) {
+                // interference...
+                i++;
+            }
+            arr[i] = 120;
+        }
+        return arr;
+    }
+
+    public byte[] no_byte_fill2() {
+        byte[] arr = new byte[300];
+        for (int i = 0; i < arr.length; i += 2) {
+            arr[i] = 120;
+        }
+        return arr;
+    }
+
+    public byte[] no_byte_fill3() {
+        byte[] arr = new byte[300];
+        for (int i = 0; i < arr.length; i += 2) {
+            arr[i] = (byte) (i * 2);
+        }
+        return arr;
+    }
+
+    public byte[] no_byte_fill4() {
+        byte[] arr = new byte[300];
+        int k = 0;
+        for (int i = 0; i < arr.length; i += 2) {
+            arr[k] = 1;
+            k++;
+        }
+        return arr;
+    }
+
+    public byte[] no_byte_fill5() {
+        byte[] arr = new byte[300];
+        int k = 0;
+        for (int i = 0; i < arr.length; i += arr.length) {
+            arr[k] = 1;
+        }
+        return arr;
+    }
+
+    public boolean[] bool_fill1() {
+        boolean[] arr = new boolean[300];
+        for (int i = 0; i < arr.length; i++) {
+            arr[i] = true;
+        }
+        if (arr[0] != true || arr[arr.length - 1] != true) {
+            throw new RuntimeException("Wrong optimization");
+        }
+        return arr;
+    }
+
+    public boolean[] bool_fill2() {
+        boolean[] arr = new boolean[300];
+        Arrays.fill(arr, true);
+        if (arr[0] != true || arr[arr.length - 1] != true) {
+            throw new RuntimeException("Wrong optimization");
+        }
+        return arr;
+    }
+
+    public boolean[] bool_fill3() {
+        boolean[] arr = new boolean[300];
+        for (int i = 0; i < 100; i++) {
+            arr[i] = true;
+        }
+        if (arr[0] != true || arr[100] != false) {
+            throw new RuntimeException("Wrong optimization");
+        }
+        return arr;
+    }
+
+    public boolean[] bool_fill4() {
+        boolean[] arr = new boolean[300];
+        Arrays.fill(arr, true);
+        if (arr[0] != true || arr[arr.length - 1] != true) {
+            throw new RuntimeException("Wrong optimization");
+        }
+        return arr;
+    }
+
+    public boolean[] bool_fill5() {
+        boolean[] arr = new boolean[300];
+        for (int i = 3; i < arr.length; i++) {
+            arr[i] = true;
+        }
+        if (arr[0] != false || arr[1] != false || arr[2] != false || arr[3] != true) {
+            throw new RuntimeException("Wrong optimization");
+        }
+        return arr;
+    }
+
+    public boolean[] bool_fill6() {
+        boolean[] arr = new boolean[300];
+        for (int i = 3; i < 100; i++) {
+            arr[i] = true;
+        }
+        if (arr[0] != false || arr[1] != false || arr[2] != false || arr[3] != true || arr[99] != true) {
+            throw new RuntimeException("Wrong optimization");
+        }
+        return arr;
+    }
+
+    public boolean[] no_bool_fill1() {
+        boolean[] arr = new boolean[300];
+        for (int i = 0; i < arr.length; i++) {
+            if (i % 2 == 0) {
+                // interference...
+                i++;
+            }
+            arr[i] = true;
+        }
+        return arr;
+    }
+
+    public boolean[] no_bool_fill2() {
+        boolean[] arr = new boolean[300];
+        for (int i = 0; i < arr.length; i += 2) {
+            arr[i] = true;
+        }
+        return arr;
+    }
+
+    public boolean[] no_bool_fill3() {
+        boolean[] arr = new boolean[300];
+        for (int i = 0; i < arr.length; i += 2) {
+            arr[i] = (i % 2 == 0);
+        }
+        return arr;
+    }
+
+    public boolean[] no_bool_fill4() {
+        boolean[] arr = new boolean[300];
+        int k = 0;
+        for (int i = 0; i < arr.length; i += 2) {
+            arr[k] = true;
+            k++;
+        }
+        return arr;
+    }
+
+    public boolean[] no_bool_fill5() {
+        boolean[] arr = new boolean[300];
+        int k = 0;
+        for (int i = 0; i < arr.length; i += arr.length) {
+            arr[k] = true;
+        }
+        return arr;
+    }
+
+    private boolean verifyReplaced(String method) {
+        StructuredGraph graph = getFinalGraph(getResolvedJavaMethod(method), getInitialOptions());
+        final StructuredGraph.ScheduleResult schedule = graph.getLastSchedule();
+        final List<Loop<Block>> loops = schedule.getCFG().getLoops();
+        final NodeIterable<ForeignCallNode> calls = graph.getNodes().filter(ForeignCallNode.class);
+        boolean loopEliminated = (loops.size() == 1); // fill memory loop only
+        boolean found = false;
+        for (ForeignCallNode call : calls) {
+            found |= isFillCallDescriptor(call.getDescriptor());
+        }
+        return loopEliminated && found;
+    }
+
+    @Test
+    public void testArrayFillReplaced() {
+        Assert.assertTrue(verifyReplaced("int_fill1"));
+        Assert.assertTrue(verifyReplaced("int_fill2"));
+        Assert.assertTrue(verifyReplaced("int_fill3"));
+        Assert.assertTrue(verifyReplaced("int_fill4"));
+        Assert.assertTrue(verifyReplaced("int_fill5"));
+        Assert.assertTrue(verifyReplaced("int_fill6"));
+        Assert.assertFalse(verifyReplaced("no_int_fill1"));
+        Assert.assertFalse(verifyReplaced("no_int_fill2"));
+        Assert.assertFalse(verifyReplaced("no_int_fill3"));
+        Assert.assertFalse(verifyReplaced("no_int_fill4"));
+        Assert.assertFalse(verifyReplaced("no_int_fill5"));
+        Assert.assertTrue(verifyReplaced("short_fill1"));
+        Assert.assertTrue(verifyReplaced("short_fill2"));
+        Assert.assertTrue(verifyReplaced("short_fill3"));
+        Assert.assertTrue(verifyReplaced("short_fill4"));
+        Assert.assertTrue(verifyReplaced("short_fill5"));
+        Assert.assertTrue(verifyReplaced("short_fill6"));
+        Assert.assertFalse(verifyReplaced("no_short_fill1"));
+        Assert.assertFalse(verifyReplaced("no_short_fill2"));
+        Assert.assertFalse(verifyReplaced("no_short_fill3"));
+        Assert.assertFalse(verifyReplaced("no_short_fill4"));
+        Assert.assertFalse(verifyReplaced("no_short_fill5"));
+        Assert.assertTrue(verifyReplaced("byte_fill1"));
+        Assert.assertTrue(verifyReplaced("byte_fill2"));
+        Assert.assertTrue(verifyReplaced("byte_fill3"));
+        Assert.assertTrue(verifyReplaced("byte_fill4"));
+        Assert.assertTrue(verifyReplaced("byte_fill5"));
+        Assert.assertTrue(verifyReplaced("byte_fill6"));
+        Assert.assertFalse(verifyReplaced("no_byte_fill1"));
+        Assert.assertFalse(verifyReplaced("no_byte_fill2"));
+        Assert.assertFalse(verifyReplaced("no_byte_fill3"));
+        Assert.assertFalse(verifyReplaced("no_byte_fill4"));
+        Assert.assertFalse(verifyReplaced("no_byte_fill5"));
+        Assert.assertTrue(verifyReplaced("bool_fill1"));
+        Assert.assertTrue(verifyReplaced("bool_fill2"));
+        Assert.assertTrue(verifyReplaced("bool_fill3"));
+        Assert.assertTrue(verifyReplaced("bool_fill4"));
+        Assert.assertTrue(verifyReplaced("bool_fill5"));
+        Assert.assertTrue(verifyReplaced("bool_fill6"));
+        Assert.assertFalse(verifyReplaced("no_bool_fill1"));
+        Assert.assertFalse(verifyReplaced("no_bool_fill2"));
+        Assert.assertFalse(verifyReplaced("no_bool_fill3"));
+        Assert.assertFalse(verifyReplaced("no_bool_fill4"));
+        Assert.assertFalse(verifyReplaced("no_bool_fill5"));
+    }
+}

--- a/compiler/src/org.graalvm.compiler.hotspot/src/org/graalvm/compiler/hotspot/GraalHotSpotVMConfig.java
+++ b/compiler/src/org.graalvm.compiler.hotspot/src/org/graalvm/compiler/hotspot/GraalHotSpotVMConfig.java
@@ -621,6 +621,13 @@ public class GraalHotSpotVMConfig extends GraalHotSpotVMConfigAccess {
     public final long unsafeArraycopy = getFieldValue("StubRoutines::_unsafe_arraycopy", Long.class, "address");
     public final long genericArraycopy = getFieldValue("StubRoutines::_generic_arraycopy", Long.class, "address");
 
+    public final long jbyteFill = getFieldValue("StubRoutines::_jbyte_fill", Long.class, "address");
+    public final long jshortFill = getFieldValue("StubRoutines::_jshort_fill", Long.class, "address");
+    public final long jintFill = getFieldValue("StubRoutines::_jint_fill", Long.class, "address");
+    public final long arrayofJbyteFill = getFieldValue("StubRoutines::_arrayof_jbyte_fill", Long.class, "address");
+    public final long arrayofJshortFill = getFieldValue("StubRoutines::_arrayof_jshort_fill", Long.class, "address");
+    public final long arrayofJintFill = getFieldValue("StubRoutines::_arrayof_jint_fill", Long.class, "address");
+
     // Allocation stubs that throw an exception when allocation fails
     public final long newInstanceAddress = getAddress("JVMCIRuntime::new_instance");
     public final long newArrayAddress = getAddress("JVMCIRuntime::new_array");

--- a/compiler/src/org.graalvm.compiler.hotspot/src/org/graalvm/compiler/hotspot/meta/DefaultHotSpotLoweringProvider.java
+++ b/compiler/src/org.graalvm.compiler.hotspot/src/org/graalvm/compiler/hotspot/meta/DefaultHotSpotLoweringProvider.java
@@ -94,6 +94,7 @@ import org.graalvm.compiler.hotspot.replacements.RegisterFinalizerSnippets;
 import org.graalvm.compiler.hotspot.replacements.StringToBytesSnippets;
 import org.graalvm.compiler.hotspot.replacements.UnsafeCopyMemoryNode;
 import org.graalvm.compiler.hotspot.replacements.UnsafeSnippets;
+import org.graalvm.compiler.hotspot.replacements.arraycopy.HotSpotArrayFillSnippets;
 import org.graalvm.compiler.hotspot.replacements.arraycopy.HotSpotArraycopySnippets;
 import org.graalvm.compiler.hotspot.stubs.ForeignCallSnippets;
 import org.graalvm.compiler.hotspot.word.KlassPointer;
@@ -121,6 +122,7 @@ import org.graalvm.compiler.nodes.calc.IsNullNode;
 import org.graalvm.compiler.nodes.calc.RemNode;
 import org.graalvm.compiler.nodes.debug.StringToBytesNode;
 import org.graalvm.compiler.nodes.debug.VerifyHeapNode;
+import org.graalvm.compiler.nodes.extended.ArrayFillNode;
 import org.graalvm.compiler.nodes.extended.BranchProbabilityNode;
 import org.graalvm.compiler.nodes.extended.BytecodeExceptionNode;
 import org.graalvm.compiler.nodes.extended.BytecodeExceptionNode.BytecodeExceptionKind;
@@ -246,6 +248,7 @@ public abstract class DefaultHotSpotLoweringProvider extends DefaultJavaLowering
     protected AssertionSnippets.Templates assertionSnippets;
     protected LogSnippets.Templates logSnippets;
     protected ArrayCopySnippets.Templates arraycopySnippets;
+    protected HotSpotArrayFillSnippets.Templates arrayFillSnippets;
     protected StringToBytesSnippets.Templates stringToBytesSnippets;
     protected ObjectSnippets.Templates objectSnippets;
     protected UnsafeSnippets.Templates unsafeSnippets;
@@ -296,6 +299,7 @@ public abstract class DefaultHotSpotLoweringProvider extends DefaultJavaLowering
         assertionSnippets = new AssertionSnippets.Templates(options, providers);
         logSnippets = new LogSnippets.Templates(options, providers);
         arraycopySnippets = new ArrayCopySnippets.Templates(new HotSpotArraycopySnippets(), runtime, options, providers);
+        arrayFillSnippets = new HotSpotArrayFillSnippets.Templates(options, factories, runtime, providers, target, config);
         stringToBytesSnippets = new StringToBytesSnippets.Templates(options, providers);
         identityHashCodeSnippets = new IdentityHashCodeSnippets.Templates(new HotSpotHashCodeSnippets(), options, providers, HotSpotReplacementsUtil.MARK_WORD_LOCATION);
         isArraySnippets = new IsArraySnippets.Templates(new HotSpotIsArraySnippets(), options, providers);
@@ -437,6 +441,8 @@ public abstract class DefaultHotSpotLoweringProvider extends DefaultJavaLowering
             }
         } else if (n instanceof ArrayCopyNode) {
             arraycopySnippets.lower((ArrayCopyNode) n, tool);
+        } else if (n instanceof ArrayFillNode) {
+            arrayFillSnippets.lower((ArrayFillNode) n, tool);
         } else if (n instanceof ArrayCopyWithDelayedLoweringNode) {
             arraycopySnippets.lower((ArrayCopyWithDelayedLoweringNode) n, tool);
         } else if (n instanceof G1PreWriteBarrier) {

--- a/compiler/src/org.graalvm.compiler.hotspot/src/org/graalvm/compiler/hotspot/meta/HotSpotHostForeignCallsProvider.java
+++ b/compiler/src/org.graalvm.compiler.hotspot/src/org/graalvm/compiler/hotspot/meta/HotSpotHostForeignCallsProvider.java
@@ -79,6 +79,12 @@ import static org.graalvm.compiler.hotspot.replacements.Log.LOG_PRIMITIVE;
 import static org.graalvm.compiler.hotspot.replacements.Log.LOG_PRINTF;
 import static org.graalvm.compiler.hotspot.replacements.MonitorSnippets.MONITORENTER;
 import static org.graalvm.compiler.hotspot.replacements.MonitorSnippets.MONITOREXIT;
+import static org.graalvm.compiler.hotspot.replacements.arraycopy.HotSpotArrayFillSnippets.ARRAYOF_JBYTE_FILL_CALL;
+import static org.graalvm.compiler.hotspot.replacements.arraycopy.HotSpotArrayFillSnippets.ARRAYOF_JINT_FILL_CALL;
+import static org.graalvm.compiler.hotspot.replacements.arraycopy.HotSpotArrayFillSnippets.ARRAYOF_JSHORT_FILL_CALL;
+import static org.graalvm.compiler.hotspot.replacements.arraycopy.HotSpotArrayFillSnippets.JBYTE_FILL_CALL;
+import static org.graalvm.compiler.hotspot.replacements.arraycopy.HotSpotArrayFillSnippets.JINT_FILL_CALL;
+import static org.graalvm.compiler.hotspot.replacements.arraycopy.HotSpotArrayFillSnippets.JSHORT_FILL_CALL;
 import static org.graalvm.compiler.hotspot.stubs.ExceptionHandlerStub.EXCEPTION_HANDLER_FOR_PC;
 import static org.graalvm.compiler.hotspot.stubs.StubUtil.VM_MESSAGE_C;
 import static org.graalvm.compiler.hotspot.stubs.UnwindExceptionToCallerStub.EXCEPTION_HANDLER_FOR_RETURN_ADDRESS;
@@ -488,6 +494,13 @@ public abstract class HotSpotHostForeignCallsProvider extends HotSpotForeignCall
         registerArrayCopy(JavaKind.Double, c.jlongArraycopy, c.jlongAlignedArraycopy, c.jlongDisjointArraycopy, c.jlongAlignedDisjointArraycopy);
         registerArrayCopy(JavaKind.Object, c.oopArraycopy, c.oopAlignedArraycopy, c.oopDisjointArraycopy, c.oopAlignedDisjointArraycopy);
         registerArrayCopy(JavaKind.Object, c.oopArraycopyUninit, c.oopAlignedArraycopyUninit, c.oopDisjointArraycopyUninit, c.oopAlignedDisjointArraycopyUninit, true);
+
+        registerForeignCall(JBYTE_FILL_CALL, c.jbyteFill, NativeCall);
+        registerForeignCall(JSHORT_FILL_CALL, c.jshortFill, NativeCall);
+        registerForeignCall(JINT_FILL_CALL, c.jintFill, NativeCall);
+        registerForeignCall(ARRAYOF_JBYTE_FILL_CALL, c.arrayofJbyteFill, NativeCall);
+        registerForeignCall(ARRAYOF_JSHORT_FILL_CALL, c.arrayofJshortFill, NativeCall);
+        registerForeignCall(ARRAYOF_JINT_FILL_CALL, c.arrayofJintFill, NativeCall);
 
         registerCheckcastArraycopyDescriptor(true, c.checkcastArraycopyUninit);
         registerCheckcastArraycopyDescriptor(false, c.checkcastArraycopy);

--- a/compiler/src/org.graalvm.compiler.hotspot/src/org/graalvm/compiler/hotspot/replacements/arraycopy/HotSpotArrayFillSnippets.java
+++ b/compiler/src/org.graalvm.compiler.hotspot/src/org/graalvm/compiler/hotspot/replacements/arraycopy/HotSpotArrayFillSnippets.java
@@ -1,0 +1,207 @@
+/*
+ * Copyright (c) 2022, Alibaba Group Holding Limited. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+package org.graalvm.compiler.hotspot.replacements.arraycopy;
+
+import jdk.vm.ci.code.CodeUtil;
+import jdk.vm.ci.meta.Constant;
+import jdk.vm.ci.meta.JavaConstant;
+import jdk.vm.ci.meta.JavaKind;
+import org.graalvm.compiler.api.directives.GraalDirectives;
+import org.graalvm.compiler.api.replacements.Snippet;
+import org.graalvm.compiler.core.common.spi.ForeignCallDescriptor;
+import org.graalvm.compiler.debug.GraalError;
+import org.graalvm.compiler.hotspot.meta.HotSpotForeignCallDescriptor;
+import org.graalvm.compiler.hotspot.meta.HotSpotProviders;
+import org.graalvm.compiler.hotspot.replacements.HotSpotReplacementsUtil;
+import org.graalvm.compiler.nodes.ComputeObjectAddressNode;
+import org.graalvm.compiler.nodes.ConstantNode;
+import org.graalvm.compiler.nodes.StructuredGraph;
+import org.graalvm.compiler.nodes.ValueNode;
+import org.graalvm.compiler.nodes.calc.AddNode;
+import org.graalvm.compiler.nodes.calc.LeftShiftNode;
+import org.graalvm.compiler.nodes.extended.ArrayFillNode;
+import org.graalvm.compiler.nodes.spi.LoweringTool;
+import org.graalvm.compiler.options.OptionValues;
+import org.graalvm.compiler.replacements.SnippetTemplate;
+import org.graalvm.compiler.replacements.arraycopy.ArrayFillSnippets;
+import org.graalvm.compiler.word.Word;
+import org.graalvm.word.LocationIdentity;
+import org.graalvm.word.WordFactory;
+
+import static org.graalvm.compiler.hotspot.GraalHotSpotVMConfig.INJECTED_VMCONFIG;
+import static org.graalvm.compiler.hotspot.meta.HotSpotForeignCallDescriptor.Reexecutability.NOT_REEXECUTABLE;
+import static org.graalvm.compiler.hotspot.meta.HotSpotForeignCallDescriptor.Transition.LEAF;
+import static org.graalvm.word.LocationIdentity.any;
+
+public class HotSpotArrayFillSnippets extends ArrayFillSnippets {
+    // Unaligned version
+    public static final HotSpotForeignCallDescriptor JINT_FILL_CALL = new HotSpotForeignCallDescriptor(LEAF, NOT_REEXECUTABLE, any(), "jint_fill", void.class, Word.class,
+            int.class, int.class);
+    public static final HotSpotForeignCallDescriptor JSHORT_FILL_CALL = new HotSpotForeignCallDescriptor(LEAF, NOT_REEXECUTABLE, any(), "jshort_fill", void.class, Word.class,
+            int.class, int.class);
+    public static final HotSpotForeignCallDescriptor JBYTE_FILL_CALL = new HotSpotForeignCallDescriptor(LEAF, NOT_REEXECUTABLE, any(), "jbyte_fill", void.class, Word.class,
+            int.class, int.class);
+    // Aligned version
+    public static final HotSpotForeignCallDescriptor ARRAYOF_JINT_FILL_CALL = new HotSpotForeignCallDescriptor(LEAF, NOT_REEXECUTABLE, any(), "arrayof_jint_fill", void.class, Word.class,
+            int.class, int.class);
+    public static final HotSpotForeignCallDescriptor ARRAYOF_JSHORT_FILL_CALL = new HotSpotForeignCallDescriptor(LEAF, NOT_REEXECUTABLE, any(), "arrayof_jshort_fill", void.class, Word.class,
+            int.class, int.class);
+    public static final HotSpotForeignCallDescriptor ARRAYOF_JBYTE_FILL_CALL = new HotSpotForeignCallDescriptor(LEAF, NOT_REEXECUTABLE, any(), "arrayof_jbyte_fill", void.class, Word.class,
+            int.class, int.class);
+
+    @Snippet
+    public void jintFillSnippet(Object to, int offset, int value, int count, @Snippet.ConstantParameter JavaKind elementKind) {
+        Object toObj = GraalDirectives.guardingNonNull(to);
+        Word toAddr = WordFactory.unsigned(ComputeObjectAddressNode.get(toObj, offset));
+        jintFill(jintFillCallDescriptor(), toAddr, value, count);
+    }
+
+    @Snippet
+    public void jshortFillSnippet(Object to, int offset, int value, int count, @Snippet.ConstantParameter JavaKind elementKind) {
+        Object toObj = GraalDirectives.guardingNonNull(to);
+        Word toAddr = WordFactory.unsigned(ComputeObjectAddressNode.get(toObj, offset));
+        jshortFill(jshortFillCallDescriptor(), toAddr, value, count);
+    }
+
+    @Snippet
+    public void jbyteFillSnippet(Object to, int offset, int value, int count, @Snippet.ConstantParameter JavaKind elementKind) {
+        Object toObj = GraalDirectives.guardingNonNull(to);
+        Word toAddr = WordFactory.unsigned(ComputeObjectAddressNode.get(toObj, offset));
+        jbyteFill(jbyteFillCallDescriptor(), toAddr, value, count);
+    }
+
+    @Snippet
+    public void arrayofJintFillSnippet(Object to, int offset, int value, int count, @Snippet.ConstantParameter JavaKind elementKind) {
+        Object toObj = GraalDirectives.guardingNonNull(to);
+        Word toAddr = WordFactory.unsigned(ComputeObjectAddressNode.get(toObj, offset));
+        arrayofJintFill(arrayofJintFillCallDescriptor(), toAddr, value, count);
+    }
+
+    @Snippet
+    public void arrayofJshortFillSnippet(Object to, int offset, int value, int count, @Snippet.ConstantParameter JavaKind elementKind) {
+        Object toObj = GraalDirectives.guardingNonNull(to);
+        Word toAddr = WordFactory.unsigned(ComputeObjectAddressNode.get(toObj, offset));
+        arrayofJshortFill(arrayofJshortFillCallDescriptor(), toAddr, value, count);
+    }
+
+    @Snippet
+    public void arrayofJbyteFillSnippet(Object to, int offset, int value, int count, @Snippet.ConstantParameter JavaKind elementKind) {
+        Object toObj = GraalDirectives.guardingNonNull(to);
+        Word toAddr = WordFactory.unsigned(ComputeObjectAddressNode.get(toObj, offset));
+        arrayofJbyteFill(arrayofJbyteFillCallDescriptor(), toAddr, value, count);
+    }
+
+    @Override
+    protected ForeignCallDescriptor jintFillCallDescriptor() {
+        return JINT_FILL_CALL;
+    }
+
+    @Override
+    protected ForeignCallDescriptor jshortFillCallDescriptor() {
+        return JSHORT_FILL_CALL;
+    }
+
+    @Override
+    protected ForeignCallDescriptor jbyteFillCallDescriptor() {
+        return JBYTE_FILL_CALL;
+    }
+
+    @Override
+    protected ForeignCallDescriptor arrayofJintFillCallDescriptor() {
+        return ARRAYOF_JINT_FILL_CALL;
+    }
+
+    @Override
+    protected ForeignCallDescriptor arrayofJshortFillCallDescriptor() {
+        return ARRAYOF_JSHORT_FILL_CALL;
+    }
+
+    @Override
+    protected ForeignCallDescriptor arrayofJbyteFillCallDescriptor() {
+        return ARRAYOF_JBYTE_FILL_CALL;
+    }
+
+    public static class Templates extends SnippetTemplate.AbstractTemplates {
+        private final SnippetTemplate.SnippetInfo jintFillSnippet;
+        private final SnippetTemplate.SnippetInfo jshortFillSnippet;
+        private final SnippetTemplate.SnippetInfo jbyteFillSnippet;
+        private final SnippetTemplate.SnippetInfo arrayofJintFillSnippet;
+        private final SnippetTemplate.SnippetInfo arrayofJshortFillSnippet;
+        private final SnippetTemplate.SnippetInfo arrayofJbyteFillSnippet;
+
+        public Templates(OptionValues options, HotSpotProviders providers) {
+            super(options, providers);
+            HotSpotArrayFillSnippets receiver = new HotSpotArrayFillSnippets();
+            jintFillSnippet = snippet(HotSpotArrayFillSnippets.class, "jintFillSnippet", null, receiver, LocationIdentity.any());
+            jshortFillSnippet = snippet(HotSpotArrayFillSnippets.class, "jshortFillSnippet", null, receiver, LocationIdentity.any());
+            jbyteFillSnippet = snippet(HotSpotArrayFillSnippets.class, "jbyteFillSnippet", null, receiver, LocationIdentity.any());
+            arrayofJintFillSnippet = snippet(HotSpotArrayFillSnippets.class, "arrayofJintFillSnippet", null, receiver, LocationIdentity.any());
+            arrayofJshortFillSnippet = snippet(HotSpotArrayFillSnippets.class, "arrayofJshortFillSnippet", null, receiver, LocationIdentity.any());
+            arrayofJbyteFillSnippet = snippet(HotSpotArrayFillSnippets.class, "arrayofJbyteFillSnippet", null, receiver, LocationIdentity.any());
+        }
+
+        public void lower(ArrayFillNode fillNode, LoweringTool tool) {
+            SnippetTemplate.SnippetInfo snippetInfo;
+            final int arrayBaseOffset = getMetaAccess().getArrayBaseOffset(fillNode.getElementType());
+            final int elementSize = tool.getMetaAccess().getArrayIndexScale(fillNode.getElementType());
+            boolean aligned = false;
+            if (fillNode.getDstOffset().isConstant()) {
+                Constant ciConst = fillNode.getDst().asConstant();
+                if (ciConst instanceof JavaConstant) {
+                    int offsetConst = ((JavaConstant) ciConst).asInt();
+                    final int heapWordSize = HotSpotReplacementsUtil.getHeapWordSize(INJECTED_VMCONFIG);
+                    if (((offsetConst * elementSize + arrayBaseOffset) % heapWordSize) == 0) {
+                        aligned = true;
+                    }
+                }
+            }
+            switch (fillNode.getElementType()) {
+                case Byte:
+                case Boolean:
+                    snippetInfo = aligned ? arrayofJbyteFillSnippet : jbyteFillSnippet;
+                    break;
+                case Char:
+                case Short:
+                    snippetInfo = aligned ? arrayofJshortFillSnippet : jshortFillSnippet;
+                    break;
+                case Int:
+                    snippetInfo = aligned ? arrayofJintFillSnippet : jintFillSnippet;
+                    break;
+                default:
+                    throw new GraalError("no matched filling stubs");
+            }
+            final StructuredGraph graph = fillNode.graph();
+            int shift = CodeUtil.log2(elementSize);
+            ValueNode shiftNode = graph.unique(new LeftShiftNode(fillNode.getDstOffset(), ConstantNode.forInt(shift, graph)));
+            ValueNode offset = graph.unique(new AddNode(shiftNode, ConstantNode.forInt(arrayBaseOffset, graph)));
+            SnippetTemplate.Arguments args = new SnippetTemplate.Arguments(snippetInfo, graph.getGuardsStage(), tool.getLoweringStage());
+            args.add("to", fillNode.getDst());
+            args.add("offset", offset);
+            args.add("value", fillNode.getValue());
+            args.add("count", fillNode.getCount());
+            args.addConst("elementKind", fillNode.getElementType());
+            template(fillNode, args).instantiate(getMetaAccess(), fillNode, SnippetTemplate.DEFAULT_REPLACER, args);
+        }
+    }
+}

--- a/compiler/src/org.graalvm.compiler.nodes/src/org/graalvm/compiler/nodes/extended/ArrayFillNode.java
+++ b/compiler/src/org.graalvm.compiler.nodes/src/org/graalvm/compiler/nodes/extended/ArrayFillNode.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2022, Alibaba Group Holding Limited. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+package org.graalvm.compiler.nodes.extended;
+
+import jdk.vm.ci.meta.JavaKind;
+import org.graalvm.compiler.core.common.type.StampFactory;
+import org.graalvm.compiler.graph.NodeClass;
+import org.graalvm.compiler.nodeinfo.NodeInfo;
+import org.graalvm.compiler.nodes.ValueNode;
+import org.graalvm.compiler.nodes.memory.AbstractMemoryCheckpoint;
+import org.graalvm.compiler.nodes.spi.Lowerable;
+
+@NodeInfo
+public final class ArrayFillNode extends AbstractMemoryCheckpoint implements Lowerable {
+    public static final NodeClass<ArrayFillNode> TYPE = NodeClass.create(ArrayFillNode.class);
+    private final JavaKind elementType;
+    @Input
+    ValueNode dst;
+    @Input
+    ValueNode dstOffset;
+    @Input
+    ValueNode value;
+    @Input
+    ValueNode count;
+
+    public ArrayFillNode(ValueNode dst, ValueNode dstOffset, ValueNode value, ValueNode count, JavaKind elementType) {
+        super(TYPE, StampFactory.forKind(JavaKind.Void));
+        this.value = value;
+        this.dstOffset = dstOffset;
+        this.count = count;
+        this.dst = dst;
+        this.elementType = elementType;
+    }
+
+    public ValueNode getValue() {
+        return value;
+    }
+
+    public ValueNode getCount() {
+        return count;
+    }
+
+    public ValueNode getDst() {
+        return dst;
+    }
+
+    public ValueNode getDstOffset() {
+        return dstOffset;
+    }
+
+    public JavaKind getElementType() {
+        return elementType;
+    }
+}

--- a/compiler/src/org.graalvm.compiler.phases.common/src/org/graalvm/compiler/phases/common/IntrinsifyArrayFillPhase.java
+++ b/compiler/src/org.graalvm.compiler.phases.common/src/org/graalvm/compiler/phases/common/IntrinsifyArrayFillPhase.java
@@ -1,0 +1,199 @@
+/*
+ * Copyright (c) 2022, Alibaba Group Holding Limited. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+package org.graalvm.compiler.phases.common;
+
+import org.graalvm.compiler.debug.DebugContext;
+import org.graalvm.compiler.graph.Node;
+import org.graalvm.compiler.graph.NodeBitMap;
+import org.graalvm.compiler.nodes.ControlSplitNode;
+import org.graalvm.compiler.nodes.FixedNode;
+import org.graalvm.compiler.nodes.FixedWithNextNode;
+import org.graalvm.compiler.nodes.FrameState;
+import org.graalvm.compiler.nodes.LoopExitNode;
+import org.graalvm.compiler.nodes.StructuredGraph;
+import org.graalvm.compiler.nodes.ValueNode;
+import org.graalvm.compiler.nodes.calc.AddNode;
+import org.graalvm.compiler.nodes.calc.SubNode;
+import org.graalvm.compiler.nodes.extended.ArrayFillNode;
+import org.graalvm.compiler.nodes.java.StoreIndexedNode;
+import org.graalvm.compiler.nodes.loop.LoopEx;
+import org.graalvm.compiler.nodes.loop.LoopsData;
+import org.graalvm.compiler.nodes.spi.CoreProviders;
+import org.graalvm.compiler.nodes.util.GraphUtil;
+import org.graalvm.compiler.phases.BasePhase;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Array filling optimization. Mirror of C2's OptimizeFill phase in loop optimizations.
+ * <p>
+ * Process all the loops in the loop tree and replace any fill
+ * patterns with an intrinsic version.
+ */
+public class IntrinsifyArrayFillPhase extends BasePhase<CoreProviders> {
+    private static final String FAILURE_FORMAT = "intrinsify fill failure: %s";
+    private StoreIndexedNode store;
+
+    @Override
+    protected void run(StructuredGraph graph, CoreProviders context) {
+        DebugContext debug = graph.getDebug();
+        if (graph.hasLoops()) {
+            final LoopsData loopsData = context.getLoopsDataProvider().getLoopsData(graph);
+            loopsData.detectedCountedLoops();
+            List<LoopEx> countedLoops = loopsData.countedLoops();
+            for (LoopEx loop : countedLoops) {
+                if (matchLoopFill(debug, loop)) {
+                    List<LoopExitNode> exits = loop.loopBegin().loopExits().snapshot();
+                    if (exits.size() == 1) {
+                        replaceLoopWithFillStub(graph, loop, exits.get(0));
+                        debug.log("Replace array fill counted loop with fill stub call");
+                    } else {
+                        debug.log("Multiple exits of counted loop, can not apply array fill optimization");
+                    }
+                }
+            }
+        }
+    }
+
+    private void replaceLoopWithFillStub(StructuredGraph graph, LoopEx loop, LoopExitNode exit) {
+        final InductionVariable iv = loop.counted().getCounter();
+        final ValueNode init = iv.initNode();
+        final ValueNode limit = loop.counted().getLimit();
+        ValueNode count = graph.unique(new SubNode(limit, init));
+        // Rewire loop entry and continuation code to newly created stub call node
+        ArrayFillNode fill = graph.add(new ArrayFillNode(store.array(), init, store.value(), count, store.elementKind()));
+        fill.setStateAfter(graph.start().stateAfter());
+        FixedWithNextNode entryPoint = (FixedWithNextNode) loop.entryPoint().predecessor();
+        entryPoint.clearSuccessors();
+        entryPoint.setNext(fill);
+        FixedNode exitNext = exit.next();
+        exit.clearSuccessors();
+        fill.setNext(exitNext);
+        // Mark all node within loop body as dead so that they can be removed by later DCE phase
+        GraphUtil.killCFG(loop.entryPoint());
+        for (Node node : loop.whole().nodes()) {
+            if (node instanceof FixedNode) {
+                GraphUtil.killCFG((FixedNode) node);
+            }
+        }
+        store = null;
+    }
+
+    private boolean matchLoopFill(DebugContext debug, LoopEx loop) {
+        // Must have constant unit stride
+        CountedLoopInfo info = loop.counted();
+        if (!info.getCounter().isConstantStride() || info.getCounter().constantStride() != 1) {
+            debug.log(FAILURE_FORMAT, "stride must be const 1");
+            return false;
+        }
+        // Check that the body only contains a store of a loop invariant
+        // value that is indexed by the loop phi.
+        NodeBitMap body = loop.whole().nodes();
+        for (Node node : body) {
+            // Ignore dead data nodes
+            if (!(node instanceof FixedNode) && node.usages().isEmpty()) {
+                continue;
+            }
+            if (node instanceof StoreIndexedNode) {
+                StoreIndexedNode st = (StoreIndexedNode) node;
+                if (store != null) {
+                    debug.log(FAILURE_FORMAT, "multiple stores");
+                    return false;
+                }
+                if (!st.elementKind().isPrimitive()) {
+                    debug.log(FAILURE_FORMAT, "oop fills not handled");
+                    return false;
+                }
+                // Make sure the address expression can be handled
+                ValueNode valueIn = st.value();
+                ValueNode index = st.index();
+                if (!loop.isOutsideLoop(valueIn)) {
+                    debug.log(FAILURE_FORMAT, "variant store value");
+                    return false;
+                }
+                if (index != info.getCounter().valueNode()) {
+                    debug.log("store index isn't proper phi");
+                    return false;
+                }
+                store = st;
+            } else if (node instanceof ControlSplitNode && node != info.getLimitTest()) {
+                debug.log(FAILURE_FORMAT, "extra control flow");
+                return false;
+            }
+        }
+        // No store in loop
+        if (store == null) {
+            return false;
+        }
+        Set<Node> accepted = new HashSet<>();
+        accepted.add(store);
+        accepted.add(loop.loopBegin());
+        accepted.addAll(loop.loopBegin().loopEnds().snapshot());
+        accepted.addAll(loop.loopBegin().loopExits().snapshot());
+        accepted.add(info.getLimitTest().condition());
+        accepted.add(info.getLimitTest());
+        accepted.add(info.getLimitTest().successor(true));
+        accepted.add(info.getLimitTest().successor(false));
+        accepted.add(info.getCounter().valueNode());
+        AddNode incr = null;
+        List<Node> strideUse = info.getCounter().strideNode().usages().snapshot();
+        for (Node use : strideUse) {
+            if (!loop.isOutsideLoop(use) && use.getUsageCount() == 1) {
+                Node phi = use.usages().first();
+                if (phi == info.getCounter().valueNode()) {
+                    // The only use of stride use is connected to counter's phi, so the
+                    // use itself must be an increment operation
+                    if (use instanceof AddNode) { // valid counted loop for array fill has up loop direction so it must be a AddNode
+                        incr = (AddNode) use;
+                    }
+                }
+            }
+        }
+        accepted.add(incr);
+        debug.log("Accept Node Set: %s", accepted.toString());
+        body = loop.whole().nodes(); // loop body is already consumed, acquire a brandy new one
+        for (Node node : body) {
+            if (accepted.contains(node)) {
+                if (node != store && !(node instanceof LoopExitNode) && node != incr) {
+                    for (Node use : node.usages()) {
+                        if (loop.isOutsideLoop(use)) {
+                            debug.log("node is used outside loop");
+                            return false;
+                        }
+                    }
+                }
+                continue;
+            }
+            if (node instanceof FrameState) {
+                continue;
+            }
+            debug.log("unhandled node");
+            return false;
+        }
+        return true;
+    }
+}

--- a/compiler/src/org.graalvm.compiler.replacements/src/org/graalvm/compiler/replacements/arraycopy/ArrayFillSnippets.java
+++ b/compiler/src/org.graalvm.compiler.replacements/src/org/graalvm/compiler/replacements/arraycopy/ArrayFillSnippets.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2022, Alibaba Group Holding Limited. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+package org.graalvm.compiler.replacements.arraycopy;
+
+import org.graalvm.compiler.core.common.spi.ForeignCallDescriptor;
+import org.graalvm.compiler.graph.Node;
+import org.graalvm.compiler.nodes.extended.ForeignCallNode;
+import org.graalvm.compiler.replacements.Snippets;
+import org.graalvm.compiler.word.Word;
+
+public abstract class ArrayFillSnippets implements Snippets {
+    @Node.NodeIntrinsic(ForeignCallNode.class)
+    protected static native void jintFill(@Node.ConstantNodeParameter ForeignCallDescriptor descriptor, Word to, int value, int count);
+
+    @Node.NodeIntrinsic(ForeignCallNode.class)
+    protected static native void jshortFill(@Node.ConstantNodeParameter ForeignCallDescriptor descriptor, Word to, int value, int count);
+
+    @Node.NodeIntrinsic(ForeignCallNode.class)
+    protected static native void jbyteFill(@Node.ConstantNodeParameter ForeignCallDescriptor descriptor, Word to, int value, int count);
+
+    @Node.NodeIntrinsic(ForeignCallNode.class)
+    protected static native void arrayofJintFill(@Node.ConstantNodeParameter ForeignCallDescriptor descriptor, Word to, int value, int count);
+
+    @Node.NodeIntrinsic(ForeignCallNode.class)
+    protected static native void arrayofJshortFill(@Node.ConstantNodeParameter ForeignCallDescriptor descriptor, Word to, int value, int count);
+
+    @Node.NodeIntrinsic(ForeignCallNode.class)
+    protected static native void arrayofJbyteFill(@Node.ConstantNodeParameter ForeignCallDescriptor descriptor, Word to, int value, int count);
+
+    protected abstract ForeignCallDescriptor jintFillCallDescriptor();
+
+    protected abstract ForeignCallDescriptor jshortFillCallDescriptor();
+
+    protected abstract ForeignCallDescriptor jbyteFillCallDescriptor();
+
+    protected abstract ForeignCallDescriptor arrayofJintFillCallDescriptor();
+
+    protected abstract ForeignCallDescriptor arrayofJshortFillCallDescriptor();
+
+    protected abstract ForeignCallDescriptor arrayofJbyteFillCallDescriptor();
+}


### PR DESCRIPTION
Array filling optimization. Mirror of C2's OptimizeFill phase in loop optimizations. Process all the loops in the loop tree and replace any fill patterns with an intrinsic version.

Note j*_fill stubs are currently not exported to JVMCI compilers, I'd like to do that if anyone thinks this optimization is worth the effort.