### PR TITLE
Fix the implementation of CHECKCAST byte code instruction.

### DIFF
--- a/compiler/src/org.graalvm.compiler.java/src/org/graalvm/compiler/java/BytecodeParser.java
+++ b/compiler/src/org.graalvm.compiler.java/src/org/graalvm/compiler/java/BytecodeParser.java
@@ -1227,7 +1227,15 @@ public class BytecodeParser extends CoreProvidersDelegate implements GraphBuilde
      */
     protected void handleUnresolvedCheckCast(JavaType type, ValueNode object) {
         assert !graphBuilderConfig.unresolvedIsError();
+
+        // The CHECKCAST byte code refers to a type that could not be resolved.
+        // CHECKCAST must throw an exception if, and only if, the object is not null.
+
+        // Deoptimize (to throw an exception) if the object is non-null. Continue otherwise.
         append(new FixedGuardNode(graph.addOrUniqueWithInputs(IsNullNode.create(object)), Unresolved, InvalidateRecompile));
+
+        // Case where the object is null: CHECKCAST does not care about the type.
+        // Push "null" to the byte code stack, then continue running normally.
         frameState.push(JavaKind.Object, appendConstant(JavaConstant.NULL_POINTER));
     }
 

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/phases/SharedGraphBuilderPhase.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/phases/SharedGraphBuilderPhase.java
@@ -32,7 +32,11 @@ import org.graalvm.compiler.java.BciBlockMapping;
 import org.graalvm.compiler.java.BytecodeParser;
 import org.graalvm.compiler.java.FrameStateBuilder;
 import org.graalvm.compiler.java.GraphBuilderPhase;
+import org.graalvm.compiler.nodes.BeginNode;
 import org.graalvm.compiler.nodes.CallTargetNode.InvokeKind;
+import org.graalvm.compiler.nodes.calc.IsNullNode;
+import org.graalvm.compiler.nodes.extended.BranchProbabilityNode;
+import org.graalvm.compiler.nodes.IfNode;
 import org.graalvm.compiler.nodes.StructuredGraph;
 import org.graalvm.compiler.nodes.ValueNode;
 import org.graalvm.compiler.nodes.graphbuilderconf.GeneratedInvocationPlugin;
@@ -59,6 +63,7 @@ import com.oracle.svm.hosted.LinkAtBuildTimeSupport;
 
 import jdk.vm.ci.meta.JavaField;
 import jdk.vm.ci.meta.JavaKind;
+import jdk.vm.ci.meta.JavaConstant;
 import jdk.vm.ci.meta.JavaMethod;
 import jdk.vm.ci.meta.JavaType;
 import jdk.vm.ci.meta.JavaTypeProfile;
@@ -216,7 +221,22 @@ public abstract class SharedGraphBuilderPhase extends GraphBuilderPhase.Instance
 
         @Override
         protected void handleUnresolvedCheckCast(JavaType type, ValueNode object) {
+            // The CHECKCAST byte code refers to a type that could not be resolved.
+            // CHECKCAST must throw an exception if, and only if, the object is not null.
+            BeginNode nullObj = graph.add(new BeginNode());
+            BeginNode nonNullObj = graph.add(new BeginNode());
+            append(new IfNode(graph.addOrUniqueWithInputs(IsNullNode.create(object)),
+                            nullObj, nonNullObj, BranchProbabilityNode.NOT_FREQUENT_PROFILE));
+
+            // Case where the object is not null, and type could not be resolved: Throw an
+            // exception.
+            lastInstr = nonNullObj;
             handleUnresolvedType(type);
+
+            // Case where the object is null: CHECKCAST does not care about the type.
+            // Push "null" to the byte code stack, then continue running normally.
+            lastInstr = nullObj;
+            frameState.push(JavaKind.Object, appendConstant(JavaConstant.NULL_POINTER));
         }
 
         @Override


### PR DESCRIPTION
[`CHECKCAST`](https://docs.oracle.com/javase/specs/jvms/se11/html/jvms-6.html#jvms-6.5.checkcast) must not throw an exception when the object is `null`, even if the type cannot be resolved.
