### PR TITLE
[GR-38762] Correct AArch64 debug info location generation and update tests to ha…

### DIFF
--- a/substratevm/mx.substratevm/mx_substratevm.py
+++ b/substratevm/mx.substratevm/mx_substratevm.py
@@ -838,6 +838,8 @@ def _debuginfotest(native_image, path, build_only, args):
 
     build_debug_test(['-H:+SpawnIsolates'])
     if mx.get_os() == 'linux' and not build_only:
+        os.environ.update({'debuginfotest_arch' : mx.get_arch()})
+    if mx.get_os() == 'linux' and not build_only:
         os.environ.update({'debuginfotest_isolates' : 'yes'})
         mx.run([os.environ.get('GDB_BIN', 'gdb'), '-ex', 'python "ISOLATES=True"', '-x', join(parent, 'mx.substratevm/testhello.py'), join(path, 'hello.hello')])
 

--- a/substratevm/mx.substratevm/testhello.py
+++ b/substratevm/mx.substratevm/testhello.py
@@ -159,6 +159,8 @@ def test():
     if os.environ.get('debuginfotest_isolates', 'no') == 'yes':
         isolates = True
         
+    arch = os.environ.get('debuginfotest_arch', 'amd64')
+        
     if isolates:
         print("Testing with isolates enabled!")
     else:
@@ -676,10 +678,28 @@ def test():
     checker = Checker('backtrace in recursive inlineTo', rexp)
     checker.check(exec_string, skip_fails=False)
 
-    exec_string = execute("break hello.Hello::noInlineManyArgs")
+    # on aarch64 the initial break occurs at the stack push
+    # but we need to check the args before and after the stack push
+    # so we need to use the examine command to identify the start
+    # address of the method and place an instruction break at that
+    # address to ensure we hit the very first instruction
+    exec_string = execute("x/i 'hello.Hello'::noInlineManyArgs")
+    rexp = r"%s0x(%s)%shello.Hello::noInlineManyArgs%s"%(spaces_pattern, hex_digits_pattern, wildcard_pattern, wildcard_pattern)
+    checker = Checker('x/i hello.Hello::noInlineManyArgs', rexp)
+    matches = checker.check(exec_string)
+    # n.b can ony get here with one match
+    match = matches[0]
+    bp_address = int(match.group(1), 16)
+    print("bp = %s %x"%(match.group(1), bp_address))
+
+    # exec_string = execute("break hello.Hello::noInlineManyArgs")
+    exec_string = execute("break *0x%x"%bp_address)
     rexp = r"Breakpoint %s at %s: file hello/Hello\.java, line 188\."%(digits_pattern, address_pattern)
-    checker = Checker('break hello.Hello::noInlineManyArgs', rexp)
+    checker = Checker(r"break *0x%x"%bp_address, rexp)
     checker.check(exec_string)
+    #rexp = r"Breakpoint %s at %s: file hello/Hello\.java, line 188\."%(digits_pattern, address_pattern)
+    #checker = Checker('break hello.Hello::noInlineManyArgs', rexp)
+    #checker.check(exec_string)
 
     execute("continue")
     exec_string = execute("info args")
@@ -709,12 +729,28 @@ def test():
     checker.check(exec_string)
     
     exec_string = execute("x/i $pc")
-    rexp = r"=> 0x542100 <hello.Hello::noInlineManyArgs(int, int, int, int, boolean int, int, long, int, long, float, float, float, float, double, float, float, float, float, double, boolean, float)>:	sub    $0x68,%rsp"
-    rexp = r".*sub %s\$0x%s,%%rsp"%(spaces_pattern, hex_digits_pattern)
+    if arch == 'aarch64':
+        rexp = r"%ssub%ssp, sp, #0x%s"%(wildcard_pattern, spaces_pattern, hex_digits_pattern)
+    else:
+        rexp = r"%ssub %s\$0x%s,%%rsp"%(wildcard_pattern, spaces_pattern, hex_digits_pattern)
     checker = Checker('x/i $pc', rexp)
     checker.check(exec_string)
 
-    execute("stepi")
+    if arch == 'aarch64':
+        exec_string = execute("stepi")
+        print(exec_string)
+        # n.b. stack param offsets will be wrong here because
+        # aarch64 creates the frame in two steps, a sub of
+        # the frame size followed by a stack push of [lr,sp]
+        # (needs fixing in the initial frame location info split
+        # in the generator not here)
+        exec_string = execute("x/i $pc")
+        print(exec_string)
+        exec_string = execute("stepi")
+        print(exec_string)
+    else:
+        exec_string = execute("stepi")
+
     exec_string = execute("info args")
     rexp =[r"i0 = 0",
            r"i1 = 1",

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/MethodEntry.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/MethodEntry.java
@@ -26,15 +26,16 @@
 
 package com.oracle.objectfile.debugentry;
 
-import jdk.vm.ci.meta.JavaKind;
+import java.util.ArrayList;
+import java.util.ListIterator;
+
 import com.oracle.objectfile.debuginfo.DebugInfoProvider.DebugCodeInfo;
 import com.oracle.objectfile.debuginfo.DebugInfoProvider.DebugLocalInfo;
 import com.oracle.objectfile.debuginfo.DebugInfoProvider.DebugLocalValueInfo;
 import com.oracle.objectfile.debuginfo.DebugInfoProvider.DebugLocationInfo;
 import com.oracle.objectfile.debuginfo.DebugInfoProvider.DebugMethodInfo;
 
-import java.util.ArrayList;
-import java.util.ListIterator;
+import jdk.vm.ci.meta.JavaKind;
 
 public class MethodEntry extends MemberEntry {
     private final TypeEntry[] paramTypes;

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfInfoSectionImpl.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfInfoSectionImpl.java
@@ -1412,6 +1412,7 @@ public class DwarfInfoSectionImpl extends DwarfSectionImpl {
         if (abbrevCode == DwarfDebugInfo.DW_ABBREV_CODE_method_local_location2 ||
                         abbrevCode == DwarfDebugInfo.DW_ABBREV_CODE_method_parameter_location2) {
             int locRefAddr = getRangeLocalIndex(range, localInfo);
+            log(context, "  [0x%08x]     loc list  0x%x", pos, locRefAddr);
             pos = writeAttrLocList(locRefAddr, buffer, pos);
         }
         return pos;

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfLocSectionImpl.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfLocSectionImpl.java
@@ -571,7 +571,7 @@ public class DwarfLocSectionImpl extends DwarfSectionImpl {
         ZR(31, AArch64.zr.number),
         SP(31, AArch64.sp.number),
         V0(64, AArch64.v0.number),
-        V1(65, AArch64.r1.number),
+        V1(65, AArch64.v1.number),
         V2(66, AArch64.v2.number),
         V3(67, AArch64.v3.number),
         V4(68, AArch64.v4.number),


### PR DESCRIPTION
This patch corrects a few small errors in AArch64 debug info generation and also updates the debuginfo test to be aware of architecture specific differences and run the test accordingly.

The generator fixes include correcting a type where v1 was specified instead of r1 and adjusting the stack offsets for stack passed parameters to make allowances for how the pushed return address is included in the offset and the frame size.

The test fixes ensure that stack passed parameter locations are checked at the method's first instruction and at the point where the stack adjustment completes. This requires different case handling for AMD64 vs AArch64 because

1. gdb places a method break at the first instruction on AMD64 but at stack push completion on AArch64
2. the stack adjustment takes only one instruction step on AMD64 and takes two instruction steps on AArch64

The current patch leaves an issue outstanding on AArch64. Stack offsets for stack passed parameters are temporarily incorrect (out by two words) between the first and second of the two stack adjustment instructions. That will need to be addressed by a follow-up patch.

This PR fixes issue #4582