### PR TITLE
Removes import needed by javadoc to eliminate build-time dependency

### DIFF
--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/meta/ObjectConstantEquality.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/meta/ObjectConstantEquality.java
@@ -25,7 +25,6 @@
 package com.oracle.svm.core.meta;
 
 import org.graalvm.compiler.api.replacements.Fold;
-import org.graalvm.compiler.truffle.compiler.nodes.ObjectLocationIdentity;
 import org.graalvm.nativeimage.ImageSingletons;
 
 import jdk.vm.ci.meta.ConstantReflectionProvider;
@@ -37,8 +36,9 @@ import jdk.vm.ci.meta.ConstantReflectionProvider;
  * comparable, but their {@link Object#equals} methods should not and cannot (due to dependencies)
  * have direct knowledge of other classes, so their methods delegate to this class. This code
  * overlaps with {@link ConstantReflectionProvider#constantEquals}, but existing code relies on
- * directly testing object equality on constants, such as the {@link ObjectLocationIdentity} class,
- * which is crucial for the alias analysis of memory accesses during compilation.
+ * directly testing object equality on constants, such as the
+ * {@link org.graalvm.compiler.truffle.compiler.nodes.ObjectLocationIdentity} class, which is
+ * crucial for the alias analysis of memory accesses during compilation.
  */
 public interface ObjectConstantEquality {
     @Fold


### PR DESCRIPTION
Mandrel builds don't build/include `org.graalvm.compiler.truffle.compiler` and this import is causing them to fail.

Closes https://github.com/graalvm/mandrel/issues/387