### PR TITLE
Fix file size reporting of produced image

### DIFF
--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/image/NativeImageViaCC.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/image/NativeImageViaCC.java
@@ -136,6 +136,9 @@ public abstract class NativeImageViaCC extends NativeImage {
                 }
 
                 Path imagePath = inv.getOutputFile();
+                // Set the file size for reporting again as the object file before linking might be
+                // larger than the final size.
+                resultingImageSize = (int) imagePath.toFile().length();
                 BuildArtifacts.singleton().add(imageKind.isExecutable ? ArtifactType.EXECUTABLE : ArtifactType.SHARED_LIB, imagePath);
 
                 if (Platform.includedIn(Platform.WINDOWS.class) && !imageKind.isExecutable) {


### PR DESCRIPTION
Previously the total image size as reported by ProgressReporter
would report the size of the object file (.o) prior linking to
an executable as the total size. This doesn't match the size of
the actually produced final native image.

Fix the reporting by setting the reported size again after the
linking stage in NativeImageViaCC.write().

Closes #4706