### PR TITLE
TruffleDSL: Remove inInterpreter case from cached implicit type casts

### DIFF
--- a/truffle/src/com.oracle.truffle.dsl.processor/src/com/oracle/truffle/dsl/processor/generator/TypeSystemCodeGenerator.java
+++ b/truffle/src/com.oracle.truffle.dsl.processor/src/com/oracle/truffle/dsl/processor/generator/TypeSystemCodeGenerator.java
@@ -58,7 +58,6 @@ import javax.lang.model.type.TypeMirror;
 
 import com.oracle.truffle.dsl.processor.AnnotationProcessor;
 import com.oracle.truffle.dsl.processor.ProcessorContext;
-import com.oracle.truffle.dsl.processor.TruffleTypes;
 import com.oracle.truffle.dsl.processor.java.ElementUtils;
 import com.oracle.truffle.dsl.processor.java.model.CodeExecutableElement;
 import com.oracle.truffle.dsl.processor.java.model.CodeTree;
@@ -346,16 +345,6 @@ public class TypeSystemCodeGenerator extends CodeTypeElementFactory<TypeSystemDa
             Collection<TypeMirror> sourceTypes = typeSystem.lookupSourceTypes(type);
 
             CodeTreeBuilder builder = method.createBuilder();
-
-            TruffleTypes types = context.getTypes();
-
-            if (cachedVersion) {
-                // call uncached version for the interpreter version.
-                // no need to check the state there.
-                builder.startIf().startStaticCall(types.CompilerDirectives, "inInterpreter").end().end().startBlock();
-                builder.startReturn().startCall(name).string(LOCAL_VALUE).end().end();
-                builder.end();
-            }
 
             boolean elseIf = false;
 


### PR DESCRIPTION
This is likely not beneficial any more now with hosted inlining.
In Ruby, it causes all long conversions to go through a call, and the compiler can’t use the context from previous checks to optimize.

There might be a small performance benefit: https://rebench.stefan-marr.de/compare/TruffleRuby/0b8869e410a4fc3104bfe6a0eddf732218c2008e/3eec1f52e35853535cf6ce3af13250c1edccf7a9#ruby-startup-TruffleRuby-native-interp

/cc @chumer