### PR TITLE
Make CSV link relative instead of absolute

### DIFF
--- a/substratevm/src/com.oracle.graal.pointsto/src/com/oracle/graal/pointsto/reports/CallTreePrinter.java
+++ b/substratevm/src/com.oracle.graal.pointsto/src/com/oracle/graal/pointsto/reports/CallTreePrinter.java
@@ -373,7 +373,7 @@ public final class CallTreePrinter {
         }
 
         try {
-            Files.createSymbolicLink(csvLink, csvFile);
+            Files.createSymbolicLink(csvLink, csvFile.getFileName());
         } catch (IOException e) {
             throw new RuntimeException(e);
         }


### PR DESCRIPTION
Fixes #4355

This makes links work both inside and outside containers with ease.