### PR TITLE
[GR-40096] Hint for the library naming added

### DIFF
--- a/sdk/src/org.graalvm.nativeimage/src/org/graalvm/nativeimage/c/function/CLibrary.java
+++ b/sdk/src/org.graalvm.nativeimage/src/org/graalvm/nativeimage/c/function/CLibrary.java
@@ -56,7 +56,8 @@ import java.lang.annotation.Target;
 public @interface CLibrary {
 
     /**
-     * The name of the library.
+     * The name of the library without the ending e.g. hello. 
+     * The name of the actual file should start with "lib", e.g. <code>libhello.so</code>
      *
      * @since 19.0
      */


### PR DESCRIPTION
The value of the annotation contains the name of the library prefixed with "lib" without the ending.

e.g.  @CLibrary("calculator") expects the following file: `libcalculator.so`

Also checkout: https://adambien.blog/roller/abien/entry/graalvm_how_to_call_c