### PR TITLE
Give host code a chance to create non-modifiable polyglot array

### DIFF
--- a/truffle/src/com.oracle.truffle.api.test/src/com/oracle/truffle/api/test/polyglot/ProxyAPITest.java
+++ b/truffle/src/com.oracle.truffle.api.test/src/com/oracle/truffle/api/test/polyglot/ProxyAPITest.java
@@ -84,6 +84,8 @@ import org.junit.Before;
 import org.junit.Test;
 
 import com.oracle.truffle.tck.tests.ValueAssert.Trait;
+import java.util.Collections;
+import static org.junit.Assert.fail;
 
 /**
  * Testing the behavior of proxies API and proxy interfaces.
@@ -137,6 +139,21 @@ public class ProxyAPITest {
             return getSize.get();
         }
 
+    }
+
+    @Test
+    public void readOnlyUnmodifiableList() {
+        List<String> proxy = Collections.unmodifiableList(Collections.nCopies(10, "A"));
+        Value value = context.asValue(proxy);
+        assertTrue(value.hasArrayElements());
+        try {
+            value.setArrayElement(0, "B");
+        } catch (RuntimeException ex) {
+            assertEquals("Read-only array element", ex.getMessage());
+            assertEquals(UnsupportedOperationException.class, ex.getClass());
+            return;
+        }
+        fail("Runtime exception shall have been thrown");
     }
 
     @Test


### PR DESCRIPTION
We are working on an implementation of a [functional programming language](http://enso.org) on top of Truffle. One of the important features of functional languages is [referential transparency](https://en.wikipedia.org/wiki/Referential_transparency). We can reach it in our language, but we have problems achieving it effectively when dealing with other languages across polyglot boundary.

For example, when we receive an object which _hasArrayElements_, we'd like to know whether it is _safe to use it_ as is, or whether we shall _defensively copy_ its content. Usually we have both sides (the Enso one and the Java one) under our control. E.g. the problem is just about communicating between these two whether the array can be considered immutable or not.

It has come to my attention that there is [isArrayElementModifiable](https://www.graalvm.org/truffle/javadoc/com/oracle/truffle/api/interop/InteropLibrary.html#isArrayElementModifiable-java.lang.Object-long-) which we could use to ask the array. Assuming that if all elements we read are not modifiable, then the array won't change. I consider it a good heuristic.

However then I tried to investigate what needs to be done on the (host) Java side to mark an array (or rather a `List`) as read only. I've noticed there is no such way (probably the `isArrayElementXyz` messages were added later than polyglot SDK and nobody needed to expose them yet). This PR is my attempt to allow (host) Java to express that a `List` is not mutable by using check for [friendly class implementations](https://github.com/oracle/graal/blob/01cdd0ac7b496711b8afd1dbc6649e335c4f6465/truffle/src/com.oracle.truffle.host/src/com/oracle/truffle/host/HostObject.java#L104). I don't think the current code is mergable, but it should be good enough to start discussion.

What do you think, @chumer, @tzezula, @jdunkerley, @kustosz, @radeusgd, @hubertp?