### PR TITLE
Add new predicates for load0 method

### DIFF
--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/Load0With2Args.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/Load0With2Args.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2022, 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package com.oracle.svm.core.jdk;
+
+import java.util.Arrays;
+import java.util.function.BooleanSupplier;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+/**
+ * A predicate that returns {@code true} iff
+ * {@code boolean java.lang.ClassLoader.NativeLibrary.load0(String name, boolean isBuiltin)} exists.
+ * It should only be used in conjunction with {@link JDK11OrEarlier} as {@code NativeLibrary} was
+ * moved to a top level class in later JDKs.
+ */
+// Checkstyle: allow Class.getSimpleName
+public class Load0With2Args implements BooleanSupplier {
+    @Override
+    public boolean getAsBoolean() {
+        Optional<Class<?>> nativeLibrary = Stream.of(ClassLoader.class.getDeclaredClasses()).filter(c -> c.getSimpleName().equals("NativeLibrary")).findFirst();
+        if (nativeLibrary.isPresent()) {
+            Class<?>[] signature = {String.class, boolean.class};
+            return Stream.of(nativeLibrary.get().getDeclaredMethods()).filter(m -> m.getName().equals("load0") && Arrays.equals(m.getParameters(), signature)).findFirst().isPresent();
+        }
+        return false;
+    }
+}

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/Load0With3Args.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/Load0With3Args.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2022, 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package com.oracle.svm.core.jdk;
+
+import java.util.Arrays;
+import java.util.function.BooleanSupplier;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+/**
+ * A predicate that returns {@code true} iff
+ * {@code boolean java.lang.ClassLoader.NativeLibrary.load0(String name, boolean isBuiltin, boolean throwExceptionIfFail)}
+ * exists. It should only be used in conjunction with {@link JDK11OrEarlier} as
+ * {@code NativeLibrary} was moved to a top level class in later JDKs.
+ */
+// Checkstyle: allow Class.getSimpleName
+public class Load0With3Args implements BooleanSupplier {
+    @Override
+    public boolean getAsBoolean() {
+        Optional<Class<?>> nativeLibrary = Stream.of(ClassLoader.class.getDeclaredClasses()).filter(c -> c.getSimpleName().equals("NativeLibrary")).findFirst();
+        if (nativeLibrary.isPresent()) {
+            Class<?>[] signature = {String.class, boolean.class, boolean.class};
+            return Stream.of(nativeLibrary.get().getDeclaredMethods()).filter(m -> m.getName().equals("load0") && Arrays.equals(m.getParameters(), signature)).findFirst().isPresent();
+        }
+        return false;
+    }
+}

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/Target_java_lang_ClassLoader.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/Target_java_lang_ClassLoader.java
@@ -349,16 +349,20 @@ final class Target_java_lang_ClassLoader_NativeLibrary {
     private native void load(String name, boolean isBuiltin);
 
     @Delete
+    @TargetElement(onlyWith = Load0With2Args.class)
+    private native boolean load0(String name, boolean isBuiltin);
+
+    @Delete
+    @TargetElement(onlyWith = Load0With3Args.class)
+    private native boolean load0(String name, boolean isBuiltin, boolean throwExceptionIfFail);
+
+    @Delete
     @TargetElement(onlyWith = JDK8OrEarlier.class)
     private native long find(String name);
 
     @Delete
     @TargetElement(onlyWith = JDK8OrEarlier.class)
     private native void unload(String name, boolean isBuiltin);
-
-    @Delete
-    @TargetElement(onlyWith = JDK11OrLater.class)
-    private native boolean load0(String name, boolean isBuiltin);
 
     @Delete
     @TargetElement(onlyWith = JDK11OrLater.class)


### PR DESCRIPTION
https://bugs.openjdk.java.net/browse/JDK-8275703 has been backported
to OpenJDK 11.0.15 (included in 11.0.15+6 EA). It introduces a 3-arg
native method load0, which this backport fixes.

Backport https://github.com/oracle/graal/commit/7ba248aa70de25ec78c1a5b82373a499f326d9bc from master branch.

Closes #4396