### PR TITLE
Convert Java byte array to CCharPointerHolder

### DIFF
--- a/sdk/src/org.graalvm.nativeimage/snapshot.sigtest
+++ b/sdk/src/org.graalvm.nativeimage/snapshot.sigtest
@@ -823,6 +823,7 @@ meth public static org.graalvm.nativeimage.c.type.CTypeConversion$CCharPointerHo
 meth public static org.graalvm.nativeimage.c.type.CTypeConversion$CCharPointerPointerHolder toCStrings(java.lang.CharSequence[])
 meth public static org.graalvm.word.UnsignedWord toCString(java.lang.CharSequence,java.nio.charset.Charset,org.graalvm.nativeimage.c.type.CCharPointer,org.graalvm.word.UnsignedWord)
 meth public static org.graalvm.word.UnsignedWord toCString(java.lang.CharSequence,org.graalvm.nativeimage.c.type.CCharPointer,org.graalvm.word.UnsignedWord)
+meth public static org.graalvm.nativeimage.c.type.CTypeConversion$CCharPointerHolder toCBytes(byte[])
 supr java.lang.Object
 
 CLSS public abstract interface static org.graalvm.nativeimage.c.type.CTypeConversion$CCharPointerHolder

--- a/sdk/src/org.graalvm.nativeimage/src/org/graalvm/nativeimage/c/type/CTypeConversion.java
+++ b/sdk/src/org.graalvm.nativeimage/src/org/graalvm/nativeimage/c/type/CTypeConversion.java
@@ -275,4 +275,11 @@ public final class CTypeConversion {
     public static ByteBuffer asByteBuffer(PointerBase address, int size) {
         return ImageSingletons.lookup(CTypeConversionSupport.class).asByteBuffer(address, size);
     }
+
+    /**
+     * Provides access to a C pointer for the provided Java byte array.
+     */
+    public static CCharPointerHolder toCBytes(byte[] bytes) {
+        return ImageSingletons.lookup(CTypeConversionSupport.class).toCBytes(bytes);
+    }
 }

--- a/sdk/src/org.graalvm.nativeimage/src/org/graalvm/nativeimage/impl/CTypeConversionSupport.java
+++ b/sdk/src/org.graalvm.nativeimage/src/org/graalvm/nativeimage/impl/CTypeConversionSupport.java
@@ -62,5 +62,7 @@ public interface CTypeConversionSupport {
 
     String toJavaString(CCharPointer cString, UnsignedWord length, Charset charset);
 
+    CCharPointerHolder toCBytes(byte[] bytes);
+
     ByteBuffer asByteBuffer(PointerBase address, int size);
 }

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/c/CTypeConversionSupportImpl.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/c/CTypeConversionSupportImpl.java
@@ -136,6 +136,14 @@ class CTypeConversionSupportImpl implements CTypeConversionSupport {
     }
 
     @Override
+    public CCharPointerHolder toCBytes(byte[] bytes) {
+        if (bytes == null) {
+            return NULL_HOLDER;
+        }
+        return new CCharPointerHolderImpl(bytes);
+    }
+
+    @Override
     public ByteBuffer asByteBuffer(PointerBase address, int size) {
         ByteBuffer byteBuffer = SubstrateUtil.cast(new Target_java_nio_DirectByteBuffer(address.rawValue(), size), ByteBuffer.class);
         return byteBuffer.order(ConfigurationValues.getTarget().arch.getByteOrder());
@@ -150,6 +158,10 @@ final class CCharPointerHolderImpl implements CCharPointerHolder {
         byte[] bytes = javaString.toString().getBytes();
         /* Append the terminating 0. */
         bytes = Arrays.copyOf(bytes, bytes.length + 1);
+        cstring = PinnedObject.create(bytes);
+    }
+
+    CCharPointerHolderImpl(byte[] bytes) {
         cstring = PinnedObject.create(bytes);
     }
 


### PR DESCRIPTION
The class `org.graalvm.nativeimage.c.type.CTypeConversion` has provided some convenient methods to convert types between Java and C, but there is no method to transfer a Java byte array to C. This requirement seems duplicated with the existing `toCString` methods, but not all byte arrays are from String. A `toCBytes` method would be more general.
Therefore, this PR proposes to add a new `toCBytes` in `CTypeConversion` class.