### PR TITLE
[GR-40096] Limit the scope of the try catch block in FeatureHandler#registerFeature

### DIFF
--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/FeatureHandler.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/FeatureHandler.java
@@ -129,11 +129,13 @@ public class FeatureHandler {
         }
 
         for (String featureName : Options.userEnabledFeatures()) {
+            Class<?> featureClass;
             try {
-                registerFeature(Class.forName(featureName, true, loader.getClassLoader()), specificClassProvider, access);
+                featureClass = Class.forName(featureName, true, loader.getClassLoader());
             } catch (ClassNotFoundException e) {
                 throw UserError.abort("Feature %s class not found on the classpath. Ensure that the name is correct and that the class is on the classpath.", featureName);
             }
+            registerFeature(featureClass, specificClassProvider, access);
         }
         if (NativeImageOptions.PrintFeatures.getValue()) {
             ReportUtils.report("feature information", SubstrateOptions.reportsPath(), "feature_info", "csv", out -> {


### PR DESCRIPTION
This prevents `NoClassDefFoundError`s from other methods, e.g. `org.graalvm.nativeimage.hosted.Feature#getRequiredFeatures`, to get caught and wrongly reported.

Relates to https://github.com/oracle/graal/issues/4736