### PR TITLE
Prints unsupported features before throwing a ParsingError

### DIFF
--- a/substratevm/src/com.oracle.graal.pointsto/src/com/oracle/graal/pointsto/flow/MethodTypeFlow.java
+++ b/substratevm/src/com.oracle.graal.pointsto/src/com/oracle/graal/pointsto/flow/MethodTypeFlow.java
@@ -31,6 +31,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
+import com.oracle.graal.pointsto.constraints.UnsupportedFeatureException;
 import org.graalvm.collections.EconomicMap;
 import org.graalvm.compiler.nodes.ParameterNode;
 import org.graalvm.compiler.nodes.ReturnNode;
@@ -104,7 +105,19 @@ public class MethodTypeFlow extends TypeFlow<AnalysisMethod> {
 
                 initFlowsGraph(bb);
             } catch (Throwable t) {
-                /* Wrap all other errors as parsing errors. */
+                /*
+                 * Wrap all other errors as parsing errors, but first print any UnsupportedFeatures
+                 */
+                try {
+                    bb.getUnsupportedFeatures().report(bb);
+                } catch (UnsupportedFeatureException uee) {
+                    System.err.println(uee.getMessage());
+                    Throwable cause = uee.getCause();
+                    if (cause != null) {
+                        System.err.print("Original exception that caused the problem: ");
+                        cause.printStackTrace(System.err);
+                    }
+                }
                 throw AnalysisError.parsingError(method, t);
             }
         }

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/LinkAtBuildTimeSupport.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/LinkAtBuildTimeSupport.java
@@ -208,7 +208,7 @@ public final class LinkAtBuildTimeSupport {
 
     public String errorMessageFor(Class<?> clazz) {
         assert linkAtBuildTime(clazz);
-        return "This error is reported at image build time because class " + clazz.getTypeName() + " is registered for linking at image build time by " + linkAtBuildTimeReason(clazz);
+        return "This error is reported at image build time because class " + clazz.getTypeName() + " is registered for linking at image build time by " + linkAtBuildTimeReason(clazz) + ".";
     }
 
     @SuppressWarnings("unchecked")


### PR DESCRIPTION
Parsing errors without the accompanying unsupported features might be
misleading when using `link-at-build-time`. For instance if a Class `A`
cannot be initialized because of a `NoClassDefFoundException` caused by
a missing dependency, the exception and a corresponding message will be
added to unsupported features and the Class `A` will be marked as
`BUILD_TIME` initialized to allow the analysis to proceed and delay the
error reporting. Later, while parsing bytecode an
`UnresolvedElementException` may be thrown if the bytecode tries to
instantiate the Class that was marked for `BUILD_TIME`
initialization. Unfortunately at this point printing only the info
regarding `UnresolvedElementException` makes it appear like the Class
`A` methods are not reachable (because the Class is not initialized)
while that's not actually true.

Example of logs before this patch:

```
Fatal error: com.oracle.graal.pointsto.util.AnalysisError$ParsingError: Error encountered while parsing net.sf.oval.expression.ExpressionLanguageRegistry._initializeDefaultEL(java.lang.String)
Parsing context:
   at net.sf.oval.expression.ExpressionLanguageRegistry._initializeDefaultEL(ExpressionLanguageRegistry.java:33)
   at net.sf.oval.expression.ExpressionLanguageRegistry.getExpressionLanguage(ExpressionLanguageRegistry.java:83)
   at net.sf.oval.AbstractCheck.isActive(AbstractCheck.java:151)
   at net.sf.oval.Validator.checkConstraint(Validator.java:763)
   at net.sf.oval.Validator._validateStaticInvariants(Validator.java:656)
   at net.sf.oval.Validator.validateInvariants(Validator.java:1382)
   at net.sf.oval.Validator.validate(Validator.java:1308)
   at gdv.xport.feld.Feld.validateInvariants(Feld.java:623)
   at gdv.xport.feld.Feld.validate(Feld.java:605)
   at gdv.xport.feld.AlphaNumFeld.validate(AlphaNumFeld.java:161)
   at gdv.xport.feld.Feld.validate(Feld.java:601)
   at gdv.xport.feld.Satznummer.validate(Satznummer.java:232)
   at gdv.xport.feld.Feld.isValid(Feld.java:583)
   at gdv.xport.feld.Feld.isInvalid(Feld.java:592)
   at gdv.xport.satz.Teildatensatz.getSatznummer(Teildatensatz.java:146)
   at gdv.xport.satz.Satz.importFrom(Satz.java:1063)
   at gdv.xport.Datenpaket.importNachsatzFrom(Datenpaket.java:482)
   at gdv.xport.Datenpaket.importSatz(Datenpaket.java:443)
   at gdv.xport.Datenpaket.importFrom(Datenpaket.java:420)
   at gdv.xport.Datenpaket.importFrom(Datenpaket.java:394)
   at de.knuspertante.MemberResource.hello(MemberResource.java:41)
   at de.knuspertante.MemberResource$quarkusrestinvoker$hello_e747664148511e1e5212d3e0f4b40d45c56ab8a1.invoke(Unknown Source)
   at org.jboss.resteasy.reactive.server.handlers.InvocationHandler.handle(InvocationHandler.java:29)
   at io.quarkus.resteasy.reactive.server.runtime.QuarkusResteasyReactiveRequestContext.invokeHandler(QuarkusResteasyReactiveRequestContext.java:117)
   at org.jboss.resteasy.reactive.common.core.AbstractResteasyReactiveContext.run(AbstractResteasyReactiveContext.java:141)
   at java.base@11.0.16-beta/java.lang.Shutdown.runHooks(Shutdown.java:130)
   at java.base@11.0.16-beta/java.lang.Shutdown.shutdown(Shutdown.java:186)
   at app//com.oracle.svm.core.jdk.RuntimeSupport.shutdown(RuntimeSupport.java:158)
   at app//com.oracle.svm.core.JavaMainWrapper.runShutdown0(JavaMainWrapper.java:197)
   at app//com.oracle.svm.core.JavaMainWrapper.runShutdown(JavaMainWrapper.java:184)
   at app//com.oracle.svm.core.JavaMainWrapper.run(JavaMainWrapper.java:219)
   at com.oracle.svm.core.code.IsolateEnterStub.JavaMainWrapper_run_5087f5482cc9a6abc971913ece43acb471d2631b(generated:0)

	at com.oracle.graal.pointsto.util.AnalysisError.parsingError(AnalysisError.java:152)
	at com.oracle.graal.pointsto.flow.MethodTypeFlow.createFlowsGraph(MethodTypeFlow.java:117)
	at com.oracle.graal.pointsto.flow.MethodTypeFlow.ensureFlowsGraphCreated(MethodTypeFlow.java:84)
	at com.oracle.graal.pointsto.flow.MethodTypeFlow.getOrCreateMethodFlowsGraph(MethodTypeFlow.java:66)
	at com.oracle.graal.pointsto.typestate.DefaultSpecialInvokeTypeFlow.onObservedUpdate(DefaultSpecialInvokeTypeFlow.java:61)
	at com.oracle.graal.pointsto.flow.TypeFlow.update(TypeFlow.java:558)
	at com.oracle.graal.pointsto.PointsToAnalysis$1.run(PointsToAnalysis.java:635)
	at com.oracle.graal.pointsto.util.CompletionExecutor.executeCommand(CompletionExecutor.java:193)
	at com.oracle.graal.pointsto.util.CompletionExecutor.lambda$executeService$0(CompletionExecutor.java:177)
	at java.base/java.util.concurrent.ForkJoinTask$RunnableExecuteAction.exec(ForkJoinTask.java:1426)
	at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:290)
	at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1020)
	at java.base/java.util.concurrent.ForkJoinPool.scan(ForkJoinPool.java:1656)
	at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1594)
	at java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:183)
Caused by: org.graalvm.compiler.java.BytecodeParser$BytecodeParserError: com.oracle.graal.pointsto.constraints.UnresolvedElementException: Discovered unresolved method during parsing: net.sf.oval.expression.ExpressionLanguageJEXLImpl.<init>(). This error is reported at image build time because class net.sf.oval.expression.ExpressionLanguageRegistry is registered for linking at image build time by command line.
	at parsing net.sf.oval.expression.ExpressionLanguageRegistry._initializeDefaultEL(ExpressionLanguageRegistry.java:58)
	at jdk.internal.vm.compiler/org.graalvm.compiler.java.BytecodeParser.throwParserError(BytecodeParser.java:2506)
	at com.oracle.svm.hosted.phases.SharedGraphBuilderPhase$SharedBytecodeParser.throwParserError(SharedGraphBuilderPhase.java:105)
	at jdk.internal.vm.compiler/org.graalvm.compiler.java.BytecodeParser.iterateBytecodesForBlock(BytecodeParser.java:3367)
	at jdk.internal.vm.compiler/org.graalvm.compiler.java.BytecodeParser.handleBytecodeBlock(BytecodeParser.java:3319)
	at jdk.internal.vm.compiler/org.graalvm.compiler.java.BytecodeParser.processBlock(BytecodeParser.java:3164)
	at jdk.internal.vm.compiler/org.graalvm.compiler.java.BytecodeParser.build(BytecodeParser.java:1138)
	at jdk.internal.vm.compiler/org.graalvm.compiler.java.BytecodeParser.buildRootMethod(BytecodeParser.java:1030)
	at jdk.internal.vm.compiler/org.graalvm.compiler.java.GraphBuilderPhase$Instance.run(GraphBuilderPhase.java:84)
	at com.oracle.svm.hosted.phases.SharedGraphBuilderPhase.run(SharedGraphBuilderPhase.java:79)
	at jdk.internal.vm.compiler/org.graalvm.compiler.phases.Phase.run(Phase.java:49)
	at jdk.internal.vm.compiler/org.graalvm.compiler.phases.BasePhase.apply(BasePhase.java:261)
	at jdk.internal.vm.compiler/org.graalvm.compiler.phases.Phase.apply(Phase.java:42)
	at jdk.internal.vm.compiler/org.graalvm.compiler.phases.Phase.apply(Phase.java:38)
	at com.oracle.graal.pointsto.flow.AnalysisParsedGraph.parseBytecode(AnalysisParsedGraph.java:135)
	at com.oracle.graal.pointsto.meta.AnalysisMethod.ensureGraphParsed(AnalysisMethod.java:701)
	at com.oracle.graal.pointsto.flow.MethodTypeFlowBuilder.parse(MethodTypeFlowBuilder.java:168)
	at com.oracle.graal.pointsto.flow.MethodTypeFlowBuilder.apply(MethodTypeFlowBuilder.java:343)
	at com.oracle.graal.pointsto.flow.MethodTypeFlow.createFlowsGraph(MethodTypeFlow.java:94)
	... 13 more
Caused by: com.oracle.graal.pointsto.constraints.UnresolvedElementException: Discovered unresolved method during parsing: net.sf.oval.expression.ExpressionLanguageJEXLImpl.<init>(). This error is reported at image build time because class net.sf.oval.expression.ExpressionLanguageRegistry is registered for linking at image build time by command line.
	at com.oracle.svm.hosted.phases.SharedGraphBuilderPhase$SharedBytecodeParser.reportUnresolvedElement(SharedGraphBuilderPhase.java:298)
	at com.oracle.svm.hosted.phases.SharedGraphBuilderPhase$SharedBytecodeParser.handleUnresolvedMethod(SharedGraphBuilderPhase.java:288)
	at com.oracle.svm.hosted.phases.SharedGraphBuilderPhase$SharedBytecodeParser.handleUnresolvedInvoke(SharedGraphBuilderPhase.java:244)
	at jdk.internal.vm.compiler/org.graalvm.compiler.java.BytecodeParser.genInvokeSpecial(BytecodeParser.java:1766)
	at jdk.internal.vm.compiler/org.graalvm.compiler.java.BytecodeParser.genInvokeSpecial(BytecodeParser.java:1756)
	at jdk.internal.vm.compiler/org.graalvm.compiler.java.BytecodeParser.processBytecode(BytecodeParser.java:5223)
	at jdk.internal.vm.compiler/org.graalvm.compiler.java.BytecodeParser.iterateBytecodesForBlock(BytecodeParser.java:3359)
	... 28 more
```

and after this patch:

```
Class initialization of net.sf.oval.expression.ExpressionLanguageJEXLImpl failed. This error is reported at image build time because class net.sf.oval.expression.ExpressionLanguageJEXLImpl is registered for linking at image build time by command line. Use the option --initialize-at-run-time=net.sf.oval.expression.ExpressionLanguageJEXLImpl to explicitly request delayed initialization of this class.
Detailed message:

Original exception that caused the problem: java.lang.NoClassDefFoundError: org/apache/commons/jexl2/JexlContext
	at java.base/jdk.internal.misc.Unsafe.ensureClassInitialized0(Native Method)
	at java.base/jdk.internal.misc.Unsafe.ensureClassInitialized(Unsafe.java:1042)
	at com.oracle.svm.hosted.classinitialization.ConfigurableClassInitialization.ensureClassInitialized(ConfigurableClassInitialization.java:183)
	at com.oracle.svm.hosted.classinitialization.ConfigurableClassInitialization.computeInitKindAndMaybeInitializeClass(ConfigurableClassInitialization.java:653)
	at com.oracle.svm.hosted.classinitialization.ConfigurableClassInitialization.computeInitKindAndMaybeInitializeClass(ConfigurableClassInitialization.java:136)
	at com.oracle.svm.hosted.classinitialization.ConfigurableClassInitialization.shouldInitializeAtRuntime(ConfigurableClassInitialization.java:164)
	at com.oracle.svm.hosted.SVMHost.isInitialized(SVMHost.java:289)
	at com.oracle.graal.pointsto.meta.AnalysisType.isInitialized(AnalysisType.java:841)
	at jdk.internal.vm.compiler/org.graalvm.compiler.java.BytecodeParser.maybeEagerlyInitialize(BytecodeParser.java:4264)
	at jdk.internal.vm.compiler/org.graalvm.compiler.java.BytecodeParser.genNewInstance(BytecodeParser.java:4462)
	at jdk.internal.vm.compiler/org.graalvm.compiler.java.BytecodeParser.genNewInstance(BytecodeParser.java:4451)
	at jdk.internal.vm.compiler/org.graalvm.compiler.java.BytecodeParser.genNewInstance(BytecodeParser.java:4446)
	at jdk.internal.vm.compiler/org.graalvm.compiler.java.BytecodeParser.processBytecode(BytecodeParser.java:5227)
	at jdk.internal.vm.compiler/org.graalvm.compiler.java.BytecodeParser.iterateBytecodesForBlock(BytecodeParser.java:3359)
	at jdk.internal.vm.compiler/org.graalvm.compiler.java.BytecodeParser.handleBytecodeBlock(BytecodeParser.java:3319)
	at jdk.internal.vm.compiler/org.graalvm.compiler.java.BytecodeParser.processBlock(BytecodeParser.java:3164)
	at jdk.internal.vm.compiler/org.graalvm.compiler.java.BytecodeParser.build(BytecodeParser.java:1138)
	at jdk.internal.vm.compiler/org.graalvm.compiler.java.BytecodeParser.buildRootMethod(BytecodeParser.java:1030)
	at jdk.internal.vm.compiler/org.graalvm.compiler.java.GraphBuilderPhase$Instance.run(GraphBuilderPhase.java:84)
	at com.oracle.svm.hosted.phases.SharedGraphBuilderPhase.run(SharedGraphBuilderPhase.java:79)
	at jdk.internal.vm.compiler/org.graalvm.compiler.phases.Phase.run(Phase.java:49)
	at jdk.internal.vm.compiler/org.graalvm.compiler.phases.BasePhase.apply(BasePhase.java:261)
	at jdk.internal.vm.compiler/org.graalvm.compiler.phases.Phase.apply(Phase.java:42)
	at jdk.internal.vm.compiler/org.graalvm.compiler.phases.Phase.apply(Phase.java:38)
	at com.oracle.graal.pointsto.flow.AnalysisParsedGraph.parseBytecode(AnalysisParsedGraph.java:135)
	at com.oracle.graal.pointsto.meta.AnalysisMethod.ensureGraphParsed(AnalysisMethod.java:701)
	at com.oracle.graal.pointsto.flow.MethodTypeFlowBuilder.parse(MethodTypeFlowBuilder.java:168)
	at com.oracle.graal.pointsto.flow.MethodTypeFlowBuilder.apply(MethodTypeFlowBuilder.java:343)
	at com.oracle.graal.pointsto.flow.MethodTypeFlow.createFlowsGraph(MethodTypeFlow.java:94)
	at com.oracle.graal.pointsto.flow.MethodTypeFlow.ensureFlowsGraphCreated(MethodTypeFlow.java:84)
	at com.oracle.graal.pointsto.flow.MethodTypeFlow.getOrCreateMethodFlowsGraph(MethodTypeFlow.java:66)
	at com.oracle.graal.pointsto.typestate.DefaultSpecialInvokeTypeFlow.onObservedUpdate(DefaultSpecialInvokeTypeFlow.java:61)
	at com.oracle.graal.pointsto.flow.TypeFlow.update(TypeFlow.java:558)
	at com.oracle.graal.pointsto.PointsToAnalysis$1.run(PointsToAnalysis.java:635)
	at com.oracle.graal.pointsto.util.CompletionExecutor.executeCommand(CompletionExecutor.java:193)
	at com.oracle.graal.pointsto.util.CompletionExecutor.lambda$executeService$0(CompletionExecutor.java:177)
	at java.base/java.util.concurrent.ForkJoinTask$RunnableExecuteAction.exec(ForkJoinTask.java:1426)
	at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:290)
	at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1020)
	at java.base/java.util.concurrent.ForkJoinPool.scan(ForkJoinPool.java:1656)
	at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1594)
	at java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:183)
Caused by: java.lang.ClassNotFoundException: org.apache.commons.jexl2.JexlContext
	at java.base/java.net.URLClassLoader.findClass(URLClassLoader.java:476)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:589)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:522)
	... 42 more
[2/7] Performing analysis...  [*]                                                                       (50.5s @ 1.85GB)
  10,773 (90.20%) of 11,944 classes reachable
  15,126 (58.82%) of 25,715 fields reachable
Listening for transport dt_socket at address: 8000
  53,400 (66.43%) of 80,381 methods reachable
     418 classes,     9 fields, and   758 methods registered for reflection

Fatal error: com.oracle.graal.pointsto.util.AnalysisError$ParsingError: Error encountered while parsing net.sf.oval.expression.ExpressionLanguageRegistry._initializeDefaultEL(java.lang.String)
Parsing context:
   at net.sf.oval.expression.ExpressionLanguageRegistry._initializeDefaultEL(ExpressionLanguageRegistry.java:33)
   at net.sf.oval.expression.ExpressionLanguageRegistry.getExpressionLanguage(ExpressionLanguageRegistry.java:83)
   at net.sf.oval.AbstractCheck.isActive(AbstractCheck.java:151)
   at net.sf.oval.Validator.checkConstraint(Validator.java:763)
   at net.sf.oval.Validator._validateStaticInvariants(Validator.java:656)
   at net.sf.oval.Validator.validateInvariants(Validator.java:1382)
   at net.sf.oval.Validator.validate(Validator.java:1308)
   at gdv.xport.feld.Feld.validateInvariants(Feld.java:623)
   at gdv.xport.feld.Feld.validate(Feld.java:605)
   at gdv.xport.feld.AlphaNumFeld.validate(AlphaNumFeld.java:161)
   at gdv.xport.feld.Feld.validate(Feld.java:601)
   at gdv.xport.feld.Satznummer.validate(Satznummer.java:232)
   at gdv.xport.feld.Feld.isValid(Feld.java:583)
   at gdv.xport.feld.Feld.isInvalid(Feld.java:592)
   at gdv.xport.satz.Teildatensatz.getSatznummer(Teildatensatz.java:146)
   at gdv.xport.satz.Satz.importFrom(Satz.java:1063)
   at gdv.xport.Datenpaket.importNachsatzFrom(Datenpaket.java:482)
   at gdv.xport.Datenpaket.importSatz(Datenpaket.java:443)
   at gdv.xport.Datenpaket.importFrom(Datenpaket.java:420)
   at gdv.xport.Datenpaket.importFrom(Datenpaket.java:394)
   at de.knuspertante.MemberResource.hello(MemberResource.java:41)
   at de.knuspertante.MemberResource$quarkusrestinvoker$hello_e747664148511e1e5212d3e0f4b40d45c56ab8a1.invoke(Unknown Source)
   at org.jboss.resteasy.reactive.server.handlers.InvocationHandler.handle(InvocationHandler.java:29)
   at io.quarkus.resteasy.reactive.server.runtime.QuarkusResteasyReactiveRequestContext.invokeHandler(QuarkusResteasyReactiveRequestContext.java:117)
   at org.jboss.resteasy.reactive.common.core.AbstractResteasyReactiveContext.run(AbstractResteasyReactiveContext.java:141)
   at java.base@11.0.16-beta/java.lang.Shutdown.runHooks(Shutdown.java:130)
   at java.base@11.0.16-beta/java.lang.Shutdown.shutdown(Shutdown.java:186)
   at app//com.oracle.svm.core.jdk.RuntimeSupport.shutdown(RuntimeSupport.java:158)
   at app//com.oracle.svm.core.JavaMainWrapper.runShutdown0(JavaMainWrapper.java:197)
   at app//com.oracle.svm.core.JavaMainWrapper.runShutdown(JavaMainWrapper.java:184)
   at app//com.oracle.svm.core.JavaMainWrapper.run(JavaMainWrapper.java:219)
   at com.oracle.svm.core.code.IsolateEnterStub.JavaMainWrapper_run_5087f5482cc9a6abc971913ece43acb471d2631b(generated:0)

	at com.oracle.graal.pointsto.util.AnalysisError.parsingError(AnalysisError.java:152)
	at com.oracle.graal.pointsto.flow.MethodTypeFlow.createFlowsGraph(MethodTypeFlow.java:117)
	at com.oracle.graal.pointsto.flow.MethodTypeFlow.ensureFlowsGraphCreated(MethodTypeFlow.java:84)
	at com.oracle.graal.pointsto.flow.MethodTypeFlow.getOrCreateMethodFlowsGraph(MethodTypeFlow.java:66)
	at com.oracle.graal.pointsto.typestate.DefaultSpecialInvokeTypeFlow.onObservedUpdate(DefaultSpecialInvokeTypeFlow.java:61)
	at com.oracle.graal.pointsto.flow.TypeFlow.update(TypeFlow.java:558)
	at com.oracle.graal.pointsto.PointsToAnalysis$1.run(PointsToAnalysis.java:635)
	at com.oracle.graal.pointsto.util.CompletionExecutor.executeCommand(CompletionExecutor.java:193)
	at com.oracle.graal.pointsto.util.CompletionExecutor.lambda$executeService$0(CompletionExecutor.java:177)
	at java.base/java.util.concurrent.ForkJoinTask$RunnableExecuteAction.exec(ForkJoinTask.java:1426)
	at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:290)
	at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1020)
	at java.base/java.util.concurrent.ForkJoinPool.scan(ForkJoinPool.java:1656)
	at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1594)
	at java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:183)
Caused by: org.graalvm.compiler.java.BytecodeParser$BytecodeParserError: com.oracle.graal.pointsto.constraints.UnresolvedElementException: Discovered unresolved method during parsing: net.sf.oval.expression.ExpressionLanguageJEXLImpl.<init>(). This error is reported at image build time because class net.sf.oval.expression.ExpressionLanguageRegistry is registered for linking at image build time by command line.
	at parsing net.sf.oval.expression.ExpressionLanguageRegistry._initializeDefaultEL(ExpressionLanguageRegistry.java:58)
	at jdk.internal.vm.compiler/org.graalvm.compiler.java.BytecodeParser.throwParserError(BytecodeParser.java:2506)
	at com.oracle.svm.hosted.phases.SharedGraphBuilderPhase$SharedBytecodeParser.throwParserError(SharedGraphBuilderPhase.java:105)
	at jdk.internal.vm.compiler/org.graalvm.compiler.java.BytecodeParser.iterateBytecodesForBlock(BytecodeParser.java:3367)
	at jdk.internal.vm.compiler/org.graalvm.compiler.java.BytecodeParser.handleBytecodeBlock(BytecodeParser.java:3319)
	at jdk.internal.vm.compiler/org.graalvm.compiler.java.BytecodeParser.processBlock(BytecodeParser.java:3164)
	at jdk.internal.vm.compiler/org.graalvm.compiler.java.BytecodeParser.build(BytecodeParser.java:1138)
	at jdk.internal.vm.compiler/org.graalvm.compiler.java.BytecodeParser.buildRootMethod(BytecodeParser.java:1030)
	at jdk.internal.vm.compiler/org.graalvm.compiler.java.GraphBuilderPhase$Instance.run(GraphBuilderPhase.java:84)
	at com.oracle.svm.hosted.phases.SharedGraphBuilderPhase.run(SharedGraphBuilderPhase.java:79)
	at jdk.internal.vm.compiler/org.graalvm.compiler.phases.Phase.run(Phase.java:49)
	at jdk.internal.vm.compiler/org.graalvm.compiler.phases.BasePhase.apply(BasePhase.java:261)
	at jdk.internal.vm.compiler/org.graalvm.compiler.phases.Phase.apply(Phase.java:42)
	at jdk.internal.vm.compiler/org.graalvm.compiler.phases.Phase.apply(Phase.java:38)
	at com.oracle.graal.pointsto.flow.AnalysisParsedGraph.parseBytecode(AnalysisParsedGraph.java:135)
	at com.oracle.graal.pointsto.meta.AnalysisMethod.ensureGraphParsed(AnalysisMethod.java:701)
	at com.oracle.graal.pointsto.flow.MethodTypeFlowBuilder.parse(MethodTypeFlowBuilder.java:168)
	at com.oracle.graal.pointsto.flow.MethodTypeFlowBuilder.apply(MethodTypeFlowBuilder.java:343)
	at com.oracle.graal.pointsto.flow.MethodTypeFlow.createFlowsGraph(MethodTypeFlow.java:94)
	... 13 more
Caused by: com.oracle.graal.pointsto.constraints.UnresolvedElementException: Discovered unresolved method during parsing: net.sf.oval.expression.ExpressionLanguageJEXLImpl.<init>(). This error is reported at image build time because class net.sf.oval.expression.ExpressionLanguageRegistry is registered for linking at image build time by command line.
	at com.oracle.svm.hosted.phases.SharedGraphBuilderPhase$SharedBytecodeParser.reportUnresolvedElement(SharedGraphBuilderPhase.java:298)
	at com.oracle.svm.hosted.phases.SharedGraphBuilderPhase$SharedBytecodeParser.handleUnresolvedMethod(SharedGraphBuilderPhase.java:288)
	at com.oracle.svm.hosted.phases.SharedGraphBuilderPhase$SharedBytecodeParser.handleUnresolvedInvoke(SharedGraphBuilderPhase.java:244)
	at jdk.internal.vm.compiler/org.graalvm.compiler.java.BytecodeParser.genInvokeSpecial(BytecodeParser.java:1766)
	at jdk.internal.vm.compiler/org.graalvm.compiler.java.BytecodeParser.genInvokeSpecial(BytecodeParser.java:1756)
	at jdk.internal.vm.compiler/org.graalvm.compiler.java.BytecodeParser.processBytecode(BytecodeParser.java:5223)
	at jdk.internal.vm.compiler/org.graalvm.compiler.java.BytecodeParser.iterateBytecodesForBlock(BytecodeParser.java:3359)
	... 28 more
```