### PR TITLE
[GR-38665] Avoid compile failures on AArch64 when full infopoints enabled

### DIFF
--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/CalleeSavedRegisters.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/CalleeSavedRegisters.java
@@ -100,6 +100,10 @@ public class CalleeSavedRegisters {
         VMError.guarantee(saveAreaOffsetInFrame == checkedSaveAreaOffsetInFrame, "Must have a single value for the callee save register area");
     }
 
+    public boolean calleeSaveable(Register register) {
+        return offsetsInSaveArea.get(register) != null;
+    }
+
     public int getSaveAreaSize() {
         return saveAreaSize;
     }

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/heap/SubstrateReferenceMapBuilder.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/heap/SubstrateReferenceMapBuilder.java
@@ -61,7 +61,7 @@ public class SubstrateReferenceMapBuilder extends ReferenceMapBuilder {
         } else if (ValueUtil.isRegister(value)) {
             Register register = ValueUtil.asRegister(value);
             assert referenceMap.debugMarkRegister(ValueUtil.asRegister(value).number, value);
-            if (CalleeSavedRegisters.supportedByPlatform()) {
+            if (CalleeSavedRegisters.supportedByPlatform() && CalleeSavedRegisters.singleton().calleeSaveable(register)) {
                 offset = CalleeSavedRegisters.singleton().getOffsetInFrame(register);
                 offsetValid = true;
             }


### PR DESCRIPTION
This patch fixes the problem reported in issue #4542.