### PR TITLE
[GR-38821] Add Java version to new build output.

### DIFF
--- a/docs/reference-manual/native-image/BuildOutput.md
+++ b/docs/reference-manual/native-image/BuildOutput.md
@@ -72,6 +72,10 @@ The version info of the Native Image process.
 This string is also used for the `java.vm.version` property within the generated image.
 Please report this version info when you [file issues][new_issue].
 
+#### <a name="glossary-java-version-info"></a>Java Version Info
+The precise base Java version info of the Native Image process.
+Please report this version info when you [file issues][new_issue].
+
 #### <a name="glossary-ccompiler"></a>C Compiler
 The C compiler executable, vendor, target architecture, and version info used by the Native Image build process.
 

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/ProgressReporter.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/ProgressReporter.java
@@ -240,6 +240,10 @@ public class ProgressReporter {
     public void printInitializeEnd(Collection<String> libraries) {
         stagePrinter.end(getTimer(TimerCollection.Registry.CLASSLIST).getTotalTime() + getTimer(TimerCollection.Registry.SETUP).getTotalTime());
         l().a(" ").doclink("Version info", "#glossary-version-info").a(": '").a(ImageSingletons.lookup(VM.class).version).a("'").println();
+        String javaVersion = System.getProperty("java.runtime.version");
+        if (javaVersion != null) {
+            l().a(" ").doclink("Java version info", "#glossary-java-version-info").a(": '").a(javaVersion).a("'").println();
+        }
         if (ImageSingletons.contains(CCompilerInvoker.class)) {
             l().a(" ").doclink("C compiler", "#glossary-ccompiler").a(": ").a(ImageSingletons.lookup(CCompilerInvoker.class).compilerInfo.getShortDescription()).println();
         }


### PR DESCRIPTION
This simple patch adds the precise Java version to the build output. Example:

```
[1/7] Initializing...                                                                                    (3.1s @ 0.15GB)
 Version info: 'GraalVM 22.2.0-dev CE Java 17'
 Java version info: '17.0.2+8'
 C compiler: gcc (redhat, x86_64, 11.2.1)
 Garbage collector: Serial GC
```

This would make the version info available via the build output (and which is also available by invoking `native-image --version`). Right now the precise Java version used is not clear from the output. Thoughts?

Example from `native-image --version` which does show the OpenJDK security update and build version, not just the major version:
```
GraalVM 22.0.0.2 Java 17 CE (Java Version 17.0.2+8-jvmci-22.0-b05)
```