### PR TITLE
Combine Windows debugger line number records.

### DIFF
--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/pecoff/cv/CVLineRecord.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/pecoff/cv/CVLineRecord.java
@@ -124,13 +124,19 @@ final class CVLineRecord extends CVSymbolRecord {
 
         private final ArrayList<LineEntry> lineEntries = new ArrayList<>(DEFAULT_LINE_ENTRY_COUNT);
         private final int fileId;
+        private int previousLine;
 
         FileBlock(int fileId) {
             this.fileId = fileId;
+            this.previousLine = -2;
         }
 
         void addEntry(LineEntry le) {
-            lineEntries.add(le);
+            /* Only add an entry if the line number has changed. */
+            if (le.lineAndFlags != previousLine) {
+                lineEntries.add(le);
+                previousLine = le.lineAndFlags;
+            }
         }
 
         int computeContents(byte[] buffer, int initialPos) {
@@ -167,7 +173,7 @@ final class CVLineRecord extends CVSymbolRecord {
         static final int LINE_ENTRY_SIZE = 2 * Integer.BYTES;
 
         int addr;
-        int lineAndFLags;
+        int lineAndFlags;
 
         LineEntry(int addr, int line, int deltaEnd, boolean isStatement) {
             this.addr = addr;
@@ -175,7 +181,7 @@ final class CVLineRecord extends CVSymbolRecord {
             assert line >= 0;
             assert deltaEnd <= 0x7f;
             assert deltaEnd >= 0;
-            lineAndFLags = line | (deltaEnd << 24) | (isStatement ? 0x80000000 : 0);
+            lineAndFlags = line | (deltaEnd << 24) | (isStatement ? 0x80000000 : 0);
         }
 
         LineEntry(int addr, int line) {
@@ -185,7 +191,7 @@ final class CVLineRecord extends CVSymbolRecord {
         int computeContents(byte[] buffer, int initialPos) {
             int pos = initialPos;
             pos = CVUtil.putInt(addr, buffer, pos);
-            pos = CVUtil.putInt(lineAndFLags, buffer, pos);
+            pos = CVUtil.putInt(lineAndFlags, buffer, pos);
             return pos;
         }
     }

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/pecoff/cv/CVLineRecord.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/pecoff/cv/CVLineRecord.java
@@ -122,16 +122,20 @@ final class CVLineRecord extends CVSymbolRecord {
         /* Fileblock header: fileId (4 bytes) lineEntry count (4 bytes) tablesize (4 bytes) */
         static final int FILE_BLOCK_HEADER_SIZE = Integer.BYTES * 3;
 
+        /* Initial value (that can never occur) for previousLine when there is no previous line. */
+        static final int NO_PREVIOUS_LINE = -2;
+
         private final ArrayList<LineEntry> lineEntries = new ArrayList<>(DEFAULT_LINE_ENTRY_COUNT);
         private final int fileId;
         private int previousLine;
 
         FileBlock(int fileId) {
             this.fileId = fileId;
-            this.previousLine = -2;
+            this.previousLine = NO_PREVIOUS_LINE;
         }
 
         void addEntry(LineEntry le) {
+            assert le.lineAndFlags != NO_PREVIOUS_LINE;
             /* Only add an entry if the line number has changed. */
             if (le.lineAndFlags != previousLine) {
                 lineEntries.add(le);

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/pecoff/cv/CVLineRecordBuilder.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/pecoff/cv/CVLineRecordBuilder.java
@@ -101,10 +101,9 @@ public class CVLineRecordBuilder {
         }
 
         /* Add line record. */
-        /* An optimization would be to merge adjacent line records. */
         int lineLoAddr = range.getLo() - primaryEntry.getPrimary().getLo();
         int line = Math.max(range.getLine(), 1);
-        debug("  processRange:   addNewLine: 0x%05x-0x%05x %s", lineLoAddr, range.getLo() - primaryEntry.getPrimary().getHi(), line);
+        debug("  processRange:   addNewLine: 0x%05x-0x%05x %s", lineLoAddr, range.getHi() - primaryEntry.getPrimary().getLo(), line);
         lineRecord.addNewLine(lineLoAddr, line);
     }
 }

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/pecoff/cv/CVLineRecordBuilder.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/pecoff/cv/CVLineRecordBuilder.java
@@ -61,15 +61,15 @@ public class CVLineRecordBuilder {
         this.primaryEntry = entry;
         Range primaryRange = primaryEntry.getPrimary();
 
-        debug("DEBUG_S_LINES linerecord for 0x%05x file: %s:%d\n", primaryRange.getLo(), primaryRange.getFileName(), primaryRange.getLine());
+        debug("DEBUG_S_LINES linerecord for 0x%05x file: %s:%d", primaryRange.getLo(), primaryRange.getFileName(), primaryRange.getLine());
         this.lineRecord = new CVLineRecord(cvDebugInfo, primaryRange.getSymbolName());
-        debug("CVLineRecord.computeContents: processing primary range %s\n", primaryRange);
+        debug("CVLineRecord.computeContents: processing primary range %s", primaryRange);
 
         processRange(primaryRange);
         Iterator<Range> iterator = primaryEntry.leafRangeIterator();
         while (iterator.hasNext()) {
             Range subRange = iterator.next();
-            debug("CVLineRecord.computeContents: processing range %s\n", subRange);
+            debug("CVLineRecord.computeContents: processing range %s", subRange);
             processRange(subRange);
         }
         return lineRecord;
@@ -85,18 +85,18 @@ public class CVLineRecordBuilder {
 
         FileEntry file = range.getFileEntry();
         if (file == null) {
-            debug("processRange: range has no file: %s\n", range);
+            debug("  processRange: range has no file: %s", range);
             return;
         }
 
-        if (range.getLine() == -1) {
-            debug("processRange: ignoring: bad line number\n");
+        if (range.getLine() < 0) {
+            debug("  processRange: ignoring: bad line number: %d", range.getLine());
             return;
         }
 
         int fileId = cvDebugInfo.getCVSymbolSection().getFileTableRecord().addFile(file);
         if (lineRecord.isEmpty() || lineRecord.getCurrentFileId() != fileId) {
-            debug("processRange: addNewFile: %s\n", file);
+            debug("  processRange: addNewFile: %s", file);
             lineRecord.addNewFile(fileId);
         }
 
@@ -104,7 +104,7 @@ public class CVLineRecordBuilder {
         /* An optimization would be to merge adjacent line records. */
         int lineLoAddr = range.getLo() - primaryEntry.getPrimary().getLo();
         int line = Math.max(range.getLine(), 1);
-        debug("processRange:   addNewLine: 0x%05x %s\n", lineLoAddr, line);
+        debug("  processRange:   addNewLine: 0x%05x-0x%05x %s", lineLoAddr, range.getLo() - primaryEntry.getPrimary().getHi(), line);
         lineRecord.addNewLine(lineLoAddr, line);
     }
 }


### PR DESCRIPTION
Currently when emitting CodeView debugger records, Graal emits several (binary address, source line) records per line.  While this works, the user experience is less than ideal; single-stepping may appear to stay on the same line, for example, and setting a breakpoint may actually set multiple breakpoints.

This patch will not emit a new line record if the source line is the same as the previous source line.
Besides improving the user experience, there is a 1% reduction in object file size.

This patch also modifies some debug() statements to improve readability.