### PR TITLE
[GR-39018] Debug id cleanup

### DIFF
--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/ArrayTypeEntry.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/ArrayTypeEntry.java
@@ -29,6 +29,7 @@ package com.oracle.objectfile.debugentry;
 import com.oracle.objectfile.debuginfo.DebugInfoProvider.DebugArrayTypeInfo;
 import com.oracle.objectfile.debuginfo.DebugInfoProvider.DebugTypeInfo;
 import com.oracle.objectfile.debuginfo.DebugInfoProvider.DebugTypeInfo.DebugTypeKind;
+import jdk.vm.ci.meta.ResolvedJavaType;
 import org.graalvm.compiler.debug.DebugContext;
 
 public class ArrayTypeEntry extends StructureTypeEntry {
@@ -48,13 +49,13 @@ public class ArrayTypeEntry extends StructureTypeEntry {
     @Override
     public void addDebugInfo(DebugInfoBase debugInfoBase, DebugTypeInfo debugTypeInfo, DebugContext debugContext) {
         DebugArrayTypeInfo debugArrayTypeInfo = (DebugArrayTypeInfo) debugTypeInfo;
-        String elementTypeName = TypeEntry.canonicalize(debugArrayTypeInfo.elementType());
-        this.elementType = debugInfoBase.lookupTypeEntry(elementTypeName);
+        ResolvedJavaType eltType = debugArrayTypeInfo.elementType();
+        this.elementType = debugInfoBase.lookupTypeEntry(eltType);
         this.baseSize = debugArrayTypeInfo.baseSize();
         this.lengthOffset = debugArrayTypeInfo.lengthOffset();
         /* Add details of fields and field types */
         debugArrayTypeInfo.fieldInfoProvider().forEach(debugFieldInfo -> this.processField(debugFieldInfo, debugInfoBase, debugContext));
-        debugContext.log("typename %s element type %s base size %d length offset %d\n", typeName, elementTypeName, baseSize, lengthOffset);
+        debugContext.log("typename %s element type %s base size %d length offset %d\n", typeName, this.elementType.getTypeName(), baseSize, lengthOffset);
     }
 
     public TypeEntry getElementType() {

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/ClassEntry.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/ClassEntry.java
@@ -130,13 +130,13 @@ public class ClassEntry extends StructureTypeEntry {
 
     @Override
     public void addDebugInfo(DebugInfoBase debugInfoBase, DebugTypeInfo debugTypeInfo, DebugContext debugContext) {
-        assert TypeEntry.canonicalize(debugTypeInfo.typeName()).equals(typeName);
+        assert debugTypeInfo.typeName().equals(typeName);
         DebugInstanceTypeInfo debugInstanceTypeInfo = (DebugInstanceTypeInfo) debugTypeInfo;
         /* Add details of super and interface classes */
         ResolvedJavaType superType = debugInstanceTypeInfo.superClass();
         String superName;
         if (superType != null) {
-            superName = TypeEntry.canonicalize(superType.toJavaName());
+            superName = superType.toJavaName();
         } else {
             superName = "";
         }
@@ -291,7 +291,7 @@ public class ClassEntry extends StructureTypeEntry {
     protected MethodEntry processMethod(DebugMethodInfo debugMethodInfo, DebugInfoBase debugInfoBase, DebugContext debugContext) {
         String methodName = debugMethodInfo.name();
         ResolvedJavaType resultType = debugMethodInfo.valueType();
-        String resultTypeName = TypeEntry.canonicalize(resultType.toJavaName());
+        String resultTypeName = resultType.toJavaName();
         int modifiers = debugMethodInfo.modifiers();
         DebugLocalInfo[] paramInfos = debugMethodInfo.getParamInfo();
         DebugLocalInfo thisParam = debugMethodInfo.getThisParamInfo();

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/DebugInfoBase.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/DebugInfoBase.java
@@ -231,7 +231,7 @@ public abstract class DebugInfoBase {
         /* Create all the types. */
         debugInfoProvider.typeInfoProvider().forEach(debugTypeInfo -> debugTypeInfo.debugContext((debugContext) -> {
             ResolvedJavaType idType = debugTypeInfo.idType();
-            String typeName = TypeEntry.canonicalize(debugTypeInfo.typeName());
+            String typeName = debugTypeInfo.typeName();
             typeName = stringTable.uniqueDebugString(typeName);
             DebugTypeKind typeKind = debugTypeInfo.typeKind();
             int byteSize = debugTypeInfo.size();
@@ -246,7 +246,7 @@ public abstract class DebugInfoBase {
         /* Now we can cross reference static and instance field details. */
         debugInfoProvider.typeInfoProvider().forEach(debugTypeInfo -> debugTypeInfo.debugContext((debugContext) -> {
             ResolvedJavaType idType = debugTypeInfo.idType();
-            String typeName = TypeEntry.canonicalize(debugTypeInfo.typeName());
+            String typeName = debugTypeInfo.typeName();
             DebugTypeKind typeKind = debugTypeInfo.typeKind();
 
             debugContext.log(DebugContext.INFO_LEVEL, "Process %s type %s ", typeKind.toString(), typeName);
@@ -348,7 +348,7 @@ public abstract class DebugInfoBase {
     public TypeEntry lookupTypeEntry(ResolvedJavaType type) {
         TypeEntry typeEntry = typesIndex.get(type);
         if (typeEntry == null) {
-            throw new RuntimeException("type entry not found " + TypeEntry.canonicalize(type.getName()));
+            throw new RuntimeException("type entry not found " + type.getName());
         }
         return typeEntry;
     }
@@ -356,7 +356,7 @@ public abstract class DebugInfoBase {
     ClassEntry lookupClassEntry(ResolvedJavaType type) {
         TypeEntry typeEntry = typesIndex.get(type);
         if (typeEntry == null || !(typeEntry.isClass())) {
-            throw new RuntimeException("class entry not found " + TypeEntry.canonicalize(type.getName()));
+            throw new RuntimeException("class entry not found " + type.getName());
         }
         return (ClassEntry) typeEntry;
     }
@@ -386,7 +386,7 @@ public abstract class DebugInfoBase {
         DebugLocationInfo callerLocationInfo = locationInfo.getCaller();
         boolean isTopLevel = callerLocationInfo == null;
         assert (!isTopLevel || (locationInfo.name().equals(primaryRange.getMethodName()) &&
-                        TypeEntry.canonicalize(locationInfo.ownerType().toJavaName()).equals(primaryRange.getClassName())));
+                        locationInfo.ownerType().toJavaName().equals(primaryRange.getClassName())));
         Range caller = (isTopLevel ? primaryRange : subRangeIndex.get(callerLocationInfo));
         // the frame tree is walked topdown so inline ranges should always have a caller range
         assert caller != null;
@@ -428,7 +428,7 @@ public abstract class DebugInfoBase {
             primaryClasses.add(classEntry);
             primaryClassesIndex.put(type, classEntry);
         }
-        assert (classEntry.getTypeName().equals(TypeEntry.canonicalize(type.toJavaName())));
+        assert (classEntry.getTypeName().equals(type.toJavaName()));
         return classEntry;
     }
 

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/EnumClassEntry.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/EnumClassEntry.java
@@ -26,7 +26,7 @@
 
 package com.oracle.objectfile.debugentry;
 
-import com.oracle.objectfile.debuginfo.DebugInfoProvider;
+import com.oracle.objectfile.debuginfo.DebugInfoProvider.DebugTypeInfo;
 import com.oracle.objectfile.debuginfo.DebugInfoProvider.DebugEnumTypeInfo;
 import com.oracle.objectfile.debuginfo.DebugInfoProvider.DebugTypeInfo.DebugTypeKind;
 import org.graalvm.compiler.debug.DebugContext;
@@ -42,7 +42,7 @@ public class EnumClassEntry extends ClassEntry {
     }
 
     @Override
-    public void addDebugInfo(DebugInfoBase debugInfoBase, DebugInfoProvider.DebugTypeInfo debugTypeInfo, DebugContext debugContext) {
+    public void addDebugInfo(DebugInfoBase debugInfoBase, DebugTypeInfo debugTypeInfo, DebugContext debugContext) {
         assert debugTypeInfo instanceof DebugEnumTypeInfo;
         super.addDebugInfo(debugInfoBase, debugTypeInfo, debugContext);
     }

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/HeaderTypeEntry.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/HeaderTypeEntry.java
@@ -45,7 +45,7 @@ public class HeaderTypeEntry extends StructureTypeEntry {
 
     @Override
     public void addDebugInfo(DebugInfoBase debugInfoBase, DebugTypeInfo debugTypeInfo, DebugContext debugContext) {
-        assert TypeEntry.canonicalize(debugTypeInfo.typeName()).equals(typeName);
+        assert debugTypeInfo.typeName().equals(typeName);
         DebugHeaderTypeInfo debugHeaderTypeInfo = (DebugHeaderTypeInfo) debugTypeInfo;
         debugHeaderTypeInfo.fieldInfoProvider().forEach(debugFieldInfo -> this.processField(debugFieldInfo, debugInfoBase, debugContext));
     }

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/MethodEntry.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/MethodEntry.java
@@ -36,6 +36,7 @@ import com.oracle.objectfile.debuginfo.DebugInfoProvider.DebugLocationInfo;
 import com.oracle.objectfile.debuginfo.DebugInfoProvider.DebugMethodInfo;
 
 import jdk.vm.ci.meta.JavaKind;
+import jdk.vm.ci.meta.ResolvedJavaType;
 
 public class MethodEntry extends MemberEntry {
     private final TypeEntry[] paramTypes;
@@ -283,6 +284,11 @@ public class MethodEntry extends MemberEntry {
         DebugLocalInfoWrapper(DebugLocalValueInfo value) {
             this.value = value;
             this.line = value.line();
+        }
+
+        @Override
+        public ResolvedJavaType valueType() {
+            return value.valueType();
         }
 
         @Override

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/StructureTypeEntry.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/StructureTypeEntry.java
@@ -27,6 +27,7 @@
 package com.oracle.objectfile.debugentry;
 
 import com.oracle.objectfile.debuginfo.DebugInfoProvider.DebugFieldInfo;
+import jdk.vm.ci.meta.ResolvedJavaType;
 import org.graalvm.compiler.debug.DebugContext;
 
 import java.lang.reflect.Modifier;
@@ -60,19 +61,20 @@ public abstract class StructureTypeEntry extends TypeEntry {
 
     protected FieldEntry addField(DebugFieldInfo debugFieldInfo, DebugInfoBase debugInfoBase, DebugContext debugContext) {
         String fieldName = debugInfoBase.uniqueDebugString(debugFieldInfo.name());
-        String valueTypeName = TypeEntry.canonicalize(debugFieldInfo.valueType());
+        ResolvedJavaType valueType = debugFieldInfo.valueType();
+        String valueTypeName = TypeEntry.canonicalize(valueType.toJavaName());
         int fieldSize = debugFieldInfo.size();
         int fieldoffset = debugFieldInfo.offset();
         int fieldModifiers = debugFieldInfo.modifiers();
         debugContext.log("typename %s adding %s field %s type %s size %s at offset 0x%x\n",
                         typeName, memberModifiers(fieldModifiers), fieldName, valueTypeName, fieldSize, fieldoffset);
-        TypeEntry valueType = debugInfoBase.lookupTypeEntry(valueTypeName);
+        TypeEntry valueTypeEntry = debugInfoBase.lookupTypeEntry(valueType);
         /*
          * n.b. the field file may differ from the owning class file when the field is a
          * substitution
          */
         FileEntry fileEntry = debugInfoBase.ensureFileEntry(debugFieldInfo);
-        FieldEntry fieldEntry = new FieldEntry(fileEntry, fieldName, this, valueType, fieldSize, fieldoffset, fieldModifiers);
+        FieldEntry fieldEntry = new FieldEntry(fileEntry, fieldName, this, valueTypeEntry, fieldSize, fieldoffset, fieldModifiers);
         fields.add(fieldEntry);
         return fieldEntry;
     }

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/StructureTypeEntry.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/StructureTypeEntry.java
@@ -62,7 +62,7 @@ public abstract class StructureTypeEntry extends TypeEntry {
     protected FieldEntry addField(DebugFieldInfo debugFieldInfo, DebugInfoBase debugInfoBase, DebugContext debugContext) {
         String fieldName = debugInfoBase.uniqueDebugString(debugFieldInfo.name());
         ResolvedJavaType valueType = debugFieldInfo.valueType();
-        String valueTypeName = TypeEntry.canonicalize(valueType.toJavaName());
+        String valueTypeName = valueType.toJavaName();
         int fieldSize = debugFieldInfo.size();
         int fieldoffset = debugFieldInfo.offset();
         int fieldModifiers = debugFieldInfo.modifiers();

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/TypeEntry.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/TypeEntry.java
@@ -96,8 +96,4 @@ public abstract class TypeEntry {
     }
 
     public abstract void addDebugInfo(DebugInfoBase debugInfoBase, DebugTypeInfo debugTypeInfo, DebugContext debugContext);
-
-    public static String canonicalize(String typeName) {
-        return typeName.replace(" ", "__");
-    }
 }

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debuginfo/DebugInfoProvider.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debuginfo/DebugInfoProvider.java
@@ -71,7 +71,7 @@ public interface DebugInfoProvider {
     /**
      * An interface implemented by items that can be located in a file.
      */
-    interface DebugFileInfo {
+    public interface DebugFileInfo {
         /**
          * @return the name of the file containing a file element excluding any path.
          */
@@ -90,7 +90,9 @@ public interface DebugInfoProvider {
         Path cachePath();
     }
 
-    interface DebugTypeInfo extends DebugFileInfo {
+    public interface DebugTypeInfo extends DebugFileInfo {
+        ResolvedJavaType idType();
+
         enum DebugTypeKind {
             PRIMITIVE,
             ENUM,
@@ -132,35 +134,35 @@ public interface DebugInfoProvider {
         int size();
     }
 
-    interface DebugInstanceTypeInfo extends DebugTypeInfo {
+    public interface DebugInstanceTypeInfo extends DebugTypeInfo {
         int headerSize();
 
         Stream<DebugFieldInfo> fieldInfoProvider();
 
         Stream<DebugMethodInfo> methodInfoProvider();
 
-        String superName();
+        ResolvedJavaType superClass();
 
-        Stream<String> interfaces();
+        Stream<ResolvedJavaType> interfaces();
     }
 
-    interface DebugEnumTypeInfo extends DebugInstanceTypeInfo {
+    public interface DebugEnumTypeInfo extends DebugInstanceTypeInfo {
     }
 
-    interface DebugInterfaceTypeInfo extends DebugInstanceTypeInfo {
+    public interface DebugInterfaceTypeInfo extends DebugInstanceTypeInfo {
     }
 
-    interface DebugArrayTypeInfo extends DebugTypeInfo {
+    public interface DebugArrayTypeInfo extends DebugTypeInfo {
         int baseSize();
 
         int lengthOffset();
 
-        String elementType();
+        ResolvedJavaType elementType();
 
         Stream<DebugFieldInfo> fieldInfoProvider();
     }
 
-    interface DebugPrimitiveTypeInfo extends DebugTypeInfo {
+    public interface DebugPrimitiveTypeInfo extends DebugTypeInfo {
         /*
          * NUMERIC excludes LOGICAL types boolean and void
          */
@@ -181,27 +183,27 @@ public interface DebugInfoProvider {
         int flags();
     }
 
-    interface DebugHeaderTypeInfo extends DebugTypeInfo {
+    public interface DebugHeaderTypeInfo extends DebugTypeInfo {
 
         Stream<DebugFieldInfo> fieldInfoProvider();
     }
 
-    interface DebugMemberInfo extends DebugFileInfo {
+    public interface DebugMemberInfo extends DebugFileInfo {
 
         String name();
 
-        String valueType();
+        ResolvedJavaType valueType();
 
         int modifiers();
     }
 
-    interface DebugFieldInfo extends DebugMemberInfo {
+    public interface DebugFieldInfo extends DebugMemberInfo {
         int offset();
 
         int size();
     }
 
-    interface DebugMethodInfo extends DebugMemberInfo {
+    public interface DebugMethodInfo extends DebugMemberInfo {
         /**
          * @return an array of DebugLocalInfo objects holding details of this method's parameters
          */
@@ -256,7 +258,7 @@ public interface DebugInfoProvider {
      * Access details of a compiled top level or inline method producing the code in a specific
      * {@link com.oracle.objectfile.debugentry.Range}.
      */
-    interface DebugRangeInfo extends DebugMethodInfo {
+    public interface DebugRangeInfo extends DebugMethodInfo {
 
         /**
          * @return the lowest address containing code generated for an outer or inlined code segment
@@ -280,7 +282,7 @@ public interface DebugInfoProvider {
     /**
      * Access details of a specific compiled method.
      */
-    interface DebugCodeInfo extends DebugRangeInfo {
+    public interface DebugCodeInfo extends DebugRangeInfo {
         void debugContext(Consumer<DebugContext> action);
 
         /**
@@ -304,7 +306,7 @@ public interface DebugInfoProvider {
     /**
      * Access details of a specific heap object.
      */
-    interface DebugDataInfo {
+    public interface DebugDataInfo {
         void debugContext(Consumer<DebugContext> action);
 
         String getProvenance();
@@ -324,7 +326,7 @@ public interface DebugInfoProvider {
      * Access details of code generated for a specific outer or inlined method at a given line
      * number.
      */
-    interface DebugLocationInfo extends DebugRangeInfo {
+    public interface DebugLocationInfo extends DebugRangeInfo {
         /**
          * @return the {@link DebugLocationInfo} of the nested inline caller-line
          */
@@ -341,7 +343,9 @@ public interface DebugInfoProvider {
      * A DebugLocalInfo details a local or parameter variable recording its name and type, the
      * (abstract machine) local slot index it resides in and the number of slots it occupies.
      */
-    interface DebugLocalInfo {
+    public interface DebugLocalInfo {
+        ResolvedJavaType valueType();
+
         String name();
 
         String typeName();
@@ -360,7 +364,7 @@ public interface DebugInfoProvider {
      * frame. The value may be undefined. If not then the instance records its type and either its
      * (constant) value or the register or stack location in which the value resides.
      */
-    interface DebugLocalValueInfo extends DebugLocalInfo {
+    public interface DebugLocalValueInfo extends DebugLocalInfo {
         enum LocalKind {
             UNDEFINED,
             REGISTER,
@@ -379,7 +383,7 @@ public interface DebugInfoProvider {
         JavaConstant constantValue();
     }
 
-    interface DebugFrameSizeChange {
+    public interface DebugFrameSizeChange {
         enum Type {
             EXTEND,
             CONTRACT

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debuginfo/DebugInfoProvider.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debuginfo/DebugInfoProvider.java
@@ -33,6 +33,7 @@ import java.util.stream.Stream;
 
 import jdk.vm.ci.meta.JavaConstant;
 import jdk.vm.ci.meta.JavaKind;
+import jdk.vm.ci.meta.ResolvedJavaMethod;
 import jdk.vm.ci.meta.ResolvedJavaType;
 import org.graalvm.compiler.debug.DebugContext;
 
@@ -248,10 +249,20 @@ public interface DebugInfoProvider {
 
         /*
          * Return the unique type that owns this method. <p/>
-         * 
+         *
          * @return the unique type that owns this method
          */
         ResolvedJavaType ownerType();
+
+        /*
+         * Return the unique identifier for this method. The result can be used to unify details of
+         * methods presented via interface DebugTypeInfo with related details of compiled methods
+         * presented via interface DebugRangeInfo and of call frame methods presented via interface
+         * DebugLocationInfo. <p/>
+         *
+         * @return the unique identifier for this method
+         */
+        ResolvedJavaMethod idMethod();
     }
 
     /**

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfInfoSectionImpl.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfInfoSectionImpl.java
@@ -309,7 +309,6 @@ public class DwarfInfoSectionImpl extends DwarfSectionImpl {
         int pos = p;
         String fieldName = fieldEntry.fieldName();
         TypeEntry valueType = fieldEntry.getValueType();
-        String valueTypeName = valueType.getTypeName();
         /* use the indirect type for the field so pointers get translated */
         int valueTypeIdx = getIndirectTypeIndex(valueType);
         log(context, "  [0x%08x] header field", pos);
@@ -318,7 +317,7 @@ public class DwarfInfoSectionImpl extends DwarfSectionImpl {
         pos = writeAbbrevCode(abbrevCode, buffer, pos);
         log(context, "  [0x%08x]     name  0x%x (%s)", pos, debugStringIndex(fieldName), fieldName);
         pos = writeAttrStrp(fieldName, buffer, pos);
-        log(context, "  [0x%08x]     type 0x%x (%s)", pos, valueTypeIdx, valueTypeName);
+        log(context, "  [0x%08x]     type 0x%x (%s)", pos, valueTypeIdx, valueType.getTypeName());
         pos = writeAttrRefAddr(valueTypeIdx, buffer, pos);
         byte offset = (byte) fieldEntry.getOffset();
         int size = fieldEntry.getSize();
@@ -627,10 +626,9 @@ public class DwarfInfoSectionImpl extends DwarfSectionImpl {
             /* At present we definitely don't have line numbers. */
         }
         TypeEntry valueType = fieldEntry.getValueType();
-        String valueTypeName = valueType.getTypeName();
         /* use the indirect type for the field so pointers get translated if needed */
         int typeIdx = getIndirectTypeIndex(valueType);
-        log(context, "  [0x%08x]     type  0x%x (%s)", pos, typeIdx, valueTypeName);
+        log(context, "  [0x%08x]     type  0x%x (%s)", pos, typeIdx, valueType.getTypeName());
         pos = writeAttrRefAddr(typeIdx, buffer, pos);
         if (!isStatic) {
             int memberOffset = fieldEntry.getOffset();
@@ -688,9 +686,8 @@ public class DwarfInfoSectionImpl extends DwarfSectionImpl {
         log(context, "  [0x%08x]     file 0x%x (%s)", pos, fileIdx, fileEntry.getFullName());
         pos = writeAttrData2((short) fileIdx, buffer, pos);
         TypeEntry returnType = method.getValueType();
-        String returnTypeName = returnType.getTypeName();
         int retTypeIdx = getTypeIndex(returnType);
-        log(context, "  [0x%08x]     type 0x%x (%s)", pos, retTypeIdx, returnTypeName);
+        log(context, "  [0x%08x]     type 0x%x (%s)", pos, retTypeIdx, returnType.getTypeName());
         pos = writeAttrRefAddr(retTypeIdx, buffer, pos);
         log(context, "  [0x%08x]     artificial %s", pos, method.isDeopt() ? "true" : "false");
         pos = writeFlag((method.isDeopt() ? (byte) 1 : (byte) 0), buffer, pos);
@@ -749,7 +746,6 @@ public class DwarfInfoSectionImpl extends DwarfSectionImpl {
         int abbrevCode;
         String paramName = paramInfo.name();
         TypeEntry paramType = lookupType(paramInfo.valueType());
-        String paramTypeName = paramType.getTypeName();
         int line = paramInfo.line();
         if (artificial) {
             abbrevCode = DwarfDebugInfo.DW_ABBREV_CODE_method_parameter_declaration1;
@@ -769,7 +765,7 @@ public class DwarfInfoSectionImpl extends DwarfSectionImpl {
             pos = writeAttrData2((short) line, buffer, pos);
         }
         int typeIdx = getTypeIndex(paramType);
-        log(context, "  [0x%08x]     type 0x%x (%s)", pos, typeIdx, paramTypeName);
+        log(context, "  [0x%08x]     type 0x%x (%s)", pos, typeIdx, paramType.getTypeName());
         pos = writeAttrRefAddr(typeIdx, buffer, pos);
         if (abbrevCode == DwarfDebugInfo.DW_ABBREV_CODE_method_parameter_declaration1) {
             log(context, "  [0x%08x]     artificial true", pos);
@@ -799,7 +795,6 @@ public class DwarfInfoSectionImpl extends DwarfSectionImpl {
         int abbrevCode;
         String paramName = paramInfo.name();
         TypeEntry paramType = lookupType(paramInfo.valueType());
-        String paramTypeName = paramType.getTypeName();
         int line = paramInfo.line();
         if (line >= 0) {
             abbrevCode = DwarfDebugInfo.DW_ABBREV_CODE_method_local_declaration1;
@@ -817,7 +812,7 @@ public class DwarfInfoSectionImpl extends DwarfSectionImpl {
             pos = writeAttrData2((short) line, buffer, pos);
         }
         int typeIdx = getTypeIndex(paramType);
-        log(context, "  [0x%08x]     type 0x%x (%s)", pos, typeIdx, paramTypeName);
+        log(context, "  [0x%08x]     type 0x%x (%s)", pos, typeIdx, paramType.getTypeName());
         pos = writeAttrRefAddr(typeIdx, buffer, pos);
         log(context, "  [0x%08x]     declaration true", pos);
         pos = writeFlag((byte) 1, buffer, pos);

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfInfoSectionImpl.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfInfoSectionImpl.java
@@ -1214,8 +1214,9 @@ public class DwarfInfoSectionImpl extends DwarfSectionImpl {
     private int writeArraySuperReference(DebugContext context, byte[] buffer, int p) {
         int pos = p;
         /* Arrays all inherit from java.lang.Object */
-        String superName = "java.lang.Object";
-        TypeEntry objectType = lookupType(superName);
+        TypeEntry objectType = lookupObjectClass();
+        String superName = objectType.getTypeName();
+        assert objectType != null;
         assert objectType instanceof ClassEntry;
         int superOffset = getLayoutIndex((ClassEntry) objectType);
         return writeSuperReference(context, superOffset, superName, buffer, pos);

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfSectionImpl.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfSectionImpl.java
@@ -40,6 +40,7 @@ import com.oracle.objectfile.debuginfo.DebugInfoProvider.DebugLocalInfo;
 import com.oracle.objectfile.debuginfo.DebugInfoProvider.DebugLocalValueInfo;
 import com.oracle.objectfile.elf.ELFMachine;
 import com.oracle.objectfile.elf.ELFObjectFile;
+import jdk.vm.ci.meta.ResolvedJavaType;
 import org.graalvm.compiler.debug.DebugContext;
 
 import java.nio.ByteOrder;
@@ -607,8 +608,12 @@ public abstract class DwarfSectionImpl extends BasicProgbitsSectionImpl {
         return dwarfSections.uniqueDebugString(str);
     }
 
-    protected TypeEntry lookupType(String typeName) {
-        return dwarfSections.lookupTypeEntry(typeName);
+    protected TypeEntry lookupType(ResolvedJavaType type) {
+        return dwarfSections.lookupTypeEntry(type);
+    }
+
+    protected TypeEntry lookupObjectClass() {
+        return dwarfSections.lookupObjectClass();
     }
 
     protected int getTypeIndex(String typeName) {

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfSectionImpl.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfSectionImpl.java
@@ -616,22 +616,22 @@ public abstract class DwarfSectionImpl extends BasicProgbitsSectionImpl {
         return dwarfSections.lookupObjectClass();
     }
 
-    protected int getTypeIndex(String typeName) {
+    protected int getTypeIndex(TypeEntry typeEntry) {
         if (!contentByteArrayCreated()) {
             return 0;
         }
-        return dwarfSections.getTypeIndex(typeName);
+        return dwarfSections.getTypeIndex(typeEntry);
     }
 
     protected void setTypeIndex(TypeEntry typeEntry, int pos) {
         dwarfSections.setTypeIndex(typeEntry, pos);
     }
 
-    protected int getIndirectTypeIndex(String typeName) {
+    protected int getIndirectTypeIndex(TypeEntry typeEntry) {
         if (!contentByteArrayCreated()) {
             return 0;
         }
-        return dwarfSections.getIndirectTypeIndex(typeName);
+        return dwarfSections.getIndirectTypeIndex(typeEntry);
     }
 
     protected void setIndirectTypeIndex(TypeEntry typeEntry, int pos) {
@@ -726,26 +726,26 @@ public abstract class DwarfSectionImpl extends BasicProgbitsSectionImpl {
         return dwarfSections.getFieldDeclarationIndex(entry, fieldName);
     }
 
-    protected void setMethodDeclarationIndex(ClassEntry classEntry, String methodName, int pos) {
-        dwarfSections.setMethodDeclarationIndex(classEntry, methodName, pos);
+    protected void setMethodDeclarationIndex(MethodEntry methodEntry, int pos) {
+        dwarfSections.setMethodDeclarationIndex(methodEntry, pos);
     }
 
-    protected int getMethodDeclarationIndex(ClassEntry classEntry, String methodName) {
+    protected int getMethodDeclarationIndex(MethodEntry methodEntry) {
         if (!contentByteArrayCreated()) {
             return 0;
         }
-        return dwarfSections.getMethodDeclarationIndex(classEntry, methodName);
+        return dwarfSections.getMethodDeclarationIndex(methodEntry);
     }
 
-    protected void setAbstractInlineMethodIndex(ClassEntry classEntry, String methodName, int pos) {
-        dwarfSections.setAbstractInlineMethodIndex(classEntry, methodName, pos);
+    protected void setAbstractInlineMethodIndex(MethodEntry methodEntry, int pos) {
+        dwarfSections.setAbstractInlineMethodIndex(methodEntry, pos);
     }
 
-    protected int getAbstractInlineMethodIndex(ClassEntry classEntry, String methodName) {
+    protected int getAbstractInlineMethodIndex(MethodEntry methodEntry) {
         if (!contentByteArrayCreated()) {
             return 0;
         }
-        return dwarfSections.getAbstractInlineMethodIndex(classEntry, methodName);
+        return dwarfSections.getAbstractInlineMethodIndex(methodEntry);
     }
 
     protected void setMethodLocalIndex(MethodEntry methodEntry, DebugLocalInfo localInfo, int index) {


### PR DESCRIPTION
This PR is the promised cleanup to the debug info generator that ensures the model of the class base used to drive debug info generation is built by identifying TypeEntry and MethodEntry records using ResolvedJavaClass and ResolvedJavaMethod instances rather than their associated names.  This means the model can cope with multiple types that have the same name and cope with multiple methods attached to some given class that have the same name and signature.

The cleanup also modifies the Dwarf Properties model that associates Dwarf section offsets and other information with a TypeEntry, MethodEntry or Range. Properties records are still stored in hash tables. However, the hash tables are now keyed using the Type/MethodEntry objects rather than the type/method names. Also method Properties are stored in one top level hash table rather than being nested in hash tables embedded in the type Properties.

n.b. the properties model really needs a further cleanup to allow the properties to be hung directly off the TypeEntry, MethodEntry or Range rather than indexed using an auxiliary hash table. That will be addressed in a follow-up PR.