### PR TITLE
Typo fix "darvin" -> "darwin"

### DIFF
--- a/docs/getting-started/graalvm-community/macos.md
+++ b/docs/getting-started/graalvm-community/macos.md
@@ -19,7 +19,7 @@ Follow these steps to install GraalVM Community on the macOS operating system:
 1. Navigate to [GraalVM Releases repository on GitHub](https://github.com/graalvm/graalvm-ce-builds/releases). Select Java 11 based or Java 17 based distribution for macOS, and download.
 2. Unzip the archive.
   ```shell
-   tar -xzf graalvm-ce-java<version>-darvin-amd64-<version>.tar.gz
+   tar -xzf graalvm-ce-java<version>-darwin-amd64-<version>.tar.gz
   ```
   Alternatively, open the file in Finder.
   > Note: If you are using macOS Catalina and later you may need to remove the quarantine attribute. See [Installation Notes](#installation-notes) below.

--- a/docs/getting-started/graalvm-enterprise/installation-macos.md
+++ b/docs/getting-started/graalvm-enterprise/installation-macos.md
@@ -15,10 +15,10 @@ Follow these steps to install Oracle GraalVM Enterprise Edition on the macOS ope
 1. Navigate to[ Oracle GraalVM Downloads](https://www.oracle.com/downloads/graalvm-downloads.html).
 2. Select the preferable GraalVM Enterprise version in the Release Version dropdown, **11** or **17** for the Java version, and **macOS** for the operating system.
 3. Click on the **GraalVM Enterprise Core** download link. Before you download a file, you must accept the [Oracle License Agreement](https://www.oracle.com/downloads/licenses/graalvm-otn-license.html) in the popup window.
-4. When the download button becomes active, press it to start downloading **graalvm-ee-java<version>-darvin-amd64-<version>.tar.gz**.
+4. When the download button becomes active, press it to start downloading **graalvm-ee-java<version>-darwin-amd64-<version>.tar.gz**.
 5. Unzip the archive:
   ```shell
-  tar -xzf graalvm-ee-java<version>-darvin-amd64-<version>.tar.gz
+  tar -xzf graalvm-ee-java<version>-darwin-amd64-<version>.tar.gz
   ```
   Alternatively, open the file in Finder.
   > Note: If you are using macOS Catalina and later you may need to remove the quarantine attribute. See [Installation Notes](#installation-notes) below.


### PR DESCRIPTION
Fixed a typo in the MacOS documentation where "darvin" was used instead of "darwin"