### PR TITLE
[GR-39483] Avoid implicitly setting class initialization reason for classes/packages

### DIFF
--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/classinitialization/ClassInitializationConfiguration.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/classinitialization/ClassInitializationConfiguration.java
@@ -91,6 +91,7 @@ public class ClassInitializationConfiguration {
             if (node.kind == null) {
                 node.kind = kind;
                 node.strict = strict;
+                node.reasons.add(reason);
             } else if (node.kind == kind) {
                 if (node.reasons.size() < MAX_NUMBER_OF_REASONS) {
                     node.reasons.add(reason);
@@ -110,7 +111,7 @@ public class ClassInitializationConfiguration {
             tail.remove(0);
             String nextQualifier = tail.get(0);
             if (!node.children.containsKey(nextQualifier)) {
-                node.children.put(nextQualifier, new InitializationNode(nextQualifier, node, null, false, reason));
+                node.children.put(nextQualifier, new InitializationNode(nextQualifier, node, null, false));
                 assert node.children.containsKey(nextQualifier);
             }
             insertRec(node.children.get(nextQualifier), tail, kind, reason, strict);

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/jdk/JDKInitializationFeature.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/jdk/JDKInitializationFeature.java
@@ -115,7 +115,7 @@ public class JDKInitializationFeature implements Feature {
         /* Security services */
         rci.initializeAtBuildTime("com.sun.crypto.provider", JDK_CLASS_REASON);
         rci.initializeAtBuildTime("com.sun.security.auth", JDK_CLASS_REASON);
-        rci.initializeAtBuildTime("com.sun.security.jgss", "Core JDK classes are initialized at build time for better performance");
+        rci.initializeAtBuildTime("com.sun.security.jgss", JDK_CLASS_REASON);
         rci.initializeAtBuildTime("com.sun.security.cert.internal.x509", JDK_CLASS_REASON);
         rci.initializeAtBuildTime("com.sun.security.ntlm", JDK_CLASS_REASON);
         rci.initializeAtBuildTime("com.sun.security.sasl", JDK_CLASS_REASON);


### PR DESCRIPTION
When marking a class `my.package.MyClass` for initialization for a given
reason before this patch `my` and `my.package` would also be assigned
the reason implicitly.  This resulted in reporting the wrong reason in
some cases.  For instance before this patch
`java.lang.AbstractStringBuilder` would be marked as initialized because
it's a "super type of sun.security.util.UntrustedCertificates" which is
clearly not the case.  This patch fixes the underlying problem and
reports "Core JDK classes are initialized at build time" as the reason
for initializing `AbstractStringBuilder` at `BUILD_TIME`.
