### PR TITLE
[GR-39144] Fix RuntimeSerialization#registerIncludingAssociatedClasses @since

### DIFF
--- a/sdk/src/org.graalvm.nativeimage/src/org/graalvm/nativeimage/hosted/RuntimeSerialization.java
+++ b/sdk/src/org.graalvm.nativeimage/src/org/graalvm/nativeimage/hosted/RuntimeSerialization.java
@@ -70,7 +70,7 @@ public final class RuntimeSerialization {
      * specified class at runtime.
      *
      * @param clazz the serialization target class
-     * @since 23.0
+     * @since 21.3
      */
     public static void registerIncludingAssociatedClasses(Class<?> clazz) {
         ImageSingletons.lookup(RuntimeSerializationSupport.class).registerIncludingAssociatedClasses(ConfigurationCondition.alwaysTrue(), clazz);


### PR DESCRIPTION
RuntimeSerialization#registerIncludingAssociatedClasses was introduced
in GraalVM 21.3 by https://github.com/oracle/graal/pull/3050