### PR TITLE
[GR-41270] Verify access should only be called when caller is not null

### DIFF
--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/methodhandles/Target_java_lang_invoke_MethodHandleNatives.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/methodhandles/Target_java_lang_invoke_MethodHandleNatives.java
@@ -222,7 +222,7 @@ final class Target_java_lang_invoke_MethodHandleNatives {
         Class<?> declaringClass = self.getDeclaringClass();
         Target_java_lang_invoke_MemberName resolved = Util_java_lang_invoke_MethodHandleNatives.resolve(self, caller, speculativeResolve);
         assert resolved == null || resolved.reflectAccess != null || resolved.intrinsic != null;
-        if (resolved != null && resolved.reflectAccess != null &&
+        if (resolved != null && resolved.reflectAccess != null && caller != null &&
                         !Util_java_lang_invoke_MethodHandleNatives.verifyAccess(declaringClass, resolved.reflectAccess.getDeclaringClass(), resolved.reflectAccess.getModifiers(), caller,
                                         lookupMode)) {
             throw new IllegalAccessError(resolved + " is not accessible from " + caller);

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/methodhandles/MethodHandleFeature.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/methodhandles/MethodHandleFeature.java
@@ -26,6 +26,7 @@ package com.oracle.svm.hosted.methodhandles;
 
 import java.lang.invoke.CallSite;
 import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodType;
 import java.lang.reflect.Array;
 import java.lang.reflect.Field;
@@ -35,6 +36,7 @@ import java.util.Iterator;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
+import jdk.internal.misc.Unsafe;
 import org.graalvm.compiler.serviceprovider.JavaVersionUtil;
 import org.graalvm.nativeimage.hosted.Feature;
 import org.graalvm.nativeimage.hosted.RuntimeReflection;
@@ -186,6 +188,9 @@ public class MethodHandleFeature implements Feature {
                         access.findClassByName("java.lang.invoke.VarHandle"));
 
         access.registerSubtypeReachabilityHandler(MethodHandleFeature::scanBoundMethodHandle, boundMethodHandleClass);
+
+        access.registerReachabilityHandler(MethodHandleFeature::registerUnsafePutReference,
+                        ReflectionUtil.lookupMethod(MethodHandles.Lookup.class, "unreflectSetter", Field.class));
     }
 
     private static void registerMHImplFunctionsForReflection(DuringAnalysisAccess access) {
@@ -260,6 +265,10 @@ public class MethodHandleFeature implements Feature {
                 }
             }
         }
+    }
+
+    private static void registerUnsafePutReference(DuringAnalysisAccess access) {
+        RuntimeReflection.register(ReflectionUtil.lookupMethod(Unsafe.class, "putReference", Object.class, long.class, Object.class));
     }
 
     private static String valueConverterName(Wrapper src, Wrapper dest) {


### PR DESCRIPTION
Fixes #4794.

Can you provide guidance on where to add the `Unsafe.putReference` reflection registration so that users don't have to do this?