### PR TITLE
Add AArch64 SIMD intrinsic for StringLatin1.inflate and StringUTF16.compress

### DIFF
--- a/compiler/src/org.graalvm.compiler.asm.aarch64/src/org/graalvm/compiler/asm/aarch64/AArch64ASIMDAssembler.java
+++ b/compiler/src/org.graalvm.compiler.asm.aarch64/src/org/graalvm/compiler/asm/aarch64/AArch64ASIMDAssembler.java
@@ -3025,6 +3025,33 @@ public abstract class AArch64ASIMDAssembler {
     }
 
     /**
+     * C7.2.391 Unsigned shift left long (immediate).<br>
+     * <p>
+     * From the manual: "This instruction reads each vector element in the upper half of the source
+     * SIMD&FP register, shifts the unsigned integer value left by the specified number of bits ...
+     * The destination vector elements are twice as long as the source vector elements."
+     *
+     * @param srcESize source element size. Cannot be ElementSize.DoubleWord. The destination
+     *            element size will be twice this width.
+     * @param dst SIMD register.
+     * @param src SIMD register.
+     * @param shiftAmt shift left amount.
+     */
+    public void ushll2VVI(ElementSize srcESize, Register dst, Register src, int shiftAmt) {
+        assert dst.getRegisterCategory().equals(SIMD);
+        assert src.getRegisterCategory().equals(SIMD);
+        assert srcESize != ElementSize.DoubleWord;
+
+        /* Accepted shift range */
+        assert shiftAmt >= 0 && shiftAmt < srcESize.nbits;
+
+        /* shift = imm7 - srcESize.nbits */
+        int imm7 = srcESize.nbits + shiftAmt;
+
+        shiftByImmEncoding(ASIMDInstruction.USHLL, true, imm7, dst, src);
+    }
+
+    /**
      * C7.2.392 unsigned shift right (immediate) scalar.<br>
      *
      * <code>for i in 0..n-1 do dst[i] = src[i] >>> imm</code>
@@ -3126,7 +3153,8 @@ public abstract class AArch64ASIMDAssembler {
      * C7.2.402 Extract narrow.<br>
      * <p>
      * From the manual: "This instruction reads each vector element from the source SIMD&FP
-     * register, narrows each value to half the original width, and writes the register..."
+     * register, narrows each value to half the original width, and writes into the lower half of
+     * the destination register..."
      *
      * @param dstESize destination element size. Cannot be ElementSize.DoubleWord. The source
      *            element size is twice this width.
@@ -3139,6 +3167,26 @@ public abstract class AArch64ASIMDAssembler {
         assert dstESize != ElementSize.DoubleWord;
 
         twoRegMiscEncoding(ASIMDInstruction.XTN, false, elemSizeXX(dstESize), dst, src);
+    }
+
+    /**
+     * C7.2.402 Extract narrow.<br>
+     * <p>
+     * From the manual: "This instruction reads each vector element from the source SIMD&FP
+     * register, narrows each value to half the original width, and writes into the upper half of
+     * the destination register..."
+     *
+     * @param dstESize destination element size. Cannot be ElementSize.DoubleWord. The source
+     *            element size is twice this width.
+     * @param dst SIMD register.
+     * @param src SIMD register.
+     */
+    public void xtn2VV(ElementSize dstESize, Register dst, Register src) {
+        assert dst.getRegisterCategory().equals(SIMD);
+        assert src.getRegisterCategory().equals(SIMD);
+        assert dstESize != ElementSize.DoubleWord;
+
+        twoRegMiscEncoding(ASIMDInstruction.XTN, true, elemSizeXX(dstESize), dst, src);
     }
 
     /**

--- a/compiler/src/org.graalvm.compiler.asm.aarch64/src/org/graalvm/compiler/asm/aarch64/AArch64ASIMDMacroAssembler.java
+++ b/compiler/src/org.graalvm.compiler.asm.aarch64/src/org/graalvm/compiler/asm/aarch64/AArch64ASIMDMacroAssembler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -314,5 +314,19 @@ public class AArch64ASIMDMacroAssembler extends AArch64ASIMDAssembler {
      */
     public void uxtlVV(ElementSize srcESize, Register dst, Register src) {
         ushllVVI(srcESize, dst, src, 0);
+    }
+
+    /**
+     * C7.2.398 Unsigned extend long.<br>
+     * <p>
+     * Preferred alias for ushll2 when only zero-extending the vector elements.
+     *
+     * @param srcESize source element size. Cannot be ElementSize.DoubleWord. The destination
+     *            element size will be double this width.
+     * @param dst SIMD register.
+     * @param src SIMD register.
+     */
+    public void uxtl2VV(ElementSize srcESize, Register dst, Register src) {
+        ushll2VVI(srcESize, dst, src, 0);
     }
 }

--- a/compiler/src/org.graalvm.compiler.core.aarch64/src/org/graalvm/compiler/core/aarch64/AArch64LIRGenerator.java
+++ b/compiler/src/org.graalvm.compiler.core.aarch64/src/org/graalvm/compiler/core/aarch64/AArch64LIRGenerator.java
@@ -71,6 +71,8 @@ import org.graalvm.compiler.lir.aarch64.AArch64Move;
 import org.graalvm.compiler.lir.aarch64.AArch64Move.MembarOp;
 import org.graalvm.compiler.lir.aarch64.AArch64PauseOp;
 import org.graalvm.compiler.lir.aarch64.AArch64SpeculativeBarrier;
+import org.graalvm.compiler.lir.aarch64.AArch64StringLatin1InflateOp;
+import org.graalvm.compiler.lir.aarch64.AArch64StringUTF16CompressOp;
 import org.graalvm.compiler.lir.aarch64.AArch64ZapRegistersOp;
 import org.graalvm.compiler.lir.aarch64.AArch64ZapStackOp;
 import org.graalvm.compiler.lir.aarch64.AArch64ZeroMemoryOp;
@@ -555,6 +557,18 @@ public abstract class AArch64LIRGenerator extends LIRGenerator {
     public Variable emitEncodeArray(Value src, Value dst, Value length, CharsetName charset) {
         Variable result = newVariable(LIRKind.value(AArch64Kind.DWORD));
         append(new AArch64EncodeArrayOp(this, result, asAllocatable(src), asAllocatable(dst), asAllocatable(length), charset));
+        return result;
+    }
+
+    @Override
+    public void emitStringLatin1Inflate(Value src, Value dst, Value len) {
+        append(new AArch64StringLatin1InflateOp(this, asAllocatable(src), asAllocatable(dst), asAllocatable(len)));
+    }
+
+    @Override
+    public Variable emitStringUTF16Compress(Value src, Value dst, Value len) {
+        Variable result = newVariable(LIRKind.value(AArch64Kind.DWORD));
+        append(new AArch64StringUTF16CompressOp(this, asAllocatable(src), asAllocatable(dst), asAllocatable(len), result));
         return result;
     }
 

--- a/compiler/src/org.graalvm.compiler.hotspot.aarch64/src/org/graalvm/compiler/hotspot/aarch64/AArch64HotSpotBackendFactory.java
+++ b/compiler/src/org.graalvm.compiler.hotspot.aarch64/src/org/graalvm/compiler/hotspot/aarch64/AArch64HotSpotBackendFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2022, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2018, Red Hat Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -100,7 +100,7 @@ public class AArch64HotSpotBackendFactory extends HotSpotBackendFactory {
                         replacements,
                         options,
                         target);
-        AArch64GraphBuilderPlugins.register(plugins, replacements, /* registerForeignCallMath */true, options);
+        AArch64GraphBuilderPlugins.register(plugins, replacements, /* registerForeignCallMath */true);
         return plugins;
     }
 

--- a/compiler/src/org.graalvm.compiler.hotspot/src/org/graalvm/compiler/hotspot/meta/HotSpotGraphBuilderPlugins.java
+++ b/compiler/src/org.graalvm.compiler.hotspot/src/org/graalvm/compiler/hotspot/meta/HotSpotGraphBuilderPlugins.java
@@ -220,7 +220,8 @@ public class HotSpotGraphBuilderPlugins {
                 registerGHASHPlugins(invocationPlugins, config, metaAccess, replacements);
                 registerBase64Plugins(invocationPlugins, config, metaAccess, replacements);
                 registerUnsafePlugins(invocationPlugins, config, replacements);
-                StandardGraphBuilderPlugins.registerInvocationPlugins(snippetReflection, invocationPlugins, replacements, true, false, true, graalRuntime.getHostProviders().getLowerer());
+                StandardGraphBuilderPlugins.registerInvocationPlugins(snippetReflection, invocationPlugins, replacements, true, false, true,
+                                graalRuntime.getHostProviders().getLowerer(), options);
                 registerArrayPlugins(invocationPlugins, replacements, config);
                 registerStringPlugins(invocationPlugins, replacements, wordTypes, foreignCalls, config);
                 registerArraysSupportPlugins(invocationPlugins, config, replacements);

--- a/compiler/src/org.graalvm.compiler.hotspot/src/org/graalvm/compiler/hotspot/meta/UnimplementedGraalIntrinsics.java
+++ b/compiler/src/org.graalvm.compiler.hotspot/src/org/graalvm/compiler/hotspot/meta/UnimplementedGraalIntrinsics.java
@@ -394,10 +394,6 @@ public final class UnimplementedGraalIntrinsics {
         if (arch instanceof AArch64) {
             add(toBeInvestigated,
                             "java/lang/StringCoding.hasNegatives([BII)Z",
-                            "java/lang/StringLatin1.inflate([BI[BII)V",
-                            "java/lang/StringLatin1.inflate([BI[CII)V",
-                            "java/lang/StringUTF16.compress([BI[BII)I",
-                            "java/lang/StringUTF16.compress([CI[BII)I",
                             "java/lang/Thread.onSpinWait()V",
                             "jdk/internal/util/ArraysSupport.vectorizedMismatch(Ljava/lang/Object;JLjava/lang/Object;JII)I");
         }

--- a/compiler/src/org.graalvm.compiler.lir.aarch64/src/org/graalvm/compiler/lir/aarch64/AArch64StringLatin1InflateOp.java
+++ b/compiler/src/org.graalvm.compiler.lir.aarch64/src/org/graalvm/compiler/lir/aarch64/AArch64StringLatin1InflateOp.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, Arm Limited. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.graalvm.compiler.lir.aarch64;
+
+import jdk.vm.ci.code.Register;
+import jdk.vm.ci.meta.AllocatableValue;
+import org.graalvm.compiler.asm.Label;
+import org.graalvm.compiler.asm.aarch64.AArch64ASIMDAssembler;
+import org.graalvm.compiler.asm.aarch64.AArch64Address;
+import org.graalvm.compiler.asm.aarch64.AArch64Assembler;
+import org.graalvm.compiler.asm.aarch64.AArch64MacroAssembler;
+import org.graalvm.compiler.core.common.LIRKind;
+import org.graalvm.compiler.lir.LIRInstructionClass;
+import org.graalvm.compiler.lir.Opcode;
+import org.graalvm.compiler.lir.asm.CompilationResultBuilder;
+import org.graalvm.compiler.lir.gen.LIRGeneratorTool;
+
+import static jdk.vm.ci.aarch64.AArch64.SIMD;
+import static jdk.vm.ci.aarch64.AArch64.zr;
+import static jdk.vm.ci.code.ValueUtil.asRegister;
+import static org.graalvm.compiler.lir.LIRInstruction.OperandFlag.REG;
+
+@Opcode("AArch64_STRING_INFLATE")
+public final class AArch64StringLatin1InflateOp extends AArch64LIRInstruction {
+    public static final LIRInstructionClass<AArch64StringLatin1InflateOp> TYPE = LIRInstructionClass.create(AArch64StringLatin1InflateOp.class);
+
+    final int chunkByteSize;
+    @Alive({REG}) protected AllocatableValue src;
+    @Alive({REG}) protected AllocatableValue dst;
+    @Alive({REG}) protected AllocatableValue len;
+    @Temp({REG}) protected AllocatableValue temp1;
+    @Temp({REG}) protected AllocatableValue temp2;
+    @Temp({REG}) protected AllocatableValue temp3;
+    @Temp({REG}) protected AllocatableValue vectorTemp1;
+    @Temp({REG}) protected AllocatableValue vectorTemp2;
+
+    public AArch64StringLatin1InflateOp(LIRGeneratorTool tool, AllocatableValue src, AllocatableValue dst, AllocatableValue len) {
+        super(TYPE);
+        this.src = src;
+        this.dst = dst;
+        this.len = len;
+        LIRKind archWordKind = LIRKind.value(tool.target().arch.getWordKind());
+        temp1 = tool.newVariable(archWordKind);
+        temp2 = tool.newVariable(archWordKind);
+        temp3 = tool.newVariable(archWordKind);
+        LIRKind vectorKind = LIRKind.value(tool.target().arch.getLargestStorableKind(SIMD));
+        vectorTemp1 = tool.newVariable(vectorKind);
+        vectorTemp2 = tool.newVariable(vectorKind);
+        chunkByteSize = 16;
+    }
+
+    @Override
+    public void emitCode(CompilationResultBuilder crb, AArch64MacroAssembler masm) {
+        Label simdImpl = new Label();
+        Label ret = new Label();
+
+        Register srcAddress = asRegister(temp1);
+        Register destAddress = asRegister(temp2);
+        Register length = asRegister(temp3);
+
+        masm.mov(64, srcAddress, asRegister(src));
+        masm.mov(64, destAddress, asRegister(dst));
+        /* Zero-extend the length */
+        masm.add(64, length, asRegister(len), zr, AArch64Assembler.ExtendType.UXTW, 0);
+
+        masm.compare(64, length, chunkByteSize);
+        masm.branchConditionally(AArch64Assembler.ConditionFlag.GE, simdImpl);
+        emitScalar(masm, srcAddress, destAddress, length);
+        masm.jmp(ret);
+
+        masm.bind(simdImpl);
+        emitSIMD(masm, srcAddress, destAddress, length);
+
+        masm.bind(ret);
+    }
+
+    @SuppressWarnings("static-method")
+    private void emitScalar(AArch64MacroAssembler masm, Register srcAddress, Register destAddress, Register count) {
+        Label loop = new Label();
+
+        try (AArch64MacroAssembler.ScratchRegister scratchReg1 = masm.getScratchRegister()) {
+            Register currData = scratchReg1.getRegister();
+
+            masm.align(16);
+            masm.bind(loop);
+            masm.ldr(8, currData, AArch64Address.createImmediateAddress(8, AArch64Address.AddressingMode.IMMEDIATE_POST_INDEXED, srcAddress, 1));
+            masm.str(16, currData, AArch64Address.createImmediateAddress(16, AArch64Address.AddressingMode.IMMEDIATE_POST_INDEXED, destAddress, 2));
+            masm.subs(64, count, count, 1);
+            masm.branchConditionally(AArch64Assembler.ConditionFlag.GT, loop);
+        }
+    }
+
+    private void emitSIMD(AArch64MacroAssembler masm, Register srcChunkAddress, Register destChunkAddress, Register length) {
+        Register destLowV = asRegister(vectorTemp1);
+        Register destHighV = asRegister(vectorTemp2);
+
+        Label simdLoop = new Label();
+        Label ret = new Label();
+
+        try (AArch64MacroAssembler.ScratchRegister scratchRegister1 = masm.getScratchRegister(); AArch64MacroAssembler.ScratchRegister scratchRegister2 = masm.getScratchRegister()) {
+            Register endOfSrcAddress = scratchRegister1.getRegister();
+            Register lastChunkAddress = scratchRegister2.getRegister();
+
+            masm.add(64, endOfSrcAddress, srcChunkAddress, length);
+            masm.sub(64, lastChunkAddress, endOfSrcAddress, chunkByteSize);
+
+            masm.align(16);
+            masm.bind(simdLoop);
+            masm.fldr(128, destLowV, AArch64Address.createImmediateAddress(128, AArch64Address.AddressingMode.IMMEDIATE_POST_INDEXED, srcChunkAddress, chunkByteSize));
+            masm.neon.uxtl2VV(AArch64ASIMDAssembler.ElementSize.Byte, destHighV, destLowV);
+            masm.neon.uxtlVV(AArch64ASIMDAssembler.ElementSize.Byte, destLowV, destLowV);
+            masm.fstp(128, destLowV, destHighV, AArch64Address.createImmediateAddress(128, AArch64Address.AddressingMode.IMMEDIATE_PAIR_POST_INDEXED, destChunkAddress, chunkByteSize * 2));
+            masm.cmp(64, srcChunkAddress, lastChunkAddress);
+            masm.branchConditionally(AArch64Assembler.ConditionFlag.LO, simdLoop);
+
+            /*
+             * Process the last chunk. Move the source position back to the last chunk, 16 bytes
+             * before the end of the input array. Move the destination position back twice the
+             * movement of source position.
+             */
+            masm.cmp(64, srcChunkAddress, endOfSrcAddress);
+            masm.branchConditionally(AArch64Assembler.ConditionFlag.HS, ret);
+            masm.sub(64, srcChunkAddress, srcChunkAddress, lastChunkAddress);
+            masm.sub(64, destChunkAddress, destChunkAddress, srcChunkAddress, AArch64Assembler.ShiftType.LSL, 1);
+            masm.mov(64, srcChunkAddress, lastChunkAddress);
+            masm.jmp(simdLoop);
+
+            masm.bind(ret);
+        }
+    }
+}

--- a/compiler/src/org.graalvm.compiler.lir.aarch64/src/org/graalvm/compiler/lir/aarch64/AArch64StringUTF16CompressOp.java
+++ b/compiler/src/org.graalvm.compiler.lir.aarch64/src/org/graalvm/compiler/lir/aarch64/AArch64StringUTF16CompressOp.java
@@ -1,0 +1,194 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, Arm Limited. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.graalvm.compiler.lir.aarch64;
+
+import jdk.vm.ci.code.Register;
+import jdk.vm.ci.meta.AllocatableValue;
+import org.graalvm.compiler.asm.Label;
+import org.graalvm.compiler.asm.aarch64.AArch64ASIMDAssembler;
+import org.graalvm.compiler.asm.aarch64.AArch64Address;
+import org.graalvm.compiler.asm.aarch64.AArch64Address.AddressingMode;
+import org.graalvm.compiler.asm.aarch64.AArch64Assembler;
+import org.graalvm.compiler.asm.aarch64.AArch64Assembler.ConditionFlag;
+import org.graalvm.compiler.asm.aarch64.AArch64MacroAssembler;
+import org.graalvm.compiler.asm.aarch64.AArch64MacroAssembler.ScratchRegister;
+import org.graalvm.compiler.core.common.LIRKind;
+import org.graalvm.compiler.lir.LIRInstructionClass;
+import org.graalvm.compiler.lir.Opcode;
+import org.graalvm.compiler.lir.asm.CompilationResultBuilder;
+import org.graalvm.compiler.lir.gen.LIRGeneratorTool;
+
+import static jdk.vm.ci.aarch64.AArch64.SIMD;
+import static jdk.vm.ci.aarch64.AArch64.zr;
+import static jdk.vm.ci.code.ValueUtil.asRegister;
+import static org.graalvm.compiler.lir.LIRInstruction.OperandFlag.REG;
+
+@Opcode("AArch64_STRING_COMPRESS")
+public final class AArch64StringUTF16CompressOp extends AArch64LIRInstruction {
+    public static final LIRInstructionClass<AArch64StringUTF16CompressOp> TYPE = LIRInstructionClass.create(AArch64StringUTF16CompressOp.class);
+
+    final int chunkByteSize;
+    @Def({REG}) protected AllocatableValue resultValue;
+    @Alive({REG}) protected AllocatableValue src;
+    @Alive({REG}) protected AllocatableValue dst;
+    @Use({REG}) protected AllocatableValue len;
+    @Temp({REG}) protected AllocatableValue temp1;
+    @Temp({REG}) protected AllocatableValue temp2;
+    @Temp({REG}) protected AllocatableValue vectorTemp1;
+    @Temp({REG}) protected AllocatableValue vectorTemp2;
+    @Temp({REG}) protected AllocatableValue vectorTemp3;
+
+    public AArch64StringUTF16CompressOp(LIRGeneratorTool tool, AllocatableValue src, AllocatableValue dst, AllocatableValue len, AllocatableValue result) {
+        super(TYPE);
+        this.src = src;
+        this.dst = dst;
+        this.len = len;
+        resultValue = result;
+        LIRKind archWordKind = LIRKind.value(tool.target().arch.getWordKind());
+        temp1 = tool.newVariable(archWordKind);
+        temp2 = tool.newVariable(archWordKind);
+        LIRKind vectorKind = LIRKind.value(tool.target().arch.getLargestStorableKind(SIMD));
+        vectorTemp1 = tool.newVariable(vectorKind);
+        vectorTemp2 = tool.newVariable(vectorKind);
+        vectorTemp3 = tool.newVariable(vectorKind);
+        chunkByteSize = 32;
+    }
+
+    @Override
+    public void emitCode(CompilationResultBuilder crb, AArch64MacroAssembler masm) {
+        Label simdImpl = new Label();
+        Label scalarLoop = new Label();
+        Label ret = new Label();
+
+        Register srcAddress = asRegister(temp1);
+        Register destAddress = asRegister(temp2);
+        masm.mov(64, srcAddress, asRegister(src));
+        masm.mov(64, destAddress, asRegister(dst));
+
+        /* Initialise result for successful return */
+        Register length = asRegister(resultValue);
+        /* Zero-extend the length */
+        masm.add(64, length, asRegister(len), zr, AArch64Assembler.ExtendType.UXTW, 0);
+        masm.compare(64, length, chunkByteSize);
+        masm.branchConditionally(ConditionFlag.GE, simdImpl);
+        emitScalar(masm, scalarLoop, ret, srcAddress, destAddress, length);
+
+        masm.bind(simdImpl);
+        emitSIMD(masm, scalarLoop, ret, srcAddress, destAddress, length);
+
+        masm.bind(ret);
+    }
+
+    private void emitScalar(AArch64MacroAssembler masm, Label scalarLoop, Label ret, Register srcAddress, Register destAddress, Register length) {
+        Label failToCompress = new Label();
+
+        try (ScratchRegister scratchReg1 = masm.getScratchRegister()) {
+            Register currData = scratchReg1.getRegister();
+
+            masm.align(16);
+            masm.bind(scalarLoop);
+            /*
+             * If the current char is greater than 0xFF, stop compressing and return zero as result
+             */
+            masm.ldr(16, currData, AArch64Address.createImmediateAddress(16, AddressingMode.IMMEDIATE_POST_INDEXED, srcAddress, 2));
+            masm.compare(64, currData, 0xFF);
+            masm.branchConditionally(ConditionFlag.GT, failToCompress);
+
+            masm.str(8, currData, AArch64Address.createImmediateAddress(8, AddressingMode.IMMEDIATE_POST_INDEXED, destAddress, 1));
+            masm.subs(64, length, length, 1);
+            masm.branchConditionally(ConditionFlag.GT, scalarLoop);
+            masm.mov(64, asRegister(resultValue), asRegister(len));
+            masm.jmp(ret);
+
+            masm.bind(failToCompress);
+            masm.mov(64, asRegister(resultValue), zr);
+        }
+    }
+
+    private void emitSIMD(AArch64MacroAssembler masm, Label scalarLoop, Label ret, Register srcChunkAddress, Register destChunkAddress, Register length) {
+        Register chunkPart1RegV = asRegister(vectorTemp1);
+        Register chunkPart2RegV = asRegister(vectorTemp2);
+        Register tmpRegV1 = asRegister(vectorTemp3);
+
+        Label simdLoop = new Label();
+        Label failToCompress = new Label();
+
+        AArch64ASIMDAssembler.ElementSize eSize = AArch64ASIMDAssembler.ElementSize.fromSize(16);
+        try (ScratchRegister scratchRegister1 = masm.getScratchRegister(); ScratchRegister scratchRegister2 = masm.getScratchRegister()) {
+            Register lastChunkAddress = scratchRegister1.getRegister();
+            Register endOfSrcAddress = scratchRegister2.getRegister();
+            masm.add(64, endOfSrcAddress, srcChunkAddress, length, AArch64Assembler.ShiftType.LSL, 1);
+            masm.sub(64, lastChunkAddress, endOfSrcAddress, chunkByteSize);
+
+            masm.align(16);
+            masm.bind(simdLoop);
+            masm.fldp(128, chunkPart1RegV, chunkPart2RegV, AArch64Address.createImmediateAddress(128, AddressingMode.IMMEDIATE_PAIR_POST_INDEXED, srcChunkAddress, 32));
+            /*
+             * If a char in the chunk is greater than 0xFF, stop compressing and return zero as a
+             * result
+             */
+            masm.neon.orrVVV(AArch64ASIMDAssembler.ASIMDSize.FullReg, tmpRegV1, chunkPart1RegV, chunkPart2RegV);
+            masm.neon.uzp2VVV(AArch64ASIMDAssembler.ASIMDSize.FullReg, eSize.narrow(), tmpRegV1, tmpRegV1, tmpRegV1);
+            masm.fcmpZero(64, tmpRegV1);
+            masm.branchConditionally(ConditionFlag.NE, failToCompress);
+
+            masm.neon.xtnVV(eSize.narrow(), tmpRegV1, chunkPart1RegV);
+            masm.neon.xtn2VV(eSize.narrow(), tmpRegV1, chunkPart2RegV);
+            masm.fstr(128, tmpRegV1, AArch64Address.createImmediateAddress(128, AddressingMode.IMMEDIATE_POST_INDEXED, destChunkAddress, 16));
+            masm.cmp(64, srcChunkAddress, lastChunkAddress);
+            masm.branchConditionally(ConditionFlag.LO, simdLoop);
+
+            /*
+             * Process the last chunk. Move the source position back to the last chunk, 16 bytes
+             * before the end of the input array. Move the destination position back twice the
+             * movement of source position.
+             */
+            masm.cmp(64, srcChunkAddress, endOfSrcAddress);
+            masm.branchConditionally(ConditionFlag.HS, ret);
+            masm.sub(64, srcChunkAddress, srcChunkAddress, lastChunkAddress);
+            masm.sub(64, destChunkAddress, destChunkAddress, srcChunkAddress, AArch64Assembler.ShiftType.LSR, 1);
+            masm.mov(64, srcChunkAddress, lastChunkAddress);
+            masm.jmp(simdLoop);
+        }
+
+        masm.bind(failToCompress);
+        /*
+         * Copy compressed characters until the character that failed to compress. Compress and copy
+         * the first 16 bytes if the un-compressible char(s) not present. Jump to the scalar loop to
+         * process the failed chunk char-by-char.
+         */
+        masm.sub(64, srcChunkAddress, srcChunkAddress, 32);
+        masm.mov(length, 16);
+        masm.neon.uzp2VVV(AArch64ASIMDAssembler.ASIMDSize.FullReg, eSize.narrow(), tmpRegV1, chunkPart1RegV, chunkPart1RegV);
+        masm.fcmpZero(64, tmpRegV1);
+        masm.branchConditionally(ConditionFlag.NE, scalarLoop);
+        masm.neon.xtnVV(eSize.narrow(), tmpRegV1, chunkPart1RegV);
+        masm.fstr(64, tmpRegV1, AArch64Address.createImmediateAddress(64, AddressingMode.IMMEDIATE_POST_INDEXED, destChunkAddress, 8));
+        masm.neon.moveVV(AArch64ASIMDAssembler.ASIMDSize.FullReg, chunkPart1RegV, chunkPart2RegV);
+        masm.add(64, srcChunkAddress, srcChunkAddress, 16);
+        masm.jmp(scalarLoop);
+    }
+}

--- a/compiler/src/org.graalvm.compiler.replacements.amd64/src/org/graalvm/compiler/replacements/amd64/AMD64GraphBuilderPlugins.java
+++ b/compiler/src/org.graalvm.compiler.replacements.amd64/src/org/graalvm/compiler/replacements/amd64/AMD64GraphBuilderPlugins.java
@@ -24,8 +24,6 @@
  */
 package org.graalvm.compiler.replacements.amd64;
 
-import static org.graalvm.compiler.lir.gen.LIRGeneratorTool.CharsetName.ASCII;
-import static org.graalvm.compiler.lir.gen.LIRGeneratorTool.CharsetName.ISO_8859_1;
 import static org.graalvm.compiler.replacements.nodes.BinaryMathIntrinsicNode.BinaryOperation.POW;
 import static org.graalvm.compiler.replacements.nodes.UnaryMathIntrinsicNode.UnaryOperation.COS;
 import static org.graalvm.compiler.replacements.nodes.UnaryMathIntrinsicNode.UnaryOperation.EXP;
@@ -34,47 +32,34 @@ import static org.graalvm.compiler.replacements.nodes.UnaryMathIntrinsicNode.Una
 import static org.graalvm.compiler.replacements.nodes.UnaryMathIntrinsicNode.UnaryOperation.SIN;
 import static org.graalvm.compiler.replacements.nodes.UnaryMathIntrinsicNode.UnaryOperation.TAN;
 
-import java.lang.reflect.Type;
 import java.util.Arrays;
 
 import org.graalvm.compiler.core.common.GraalOptions;
 import org.graalvm.compiler.core.common.calc.Condition;
 import org.graalvm.compiler.nodes.ComputeObjectAddressNode;
 import org.graalvm.compiler.nodes.ConstantNode;
-import org.graalvm.compiler.nodes.NamedLocationIdentity;
 import org.graalvm.compiler.nodes.NodeView;
 import org.graalvm.compiler.nodes.PauseNode;
 import org.graalvm.compiler.nodes.ValueNode;
 import org.graalvm.compiler.nodes.calc.AddNode;
 import org.graalvm.compiler.nodes.calc.CopySignNode;
-import org.graalvm.compiler.nodes.calc.EncodeArrayNode;
 import org.graalvm.compiler.nodes.calc.HasNegativesNode;
-import org.graalvm.compiler.nodes.calc.LeftShiftNode;
 import org.graalvm.compiler.nodes.calc.MaxNode;
 import org.graalvm.compiler.nodes.calc.MinNode;
-import org.graalvm.compiler.nodes.calc.NarrowNode;
-import org.graalvm.compiler.nodes.calc.ZeroExtendNode;
-import org.graalvm.compiler.nodes.extended.JavaReadNode;
 import org.graalvm.compiler.nodes.graphbuilderconf.GraphBuilderConfiguration.Plugins;
 import org.graalvm.compiler.nodes.graphbuilderconf.GraphBuilderContext;
 import org.graalvm.compiler.nodes.graphbuilderconf.InvocationPlugin;
 import org.graalvm.compiler.nodes.graphbuilderconf.InvocationPlugins;
 import org.graalvm.compiler.nodes.graphbuilderconf.InvocationPlugins.Registration;
 import org.graalvm.compiler.nodes.java.ArrayLengthNode;
-import org.graalvm.compiler.nodes.memory.OnHeapMemoryAccess;
-import org.graalvm.compiler.nodes.memory.address.IndexAddressNode;
 import org.graalvm.compiler.nodes.spi.Replacements;
 import org.graalvm.compiler.options.OptionValues;
-import org.graalvm.compiler.replacements.ArrayIndexOfNode;
 import org.graalvm.compiler.replacements.InvocationPluginHelper;
 import org.graalvm.compiler.replacements.SnippetSubstitutionInvocationPlugin;
 import org.graalvm.compiler.replacements.SnippetTemplate;
-import org.graalvm.compiler.replacements.StandardGraphBuilderPlugins;
-import org.graalvm.compiler.replacements.StandardGraphBuilderPlugins.StringLatin1IndexOfCharPlugin;
-import org.graalvm.compiler.replacements.StringLatin1Snippets;
 import org.graalvm.compiler.replacements.StringUTF16Snippets;
+import org.graalvm.compiler.replacements.StandardGraphBuilderPlugins.ArrayEqualsInvocationPlugin;
 import org.graalvm.compiler.replacements.TargetGraphBuilderPlugins;
-import org.graalvm.compiler.replacements.nodes.ArrayCompareToNode;
 import org.graalvm.compiler.replacements.nodes.BinaryMathIntrinsicNode;
 import org.graalvm.compiler.replacements.nodes.BinaryMathIntrinsicNode.BinaryOperation;
 import org.graalvm.compiler.replacements.nodes.BitCountNode;
@@ -83,12 +68,10 @@ import org.graalvm.compiler.replacements.nodes.CountTrailingZerosNode;
 import org.graalvm.compiler.replacements.nodes.FusedMultiplyAddNode;
 import org.graalvm.compiler.replacements.nodes.UnaryMathIntrinsicNode;
 import org.graalvm.compiler.replacements.nodes.UnaryMathIntrinsicNode.UnaryOperation;
-import org.graalvm.compiler.serviceprovider.JavaVersionUtil;
 
 import jdk.vm.ci.amd64.AMD64;
 import jdk.vm.ci.amd64.AMD64.CPUFeature;
 import jdk.vm.ci.code.Architecture;
-import jdk.vm.ci.code.CodeUtil;
 import jdk.vm.ci.meta.JavaKind;
 import jdk.vm.ci.meta.MetaAccessProvider;
 import jdk.vm.ci.meta.ResolvedJavaMethod;
@@ -108,7 +91,6 @@ public class AMD64GraphBuilderPlugins implements TargetGraphBuilderPlugins {
                 registerIntegerLongPlugins(invocationPlugins, JavaKind.Int, arch, replacements);
                 registerIntegerLongPlugins(invocationPlugins, JavaKind.Long, arch, replacements);
                 if (GraalOptions.EmitStringSubstitutions.getValue(options)) {
-                    registerStringLatin1Plugins(invocationPlugins, replacements);
                     registerStringUTF16Plugins(invocationPlugins, replacements);
                 }
                 registerMathPlugins(invocationPlugins, arch, replacements);
@@ -255,221 +237,10 @@ public class AMD64GraphBuilderPlugins implements TargetGraphBuilderPlugins {
         }
     }
 
-    private static final class ArrayCompareToPlugin extends InvocationPlugin {
-        private final JavaKind valueKind;
-        private final JavaKind otherKind;
-        private final boolean swapped;
-
-        private ArrayCompareToPlugin(JavaKind valueKind, JavaKind otherKind, boolean swapped, String name, Type... argumentTypes) {
-            super(name, argumentTypes);
-            this.valueKind = valueKind;
-            this.otherKind = otherKind;
-            this.swapped = swapped;
-        }
-
-        private ArrayCompareToPlugin(JavaKind valueKind, JavaKind otherKind, String name, Type... argumentTypes) {
-            this(valueKind, otherKind, false, name, argumentTypes);
-        }
-
-        @Override
-        public boolean apply(GraphBuilderContext b, ResolvedJavaMethod targetMethod, Receiver receiver, ValueNode value, ValueNode other) {
-            ValueNode nonNullValue = b.nullCheckedValue(value);
-            ValueNode nonNullOther = b.nullCheckedValue(other);
-
-            ValueNode valueLength = b.add(new ArrayLengthNode(nonNullValue));
-            ValueNode otherLength = b.add(new ArrayLengthNode(nonNullOther));
-            if (swapped) {
-                /*
-                 * Swapping array arguments because intrinsic expects order to be byte[]/char[] but
-                 * kind arguments stay in original order.
-                 */
-                b.addPush(JavaKind.Int, new ArrayCompareToNode(nonNullOther, nonNullValue, otherLength, valueLength, valueKind, otherKind));
-            } else {
-                b.addPush(JavaKind.Int, new ArrayCompareToNode(nonNullValue, nonNullOther, valueLength, otherLength, valueKind, otherKind));
-            }
-            return true;
-        }
-    }
-
-    private static void registerStringLatin1Plugins(InvocationPlugins plugins, Replacements replacements) {
-        Registration r = new Registration(plugins, "java.lang.StringLatin1", replacements);
-        r.setAllowOverwrite(true);
-        r.register(new ArrayCompareToPlugin(JavaKind.Byte, JavaKind.Byte, "compareTo", byte[].class, byte[].class));
-        r.register(new ArrayCompareToPlugin(JavaKind.Byte, JavaKind.Char, "compareToUTF16", byte[].class, byte[].class));
-        r.register(new InvocationPlugin("inflate", byte[].class, int.class, byte[].class, int.class, int.class) {
-            @SuppressWarnings("try")
-            @Override
-            public boolean apply(GraphBuilderContext b, ResolvedJavaMethod targetMethod, Receiver receiver, ValueNode src, ValueNode srcIndex, ValueNode dest, ValueNode destIndex, ValueNode len) {
-                // @formatter:off
-                //         if (injectBranchProbability(SLOWPATH_PROBABILITY, len < 0) ||
-                //                        injectBranchProbability(SLOWPATH_PROBABILITY, srcIndex < 0) ||
-                //                        injectBranchProbability(SLOWPATH_PROBABILITY, srcIndex + len > src.length) ||
-                //                        injectBranchProbability(SLOWPATH_PROBABILITY, destIndex < 0) ||
-                //                        injectBranchProbability(SLOWPATH_PROBABILITY, destIndex * 2 + len * 2 > dest.length)) {
-                //            DeoptimizeNode.deopt(DeoptimizationAction.None, DeoptimizationReason.BoundsCheckException);
-                //        }
-                //
-                //        // Offset calc. outside of the actual intrinsic.
-                //        Pointer srcPointer = Word.objectToTrackedPointer(src).add(byteArrayBaseOffset(INJECTED)).add(srcIndex * byteArrayIndexScale(INJECTED));
-                //        Pointer destPointer = Word.objectToTrackedPointer(dest).add(byteArrayBaseOffset(INJECTED)).add(destIndex * 2 * byteArrayIndexScale(INJECTED));
-                //        AMD64StringLatin1InflateNode.inflate(srcPointer, destPointer, len, JavaKind.Byte);
-                // @formatter:on
-                try (InvocationPluginHelper helper = new InvocationPluginHelper(b, targetMethod)) {
-                    helper.intrinsicRangeCheck(len, Condition.LT, ConstantNode.forInt(0));
-
-                    helper.intrinsicRangeCheck(srcIndex, Condition.LT, ConstantNode.forInt(0));
-                    ValueNode srcLength = helper.length(b.nullCheckedValue(src));
-                    helper.intrinsicRangeCheck(helper.add(srcIndex, len), Condition.GT, srcLength);
-
-                    ValueNode scaledDestIndex = helper.scale(destIndex, JavaKind.Char);
-                    helper.intrinsicRangeCheck(scaledDestIndex, Condition.LT, ConstantNode.forInt(0));
-                    ValueNode end = helper.add(scaledDestIndex, helper.scale(len, JavaKind.Char));
-                    ValueNode destLength = helper.length(b.nullCheckedValue(dest));
-                    helper.intrinsicRangeCheck(end, Condition.GT, destLength);
-
-                    ValueNode srcPointer = helper.arrayElementPointer(src, JavaKind.Byte, srcIndex);
-                    ValueNode destPointer = helper.arrayElementPointer(dest, JavaKind.Byte, scaledDestIndex);
-                    b.add(new AMD64StringLatin1InflateNode(srcPointer, destPointer, len, JavaKind.Byte));
-                }
-                return true;
-            }
-        });
-        r.register(new InvocationPlugin("inflate", byte[].class, int.class, char[].class, int.class, int.class) {
-            @SuppressWarnings("try")
-            @Override
-            public boolean apply(GraphBuilderContext b, ResolvedJavaMethod targetMethod, Receiver receiver, ValueNode src, ValueNode srcIndex, ValueNode dest, ValueNode destIndex, ValueNode len) {
-                // @formatter:off
-                //         if (injectBranchProbability(SLOWPATH_PROBABILITY, len < 0) ||
-                //                        injectBranchProbability(SLOWPATH_PROBABILITY, srcIndex < 0) ||
-                //                        injectBranchProbability(SLOWPATH_PROBABILITY, srcIndex + len > src.length) ||
-                //                        injectBranchProbability(SLOWPATH_PROBABILITY, destIndex < 0) ||
-                //                        injectBranchProbability(SLOWPATH_PROBABILITY, destIndex + len > dest.length)) {
-                //            DeoptimizeNode.deopt(DeoptimizationAction.None, DeoptimizationReason.BoundsCheckException);
-                //        }
-                //
-                //        // Offset calc. outside of the actual intrinsic.
-                //        Pointer srcPointer = Word.objectToTrackedPointer(src).add(byteArrayBaseOffset(INJECTED)).add(srcIndex * byteArrayIndexScale(INJECTED));
-                //        Pointer destPointer = Word.objectToTrackedPointer(dest).add(charArrayBaseOffset(INJECTED)).add(destIndex * charArrayIndexScale(INJECTED));
-                //        AMD64StringLatin1InflateNode.inflate(srcPointer, destPointer, len, JavaKind.Char);
-                // @formatter:on
-                try (InvocationPluginHelper helper = new InvocationPluginHelper(b, targetMethod)) {
-                    helper.intrinsicRangeCheck(len, Condition.LT, ConstantNode.forInt(0));
-
-                    helper.intrinsicRangeCheck(srcIndex, Condition.LT, ConstantNode.forInt(0));
-                    ValueNode srcLength = helper.length(b.nullCheckedValue(src));
-                    helper.intrinsicRangeCheck(helper.add(srcIndex, len), Condition.GT, srcLength);
-
-                    helper.intrinsicRangeCheck(destIndex, Condition.LT, ConstantNode.forInt(0));
-                    ValueNode end = helper.add(destIndex, len);
-                    ValueNode destLength = helper.length(b.nullCheckedValue(dest));
-                    helper.intrinsicRangeCheck(end, Condition.GT, destLength);
-
-                    ValueNode srcPointer = helper.arrayElementPointer(src, JavaKind.Byte, srcIndex);
-                    ValueNode destPointer = helper.arrayElementPointer(dest, JavaKind.Char, destIndex);
-                    b.add(new AMD64StringLatin1InflateNode(srcPointer, destPointer, len, JavaKind.Char));
-                }
-                return true;
-            }
-        });
-
-        r.register(new SnippetSubstitutionInvocationPlugin<>(StringLatin1Snippets.Templates.class,
-                        "indexOf", byte[].class, int.class, byte[].class, int.class, int.class) {
-            @Override
-            public SnippetTemplate.SnippetInfo getSnippet(StringLatin1Snippets.Templates templates) {
-                return templates.indexOf;
-            }
-        });
-        r.register(new StringLatin1IndexOfCharPlugin());
-    }
-
     private static void registerStringUTF16Plugins(InvocationPlugins plugins, Replacements replacements) {
 
         Registration r = new Registration(plugins, "java.lang.StringUTF16", replacements);
         r.setAllowOverwrite(true);
-        r.register(new ArrayCompareToPlugin(JavaKind.Char, JavaKind.Char, "compareTo", byte[].class, byte[].class));
-        r.register(new ArrayCompareToPlugin(JavaKind.Char, JavaKind.Byte, true, "compareToLatin1", byte[].class, byte[].class));
-        r.register(new InvocationPlugin("compress", byte[].class, int.class, byte[].class, int.class, int.class) {
-            @SuppressWarnings("try")
-            @Override
-            public boolean apply(GraphBuilderContext b, ResolvedJavaMethod targetMethod, Receiver receiver, ValueNode src, ValueNode srcIndex, ValueNode dest, ValueNode destIndex, ValueNode len) {
-                // @formatter:off
-                //         if (injectBranchProbability(SLOWPATH_PROBABILITY, len < 0) ||
-                //                        injectBranchProbability(SLOWPATH_PROBABILITY, srcIndex < 0) ||
-                //                        injectBranchProbability(SLOWPATH_PROBABILITY, srcIndex + len > src.length >> 1) ||
-                //                        injectBranchProbability(SLOWPATH_PROBABILITY, destIndex < 0) ||
-                //                        injectBranchProbability(SLOWPATH_PROBABILITY, destIndex + len > dest.length)) {
-                //            DeoptimizeNode.deopt(DeoptimizationAction.None, DeoptimizationReason.BoundsCheckException);
-                //        }
-                //
-                //        Pointer srcPointer = Word.objectToTrackedPointer(src).add(byteArrayBaseOffset(INJECTED)).add(srcIndex * 2 * byteArrayIndexScale(INJECTED));
-                //        Pointer destPointer = Word.objectToTrackedPointer(dest).add(byteArrayBaseOffset(INJECTED)).add(destIndex * byteArrayIndexScale(INJECTED));
-                //        return AMD64StringUTF16CompressNode.compress(srcPointer, destPointer, len, JavaKind.Byte);
-                // @formatter:on
-
-                try (InvocationPluginHelper helper = new InvocationPluginHelper(b, targetMethod)) {
-                    helper.intrinsicRangeCheck(len, Condition.LT, ConstantNode.forInt(0));
-
-                    ValueNode scaledSrcIndex = helper.scale(srcIndex, JavaKind.Char);
-                    helper.intrinsicRangeCheck(scaledSrcIndex, Condition.LT, ConstantNode.forInt(0));
-                    ValueNode end = helper.add(scaledSrcIndex, helper.scale(len, JavaKind.Char));
-                    ValueNode srcLength = helper.length(b.nullCheckedValue(src));
-                    helper.intrinsicRangeCheck(end, Condition.GT, srcLength);
-
-                    helper.intrinsicRangeCheck(destIndex, Condition.LT, ConstantNode.forInt(0));
-                    ValueNode destLength = helper.length(b.nullCheckedValue(dest));
-                    helper.intrinsicRangeCheck(helper.add(destIndex, len), Condition.GT, destLength);
-
-                    ValueNode srcPointer = helper.arrayElementPointer(src, JavaKind.Byte, scaledSrcIndex);
-                    ValueNode destPointer = helper.arrayElementPointer(dest, JavaKind.Byte, destIndex);
-                    b.addPush(JavaKind.Int, new AMD64StringUTF16CompressNode(srcPointer, destPointer, len, JavaKind.Byte));
-                }
-                return true;
-            }
-        });
-        r.register(new InvocationPlugin("compress", char[].class, int.class, byte[].class, int.class, int.class) {
-            @SuppressWarnings("try")
-            @Override
-            public boolean apply(GraphBuilderContext b, ResolvedJavaMethod targetMethod, Receiver receiver, ValueNode src, ValueNode srcIndex, ValueNode dest, ValueNode destIndex, ValueNode len) {
-                // @formatter:off
-                //         if (injectBranchProbability(SLOWPATH_PROBABILITY, len < 0) ||
-                //                        injectBranchProbability(SLOWPATH_PROBABILITY, srcIndex < 0) ||
-                //                        injectBranchProbability(SLOWPATH_PROBABILITY, srcIndex + len > src.length) ||
-                //                        injectBranchProbability(SLOWPATH_PROBABILITY, destIndex < 0) ||
-                //                        injectBranchProbability(SLOWPATH_PROBABILITY, destIndex + len > dest.length)) {
-                //            DeoptimizeNode.deopt(DeoptimizationAction.None, DeoptimizationReason.BoundsCheckException);
-                //        }
-                //
-                //        Pointer srcPointer = Word.objectToTrackedPointer(src).add(charArrayBaseOffset(INJECTED)).add(srcIndex * charArrayIndexScale(INJECTED));
-                //        Pointer destPointer = Word.objectToTrackedPointer(dest).add(byteArrayBaseOffset(INJECTED)).add(destIndex * byteArrayIndexScale(INJECTED));
-                //        return AMD64StringUTF16CompressNode.compress(srcPointer, destPointer, len, JavaKind.Char);
-                // @formatter:on
-                try (InvocationPluginHelper helper = new InvocationPluginHelper(b, targetMethod)) {
-                    helper.intrinsicRangeCheck(len, Condition.LT, ConstantNode.forInt(0));
-
-                    helper.intrinsicRangeCheck(srcIndex, Condition.LT, ConstantNode.forInt(0));
-                    ValueNode end = helper.add(srcIndex, len);
-                    ValueNode srcLength = helper.length(b.nullCheckedValue(src));
-                    helper.intrinsicRangeCheck(end, Condition.GT, srcLength);
-
-                    helper.intrinsicRangeCheck(destIndex, Condition.LT, ConstantNode.forInt(0));
-                    ValueNode destLength = helper.length(b.nullCheckedValue(dest));
-                    helper.intrinsicRangeCheck(helper.add(destIndex, len), Condition.GT, destLength);
-
-                    ValueNode srcPointer = helper.arrayElementPointer(src, JavaKind.Char, srcIndex);
-                    ValueNode destPointer = helper.arrayElementPointer(dest, JavaKind.Byte, destIndex);
-                    b.addPush(JavaKind.Int, new AMD64StringUTF16CompressNode(srcPointer, destPointer, len, JavaKind.Char));
-                }
-                return true;
-            }
-        });
-
-        r.register(new SnippetSubstitutionInvocationPlugin<>(StringUTF16Snippets.Templates.class,
-                        "indexOfUnsafe", byte[].class, int.class, byte[].class, int.class, int.class) {
-            @Override
-            public SnippetTemplate.SnippetInfo getSnippet(StringUTF16Snippets.Templates templates) {
-                return templates.indexOfUnsafe;
-            }
-        });
         r.register(new SnippetSubstitutionInvocationPlugin<>(StringUTF16Snippets.Templates.class,
                         "indexOfLatin1Unsafe", byte[].class, int.class, byte[].class, int.class, int.class) {
             @Override
@@ -478,51 +249,16 @@ public class AMD64GraphBuilderPlugins implements TargetGraphBuilderPlugins {
             }
 
         });
-        r.register(new InvocationPlugin("indexOfCharUnsafe", byte[].class, int.class, int.class, int.class) {
-            @Override
-            public boolean apply(GraphBuilderContext b, ResolvedJavaMethod targetMethod, Receiver receiver, ValueNode value, ValueNode ch, ValueNode fromIndex, ValueNode max) {
-                ZeroExtendNode toChar = b.add(new ZeroExtendNode(b.add(new NarrowNode(ch, JavaKind.Char.getBitCount())), JavaKind.Int.getBitCount()));
-                b.addPush(JavaKind.Int, new ArrayIndexOfNode(JavaKind.Byte, JavaKind.Char, false, false, value, ConstantNode.forLong(0), max, fromIndex, toChar));
-                return true;
-            }
-        });
-        Registration r2 = new Registration(plugins, StringUTF16Snippets.class, replacements);
-        r2.register(new InvocationPlugin("getChar", byte[].class, int.class) {
-            @Override
-            public boolean apply(GraphBuilderContext b, ResolvedJavaMethod targetMethod, Receiver receiver, ValueNode arg1, ValueNode arg2) {
-                b.addPush(JavaKind.Char, new JavaReadNode(JavaKind.Char,
-                                new IndexAddressNode(arg1, new LeftShiftNode(arg2, ConstantNode.forInt(1)), JavaKind.Byte),
-                                NamedLocationIdentity.getArrayLocation(JavaKind.Byte), OnHeapMemoryAccess.BarrierType.NONE, false));
-                return true;
-            }
-        });
     }
 
     private static void registerArraysEqualsPlugins(InvocationPlugins plugins, Replacements replacements) {
         Registration r = new Registration(plugins, Arrays.class, replacements);
-        r.register(new StandardGraphBuilderPlugins.ArrayEqualsInvocationPlugin(JavaKind.Float, float[].class, float[].class));
-        r.register(new StandardGraphBuilderPlugins.ArrayEqualsInvocationPlugin(JavaKind.Double, double[].class, double[].class));
+        r.register(new ArrayEqualsInvocationPlugin(JavaKind.Float, float[].class, float[].class));
+        r.register(new ArrayEqualsInvocationPlugin(JavaKind.Double, double[].class, double[].class));
     }
 
     private static void registerStringCodingPlugins(InvocationPlugins plugins, Replacements replacements) {
         Registration r = new Registration(plugins, "java.lang.StringCoding", replacements);
-        r.register(new InvocationPlugin("implEncodeISOArray", byte[].class, int.class, byte[].class, int.class, int.class) {
-            @Override
-            public boolean apply(GraphBuilderContext b, ResolvedJavaMethod targetMethod, Receiver receiver, ValueNode sa, ValueNode sp,
-                            ValueNode da, ValueNode dp, ValueNode len) {
-                MetaAccessProvider metaAccess = b.getMetaAccess();
-                int byteArrayBaseOffset = metaAccess.getArrayBaseOffset(JavaKind.Byte);
-
-                ValueNode srcOffset = AddNode.create(ConstantNode.forInt(byteArrayBaseOffset), new LeftShiftNode(sp, ConstantNode.forInt(2)), NodeView.DEFAULT);
-                ValueNode dstOffset = AddNode.create(ConstantNode.forInt(byteArrayBaseOffset), dp, NodeView.DEFAULT);
-
-                ComputeObjectAddressNode src = b.add(new ComputeObjectAddressNode(sa, srcOffset));
-                ComputeObjectAddressNode dst = b.add(new ComputeObjectAddressNode(da, dstOffset));
-
-                b.addPush(JavaKind.Int, new EncodeArrayNode(src, dst, len, ISO_8859_1));
-                return true;
-            }
-        });
         r.register(new InvocationPlugin("hasNegatives", byte[].class, int.class, int.class) {
             @Override
             public boolean apply(GraphBuilderContext b, ResolvedJavaMethod targetMethod, Receiver receiver, ValueNode ba, ValueNode off, ValueNode len) {
@@ -540,45 +276,6 @@ public class AMD64GraphBuilderPlugins implements TargetGraphBuilderPlugins {
                     ComputeObjectAddressNode array = b.add(new ComputeObjectAddressNode(ba, arrayOffset));
 
                     b.addPush(JavaKind.Int, new HasNegativesNode(array, len));
-                    return true;
-                }
-            }
-        });
-        r.register(new InvocationPlugin("implEncodeAsciiArray", char[].class, int.class, byte[].class, int.class, int.class) {
-            @Override
-            public boolean apply(GraphBuilderContext b, ResolvedJavaMethod targetMethod, Receiver receiver, ValueNode sa, ValueNode sp,
-                            ValueNode da, ValueNode dp, ValueNode len) {
-                MetaAccessProvider metaAccess = b.getMetaAccess();
-                int charArrayBaseOffset = metaAccess.getArrayBaseOffset(JavaKind.Char);
-                int byteArrayBaseOffset = metaAccess.getArrayBaseOffset(JavaKind.Byte);
-
-                int charElementShift = CodeUtil.log2(metaAccess.getArrayIndexScale(JavaKind.Char));
-
-                ValueNode srcOffset = AddNode.create(ConstantNode.forInt(charArrayBaseOffset), new LeftShiftNode(sp, ConstantNode.forInt(charElementShift)), NodeView.DEFAULT);
-                ValueNode dstOffset = AddNode.create(ConstantNode.forInt(byteArrayBaseOffset), dp, NodeView.DEFAULT);
-
-                ComputeObjectAddressNode src = b.add(new ComputeObjectAddressNode(sa, srcOffset));
-                ComputeObjectAddressNode dst = b.add(new ComputeObjectAddressNode(da, dstOffset));
-
-                b.addPush(JavaKind.Int, new EncodeArrayNode(src, dst, len, ASCII));
-                return true;
-            }
-
-            @Override
-            public boolean isOptional() {
-                return JavaVersionUtil.JAVA_SPEC < 18;
-            }
-        });
-
-        r = new Registration(plugins, "sun.nio.cs.ISO_8859_1$Encoder", replacements);
-        r.register(new InvocationPlugin("implEncodeISOArray", char[].class, int.class, byte[].class, int.class, int.class) {
-            @Override
-            public boolean apply(GraphBuilderContext b, ResolvedJavaMethod targetMethod, Receiver receiver, ValueNode sa, ValueNode sp,
-                            ValueNode da, ValueNode dp, ValueNode len) {
-                try (InvocationPluginHelper helper = new InvocationPluginHelper(b, targetMethod)) {
-                    ValueNode src = helper.arrayElementPointer(sa, JavaKind.Char, sp);
-                    ValueNode dst = helper.arrayElementPointer(da, JavaKind.Byte, dp);
-                    b.addPush(JavaKind.Int, new EncodeArrayNode(src, dst, len, ISO_8859_1));
                     return true;
                 }
             }

--- a/compiler/src/org.graalvm.compiler.replacements.test/src/org/graalvm/compiler/replacements/test/StringCompressInflateTest.java
+++ b/compiler/src/org.graalvm.compiler.replacements.test/src/org/graalvm/compiler/replacements/test/StringCompressInflateTest.java
@@ -24,21 +24,17 @@
  */
 package org.graalvm.compiler.replacements.test;
 
-import static org.junit.Assume.assumeTrue;
-
 import java.io.UnsupportedEncodingException;
 
 import org.graalvm.compiler.core.common.CompilationIdentifier;
 import org.graalvm.compiler.nodes.Invoke;
 import org.graalvm.compiler.nodes.StructuredGraph;
 import org.graalvm.compiler.nodes.StructuredGraph.AllowAssumptions;
-import org.graalvm.compiler.replacements.amd64.AMD64StringLatin1InflateNode;
-import org.graalvm.compiler.replacements.amd64.AMD64StringUTF16CompressNode;
+import org.graalvm.compiler.replacements.StringLatin1InflateNode;
+import org.graalvm.compiler.replacements.StringUTF16CompressNode;
 import org.graalvm.compiler.test.AddExports;
-import org.junit.Before;
 import org.junit.Test;
 
-import jdk.vm.ci.amd64.AMD64;
 import jdk.vm.ci.code.InstalledCode;
 import jdk.vm.ci.meta.ResolvedJavaMethod;
 
@@ -52,18 +48,12 @@ public final class StringCompressInflateTest extends MethodSubstitutionTest {
 
     static final int N = 1000;
 
-    @Before
-    public void checkAMD64() {
-        // Test case is (currently) AMD64 only.
-        assumeTrue(getTarget().arch instanceof AMD64);
-    }
-
     @Test
     public void testStringLatin1Inflate() throws ClassNotFoundException, UnsupportedEncodingException {
         Class<?> javaclass = Class.forName("java.lang.StringLatin1");
-        Class<?> testclass = AMD64StringLatin1InflateNode.class;
+        Class<?> testclass = StringLatin1InflateNode.class;
 
-        TestMethods tms = new TestMethods("testInflate", javaclass, AMD64StringLatin1InflateNode.class, "inflate",
+        TestMethods tms = new TestMethods("testInflate", javaclass, StringLatin1InflateNode.class, "inflate",
                         byte[].class, int.class, char[].class, int.class, int.class);
 
         tms.testSubstitution(testclass);
@@ -113,7 +103,7 @@ public final class StringCompressInflateTest extends MethodSubstitutionTest {
 
         ResolvedJavaMethod caller = getResolvedJavaMethod(javaclass, "inflate", byte[].class, int.class, byte[].class, int.class, int.class);
         StructuredGraph graph = getReplacements().getIntrinsicGraph(caller, CompilationIdentifier.INVALID_COMPILATION_ID, getDebugContext(), AllowAssumptions.YES, null);
-        assertInGraph(graph, AMD64StringLatin1InflateNode.class);
+        assertInGraph(graph, StringLatin1InflateNode.class);
 
         InstalledCode code = getCode(caller, graph);
 
@@ -151,7 +141,7 @@ public final class StringCompressInflateTest extends MethodSubstitutionTest {
 
         ResolvedJavaMethod caller = getResolvedJavaMethod(javaclass, "inflate", byte[].class, int.class, char[].class, int.class, int.class);
         StructuredGraph graph = getReplacements().getIntrinsicGraph(caller, CompilationIdentifier.INVALID_COMPILATION_ID, getDebugContext(), AllowAssumptions.YES, null);
-        assertInGraph(graph, AMD64StringLatin1InflateNode.class);
+        assertInGraph(graph, StringLatin1InflateNode.class);
 
         InstalledCode code = getCode(caller, graph);
 
@@ -184,8 +174,8 @@ public final class StringCompressInflateTest extends MethodSubstitutionTest {
     @Test
     public void testStringUTF16Compress() throws ClassNotFoundException, UnsupportedEncodingException {
         Class<?> javaclass = Class.forName("java.lang.StringUTF16");
-        Class<?> testclass = AMD64StringUTF16CompressNode.class;
-        TestMethods tms = new TestMethods("testCompress", javaclass, AMD64StringUTF16CompressNode.class, "compress",
+        Class<?> testclass = StringUTF16CompressNode.class;
+        TestMethods tms = new TestMethods("testCompress", javaclass, StringUTF16CompressNode.class, "compress",
                         char[].class, int.class, byte[].class, int.class, int.class);
         tms.testSubstitution(testclass);
 
@@ -216,7 +206,7 @@ public final class StringCompressInflateTest extends MethodSubstitutionTest {
 
         ResolvedJavaMethod caller = getResolvedJavaMethod(javaclass, "compress", byte[].class, int.class, byte[].class, int.class, int.class);
         StructuredGraph graph = getReplacements().getIntrinsicGraph(caller, CompilationIdentifier.INVALID_COMPILATION_ID, getDebugContext(), AllowAssumptions.YES, null);
-        assertInGraph(graph, AMD64StringUTF16CompressNode.class);
+        assertInGraph(graph, StringUTF16CompressNode.class);
 
         InstalledCode code = getCode(caller, graph);
 
@@ -252,7 +242,7 @@ public final class StringCompressInflateTest extends MethodSubstitutionTest {
 
         ResolvedJavaMethod caller = getResolvedJavaMethod(javaclass, "compress", char[].class, int.class, byte[].class, int.class, int.class);
         StructuredGraph graph = getReplacements().getIntrinsicGraph(caller, CompilationIdentifier.INVALID_COMPILATION_ID, getDebugContext(), AllowAssumptions.YES, null);
-        assertInGraph(graph, AMD64StringUTF16CompressNode.class);
+        assertInGraph(graph, StringUTF16CompressNode.class);
 
         InstalledCode code = getCode(caller, graph);
 

--- a/compiler/src/org.graalvm.compiler.replacements/src/org/graalvm/compiler/replacements/StringLatin1InflateNode.java
+++ b/compiler/src/org.graalvm.compiler.replacements/src/org/graalvm/compiler/replacements/StringLatin1InflateNode.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, Arm Limited. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,7 +23,7 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
-package org.graalvm.compiler.replacements.amd64;
+package org.graalvm.compiler.replacements;
 
 import static org.graalvm.compiler.nodeinfo.InputType.Memory;
 import static org.graalvm.compiler.nodeinfo.NodeCycles.CYCLES_UNKNOWN;
@@ -47,10 +48,10 @@ import org.graalvm.word.Pointer;
 import jdk.vm.ci.meta.JavaKind;
 
 @NodeInfo(allowedUsageTypes = Memory, size = SIZE_512, cycles = CYCLES_UNKNOWN, cyclesRationale = "depends on length")
-public final class AMD64StringLatin1InflateNode extends FixedWithNextNode
+public final class StringLatin1InflateNode extends FixedWithNextNode
                 implements LIRLowerable, MultiMemoryKill, MemoryAccess {
 
-    public static final NodeClass<AMD64StringLatin1InflateNode> TYPE = NodeClass.create(AMD64StringLatin1InflateNode.class);
+    public static final NodeClass<StringLatin1InflateNode> TYPE = NodeClass.create(StringLatin1InflateNode.class);
 
     @Input private ValueNode src;
     @Input private ValueNode dst;
@@ -66,7 +67,7 @@ public final class AMD64StringLatin1InflateNode extends FixedWithNextNode
     //
     // Represented as a graph node by:
 
-    public AMD64StringLatin1InflateNode(ValueNode src, ValueNode dst, ValueNode len, JavaKind writeKind) {
+    public StringLatin1InflateNode(ValueNode src, ValueNode dst, ValueNode len, JavaKind writeKind) {
         super(TYPE, StampFactory.forVoid());
         this.src = src;
         this.dst = dst;

--- a/compiler/src/org.graalvm.compiler.replacements/src/org/graalvm/compiler/replacements/StringUTF16CompressNode.java
+++ b/compiler/src/org.graalvm.compiler.replacements/src/org/graalvm/compiler/replacements/StringUTF16CompressNode.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, Arm Limited. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,7 +23,7 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
-package org.graalvm.compiler.replacements.amd64;
+package org.graalvm.compiler.replacements;
 
 import static org.graalvm.compiler.nodeinfo.InputType.Memory;
 import static org.graalvm.compiler.nodeinfo.NodeCycles.CYCLES_UNKNOWN;
@@ -48,10 +49,10 @@ import jdk.vm.ci.meta.JavaKind;
 import jdk.vm.ci.meta.Value;
 
 @NodeInfo(allowedUsageTypes = Memory, size = SIZE_512, cycles = CYCLES_UNKNOWN, cyclesRationale = "depends on length")
-public final class AMD64StringUTF16CompressNode extends FixedWithNextNode
+public final class StringUTF16CompressNode extends FixedWithNextNode
                 implements LIRLowerable, MultiMemoryKill, MemoryAccess {
 
-    public static final NodeClass<AMD64StringUTF16CompressNode> TYPE = NodeClass.create(AMD64StringUTF16CompressNode.class);
+    public static final NodeClass<StringUTF16CompressNode> TYPE = NodeClass.create(StringUTF16CompressNode.class);
 
     @Input private ValueNode src;
     @Input private ValueNode dst;
@@ -66,7 +67,7 @@ public final class AMD64StringUTF16CompressNode extends FixedWithNextNode
     //
     // Represented as a graph node by:
 
-    public AMD64StringUTF16CompressNode(ValueNode src, ValueNode dst, ValueNode len, JavaKind readKind) {
+    public StringUTF16CompressNode(ValueNode src, ValueNode dst, ValueNode len, JavaKind readKind) {
         super(TYPE, StampFactory.forInteger(32));
         this.src = src;
         this.dst = dst;

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/NativeImageGenerator.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/NativeImageGenerator.java
@@ -1200,11 +1200,11 @@ public class NativeImageGenerator {
         }
 
         final boolean arrayEqualsSubstitution = !SubstrateOptions.useLLVMBackend();
+        OptionValues options = aUniverse.hostVM().options();
         registerInvocationPlugins(providers.getSnippetReflection(), plugins.getInvocationPlugins(), replacements,
-                        reason == ParsingReason.JITCompilation, true, arrayEqualsSubstitution, providers.getLowerer());
+                        reason == ParsingReason.JITCompilation, true, arrayEqualsSubstitution, providers.getLowerer(), options);
 
         Architecture architecture = ConfigurationValues.getTarget().arch;
-        OptionValues options = aUniverse.hostVM().options();
         ImageSingletons.lookup(TargetGraphBuilderPlugins.class).register(plugins, replacements, architecture,
                         /* registerForeignCallMath */ false, options);
 


### PR DESCRIPTION

During microbenchmarking, the patch demonstrates speedup of about 4.5 while compressing and 2.4 while inflating
strings of 512 bytes on N1 systems.