### PR TITLE
Add jdk.JavaMonitorWait events to JavaMonitorQueuedSynchronizer

### DIFF
--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/JfrEvent.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/JfrEvent.java
@@ -55,7 +55,8 @@ public enum JfrEvent {
     SafepointEnd("jdk.SafepointEnd"),
     ExecuteVMOperation("jdk.ExecuteVMOperation"),
     JavaMonitorEnter("jdk.JavaMonitorEnter"),
-    ThreadSleep("jdk.ThreadSleep");
+    ThreadSleep("jdk.ThreadSleep"),
+    JavaMonitorWait("jdk.JavaMonitorWait");
 
     private final long id;
 

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/events/JavaMonitorWaitEvent.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/events/JavaMonitorWaitEvent.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2022, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2022, Red Hat Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package com.oracle.svm.core.jfr.events;
+import com.oracle.svm.core.annotate.Uninterruptible;
+import com.oracle.svm.core.jfr.JfrEvent;
+import com.oracle.svm.core.jfr.JfrNativeEventWriter;
+import com.oracle.svm.core.jfr.JfrNativeEventWriterData;
+import com.oracle.svm.core.jfr.JfrNativeEventWriterDataAccess;
+import com.oracle.svm.core.jfr.JfrTicks;
+import com.oracle.svm.core.jfr.SubstrateJVM;
+import org.graalvm.compiler.word.Word;
+import com.oracle.svm.core.jfr.HasJfrSupport;
+
+public class JavaMonitorWaitEvent {
+    public static void emit(long startTicks, Object obj, long notifier, long timeout, boolean timedOut) {
+        if (HasJfrSupport.get()) {
+            emit0(startTicks, obj, notifier, timeout, timedOut);
+        }
+    }
+
+    @Uninterruptible(reason = "Accesses a JFR buffer.")
+    private static void emit0(long startTicks, Object obj, long notifier, long timeout, boolean timedOut) {
+        if (SubstrateJVM.isRecording() && SubstrateJVM.get().isEnabled(JfrEvent.JavaMonitorWait)) {
+            JfrNativeEventWriterData data = org.graalvm.nativeimage.StackValue.get(JfrNativeEventWriterData.class);
+            JfrNativeEventWriterDataAccess.initializeThreadLocalNativeBuffer(data);
+            JfrNativeEventWriter.beginSmallEvent(data, JfrEvent.JavaMonitorWait);
+            JfrNativeEventWriter.putLong(data, startTicks);
+            JfrNativeEventWriter.putLong(data, JfrTicks.elapsedTicks() - startTicks);
+            JfrNativeEventWriter.putEventThread(data);
+            JfrNativeEventWriter.putLong(data, SubstrateJVM.get().getStackTraceId(JfrEvent.JavaMonitorWait, 0));
+            JfrNativeEventWriter.putClass(data, obj.getClass());
+            JfrNativeEventWriter.putLong(data, notifier);
+            JfrNativeEventWriter.putLong(data, timeout);
+            JfrNativeEventWriter.putBoolean(data, timedOut);
+            JfrNativeEventWriter.putLong(data, Word.objectToUntrackedPointer(obj).rawValue());
+            JfrNativeEventWriter.endSmallEvent(data);
+        }
+    }
+}

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/events/JavaMonitorWaitEvent.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/events/JavaMonitorWaitEvent.java
@@ -25,6 +25,7 @@
  */
 
 package com.oracle.svm.core.jfr.events;
+
 import com.oracle.svm.core.annotate.Uninterruptible;
 import com.oracle.svm.core.jfr.JfrEvent;
 import com.oracle.svm.core.jfr.JfrNativeEventWriter;

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/monitor/JavaMonitorQueuedSynchronizer.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/monitor/JavaMonitorQueuedSynchronizer.java
@@ -481,7 +481,7 @@ abstract class JavaMonitorQueuedSynchronizer {
             }
             setCurrentBlocker(null);
             node.clearStatus();
-            //waiting is done, emit wait event
+            // waiting is done, emit wait event
             JavaMonitorWaitEvent.emit(startTicks, obj, node.notifierTid, 0L, false);
             acquire(node, savedState);
             if (interrupted) {
@@ -518,7 +518,7 @@ abstract class JavaMonitorQueuedSynchronizer {
                 }
             }
             node.clearStatus();
-            //waiting is done, emit wait event
+            // waiting is done, emit wait event
             JavaMonitorWaitEvent.emit(startTicks, obj, node.notifierTid, time, cancelled);
             acquire(node, savedState);
             if (cancelled) {

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/monitor/MultiThreadedMonitorSupport.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/monitor/MultiThreadedMonitorSupport.java
@@ -331,9 +331,9 @@ public class MultiThreadedMonitorSupport extends MonitorSupport {
         JavaMonitor lock = ensureLocked(obj);
         JavaMonitorConditionObject condition = lock.getOrCreateCondition(true);
         if (timeoutMillis == 0L) {
-            condition.await();
+            condition.await(obj);
         } else {
-            condition.await(timeoutMillis, TimeUnit.MILLISECONDS);
+            condition.await(obj, timeoutMillis, TimeUnit.MILLISECONDS);
         }
     }
 


### PR DESCRIPTION
Add support for JFR jdk.JavaMonitorWait events in native images. This implementation tries to mirror the implementation in Hotspot native code by leveraging the nodes that wait on the `JavaMonitorConditionObject` wait queue.