### PR TITLE
Add thread sleep events and refactor

### DIFF
--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/JfrEvent.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/JfrEvent.java
@@ -54,7 +54,8 @@ public enum JfrEvent {
     SafepointBegin("jdk.SafepointBegin"),
     SafepointEnd("jdk.SafepointEnd"),
     ExecuteVMOperation("jdk.ExecuteVMOperation"),
-    JavaMonitorEnter("jdk.JavaMonitorEnter");
+    JavaMonitorEnter("jdk.JavaMonitorEnter"),
+    ThreadSleep("jdk.ThreadSleep");
 
     private final long id;
 

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/SubstrateJVM.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/SubstrateJVM.java
@@ -254,6 +254,11 @@ public class SubstrateJVM {
         return stackTraceRepo.getStackTraceId(skipCount, false);
     }
 
+    @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
+    public long getStackTraceId(JfrEvent eventType, int skipCount) {
+        return getStackTraceId(eventType.getId(), skipCount);
+    }
+
     /** See {@link JVM#getThreadId}. */
     public static long getThreadId(Thread thread) {
         if (HasJfrSupport.get()) {

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/events/ExecutionSampleEvent.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/events/ExecutionSampleEvent.java
@@ -69,7 +69,7 @@ public final class ExecutionSampleEvent {
             JfrNativeEventWriter.beginSmallEvent(data, JfrEvent.ExecutionSample);
             JfrNativeEventWriter.putLong(data, JfrTicks.elapsedTicks());
             JfrNativeEventWriter.putThread(data, isolateThread);
-            JfrNativeEventWriter.putLong(data, svm.getStackTraceId(JfrEvent.ExecutionSample.getId(), 0));
+            JfrNativeEventWriter.putLong(data, svm.getStackTraceId(JfrEvent.ExecutionSample, 0));
             JfrNativeEventWriter.putLong(data, JfrThreadState.getId(threadState));
             JfrNativeEventWriter.endSmallEvent(data);
         }

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/events/JavaMonitorEnterEvent.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/events/JavaMonitorEnterEvent.java
@@ -36,6 +36,7 @@ import com.oracle.svm.core.jfr.JfrNativeEventWriterData;
 import com.oracle.svm.core.jfr.JfrNativeEventWriterDataAccess;
 import com.oracle.svm.core.jfr.JfrTicks;
 import com.oracle.svm.core.jfr.SubstrateJVM;
+import org.graalvm.compiler.word.Word;
 
 public class JavaMonitorEnterEvent {
     public static void emit(Object obj, long previousOwnerTid, long startTicks) {
@@ -54,10 +55,10 @@ public class JavaMonitorEnterEvent {
             JfrNativeEventWriter.putLong(data, startTicks);
             JfrNativeEventWriter.putLong(data, JfrTicks.elapsedTicks() - startTicks);
             JfrNativeEventWriter.putEventThread(data);
-            JfrNativeEventWriter.putLong(data, SubstrateJVM.get().getStackTraceId(JfrEvent.JavaMonitorEnter.getId(), 0));
+            JfrNativeEventWriter.putLong(data, SubstrateJVM.get().getStackTraceId(JfrEvent.JavaMonitorEnter, 0));
             JfrNativeEventWriter.putClass(data, obj.getClass());
             JfrNativeEventWriter.putLong(data, previousOwnerTid);
-            JfrNativeEventWriter.putLong(data, org.graalvm.compiler.word.Word.objectToUntrackedPointer(obj).rawValue());
+            JfrNativeEventWriter.putLong(data, Word.objectToUntrackedPointer(obj).rawValue());
             JfrNativeEventWriter.endSmallEvent(data);
 
         }

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/thread/JavaThreads.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/thread/JavaThreads.java
@@ -42,6 +42,7 @@ import com.oracle.svm.core.annotate.Uninterruptible;
 import com.oracle.svm.core.jdk.StackTraceUtils;
 import com.oracle.svm.core.jdk.Target_jdk_internal_misc_VM;
 import com.oracle.svm.core.snippets.KnownIntrinsics;
+import com.oracle.svm.core.jfr.events.ThreadSleepEvent;
 
 /**
  * Implements operations on {@linkplain Target_java_lang_Thread Java threads}, which are on a higher
@@ -301,11 +302,13 @@ public final class JavaThreads {
     }
 
     static void sleep(long millis) throws InterruptedException {
+        long startTicks = com.oracle.svm.core.jfr.JfrTicks.elapsedTicks();
         if (supportsVirtual() && isVirtualDisallowLoom(Thread.currentThread())) {
             VirtualThreads.singleton().sleepMillis(millis);
         } else {
             PlatformThreads.sleep(millis);
         }
+        ThreadSleepEvent.emit(millis, startTicks);
     }
 
     static boolean isAlive(Thread thread) {


### PR DESCRIPTION
This adds JFR thread sleep events and adds method `getStackTraceId(JfrEvent,  int )` to SubstrateJVM. 