### PR TITLE
Add detail phase pause events for scanning phase

### DIFF
--- a/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/GCImpl.java
+++ b/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/GCImpl.java
@@ -709,8 +709,8 @@ public final class GCImpl implements GC {
                  * grey, so I have to use the dirty cards marks to blacken them, but that's what
                  * card marks are for.
                  */
-                 OldGeneration oldGen = HeapImpl.getHeapImpl().getOldGeneration();
-                 oldGen.emptyFromSpaceIntoToSpace();
+                OldGeneration oldGen = HeapImpl.getHeapImpl().getOldGeneration();
+                oldGen.emptyFromSpaceIntoToSpace();
             } finally {
                 JfrGCEvents.emitGCPhasePauseEvent(getCollectionEpoch(), "Promote Old Generation", startTicks);
             }

--- a/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/GCImpl.java
+++ b/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/GCImpl.java
@@ -702,18 +702,18 @@ public final class GCImpl implements GC {
     private void cheneyScanFromDirtyRoots() {
         Timer cheneyScanFromDirtyRootsTimer = timers.cheneyScanFromDirtyRoots.open();
         try {
-             long startTicks = JfrGCEvents.startGCPhasePause();
-             try {
-                  /*
-                   * Move all the chunks in fromSpace to toSpace. That does not make those chunks
-                   * grey, so I have to use the dirty cards marks to blacken them, but that's what
-                   * card marks are for.
-                   */
-                  OldGeneration oldGen = HeapImpl.getHeapImpl().getOldGeneration();
-                  oldGen.emptyFromSpaceIntoToSpace();
-             } finally {
+            long startTicks = JfrGCEvents.startGCPhasePause();
+            try {
+                /*
+                 * Move all the chunks in fromSpace to toSpace. That does not make those chunks
+                 * grey, so I have to use the dirty cards marks to blacken them, but that's what
+                 * card marks are for.
+                 */
+                 OldGeneration oldGen = HeapImpl.getHeapImpl().getOldGeneration();
+                 oldGen.emptyFromSpaceIntoToSpace();
+            } finally {
                 JfrGCEvents.emitGCPhasePauseEvent(getCollectionEpoch(), "Promote Old Generation", startTicks);
-             }
+            }
 
             startTicks = JfrGCEvents.startGCPhasePause();
             try {

--- a/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/jfr/TestGCEvents.java
+++ b/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/jfr/TestGCEvents.java
@@ -34,7 +34,8 @@ public class TestGCEvents extends JfrTest {
         return new String[]{
                         "jdk.GarbageCollection",
                         "jdk.GCPhasePause",
-                        "jdk.GCPhasePauseLevel1"
+                        "jdk.GCPhasePauseLevel1",
+                        "jdk.GCPhasePauseLevel2"
         };
     }
 


### PR DESCRIPTION
This patch adds detail phase pause events for Serial GC's scanning phase.  The phase counts majority time of a GC cycle, it makes sense to further breakdown the phase into sub phases, gives a detailed insight of GC performance characters.
