### PR TITLE
[GR-39313] Avoid NPEs in includeAnnotation when annotationValue is null

### DIFF
--- a/substratevm/src/com.oracle.svm.reflect/src/com/oracle/svm/reflect/hosted/ReflectionDataBuilder.java
+++ b/substratevm/src/com.oracle.svm.reflect/src/com/oracle/svm/reflect/hosted/ReflectionDataBuilder.java
@@ -608,6 +608,9 @@ public class ReflectionDataBuilder extends ConditionalConfigurationRegistry impl
     }
 
     private static boolean includeAnnotation(DuringAnalysisAccessImpl access, AnnotationValue annotationValue) {
+        if (annotationValue == null) {
+            return false;
+        }
         for (Class<?> type : annotationValue.getTypes()) {
             if (type == null || SubstitutionReflectivityFilter.shouldExclude(type, access.getMetaAccess(), access.getUniverse())) {
                 return false;


### PR DESCRIPTION
Fixes [issue introduced in CI runs](https://github.com/oracle/graal/runs/6960233607?check_suite_focus=true#step:8:333) by https://github.com/oracle/graal/pull/4614

`null` AnnotationValues may be generated in https://github.com/oracle/graal/blob/d5fae2920c65c6b3d2a964a6c875c5a585d54685/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/annotation/AnnotationValue.java#L69-L71