### PR TITLE
CI: Fix GH invalid workflow error "A sequence was not expected"

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,9 @@ on:
       - '.travis.yml'
       - '.github/workflows/quarkus.yml'
       - '**.md'
-  workflow_dispatch: []
+  # Enable manual dispatch of the workflow
+  # see https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow
+  workflow_dispatch:
 
 # The following aims to reduce CI CPU cycles by:
 # 1. Cancelling any previous builds of this PR when pushing new changes to it


### PR DESCRIPTION
Fixes GH workflow which now fails with:

```
Invalid workflow file: .github/workflows/main.yml#L16
The workflow is not valid. .github/workflows/main.yml (Line: 16, Col: 22): A sequence was not expected
```

Source: https://github.com/oracle/graal/actions/runs/2244856633