### PR TITLE
Add option to disable features

### DIFF
--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/NativeImageGenerator.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/NativeImageGenerator.java
@@ -555,7 +555,7 @@ public class NativeImageGenerator {
         try (DebugContext debug = new Builder(options, new GraalDebugHandlersFactory(originalSnippetReflection)).build();
                         DebugCloseable featureCleanup = () -> featureHandler.forEachFeature(Feature::cleanup)) {
             setupNativeImage(imageName, options, entryPoints, javaMainSupport, harnessSubstitutions, analysisExecutor, originalSnippetReflection, debug);
-            reporter.printFeatures(featureHandler.getUserSpecificFeatures());
+            reporter.printFeatures(featureHandler.getUserSpecificFeatures(), featureHandler.getDisabledFeatureInstances());
 
             boolean returnAfterAnalysis = runPointsToAnalysis(imageName, options, debug);
             if (returnAfterAnalysis) {

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/ProgressReporter.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/ProgressReporter.java
@@ -267,10 +267,15 @@ public class ProgressReporter {
         }
     }
 
-    public void printFeatures(List<Feature> features) {
+    public void printFeatures(List<Feature> enabledFeatures, List<Feature> disabledFeatures) {
+        printFeatures(enabledFeatures, "user-specific feature(s)");
+        printFeatures(disabledFeatures, "user-disabled feature(s)");
+    }
+
+    private void printFeatures(List<Feature> features, String hintMsg) {
         int numFeatures = features.size();
         if (numFeatures > 0) {
-            l().a(" ").a(numFeatures).a(" ").doclink("user-specific feature(s)", "#glossary-user-specific-features").println();
+            l().a(" ").a(numFeatures).a(" ").doclink(hintMsg, "#glossary-user-specific-features").println();
             features.sort((a, b) -> a.getClass().getName().compareTo(b.getClass().getName()));
             for (Feature feature : features) {
                 printFeature(l(), feature);


### PR DESCRIPTION
Add `-H:DisableFeatures` option to disable the specified features. If a feature is specified in both `-H:Features` and `-H:DisableFeatures`, it still gets disabled.
This option is useful for extending GraalVM. When extending Substrate VM with new features, there are cases that some features defined in the substratevm sources become incompatible and need to be disabled.