### PR TITLE
[GR-40874] Perf support

### DIFF
--- a/docs/reference-manual/native-image/DebuggingAndDiagnostics.md
+++ b/docs/reference-manual/native-image/DebuggingAndDiagnostics.md
@@ -8,7 +8,7 @@ permalink: /reference-manual/native-image/debugging-and-diagnostics/
 # Debugging and Diagnostics
 
 Native Image provides utilities for debugging and inspecting the produced binary:
- - For debugging produced binaries, see [Debug Information](DebugInfo.md)
+ - For debugging produced binaries and obtaining performance profile statistics, see [Debug Information](DebugInfo.md)
  - For Java-like debugging of native executables in a running state, see [Debugging Native Executables](Debugging.md)
  - For generating heap dumps, see [Heap Dump Support](guides/create-heap-dump-from-native-executable.md)
  - For JFR events recording, see [JDK Flight Recorder (JFR)](JFR.md)

--- a/substratevm/mx.substratevm/mx_substratevm.py
+++ b/substratevm/mx.substratevm/mx_substratevm.py
@@ -1274,6 +1274,17 @@ def debuginfotest(args, config=None):
         config=config
     )
 
+@mx.command(suite_name=suite.name, command_name='debuginfotestshared', usage_msg='[options]')
+def debuginfotestshared(args, config=None):
+    """
+    builds a debuginfo ctutorial image but does not yet test it with gdb"
+    """
+    # set an explicit path to the source tree for the tutorial code
+    sourcepath = mx.project('com.oracle.svm.tutorial').source_dirs()[0]
+    all_args = ['-H:GenerateDebugInfo=1', '-H:+SourceLevelDebug', '-H:DebugInfoSourceSearchPath=' + sourcepath, '-H:-DeleteLocalSymbols'] + args
+    # build and run the native image using debug info
+    # ideally we ought to script a gdb run
+    native_image_context_run(_cinterfacetutorial, all_args)
 
 @mx.command(suite_name=suite.name, command_name='helloworld', usage_msg='[options]')
 def helloworld(args, config=None):

--- a/substratevm/mx.substratevm/testhello.py
+++ b/substratevm/mx.substratevm/testhello.py
@@ -135,7 +135,8 @@ def test():
     package_file_pattern = '[a-zA-Z0-9_/]+\\.java'
     varname_pattern = '[a-zA-Z0-9_]+'
     wildcard_pattern = '.*'
-    arg_values_pattern = "(.*=.*)"
+    no_arg_values_pattern = "\(\)"
+    arg_values_pattern = "\((([^=,]+=[^=,]+)(,[^=,]+=[^=,]+)*)?\)"
     # obtain the gdb version
     # n.b. we can only test printing in gdb 10.1 upwards
     exec_string=execute("show version")
@@ -207,12 +208,11 @@ def test():
     # expect "#1  0x[0-9a-f]+ in com.oracle.svm.core.code.IsolateEnterStub.JavaMainWrapper_run_.* at [a-z/]+/JavaMainWrapper.java:[0-9]+"
     exec_string = execute("backtrace")
     checker = Checker("backtrace hello.Hello::main",
-                      [r"#0%shello\.Hello::main\(java\.lang\.String\[\] \*\)%s at hello/Hello\.java:76"%(spaces_pattern, wildcard_pattern),
-                       r"#1%s%s in com\.oracle\.svm\.core\.JavaMainWrapper::runCore0%s at %sJavaMainWrapper\.java:[0-9]+"%(spaces_pattern, address_pattern, wildcard_pattern, package_pattern),
-                       r"#2%s%s in com\.oracle\.svm\.core\.JavaMainWrapper::runCore%s at %sJavaMainWrapper\.java:[0-9]+"%(spaces_pattern, address_pattern, wildcard_pattern, package_pattern),
-                       r"#3%s com\.oracle\.svm\.core\.JavaMainWrapper::doRun%s at %sJavaMainWrapper\.java:[0-9]+"%(spaces_pattern, wildcard_pattern, package_pattern),
-                       r"#4%s%s in com\.oracle\.svm\.core\.JavaMainWrapper::run%s at %sJavaMainWrapper\.java:[0-9]+"%(spaces_pattern, address_pattern, wildcard_pattern, package_pattern),
-                       r"#5%s com\.oracle\.svm\.core\.code\.IsolateEnterStub::JavaMainWrapper_run_%s%s at %sIsolateEnterStub\.java:[0-9]+"%(spaces_pattern, hex_digits_pattern, wildcard_pattern, package_pattern)
+                      [r"#0%shello\.Hello::main %s at hello/Hello\.java:76"%(spaces_pattern, wildcard_pattern),
+                       r"#1%s%s in com\.oracle\.svm\.core\.JavaMainWrapper::runCore0 %s at %sJavaMainWrapper\.java:[0-9]+"%(spaces_pattern, address_pattern, wildcard_pattern, package_pattern),
+                       r"#2%s%s in com\.oracle\.svm\.core\.JavaMainWrapper::runCore %s at %sJavaMainWrapper\.java:[0-9]+"%(spaces_pattern, address_pattern, wildcard_pattern, package_pattern),
+                       r"#3%s com\.oracle\.svm\.core\.JavaMainWrapper::run %s at %sJavaMainWrapper\.java:[0-9]+"%(spaces_pattern, wildcard_pattern, package_pattern),
+                       r"#4%s%s in com\.oracle\.svm\.core\.code\.IsolateEnterStub::JavaMainWrapper_run_%s %s"%(spaces_pattern, address_pattern, hex_digits_pattern, wildcard_pattern)
                       ])
     checker.check(exec_string, skip_fails=False)
 
@@ -308,9 +308,9 @@ def test():
     exec_string = execute("info func greet")
     rexp = [r'All functions matching regular expression "greet":',
             r"File hello/Hello\.java:",
-            r"71:%svoid hello.Hello\$NamedGreeter::greet\(void\);"%maybe_spaces_pattern,
+            r"71:%svoid hello.Hello\$NamedGreeter::greet\(%s\);"%(maybe_spaces_pattern,wildcard_pattern),
             r"File hello/Target_hello_Hello_DefaultGreeter\.java:",
-            r"48:%svoid hello.Hello\$DefaultGreeter::greet\(void\);"%maybe_spaces_pattern]
+            r"48:%svoid hello.Hello\$DefaultGreeter::greet\(%s\);"%(maybe_spaces_pattern,wildcard_pattern)]
     checker = Checker("info func greet", rexp)
     checker.check(exec_string)
 
@@ -408,13 +408,12 @@ def test():
     # run a backtrace
     exec_string = execute("backtrace")
     checker = Checker("backtrace hello.Hello.Greeter::greeter",
-                      [r"#0%shello\.Hello\$Greeter::greeter\(java\.lang\.String\[\] \*\)%s at hello/Hello\.java:37"%(spaces_pattern, wildcard_pattern),
-                       r"#1%s%s in hello\.Hello::main\(java\.lang\.String\[\] \*\)%s at hello/Hello\.java:76"%(spaces_pattern, address_pattern, wildcard_pattern),
-                       r"#2%s%s in com\.oracle\.svm\.core\.JavaMainWrapper::runCore0%s at %sJavaMainWrapper\.java:[0-9]+"%(spaces_pattern, address_pattern, wildcard_pattern, package_pattern),
-                       r"#3%s%s in com\.oracle\.svm\.core\.JavaMainWrapper::runCore%s at %sJavaMainWrapper\.java:[0-9]+"%(spaces_pattern, address_pattern, wildcard_pattern, package_pattern),
-                       r"#4%scom\.oracle\.svm\.core\.JavaMainWrapper::doRun%s at %sJavaMainWrapper\.java:[0-9]+"%(spaces_pattern, wildcard_pattern, package_pattern),
-                       r"#5%s%s in com\.oracle\.svm\.core\.JavaMainWrapper::run%s at %sJavaMainWrapper\.java:[0-9]+"%(spaces_pattern, address_pattern, wildcard_pattern, package_pattern),
-                       r"#6%s com\.oracle\.svm\.core\.code\.IsolateEnterStub::JavaMainWrapper_run_%s%s at %sIsolateEnterStub\.java:[0-9]+"%(spaces_pattern, hex_digits_pattern, wildcard_pattern, package_pattern)
+                      [r"#0%shello\.Hello\$Greeter::greeter %s at hello/Hello\.java:37"%(spaces_pattern, wildcard_pattern),
+                       r"#1%s%s in hello\.Hello::main %s at hello/Hello\.java:76"%(spaces_pattern, address_pattern, wildcard_pattern),
+                       r"#2%s%s in com\.oracle\.svm\.core\.JavaMainWrapper::runCore0 %s at %sJavaMainWrapper\.java:[0-9]+"%(spaces_pattern, address_pattern, wildcard_pattern, package_pattern),
+                       r"#3%s%s in com\.oracle\.svm\.core\.JavaMainWrapper::runCore %s at %sJavaMainWrapper\.java:[0-9]+"%(spaces_pattern, address_pattern, wildcard_pattern, package_pattern),
+                       r"#4%scom\.oracle\.svm\.core\.JavaMainWrapper::run %s at %sJavaMainWrapper\.java:[0-9]+"%(spaces_pattern, wildcard_pattern, package_pattern),
+                       r"#5%s%s in com\.oracle\.svm\.core\.code\.IsolateEnterStub::JavaMainWrapper_run_%s %s"%(spaces_pattern, address_pattern, hex_digits_pattern, wildcard_pattern)
                       ])
     checker.check(exec_string, skip_fails=False)
 
@@ -424,7 +423,7 @@ def test():
     # check we are still in hello.Hello$Greeter.greeter but no longer in hello.Hello.java
     exec_string = execute("backtrace 1")
     checker = Checker("backtrace inline",
-                      [r"#0%shello\.Hello\$Greeter::greeter\(java\.lang\.String\[\] \*\)%s at (%s):%s"%(spaces_pattern, wildcard_pattern, package_file_pattern, digits_pattern)])
+                      [r"#0%shello\.Hello\$Greeter::greeter %s at (%s):%s"%(spaces_pattern, wildcard_pattern, package_file_pattern, digits_pattern)])
     matches = checker.check(exec_string, skip_fails=False)
     # n.b. can only get back here with one match
     match = matches[0]
@@ -561,10 +560,10 @@ def test():
     checker = Checker('step in inlineA', rexp)
     checker.check(exec_string, skip_fails=False)
     exec_string = execute("backtrace 4")
-    rexp = [r"#0%shello\.Hello::inlineA \(\) at hello/Hello\.java:133"%spaces_pattern,
-            r"#1%shello\.Hello::inlineIs \(\) at hello/Hello\.java:128"%spaces_pattern,
-            r"#2%shello\.Hello::noInlineThis\(void\) \(\) at hello/Hello\.java:123"%spaces_pattern,
-            r"#3%s%s in hello\.Hello::main\(java\.lang\.String\[\] \*\) %s at hello/Hello\.java:93"%(spaces_pattern, address_pattern, arg_values_pattern)]
+    rexp = [r"#0%shello\.Hello::inlineA %s at hello/Hello\.java:133"%(spaces_pattern, no_arg_values_pattern),
+            r"#1%shello\.Hello::inlineIs %s at hello/Hello\.java:128"%(spaces_pattern, no_arg_values_pattern),
+            r"#2%shello\.Hello::noInlineThis %s at hello/Hello\.java:123"%(spaces_pattern, no_arg_values_pattern),
+            r"#3%s%s in hello\.Hello::main %s at hello/Hello\.java:93"%(spaces_pattern, address_pattern, arg_values_pattern)]
     checker = Checker('backtrace inlineMee', rexp)
     checker.check(exec_string, skip_fails=False)
 
@@ -580,11 +579,11 @@ def test():
     checker = Checker('hit breakpoint in noInlineTest', rexp)
     checker.check(exec_string, skip_fails=False)
     exec_string = execute("backtrace 5")
-    rexp = [r"#0%shello\.Hello::noInlineTest\(void\) \(\) at hello/Hello\.java:138"%(spaces_pattern),
-            r"#1%s%s in hello\.Hello::inlineA \(\) at hello/Hello\.java:133"%(spaces_pattern, address_pattern),
-            r"#2%shello\.Hello::inlineIs \(\) at hello/Hello\.java:128"%(spaces_pattern),
-            r"#3%shello\.Hello::noInlineThis\(void\) \(\) at hello/Hello\.java:123"%(spaces_pattern),
-            r"#4%s%s in hello\.Hello::main\(java\.lang\.String\[\] \*\) %s at hello/Hello\.java:93"%(spaces_pattern, address_pattern, arg_values_pattern)]
+    rexp = [r"#0%shello\.Hello::noInlineTest %s at hello/Hello\.java:138"%(spaces_pattern, no_arg_values_pattern),
+            r"#1%s%s in hello\.Hello::inlineA %s at hello/Hello\.java:133"%(spaces_pattern, address_pattern, no_arg_values_pattern),
+            r"#2%shello\.Hello::inlineIs %s at hello/Hello\.java:128"%(spaces_pattern, no_arg_values_pattern),
+            r"#3%shello\.Hello::noInlineThis %s at hello/Hello\.java:123"%(spaces_pattern, no_arg_values_pattern),
+            r"#4%s%s in hello\.Hello::main %s at hello/Hello\.java:93"%(spaces_pattern, address_pattern, arg_values_pattern)]
     checker = Checker('backtrace in inlineMethod', rexp)
     checker.check(exec_string, skip_fails=False)
 
@@ -609,19 +608,19 @@ def test():
     execute("continue 5")
     exec_string = execute("backtrace 14")
     rexp = [r"#0%shello\.Hello::inlineMixTo %s at hello/Hello\.java:160"%(spaces_pattern, arg_values_pattern),
-            r"#1%shello\.Hello::noInlineHere\(int\) %s at hello/Hello\.java:152"%(spaces_pattern, arg_values_pattern),
+            r"#1%shello\.Hello::noInlineHere %s at hello/Hello\.java:152"%(spaces_pattern, arg_values_pattern),
             r"#2%s%s in hello\.Hello::inlineMixTo %s at hello/Hello\.java:158"%(spaces_pattern, address_pattern, arg_values_pattern),
-            r"#3%shello\.Hello::noInlineHere\(int\) %s at hello/Hello\.java:152"%(spaces_pattern, arg_values_pattern),
+            r"#3%shello\.Hello::noInlineHere %s at hello/Hello\.java:152"%(spaces_pattern, arg_values_pattern),
             r"#4%s%s in hello\.Hello::inlineMixTo %s at hello/Hello\.java:158"%(spaces_pattern, address_pattern, arg_values_pattern),
-            r"#5%shello\.Hello::noInlineHere\(int\) %s at hello/Hello\.java:152"%(spaces_pattern, arg_values_pattern),
+            r"#5%shello\.Hello::noInlineHere %s at hello/Hello\.java:152"%(spaces_pattern, arg_values_pattern),
             r"#6%s%s in hello\.Hello::inlineMixTo %s at hello/Hello\.java:158"%(spaces_pattern, address_pattern, arg_values_pattern),
-            r"#7%shello\.Hello::noInlineHere\(int\) %s at hello/Hello\.java:152"%(spaces_pattern, arg_values_pattern),
+            r"#7%shello\.Hello::noInlineHere %s at hello/Hello\.java:152"%(spaces_pattern, arg_values_pattern),
             r"#8%s%s in hello\.Hello::inlineMixTo %s at hello/Hello\.java:158"%(spaces_pattern, address_pattern, arg_values_pattern),
-            r"#9%shello\.Hello::noInlineHere\(int\) %s at hello/Hello\.java:152"%(spaces_pattern, arg_values_pattern),
+            r"#9%shello\.Hello::noInlineHere %s at hello/Hello\.java:152"%(spaces_pattern, arg_values_pattern),
             r"#10%s%s in hello\.Hello::inlineMixTo %s at hello/Hello\.java:158"%(spaces_pattern, address_pattern, arg_values_pattern),
-            r"#11%shello\.Hello::noInlineHere\(int\) %s at hello/Hello\.java:152"%(spaces_pattern, arg_values_pattern),
-            r"#12%s%s in hello\.Hello::inlineFrom \(\) at hello/Hello\.java:144"%(spaces_pattern, address_pattern),
-            r"#13%shello\.Hello::main\(java\.lang\.String\[\] \*\) %s at hello/Hello\.java:94"%(spaces_pattern, arg_values_pattern)]
+            r"#11%shello\.Hello::noInlineHere %s at hello/Hello\.java:152"%(spaces_pattern, arg_values_pattern),
+            r"#12%s%s in hello\.Hello::inlineFrom %s at hello/Hello\.java:144"%(spaces_pattern, address_pattern, no_arg_values_pattern),
+            r"#13%shello\.Hello::main %s at hello/Hello\.java:94"%(spaces_pattern, arg_values_pattern)]
     checker = Checker('backtrace in recursive inlineMixTo', rexp)
     checker.check(exec_string, skip_fails=False)
 
@@ -639,20 +638,20 @@ def test():
     # which means the format of the frame display may vary from
     # one build to the next. so we use a generic match after the
     # first pair.
-    rexp = [r"#0%shello\.Hello::inlineTo\(int\) %s at hello/Hello\.java:173"%(spaces_pattern, arg_values_pattern),
+    rexp = [r"#0%shello\.Hello::inlineTo %s at hello/Hello\.java:173"%(spaces_pattern, arg_values_pattern),
             r"#1%s%s in hello\.Hello::inlineHere %s at hello/Hello\.java:165"%(spaces_pattern, address_pattern, arg_values_pattern),
-            r"#2%shello\.Hello::inlineTo%s at hello/Hello\.java:171"%(wildcard_pattern, wildcard_pattern),
-            r"#3%shello\.Hello::inlineHere%s at hello/Hello\.java:165"%(wildcard_pattern, wildcard_pattern),
-            r"#4%shello\.Hello::inlineTo%s at hello/Hello\.java:171"%(wildcard_pattern, wildcard_pattern),
-            r"#5%shello\.Hello::inlineHere%s at hello/Hello\.java:165"%(wildcard_pattern, wildcard_pattern),
-            r"#6%shello\.Hello::inlineTo%s at hello/Hello\.java:171"%(wildcard_pattern, wildcard_pattern),
-            r"#7%shello\.Hello::inlineHere%s at hello/Hello\.java:165"%(wildcard_pattern, wildcard_pattern),
-            r"#8%shello\.Hello::inlineTo%s at hello/Hello\.java:171"%(wildcard_pattern, wildcard_pattern),
-            r"#9%shello\.Hello::inlineHere%s at hello/Hello\.java:165"%(wildcard_pattern, wildcard_pattern),
-            r"#10%shello\.Hello::inlineTo%s at hello/Hello\.java:171"%(wildcard_pattern, wildcard_pattern),
-            r"#11%shello\.Hello::inlineHere%s at hello/Hello\.java:165"%(wildcard_pattern, wildcard_pattern),
-            r"#12%shello\.Hello::inlineFrom \(\) at hello/Hello\.java:146"%(spaces_pattern),
-            r"#13%shello\.Hello::main\(java\.lang\.String\[\] \*\) %s at hello/Hello\.java:94"%(spaces_pattern, arg_values_pattern)]
+            r"#2%shello\.Hello::inlineTo %s at hello/Hello\.java:171"%(wildcard_pattern, arg_values_pattern),
+            r"#3%shello\.Hello::inlineHere %s at hello/Hello\.java:165"%(wildcard_pattern, arg_values_pattern),
+            r"#4%shello\.Hello::inlineTo %s at hello/Hello\.java:171"%(wildcard_pattern, arg_values_pattern),
+            r"#5%shello\.Hello::inlineHere %s at hello/Hello\.java:165"%(wildcard_pattern, arg_values_pattern),
+            r"#6%shello\.Hello::inlineTo %s at hello/Hello\.java:171"%(wildcard_pattern, arg_values_pattern),
+            r"#7%shello\.Hello::inlineHere %s at hello/Hello\.java:165"%(wildcard_pattern, arg_values_pattern),
+            r"#8%shello\.Hello::inlineTo %s at hello/Hello\.java:171"%(wildcard_pattern, arg_values_pattern),
+            r"#9%shello\.Hello::inlineHere %s at hello/Hello\.java:165"%(wildcard_pattern, arg_values_pattern),
+            r"#10%shello\.Hello::inlineTo %s at hello/Hello\.java:171"%(wildcard_pattern, arg_values_pattern),
+            r"#11%shello\.Hello::inlineHere %s at hello/Hello\.java:165"%(wildcard_pattern, arg_values_pattern),
+            r"#12%shello\.Hello::inlineFrom %s at hello/Hello\.java:146"%(spaces_pattern, no_arg_values_pattern),
+            r"#13%shello\.Hello::main %s at hello/Hello\.java:94"%(spaces_pattern, arg_values_pattern)]
     checker = Checker('backtrace in recursive inlineTo', rexp)
     checker.check(exec_string, skip_fails=False)
 
@@ -670,14 +669,14 @@ def test():
     # which means the format of the frame display may vary from
     # one build to the next. so we use a generic match after the
     # first one.
-    rexp = [r"#0%shello\.Hello::inlineTailRecursion\(int\) %s at hello/Hello\.java:179"%(spaces_pattern, arg_values_pattern),
-            r"#1%shello\.Hello::inlineTailRecursion%s at hello/Hello\.java:182"%(wildcard_pattern, wildcard_pattern),
-            r"#2%shello\.Hello::inlineTailRecursion%s at hello/Hello\.java:182"%(wildcard_pattern, wildcard_pattern),
-            r"#3%shello\.Hello::inlineTailRecursion%s at hello/Hello\.java:182"%(wildcard_pattern, wildcard_pattern),
-            r"#4%shello\.Hello::inlineTailRecursion%s at hello/Hello\.java:182"%(wildcard_pattern, wildcard_pattern),
-            r"#5%shello\.Hello::inlineTailRecursion%s at hello/Hello\.java:182"%(wildcard_pattern, wildcard_pattern),
-            r"#6%shello\.Hello::inlineFrom \(\) at hello/Hello\.java:147"%(spaces_pattern),
-            r"#7%shello\.Hello::main\(java\.lang\.String\[\] \*\) %s at hello/Hello\.java:94"%(spaces_pattern, arg_values_pattern)]
+    rexp = [r"#0%shello\.Hello::inlineTailRecursion %s at hello/Hello\.java:179"%(spaces_pattern, arg_values_pattern),
+            r"#1%shello\.Hello::inlineTailRecursion %s at hello/Hello\.java:182"%(wildcard_pattern, arg_values_pattern),
+            r"#2%shello\.Hello::inlineTailRecursion %s at hello/Hello\.java:182"%(wildcard_pattern, arg_values_pattern),
+            r"#3%shello\.Hello::inlineTailRecursion %s at hello/Hello\.java:182"%(wildcard_pattern, arg_values_pattern),
+            r"#4%shello\.Hello::inlineTailRecursion %s at hello/Hello\.java:182"%(wildcard_pattern, arg_values_pattern),
+            r"#5%shello\.Hello::inlineTailRecursion %s at hello/Hello\.java:182"%(wildcard_pattern, arg_values_pattern),
+            r"#6%shello\.Hello::inlineFrom %s at hello/Hello\.java:147"%(spaces_pattern, no_arg_values_pattern),
+            r"#7%shello\.Hello::main %s at hello/Hello\.java:94"%(spaces_pattern, arg_values_pattern)]
     checker = Checker('backtrace in recursive inlineTo', rexp)
     checker.check(exec_string, skip_fails=False)
 
@@ -703,7 +702,6 @@ def test():
     #rexp = r"Breakpoint %s at %s: file hello/Hello\.java, line 188\."%(digits_pattern, address_pattern)
     #checker = Checker('break hello.Hello::noInlineManyArgs', rexp)
     #checker.check(exec_string)
-
     execute("continue")
     exec_string = execute("info args")
     rexp =[r"i0 = 0",

--- a/substratevm/mx.substratevm/testhello.py
+++ b/substratevm/mx.substratevm/testhello.py
@@ -211,8 +211,9 @@ def test():
                       [r"#0%shello\.Hello::main %s at hello/Hello\.java:76"%(spaces_pattern, wildcard_pattern),
                        r"#1%s%s in com\.oracle\.svm\.core\.JavaMainWrapper::runCore0 %s at %sJavaMainWrapper\.java:[0-9]+"%(spaces_pattern, address_pattern, wildcard_pattern, package_pattern),
                        r"#2%s%s in com\.oracle\.svm\.core\.JavaMainWrapper::runCore %s at %sJavaMainWrapper\.java:[0-9]+"%(spaces_pattern, address_pattern, wildcard_pattern, package_pattern),
-                       r"#3%s com\.oracle\.svm\.core\.JavaMainWrapper::run %s at %sJavaMainWrapper\.java:[0-9]+"%(spaces_pattern, wildcard_pattern, package_pattern),
-                       r"#4%s%s in com\.oracle\.svm\.core\.code\.IsolateEnterStub::JavaMainWrapper_run_%s %s"%(spaces_pattern, address_pattern, hex_digits_pattern, wildcard_pattern)
+                       r"#3%scom\.oracle\.svm\.core\.JavaMainWrapper::doRun %s at %sJavaMainWrapper\.java:[0-9]+"%(spaces_pattern, wildcard_pattern, package_pattern),
+                       r"#4%s%s in com\.oracle\.svm\.core\.JavaMainWrapper::run %s at %sJavaMainWrapper\.java:[0-9]+"%(spaces_pattern, address_pattern, wildcard_pattern, package_pattern),
+                       r"#5%scom\.oracle\.svm\.core\.code\.IsolateEnterStub::JavaMainWrapper_run_%s %s"%(spaces_pattern, hex_digits_pattern, wildcard_pattern)
                       ])
     checker.check(exec_string, skip_fails=False)
 
@@ -412,8 +413,9 @@ def test():
                        r"#1%s%s in hello\.Hello::main %s at hello/Hello\.java:76"%(spaces_pattern, address_pattern, wildcard_pattern),
                        r"#2%s%s in com\.oracle\.svm\.core\.JavaMainWrapper::runCore0 %s at %sJavaMainWrapper\.java:[0-9]+"%(spaces_pattern, address_pattern, wildcard_pattern, package_pattern),
                        r"#3%s%s in com\.oracle\.svm\.core\.JavaMainWrapper::runCore %s at %sJavaMainWrapper\.java:[0-9]+"%(spaces_pattern, address_pattern, wildcard_pattern, package_pattern),
-                       r"#4%scom\.oracle\.svm\.core\.JavaMainWrapper::run %s at %sJavaMainWrapper\.java:[0-9]+"%(spaces_pattern, wildcard_pattern, package_pattern),
-                       r"#5%s%s in com\.oracle\.svm\.core\.code\.IsolateEnterStub::JavaMainWrapper_run_%s %s"%(spaces_pattern, address_pattern, hex_digits_pattern, wildcard_pattern)
+                       r"#4%scom\.oracle\.svm\.core\.JavaMainWrapper::doRun %s at %sJavaMainWrapper\.java:[0-9]+"%(spaces_pattern, wildcard_pattern, package_pattern),
+                       r"#5%s%s in com\.oracle\.svm\.core\.JavaMainWrapper::run %s at %sJavaMainWrapper\.java:[0-9]+"%(spaces_pattern, address_pattern, wildcard_pattern, package_pattern),
+                       r"#6%scom\.oracle\.svm\.core\.code\.IsolateEnterStub::JavaMainWrapper_run_%s %s"%(spaces_pattern, hex_digits_pattern, wildcard_pattern)
                       ])
     checker.check(exec_string, skip_fails=False)
 

--- a/substratevm/mx.substratevm/testhello.py
+++ b/substratevm/mx.substratevm/testhello.py
@@ -130,6 +130,7 @@ def test():
     spaces_pattern = '[ \t]+'
     maybe_spaces_pattern = '[ \t]*'
     digits_pattern = '[0-9]+'
+    line_number_prefix_pattern = digits_pattern + ':' + spaces_pattern
     package_pattern = '[a-z/]+'
     package_file_pattern = '[a-zA-Z0-9_/]+\\.java'
     varname_pattern = '[a-zA-Z0-9_]+'
@@ -307,9 +308,9 @@ def test():
     exec_string = execute("info func greet")
     rexp = [r'All functions matching regular expression "greet":',
             r"File hello/Hello\.java:",
-            r"%svoid hello.Hello\$NamedGreeter::greet\(void\);"%maybe_spaces_pattern,
+            r"71:%svoid hello.Hello\$NamedGreeter::greet\(void\);"%maybe_spaces_pattern,
             r"File hello/Target_hello_Hello_DefaultGreeter\.java:",
-            r"%svoid hello.Hello\$DefaultGreeter::greet\(void\);"%maybe_spaces_pattern]
+            r"48:%svoid hello.Hello\$DefaultGreeter::greet\(void\);"%maybe_spaces_pattern]
     checker = Checker("info func greet", rexp)
     checker.check(exec_string)
 
@@ -523,10 +524,10 @@ def test():
     exec_string = execute("info func nline")
     rexp = [r"All functions matching regular expression \"nline\":",
             r"File hello/Hello\.java:",
-            r"%svoid hello\.Hello::noInlineFoo\(void\);"%spaces_pattern,
-            r"%svoid hello\.Hello::noInlineHere\(int\);"%spaces_pattern,
-            r"%svoid hello\.Hello::noInlineTest\(void\);"%spaces_pattern,
-            r"%svoid hello\.Hello::noInlineThis\(void\);"%spaces_pattern]
+            r"%svoid hello\.Hello::noInlineFoo\(void\);"%line_number_prefix_pattern,
+            r"%svoid hello\.Hello::noInlineHere\(int\);"%line_number_prefix_pattern,
+            r"%svoid hello\.Hello::noInlineTest\(void\);"%line_number_prefix_pattern,
+            r"%svoid hello\.Hello::noInlineThis\(void\);"%line_number_prefix_pattern]
     checker = Checker('info func nline', rexp)
     checker.check(exec_string)
 

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/ClassEntry.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/ClassEntry.java
@@ -290,6 +290,7 @@ public class ClassEntry extends StructureTypeEntry {
 
     protected MethodEntry processMethod(DebugMethodInfo debugMethodInfo, DebugInfoBase debugInfoBase, DebugContext debugContext) {
         String methodName = debugMethodInfo.name();
+        int line = debugMethodInfo.line();
         ResolvedJavaType resultType = debugMethodInfo.valueType();
         String resultTypeName = resultType.toJavaName();
         int modifiers = debugMethodInfo.modifiers();
@@ -297,7 +298,7 @@ public class ClassEntry extends StructureTypeEntry {
         DebugLocalInfo thisParam = debugMethodInfo.getThisParamInfo();
         int paramCount = paramInfos.length;
         debugContext.log("typename %s adding %s method %s %s(%s)\n",
-                        typeName, memberModifiers(modifiers), resultTypeName, methodName, formatParams(paramInfos));
+                typeName, memberModifiers(modifiers), resultTypeName, methodName, formatParams(paramInfos));
         TypeEntry resultTypeEntry = debugInfoBase.lookupTypeEntry(resultType);
         TypeEntry[] typeEntries = new TypeEntry[paramCount];
         for (int i = 0; i < paramCount; i++) {
@@ -308,8 +309,8 @@ public class ClassEntry extends StructureTypeEntry {
          * substitution
          */
         FileEntry methodFileEntry = debugInfoBase.ensureFileEntry(debugMethodInfo);
-        MethodEntry methodEntry = new MethodEntry(debugInfoBase, debugMethodInfo, methodFileEntry, methodName,
-                        this, resultTypeEntry, typeEntries, paramInfos, thisParam);
+        MethodEntry methodEntry = new MethodEntry(debugInfoBase, debugMethodInfo, methodFileEntry, line, methodName,
+                this, resultTypeEntry, typeEntries, paramInfos, thisParam);
         indexMethodEntry(methodEntry, debugMethodInfo.idMethod());
 
         return methodEntry;

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/ClassEntry.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/ClassEntry.java
@@ -298,7 +298,7 @@ public class ClassEntry extends StructureTypeEntry {
         DebugLocalInfo thisParam = debugMethodInfo.getThisParamInfo();
         int paramCount = paramInfos.length;
         debugContext.log("typename %s adding %s method %s %s(%s)\n",
-                typeName, memberModifiers(modifiers), resultTypeName, methodName, formatParams(paramInfos));
+                        typeName, memberModifiers(modifiers), resultTypeName, methodName, formatParams(paramInfos));
         TypeEntry resultTypeEntry = debugInfoBase.lookupTypeEntry(resultType);
         TypeEntry[] typeEntries = new TypeEntry[paramCount];
         for (int i = 0; i < paramCount; i++) {
@@ -310,7 +310,7 @@ public class ClassEntry extends StructureTypeEntry {
          */
         FileEntry methodFileEntry = debugInfoBase.ensureFileEntry(debugMethodInfo);
         MethodEntry methodEntry = new MethodEntry(debugInfoBase, debugMethodInfo, methodFileEntry, line, methodName,
-                this, resultTypeEntry, typeEntries, paramInfos, thisParam);
+                        this, resultTypeEntry, typeEntries, paramInfos, thisParam);
         indexMethodEntry(methodEntry, debugMethodInfo.idMethod());
 
         return methodEntry;
@@ -394,7 +394,7 @@ public class ClassEntry extends StructureTypeEntry {
     public int hipc() {
         assert isPrimary();
         if (!includesDeoptTarget()) {
-             return primaryEntries.get(primaryEntries.size() - 1).getPrimary().getHi();
+            return primaryEntries.get(primaryEntries.size() - 1).getPrimary().getHi();
         } else {
             Range lastPrimary = null;
             for (PrimaryEntry primaryEntry : primaryEntries) {

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/ClassEntry.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/ClassEntry.java
@@ -370,4 +370,48 @@ public class ClassEntry extends StructureTypeEntry {
     public List<MethodEntry> getMethods() {
         return methods;
     }
+
+    public int lowpc() {
+        assert isPrimary();
+        return primaryEntries.get(0).getPrimary().getLo();
+    }
+
+    public int lowpcDeopt() {
+        assert isPrimary();
+        assert includesDeoptTarget();
+        int lowpc = -1;
+        for (PrimaryEntry primaryEntry : primaryEntries) {
+            Range primary = primaryEntry.getPrimary();
+            if (primary.isDeoptTarget()) {
+                lowpc = primary.getLo();
+                break;
+            }
+        }
+        assert lowpc >= 0;
+        return lowpc;
+    }
+
+    public int hipc() {
+        assert isPrimary();
+        if (!includesDeoptTarget()) {
+             return primaryEntries.get(primaryEntries.size() - 1).getPrimary().getHi();
+        } else {
+            Range lastPrimary = null;
+            for (PrimaryEntry primaryEntry : primaryEntries) {
+                Range primary = primaryEntry.getPrimary();
+                if (primary.isDeoptTarget()) {
+                    break;
+                }
+                lastPrimary = primary;
+            }
+            assert lastPrimary != null;
+            return lastPrimary.getHi();
+        }
+    }
+
+    public int hipcDeopt() {
+        assert isPrimary();
+        assert includesDeoptTarget();
+        return primaryEntries.get(primaryEntries.size() - 1).getPrimary().getHi();
+    }
 }

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/CompiledMethodEntry.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/CompiledMethodEntry.java
@@ -33,9 +33,9 @@ import java.util.Iterator;
 import java.util.List;
 
 /**
- * Tracks debug info associated with a primary method. i.e. a top level compiled method
+ * Tracks debug info associated with a top level compiled method.
  */
-public class PrimaryEntry {
+public class CompiledMethodEntry {
     /**
      * The primary range detailed by this object.
      */
@@ -53,7 +53,7 @@ public class PrimaryEntry {
      */
     private int frameSize;
 
-    public PrimaryEntry(Range primary, List<DebugFrameSizeChange> frameSizeInfos, int frameSize, ClassEntry classEntry) {
+    public CompiledMethodEntry(Range primary, List<DebugFrameSizeChange> frameSizeInfos, int frameSize, ClassEntry classEntry) {
         this.primary = primary;
         this.classEntry = classEntry;
         this.frameSizeInfos = frameSizeInfos;
@@ -69,8 +69,8 @@ public class PrimaryEntry {
     }
 
     /**
-     * Returns an iterator that traverses all the callees of the primary range associated with this
-     * entry. The iterator performs a depth-first pre-order traversal of the call tree.
+     * Returns an iterator that traverses all the callees of the method associated with this entry.
+     * The iterator performs a depth-first pre-order traversal of the call tree.
      *
      * @return the iterator
      */
@@ -115,9 +115,9 @@ public class PrimaryEntry {
     }
 
     /**
-     * Returns an iterator that traverses the callees of the primary range associated with this
-     * entry and returns only the leafs. The iterator performs a depth-first pre-order traversal of
-     * the call tree returning only ranges with no callees.
+     * Returns an iterator that traverses the callees of the method associated with this entry and
+     * returns only the leafs. The iterator performs a depth-first pre-order traversal of the call
+     * tree returning only ranges with no callees.
      *
      * @return the iterator
      */

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/DebugInfoBase.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/DebugInfoBase.java
@@ -423,7 +423,7 @@ public abstract class DebugInfoBase {
     }
 
     private ClassEntry ensureClassEntry(ResolvedJavaType type) {
-        /* We should already have an entry  -- TODO prove that claim. */
+        /* We should already have an entry -- TODO prove that claim. */
         ClassEntry classEntry = instanceClassesIndex.get(type);
         if (classEntry == null) {
             /* We must have a type entry -- TODO prove we never reach here. */
@@ -435,6 +435,7 @@ public abstract class DebugInfoBase {
         assert (classEntry.getTypeName().equals(type.toJavaName()));
         return classEntry;
     }
+
     private void indexInstanceClass(ResolvedJavaType idType, ClassEntry classEntry) {
         instanceClasses.add(classEntry);
         instanceClassesIndex.put(idType, classEntry);

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/FieldEntry.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/FieldEntry.java
@@ -36,6 +36,10 @@ public class FieldEntry extends MemberEntry {
         this.offset = offset;
     }
 
+    public String fieldName() {
+        return memberName;
+    }
+
     public int getSize() {
         return size;
     }

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/MemberEntry.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/MemberEntry.java
@@ -32,13 +32,19 @@ package com.oracle.objectfile.debugentry;
  */
 public abstract class MemberEntry {
     protected FileEntry fileEntry;
+    protected int line;
     protected final String memberName;
     protected final StructureTypeEntry ownerType;
     protected final TypeEntry valueType;
     protected final int modifiers;
 
     public MemberEntry(FileEntry fileEntry, String memberName, StructureTypeEntry ownerType, TypeEntry valueType, int modifiers) {
+        this(fileEntry, 0, memberName, ownerType, valueType, modifiers);
+    }
+    public MemberEntry(FileEntry fileEntry, int line, String memberName, StructureTypeEntry ownerType, TypeEntry valueType, int modifiers) {
+        assert line >= 0;
         this.fileEntry = fileEntry;
+        this.line = line;
         this.memberName = memberName;
         this.ownerType = ownerType;
         this.valueType = valueType;
@@ -75,8 +81,8 @@ public abstract class MemberEntry {
         return fileEntry;
     }
 
-    public String fieldName() {
-        return memberName;
+    public int getLine() {
+        return line;
     }
 
     public StructureTypeEntry ownerType() {

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/MemberEntry.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/MemberEntry.java
@@ -41,6 +41,7 @@ public abstract class MemberEntry {
     public MemberEntry(FileEntry fileEntry, String memberName, StructureTypeEntry ownerType, TypeEntry valueType, int modifiers) {
         this(fileEntry, 0, memberName, ownerType, valueType, modifiers);
     }
+
     public MemberEntry(FileEntry fileEntry, int line, String memberName, StructureTypeEntry ownerType, TypeEntry valueType, int modifiers) {
         assert line >= 0;
         this.fileEntry = fileEntry;

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/MethodEntry.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/MethodEntry.java
@@ -197,11 +197,11 @@ public class MethodEntry extends MemberEntry {
         if (debugMethodInfo instanceof DebugLocationInfo) {
             DebugLocationInfo locationInfo = (DebugLocationInfo) debugMethodInfo;
             if (locationInfo.getCaller() != null) {
-                /* this is a real inlined method not just a top level primary range */
+                /* this is a real inlined method */
                 setIsInlined();
             }
         } else if (debugMethodInfo instanceof DebugCodeInfo) {
-            /* this method has been seen in a primary range */
+            /* this method is being notified as a top level compiled method */
             if (isInRange()) {
                 /* it has already been seen -- just check for consistency */
                 assert fileEntry == debugInfoBase.ensureFileEntry(debugMethodInfo);

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/MethodEntry.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/MethodEntry.java
@@ -56,9 +56,9 @@ public class MethodEntry extends MemberEntry {
     final String symbolName;
 
     public MethodEntry(DebugInfoBase debugInfoBase, DebugMethodInfo debugMethodInfo,
-                    FileEntry fileEntry, String methodName, ClassEntry ownerType,
+                    FileEntry fileEntry, int line, String methodName, ClassEntry ownerType,
                     TypeEntry valueType, TypeEntry[] paramTypes, DebugLocalInfo[] paramInfos, DebugLocalInfo thisParam) {
-        super(fileEntry, methodName, ownerType, valueType, debugMethodInfo.modifiers());
+        super(fileEntry, line, methodName, ownerType, valueType, debugMethodInfo.modifiers());
         this.paramTypes = paramTypes;
         this.paramInfos = paramInfos;
         this.thisParam = thisParam;

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/StringTable.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/StringTable.java
@@ -83,7 +83,7 @@ public class StringTable implements Iterable<StringEntry> {
      * Retrieves the offset at which a given string was written into the debug_str section. This
      * should only be called after the string section has been written.
      *
-     * @param string the strng whose offset is to be retrieved
+     * @param string the string whose offset is to be retrieved
      * @return the offset or -1 if the string does not define an entry or the entry has not been
      *         written to the debug_str section
      */

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debuginfo/DebugInfoProvider.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debuginfo/DebugInfoProvider.java
@@ -206,6 +206,11 @@ public interface DebugInfoProvider {
 
     public interface DebugMethodInfo extends DebugMemberInfo {
         /**
+         * @return the line number for the outer or inlined segment.
+         */
+        int line();
+
+        /**
          * @return an array of DebugLocalInfo objects holding details of this method's parameters
          */
         DebugLocalInfo[] getParamInfo();
@@ -282,12 +287,6 @@ public interface DebugInfoProvider {
          *         reported at this line represented as an offset into the code segment.
          */
         int addressHi();
-
-        /**
-         * @return the line number for the outer or inlined segment.
-         */
-        int line();
-
     }
 
     /**

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfARangesSectionImpl.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfARangesSectionImpl.java
@@ -97,7 +97,7 @@ public class DwarfARangesSectionImpl extends DwarfSectionImpl {
          * contains two zeroes.
          */
 
-        for (ClassEntry classEntry : getPrimaryClasses()) {
+        for (ClassEntry classEntry : getInstanceClasses()) {
             if (classEntry.isPrimary()) {
                 pos += DW_AR_HEADER_SIZE;
                 /*
@@ -119,7 +119,7 @@ public class DwarfARangesSectionImpl extends DwarfSectionImpl {
             }
         }
         /* Now allow for deopt target ranges. */
-        for (ClassEntry classEntry : getPrimaryClasses()) {
+        for (ClassEntry classEntry : getInstanceClasses()) {
             if (classEntry.isPrimary() && classEntry.includesDeoptTarget()) {
                 pos += DW_AR_HEADER_SIZE;
                 /*
@@ -166,7 +166,7 @@ public class DwarfARangesSectionImpl extends DwarfSectionImpl {
         enableLog(context, pos);
 
         List<ClassEntry> classEntries = new ArrayList<>();
-        for (ClassEntry classEntry : getPrimaryClasses()) {
+        for (ClassEntry classEntry : getInstanceClasses()) {
             if (classEntry.isPrimary()) {
                 classEntries.add(classEntry);
             }
@@ -224,7 +224,7 @@ public class DwarfARangesSectionImpl extends DwarfSectionImpl {
         }
         /* now write ranges for deopt targets */
         classEntries.clear();
-        for (ClassEntry classEntry : getPrimaryClasses()) {
+        for (ClassEntry classEntry : getInstanceClasses()) {
             if (classEntry.isPrimary() && classEntry.includesDeoptTarget()) {
                 classEntries.add(classEntry);
             }

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfARangesSectionImpl.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfARangesSectionImpl.java
@@ -237,8 +237,8 @@ public class DwarfARangesSectionImpl extends DwarfSectionImpl {
             int cuIndex = getDeoptCUIndex(classEntry);
             List<PrimaryEntry> classPrimaryEntries = classEntry.getPrimaryEntries();
             /*
-                 * Count only linkage stubs.
-                 */
+             * Count only linkage stubs.
+             */
             for (PrimaryEntry classPrimaryEntry : classPrimaryEntries) {
                 Range primary = classPrimaryEntry.getPrimary();
                 if (primary.isDeoptTarget()) {
@@ -248,8 +248,8 @@ public class DwarfARangesSectionImpl extends DwarfSectionImpl {
             /* we must have seen at least one stub */
             assert length > DW_AR_HEADER_SIZE + DW_AR_HEADER_PAD_SIZE - 4;
             /*
-                 * Add room for a final null entry.
-                 */
+             * Add room for a final null entry.
+             */
             length += 2 * 8;
             log(context, "  [0x%08x] %s CU linkage stubs %d length 0x%x", pos, classEntry.getFileName(), cuIndex, length);
             pos = writeInt(length, buffer, pos);
@@ -302,7 +302,6 @@ public class DwarfARangesSectionImpl extends DwarfSectionImpl {
     private int sortByLowPCDeopt(ClassEntry classEntry1, ClassEntry classEntry2) {
         return compare(classEntry1.lowpcDeopt(), classEntry2.lowpcDeopt());
     }
-
 
     /*
      * The debug_aranges section depends on debug_frame section.

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfAbbrevSectionImpl.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfAbbrevSectionImpl.java
@@ -1086,9 +1086,8 @@ public class DwarfAbbrevSectionImpl extends DwarfSectionImpl {
         pos = writeAttrForm(DwarfDebugInfo.DW_FORM_strp, buffer, pos);
         pos = writeAttrType(DwarfDebugInfo.DW_AT_decl_file, buffer, pos);
         pos = writeAttrForm(DwarfDebugInfo.DW_FORM_data2, buffer, pos);
-        /* We don't (yet?) have a proper start line for the method itself */
-        // pos = writeAttrType(DwarfDebugInfo.DW_AT_decl_line, buffer, pos);
-        // pos = writeAttrForm(DwarfDebugInfo.DW_FORM_data2, buffer, pos);
+        pos = writeAttrType(DwarfDebugInfo.DW_AT_decl_line, buffer, pos);
+        pos = writeAttrForm(DwarfDebugInfo.DW_FORM_data2, buffer, pos);
         /* This probably needs to use the symbol name */
         // pos = writeAttrType(DwarfDebugInfo.DW_AT_linkage_name, buffer, pos);
         // pos = writeAttrForm(DwarfDebugInfo.DW_FORM_strp, buffer, pos);

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfAbbrevSectionImpl.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfAbbrevSectionImpl.java
@@ -577,8 +577,12 @@ public class DwarfAbbrevSectionImpl extends DwarfSectionImpl {
          * DIE should inherit attributes from the method_definition DIE referenced as its
          * specification attribute without the need to repeat them, including attributes specified
          * in child DIEs of the method_definition. However, it is actually necessary to replicate
-         * the method_parameter DIEs of the specification as children of the abstract_inline_method
-         * DIE because gdb does not carry these attributes across from the specification DIE.
+         * the method_parameter/local_declaration DIEs of the specification as children of the
+         * abstract_inline_method DIE. This provides a CU-local target for references from the
+         * corresponding method_parameter/local_location DIEs that sit below the inlined_subroutine
+         * DIEs in the concrete inlined subroutine tree. This is needed because some tools require
+         * the location DIEs abstract_origin attribute that links the location to specification to
+         * be a CU-relative offset (FORM_Ref4) rather than an info section offset.
          *
          * <ul>
          *
@@ -1337,7 +1341,7 @@ public class DwarfAbbrevSectionImpl extends DwarfSectionImpl {
         pos = writeTag(DwarfDebugInfo.DW_TAG_variable, buffer, pos);
         pos = writeFlag(DwarfDebugInfo.DW_CHILDREN_no, buffer, pos);
         pos = writeAttrType(DwarfDebugInfo.DW_AT_specification, buffer, pos);
-        pos = writeAttrForm(DwarfDebugInfo.DW_FORM_ref_addr, buffer, pos);
+        pos = writeAttrForm(DwarfDebugInfo.DW_FORM_ref4, buffer, pos);
         /* Do we have a symbol name to use here? */
         // pos = writeAttrType(DwarfDebugInfo.DW_AT_linkage_name, buffer, pos);
         // pos = writeAttrForm(DwarfDebugInfo.DW_FORM_strp, buffer, pos);
@@ -1511,8 +1515,8 @@ public class DwarfAbbrevSectionImpl extends DwarfSectionImpl {
         pos = writeAbbrevCode(abbrevCode, buffer, pos);
         pos = writeTag(DwarfDebugInfo.DW_TAG_formal_parameter, buffer, pos);
         pos = writeFlag(DwarfDebugInfo.DW_CHILDREN_no, buffer, pos);
-        pos = writeAttrType(DwarfDebugInfo.DW_AT_specification, buffer, pos);
-        pos = writeAttrForm(DwarfDebugInfo.DW_FORM_ref_addr, buffer, pos);
+        pos = writeAttrType(DwarfDebugInfo.DW_AT_abstract_origin, buffer, pos);
+        pos = writeAttrForm(DwarfDebugInfo.DW_FORM_ref4, buffer, pos);
         if (abbrevCode == DwarfDebugInfo.DW_ABBREV_CODE_method_parameter_location2) {
             pos = writeAttrType(DwarfDebugInfo.DW_AT_location, buffer, pos);
             pos = writeAttrForm(DwarfDebugInfo.DW_FORM_sec_offset, buffer, pos);
@@ -1530,8 +1534,8 @@ public class DwarfAbbrevSectionImpl extends DwarfSectionImpl {
         pos = writeAbbrevCode(abbrevCode, buffer, pos);
         pos = writeTag(DwarfDebugInfo.DW_TAG_variable, buffer, pos);
         pos = writeFlag(DwarfDebugInfo.DW_CHILDREN_no, buffer, pos);
-        pos = writeAttrType(DwarfDebugInfo.DW_AT_specification, buffer, pos);
-        pos = writeAttrForm(DwarfDebugInfo.DW_FORM_ref_addr, buffer, pos);
+        pos = writeAttrType(DwarfDebugInfo.DW_AT_abstract_origin, buffer, pos);
+        pos = writeAttrForm(DwarfDebugInfo.DW_FORM_ref4, buffer, pos);
         if (abbrevCode == DwarfDebugInfo.DW_ABBREV_CODE_method_local_location2) {
             pos = writeAttrType(DwarfDebugInfo.DW_AT_location, buffer, pos);
             pos = writeAttrForm(DwarfDebugInfo.DW_FORM_sec_offset, buffer, pos);
@@ -1556,7 +1560,7 @@ public class DwarfAbbrevSectionImpl extends DwarfSectionImpl {
         pos = writeTag(DwarfDebugInfo.DW_TAG_inlined_subroutine, buffer, pos);
         pos = writeFlag(withChildren ? DwarfDebugInfo.DW_CHILDREN_yes : DwarfDebugInfo.DW_CHILDREN_no, buffer, pos);
         pos = writeAttrType(DwarfDebugInfo.DW_AT_abstract_origin, buffer, pos);
-        pos = writeAttrForm(DwarfDebugInfo.DW_FORM_ref_addr, buffer, pos);
+        pos = writeAttrForm(DwarfDebugInfo.DW_FORM_ref4, buffer, pos);
         pos = writeAttrType(DwarfDebugInfo.DW_AT_low_pc, buffer, pos);
         pos = writeAttrForm(DwarfDebugInfo.DW_FORM_addr, buffer, pos);
         pos = writeAttrType(DwarfDebugInfo.DW_AT_hi_pc, buffer, pos);

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfAbbrevSectionImpl.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfAbbrevSectionImpl.java
@@ -1080,9 +1080,8 @@ public class DwarfAbbrevSectionImpl extends DwarfSectionImpl {
         pos = writeAttrForm(DwarfDebugInfo.DW_FORM_data2, buffer, pos);
         pos = writeAttrType(DwarfDebugInfo.DW_AT_decl_line, buffer, pos);
         pos = writeAttrForm(DwarfDebugInfo.DW_FORM_data2, buffer, pos);
-        /* This probably needs to use the symbol name */
-        // pos = writeAttrType(DwarfDebugInfo.DW_AT_linkage_name, buffer, pos);
-        // pos = writeAttrForm(DwarfDebugInfo.DW_FORM_strp, buffer, pos);
+        pos = writeAttrType(DwarfDebugInfo.DW_AT_linkage_name, buffer, pos);
+        pos = writeAttrForm(DwarfDebugInfo.DW_FORM_strp, buffer, pos);
         pos = writeAttrType(DwarfDebugInfo.DW_AT_type, buffer, pos);
         pos = writeAttrForm(DwarfDebugInfo.DW_FORM_ref_addr, buffer, pos);
         pos = writeAttrType(DwarfDebugInfo.DW_AT_artificial, buffer, pos);
@@ -1338,7 +1337,6 @@ public class DwarfAbbrevSectionImpl extends DwarfSectionImpl {
         pos = writeFlag(DwarfDebugInfo.DW_CHILDREN_no, buffer, pos);
         pos = writeAttrType(DwarfDebugInfo.DW_AT_specification, buffer, pos);
         pos = writeAttrForm(DwarfDebugInfo.DW_FORM_ref4, buffer, pos);
-        /* Do we have a symbol name to use here? */
         // pos = writeAttrType(DwarfDebugInfo.DW_AT_linkage_name, buffer, pos);
         // pos = writeAttrForm(DwarfDebugInfo.DW_FORM_strp, buffer, pos);
         pos = writeAttrType(DwarfDebugInfo.DW_AT_location, buffer, pos);

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfAbbrevSectionImpl.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfAbbrevSectionImpl.java
@@ -570,18 +570,15 @@ public class DwarfAbbrevSectionImpl extends DwarfSectionImpl {
          *
          * </ul>
          *
-         * Abstract Inline Methods: For any method which has been inlined into another compiled
-         * method there will be a corresponding level 1 DIE that identifies the method declaration
-         * and serves as the target reference for concrete inlined method DIEs. This DIE should
-         * inherit attributes from the method_definition DIE referenced from its specification
-         * attribute without the need to repeat them, including attributes specified in child DIEs
-         * of the method_definition. However, it is actually necessary to replicate the
-         * method_parameter DIEs as children of this DIE because gdb does not carry these attributes
-         * across from the specification DIE.
-         *
-         * Note that an abstract inline method DIE is generated in the compile unit of the class
-         * which declares the inlined method whereas a concrete inlined method DIE is generated in
-         * the compile unit of the class which declares method into which code has been inlined.
+         * Abstract Inline Methods: For any method m' which has been inlined into a top level
+         * compiled method m there will be an abstract_inline_method DIE for m' at level 1 DIE in
+         * the CU to which m belongs. The declaration serves as an abstract_origin for any
+         * corresponding inlined method DIEs appearing as children of m. The abstract_inline_method
+         * DIE should inherit attributes from the method_definition DIE referenced as its
+         * specification attribute without the need to repeat them, including attributes specified
+         * in child DIEs of the method_definition. However, it is actually necessary to replicate
+         * the method_parameter DIEs of the specification as children of the abstract_inline_method
+         * DIE because gdb does not carry these attributes across from the specification DIE.
          *
          * <ul>
          *
@@ -596,9 +593,9 @@ public class DwarfAbbrevSectionImpl extends DwarfSectionImpl {
          *
          * </ul>
          *
-         * Concrete Inlined Methods: Concrete inlined methods are nested as a tree of children under
-         * the method_location DIE for the method into which they have been inlined. Each inlined
-         * method DIE defines an address range that is a subrange of its parent DIE. A
+         * Concrete Inlined Methods: Concrete inlined method DIEs are nested as a tree of children
+         * under the method_location DIE for the method into which they have been inlined. Each
+         * inlined method DIE defines an address range that is a subrange of its parent DIE. A
          * method_location DIE occurs at depth 1 in a compile unit (class_unit). So, this means that
          * for any method which has been inlined into a compiled method at depth K in the inline
          * frame stack there will be a corresponding level 2+K DIE that identifies the method that
@@ -611,11 +608,6 @@ public class DwarfAbbrevSectionImpl extends DwarfSectionImpl {
          * m2 referencing the abstract entry for m2 with f1 and l1 as file and line and a level 3
          * DIE for the inline code range derived from m3 referencing the abstract entry for m3 with
          * f2 and l2 as file and line.
-         *
-         * Note that a concrete inlined method DIE is generated in the compile unit of the class
-         * which declares the method into which code has been inlined whereas an abstract inlined
-         * method DIE is generated in the compile unit of the class which declares of the inlined
-         * method.
          *
          * <ul>
          *

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfAbbrevSectionImpl.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfAbbrevSectionImpl.java
@@ -98,7 +98,7 @@ public class DwarfAbbrevSectionImpl extends DwarfSectionImpl {
          * <li><code>code = builtin_unit, TAG = compile_unit<code> - Java primitive and header type
          * compile unit
          *
-         * <li><code>code = class_unit1/2/3, tag = compile_unit<code> - Java instance type compile
+         * <li><code>code = class_unit1/2, tag = compile_unit<code> - Java instance type compile
          * unit
          *
          * <li><code>code = array_unit, tag = compile_unit<code> - Java array type compile unit
@@ -263,12 +263,13 @@ public class DwarfAbbrevSectionImpl extends DwarfSectionImpl {
          *
          * Instance Classes: For each class there is a level 0 DIE defining the class compilation
          * unit. low_pc and hi_pc are only included if the class has compiled methods i.e. for
-         * variants 1 and 2. stmt_list is is only included if the class has an associated source
-         * file and may therefore have line info i.e. for variant 1.
+         * variants 1 and 2. stmt_list is included for all classes, even when they have no compiled
+         * methods, to ensure that a basic line entry record exists for the class. This is needed to
+         * ensure some tools report a file name for methods that may only exist inlined.
          *
          * <ul>
          *
-         * <li><code>abbrev_code == class_unit1/2/3, tag == DW_TAG_compilation_unit,
+         * <li><code>abbrev_code == class_unit1/2, tag == DW_TAG_compilation_unit,
          * has_children</code>
          *
          * <li><code>DW_AT_language : ... DW_FORM_data1</code>
@@ -278,15 +279,14 @@ public class DwarfAbbrevSectionImpl extends DwarfSectionImpl {
          * <li><code>DW_AT_comp_dir : ... DW_FORM_strp</code>
          *
          * <li><code>DW_AT_low_pc : ..... DW_FORM_address</code> n.b only for <code>abbrev-code ==
-         * class_unit1/2</code>
+         * class_unit1</code>
          *
          * <li><code>DW_AT_hi_pc : ...... DW_FORM_address</code> n.b only for <code>abbrev-code ==
-         * class_unit1/2</code>
+         * class_unit1</code>
          *
          * <li><code>DW_AT_use_UTF8 : ... DW_FORM_flag</code>
          *
-         * <li><code>DW_AT_stmt_list : .. DW_FORM_sec_offset</code> n.b only for <code>abbrev-code
-         * == class_unit1</code>
+         * <li><code>DW_AT_stmt_list : .. DW_FORM_sec_offset</code>
          *
          * </ul>
          *
@@ -897,10 +897,8 @@ public class DwarfAbbrevSectionImpl extends DwarfSectionImpl {
         int pos = p;
         /* class compile unit with compiled methods and line info */
         pos = writeClassUnitAbbrev(context, DwarfDebugInfo.DW_ABBREV_CODE_class_unit1, buffer, pos);
-        /* class compile unit with compiled methods but without line info */
+        /* class compile unit without compiled methods */
         pos = writeClassUnitAbbrev(context, DwarfDebugInfo.DW_ABBREV_CODE_class_unit2, buffer, pos);
-        /* class compile unit without compiled methods and without line info */
-        pos = writeClassUnitAbbrev(context, DwarfDebugInfo.DW_ABBREV_CODE_class_unit3, buffer, pos);
         return pos;
     }
 
@@ -917,16 +915,14 @@ public class DwarfAbbrevSectionImpl extends DwarfSectionImpl {
         pos = writeAttrForm(DwarfDebugInfo.DW_FORM_strp, buffer, pos);
         pos = writeAttrType(DwarfDebugInfo.DW_AT_comp_dir, buffer, pos);
         pos = writeAttrForm(DwarfDebugInfo.DW_FORM_strp, buffer, pos);
-        if (abbrevCode == DwarfDebugInfo.DW_ABBREV_CODE_class_unit1 || abbrevCode == DwarfDebugInfo.DW_ABBREV_CODE_class_unit2) {
+        if (abbrevCode == DwarfDebugInfo.DW_ABBREV_CODE_class_unit1) {
             pos = writeAttrType(DwarfDebugInfo.DW_AT_low_pc, buffer, pos);
             pos = writeAttrForm(DwarfDebugInfo.DW_FORM_addr, buffer, pos);
             pos = writeAttrType(DwarfDebugInfo.DW_AT_hi_pc, buffer, pos);
             pos = writeAttrForm(DwarfDebugInfo.DW_FORM_addr, buffer, pos);
         }
-        if (abbrevCode == DwarfDebugInfo.DW_ABBREV_CODE_class_unit1) {
-            pos = writeAttrType(DwarfDebugInfo.DW_AT_stmt_list, buffer, pos);
-            pos = writeAttrForm(DwarfDebugInfo.DW_FORM_sec_offset, buffer, pos);
-        }
+        pos = writeAttrType(DwarfDebugInfo.DW_AT_stmt_list, buffer, pos);
+        pos = writeAttrForm(DwarfDebugInfo.DW_FORM_sec_offset, buffer, pos);
         /*
          * Now terminate.
          */

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfDebugInfo.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfDebugInfo.java
@@ -73,7 +73,7 @@ public class DwarfDebugInfo extends DebugInfoBase {
     public static final int DW_ABBREV_CODE_builtin_unit = 1;
     public static final int DW_ABBREV_CODE_class_unit1 = 2;
     public static final int DW_ABBREV_CODE_class_unit2 = 3;
-    public static final int DW_ABBREV_CODE_class_unit3 = 4;
+    // public static final int DW_ABBREV_CODE_class_unit3 = 4;
     public static final int DW_ABBREV_CODE_array_unit = 5;
     /* Level 1 DIEs. */
     public static final int DW_ABBREV_CODE_primitive_type = 6;

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfDebugInfo.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfDebugInfo.java
@@ -499,6 +499,10 @@ public class DwarfDebugInfo extends DebugInfoBase {
          * Map from field names to info section index for the field declaration.
          */
         private HashMap<String, Integer> fieldDeclarationIndex;
+        /**
+         * Map from method entries to associated abstract inline method index.
+         */
+        private HashMap<MethodEntry, Integer> abstractInlineMethodIndex;
 
         DwarfClassProperties(StructureTypeEntry entry) {
             super(entry);
@@ -510,6 +514,7 @@ public class DwarfDebugInfo extends DebugInfoBase {
             this.linePrologueSize = -1;
             this.lineSectionSize = -1;
             fieldDeclarationIndex = null;
+            abstractInlineMethodIndex = null;
         }
     }
 
@@ -782,14 +787,29 @@ public class DwarfDebugInfo extends DebugInfoBase {
         return methodProperties.getMethodDeclarationIndex();
     }
 
-    public void setAbstractInlineMethodIndex(MethodEntry methodEntry, int pos) {
-        DwarfMethodProperties methodProperties = lookupMethodProperties(methodEntry);
-        methodProperties.setAbstractInlineMethodIndex(pos);
+    public void setAbstractInlineMethodIndex(ClassEntry classEntry, MethodEntry methodEntry, int pos) {
+        DwarfClassProperties classProperties = lookupClassProperties(classEntry);
+        assert classProperties.getTypeEntry() == classEntry;
+        HashMap<MethodEntry, Integer> abstractInlineMethodIndex = classProperties.abstractInlineMethodIndex;
+        if (abstractInlineMethodIndex == null) {
+            classProperties.abstractInlineMethodIndex = abstractInlineMethodIndex = new HashMap<>();
+        }
+        if (abstractInlineMethodIndex.get(methodEntry) != null) {
+            assert abstractInlineMethodIndex.get(methodEntry) == pos : classEntry.getTypeName() + " & " + methodEntry.getSymbolName();
+            ;
+        } else {
+            abstractInlineMethodIndex.put(methodEntry, pos);
+        }
     }
 
-    public int getAbstractInlineMethodIndex(MethodEntry methodEntry) {
-        DwarfMethodProperties methodProperties = lookupMethodProperties(methodEntry);
-        return methodProperties.getAbstractInlineMethodIndex();
+    public int getAbstractInlineMethodIndex(ClassEntry classEntry, MethodEntry methodEntry) {
+        DwarfClassProperties classProperties = lookupClassProperties(classEntry);
+        assert classProperties.getTypeEntry() == classEntry;
+        HashMap<MethodEntry, Integer> abstractInlineMethodIndex = classProperties.abstractInlineMethodIndex;
+        assert abstractInlineMethodIndex != null : classEntry.getTypeName() + " & " + methodEntry.getSymbolName();
+        assert abstractInlineMethodIndex.get(methodEntry) != null : classEntry.getTypeName() + " & " + methodEntry.getSymbolName();
+        ;
+        return abstractInlineMethodIndex.get(methodEntry);
     }
 
     /**

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfDebugInfo.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfDebugInfo.java
@@ -169,6 +169,7 @@ public class DwarfDebugInfo extends DebugInfoBase {
     public static final int DW_AT_call_file = 0x58;
     public static final int DW_AT_call_line = 0x59;
     public static final int DW_AT_object_pointer = 0x64;
+    public static final int DW_AT_linkage_name = 0x6e;
 
     /*
      * Define all the Dwarf attribute forms we need for our DIEs.

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfDebugInfo.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfDebugInfo.java
@@ -73,49 +73,48 @@ public class DwarfDebugInfo extends DebugInfoBase {
     public static final int DW_ABBREV_CODE_builtin_unit = 1;
     public static final int DW_ABBREV_CODE_class_unit1 = 2;
     public static final int DW_ABBREV_CODE_class_unit2 = 3;
-    // public static final int DW_ABBREV_CODE_class_unit3 = 4;
-    public static final int DW_ABBREV_CODE_array_unit = 5;
+    public static final int DW_ABBREV_CODE_array_unit = 4;
     /* Level 1 DIEs. */
-    public static final int DW_ABBREV_CODE_primitive_type = 6;
-    public static final int DW_ABBREV_CODE_void_type = 7;
-    public static final int DW_ABBREV_CODE_object_header = 8;
-    public static final int DW_ABBREV_CODE_class_layout1 = 9;
-    public static final int DW_ABBREV_CODE_class_layout2 = 10;
-    public static final int DW_ABBREV_CODE_class_pointer = 11;
-    public static final int DW_ABBREV_CODE_method_location = 12;
-    public static final int DW_ABBREV_CODE_abstract_inline_method = 13;
-    public static final int DW_ABBREV_CODE_static_field_location = 14;
-    public static final int DW_ABBREV_CODE_array_layout = 15;
-    public static final int DW_ABBREV_CODE_array_pointer = 16;
-    public static final int DW_ABBREV_CODE_interface_layout = 17;
-    public static final int DW_ABBREV_CODE_interface_pointer = 18;
-    public static final int DW_ABBREV_CODE_indirect_layout = 19;
-    public static final int DW_ABBREV_CODE_indirect_pointer = 20;
+    public static final int DW_ABBREV_CODE_primitive_type = 5;
+    public static final int DW_ABBREV_CODE_void_type = 6;
+    public static final int DW_ABBREV_CODE_object_header = 7;
+    public static final int DW_ABBREV_CODE_class_layout1 = 8;
+    public static final int DW_ABBREV_CODE_class_layout2 = 9;
+    public static final int DW_ABBREV_CODE_class_pointer = 10;
+    public static final int DW_ABBREV_CODE_method_location = 11;
+    public static final int DW_ABBREV_CODE_abstract_inline_method = 12;
+    public static final int DW_ABBREV_CODE_static_field_location = 13;
+    public static final int DW_ABBREV_CODE_array_layout = 14;
+    public static final int DW_ABBREV_CODE_array_pointer = 15;
+    public static final int DW_ABBREV_CODE_interface_layout = 16;
+    public static final int DW_ABBREV_CODE_interface_pointer = 17;
+    public static final int DW_ABBREV_CODE_indirect_layout = 18;
+    public static final int DW_ABBREV_CODE_indirect_pointer = 19;
     /* Level 2 DIEs. */
-    public static final int DW_ABBREV_CODE_method_declaration = 21;
-    public static final int DW_ABBREV_CODE_method_declaration_static = 22;
-    public static final int DW_ABBREV_CODE_field_declaration1 = 23;
-    public static final int DW_ABBREV_CODE_field_declaration2 = 24;
-    public static final int DW_ABBREV_CODE_field_declaration3 = 25;
-    public static final int DW_ABBREV_CODE_field_declaration4 = 26;
-    public static final int DW_ABBREV_CODE_header_field = 27;
-    public static final int DW_ABBREV_CODE_array_data_type = 28;
-    public static final int DW_ABBREV_CODE_super_reference = 29;
-    public static final int DW_ABBREV_CODE_interface_implementor = 30;
+    public static final int DW_ABBREV_CODE_method_declaration = 20;
+    public static final int DW_ABBREV_CODE_method_declaration_static = 21;
+    public static final int DW_ABBREV_CODE_field_declaration1 = 22;
+    public static final int DW_ABBREV_CODE_field_declaration2 = 23;
+    public static final int DW_ABBREV_CODE_field_declaration3 = 24;
+    public static final int DW_ABBREV_CODE_field_declaration4 = 25;
+    public static final int DW_ABBREV_CODE_header_field = 26;
+    public static final int DW_ABBREV_CODE_array_data_type = 27;
+    public static final int DW_ABBREV_CODE_super_reference = 28;
+    public static final int DW_ABBREV_CODE_interface_implementor = 29;
     /* Level 2+K DIEs (where inline depth K >= 0) */
-    public static final int DW_ABBREV_CODE_inlined_subroutine = 31;
-    public static final int DW_ABBREV_CODE_inlined_subroutine_with_children = 32;
+    public static final int DW_ABBREV_CODE_inlined_subroutine = 30;
+    public static final int DW_ABBREV_CODE_inlined_subroutine_with_children = 31;
     /* Level 2 DIEs. */
-    public static final int DW_ABBREV_CODE_method_parameter_declaration1 = 33;
-    public static final int DW_ABBREV_CODE_method_parameter_declaration2 = 34;
-    public static final int DW_ABBREV_CODE_method_parameter_declaration3 = 35;
-    public static final int DW_ABBREV_CODE_method_local_declaration1 = 36;
-    public static final int DW_ABBREV_CODE_method_local_declaration2 = 37;
+    public static final int DW_ABBREV_CODE_method_parameter_declaration1 = 32;
+    public static final int DW_ABBREV_CODE_method_parameter_declaration2 = 33;
+    public static final int DW_ABBREV_CODE_method_parameter_declaration3 = 34;
+    public static final int DW_ABBREV_CODE_method_local_declaration1 = 35;
+    public static final int DW_ABBREV_CODE_method_local_declaration2 = 36;
     /* Level 3 DIEs. */
-    public static final int DW_ABBREV_CODE_method_parameter_location1 = 38;
-    public static final int DW_ABBREV_CODE_method_parameter_location2 = 39;
-    public static final int DW_ABBREV_CODE_method_local_location1 = 40;
-    public static final int DW_ABBREV_CODE_method_local_location2 = 41;
+    public static final int DW_ABBREV_CODE_method_parameter_location1 = 37;
+    public static final int DW_ABBREV_CODE_method_parameter_location2 = 38;
+    public static final int DW_ABBREV_CODE_method_local_location1 = 39;
+    public static final int DW_ABBREV_CODE_method_local_location2 = 40;
 
     /*
      * Define all the Dwarf tags we need for our DIEs.

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfFrameSectionImpl.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfFrameSectionImpl.java
@@ -140,7 +140,7 @@ public abstract class DwarfFrameSectionImpl extends DwarfSectionImpl {
     private int writeMethodFrames(byte[] buffer, int p) {
         int pos = p;
         /* Write frames for normal methods. */
-        for (ClassEntry classEntry : getPrimaryClasses()) {
+        for (ClassEntry classEntry : getInstanceClasses()) {
             for (PrimaryEntry primaryEntry : classEntry.getPrimaryEntries()) {
                 Range range = primaryEntry.getPrimary();
                 if (!range.isDeoptTarget()) {
@@ -155,7 +155,7 @@ public abstract class DwarfFrameSectionImpl extends DwarfSectionImpl {
             }
         }
         /* Now write frames for deopt targets. */
-        for (ClassEntry classEntry : getPrimaryClasses()) {
+        for (ClassEntry classEntry : getInstanceClasses()) {
             for (PrimaryEntry primaryEntry : classEntry.getPrimaryEntries()) {
                 Range range = primaryEntry.getPrimary();
                 if (range.isDeoptTarget()) {

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfInfoSectionImpl.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfInfoSectionImpl.java
@@ -662,6 +662,7 @@ public class DwarfInfoSectionImpl extends DwarfSectionImpl {
     private int writeMethodDeclaration(DebugContext context, ClassEntry classEntry, MethodEntry method, byte[] buffer, int p) {
         int pos = p;
         String methodKey = method.getSymbolName();
+        String linkageName = uniqueDebugString(classEntry.getTypeName() + "::" + method.methodName());
         setMethodDeclarationIndex(method, pos);
         int modifiers = method.getModifiers();
         boolean isStatic = Modifier.isStatic(modifiers);
@@ -685,6 +686,8 @@ public class DwarfInfoSectionImpl extends DwarfSectionImpl {
         int line = method.getLine();
         log(context, "  [0x%08x]     line 0x%x", pos, line);
         pos = writeAttrData2((short) line, buffer, pos);
+        log(context, "  [0x%08x]     linkage_name %s", pos, linkageName);
+        pos = writeAttrStrp(linkageName, buffer, pos);
         TypeEntry returnType = method.getValueType();
         int retTypeIdx = getTypeIndex(returnType);
         log(context, "  [0x%08x]     type 0x%x (%s)", pos, retTypeIdx, returnType.getTypeName());

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfInfoSectionImpl.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfInfoSectionImpl.java
@@ -181,7 +181,7 @@ public class DwarfInfoSectionImpl extends DwarfSectionImpl {
         return pos;
     }
 
-    public int writeBuiltInUnit(DebugContext context, byte[] buffer, int p) {
+    private int writeBuiltInUnit(DebugContext context, byte[] buffer, int p) {
         int pos = p;
         int lengthPos = pos;
         log(context, "  [0x%08x] <0> builtin unit", pos);
@@ -685,6 +685,9 @@ public class DwarfInfoSectionImpl extends DwarfSectionImpl {
         int fileIdx = classEntry.localFilesIdx(fileEntry);
         log(context, "  [0x%08x]     file 0x%x (%s)", pos, fileIdx, fileEntry.getFullName());
         pos = writeAttrData2((short) fileIdx, buffer, pos);
+        int line = method.getLine();
+        log(context, "  [0x%08x]     line 0x%x", pos, line);
+        pos = writeAttrData2((short)line, buffer, pos);
         TypeEntry returnType = method.getValueType();
         int retTypeIdx = getTypeIndex(returnType);
         log(context, "  [0x%08x]     type 0x%x (%s)", pos, retTypeIdx, returnType.getTypeName());

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfSectionImpl.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfSectionImpl.java
@@ -678,7 +678,7 @@ public abstract class DwarfSectionImpl extends BasicProgbitsSectionImpl {
     }
 
     /**
-     * Retrieve the unique object header type notified via the DebugTypeInfo API
+     * Retrieve the unique object header type notified via the DebugTypeInfo API.
      * 
      * @return the unique object header type notified via the DebugTypeInfo API.
      */

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfSectionImpl.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfSectionImpl.java
@@ -765,15 +765,15 @@ public abstract class DwarfSectionImpl extends BasicProgbitsSectionImpl {
         return dwarfSections.getMethodDeclarationIndex(methodEntry);
     }
 
-    protected void setAbstractInlineMethodIndex(MethodEntry methodEntry, int pos) {
-        dwarfSections.setAbstractInlineMethodIndex(methodEntry, pos);
+    protected void setAbstractInlineMethodIndex(ClassEntry classEntry, MethodEntry methodEntry, int pos) {
+        dwarfSections.setAbstractInlineMethodIndex(classEntry, methodEntry, pos);
     }
 
-    protected int getAbstractInlineMethodIndex(MethodEntry methodEntry) {
+    protected int getAbstractInlineMethodIndex(ClassEntry classEntry, MethodEntry methodEntry) {
         if (!contentByteArrayCreated()) {
             return 0;
         }
-        return dwarfSections.getAbstractInlineMethodIndex(methodEntry);
+        return dwarfSections.getAbstractInlineMethodIndex(classEntry, methodEntry);
     }
 
     protected void setMethodLocalIndex(MethodEntry methodEntry, DebugLocalInfo localInfo, int index) {

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfSectionImpl.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfSectionImpl.java
@@ -776,21 +776,63 @@ public abstract class DwarfSectionImpl extends BasicProgbitsSectionImpl {
         return dwarfSections.getAbstractInlineMethodIndex(classEntry, methodEntry);
     }
 
-    protected void setMethodLocalIndex(MethodEntry methodEntry, DebugLocalInfo localInfo, int index) {
-        dwarfSections.setMethodLocalIndex(methodEntry, localInfo, index);
+    /**
+     * Record the info section offset of a local (or parameter) declaration DIE. The local (or
+     * parameter) can be a child of a standard method declaration in the CU of its owning class.
+     * Alternatively, it can be as a child of an abstract inline method declaration in the CU of a
+     * class into which the original's code needs to be inlined.
+     * 
+     * @param classEntry null if the local declaration belongs to a standard method declaration
+     *            otherwise the entry for the class importing the inline code.
+     * @param methodEntry the method being declared or inlined.
+     * @param localInfo the local or param whose index is to be recorded.
+     * @param index the info section offset to be recorded.
+     */
+    protected void setMethodLocalIndex(ClassEntry classEntry, MethodEntry methodEntry, DebugLocalInfo localInfo, int index) {
+        dwarfSections.setMethodLocalIndex(classEntry, methodEntry, localInfo, index);
     }
 
-    protected int getMethodLocalIndex(MethodEntry methodEntry, DebugLocalInfo localInfo) {
+    /**
+     * Retrieve the info section offset of a local (or parameter) declaration DIE. The local (or
+     * parameter) can be a child of a standard method declaration in the CU of its owning class.
+     * Alternatively, it can be as a child of an abstract inline method declaration in the CU of a
+     * class into which the original's code needs to be inlined.
+     * 
+     * @param classEntry null if the local declaration belongs to a standard method declaration
+     *            otherwise the entry for the class importing the inline code.
+     * @param methodEntry the method being declared or imported
+     * @param localInfo the local or param whose index is to be retrieved.
+     * @return the associated info section offset.
+     */
+    protected int getMethodLocalIndex(ClassEntry classEntry, MethodEntry methodEntry, DebugLocalInfo localInfo) {
         if (!contentByteArrayCreated()) {
             return 0;
         }
-        return dwarfSections.getMethodLocalIndex(methodEntry, localInfo);
+        return dwarfSections.getMethodLocalIndex(classEntry, methodEntry, localInfo);
     }
 
+    /**
+     * Record the info section offset of a local (or parameter) location DIE associated with a top
+     * level (primary) or inline method range.
+     * 
+     * @param range the top level (primary) or inline range to which the local (or parameter)
+     *            belongs.
+     * @param localInfo the local or param whose index is to be recorded.
+     * @param index the info section offset to be recorded.
+     */
     protected void setRangeLocalIndex(Range range, DebugLocalInfo localInfo, int index) {
         dwarfSections.setRangeLocalIndex(range, localInfo, index);
     }
 
+    /**
+     * Retrieve the info section offset of a local (or parameter) location DIE associated with a top
+     * level (primary) or inline method range.
+     * 
+     * @param range the top level (primary) or inline range to which the local (or parameter)
+     *            belongs.
+     * @param localInfo the local or param whose index is to be retrieved.
+     * @return the associated info section offset.
+     */
     protected int getRangeLocalIndex(Range range, DebugLocalInfo localInfo) {
         if (!contentByteArrayCreated()) {
             return 0;

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfSectionImpl.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfSectionImpl.java
@@ -456,7 +456,7 @@ public abstract class DwarfSectionImpl extends BasicProgbitsSectionImpl {
         return writeByte(value, buffer, pos);
     }
 
-    public int writeInfoSectionOffset(int offset, byte[] buffer, int pos) {
+    protected int writeInfoSectionOffset(int offset, byte[] buffer, int pos) {
         return writeDwarfSectionOffset(offset, buffer, DwarfDebugInfo.DW_INFO_SECTION_NAME, pos);
     }
 
@@ -464,11 +464,17 @@ public abstract class DwarfSectionImpl extends BasicProgbitsSectionImpl {
         return writeDwarfSectionOffset(offset, buffer, DwarfDebugInfo.DW_LINE_SECTION_NAME, pos);
     }
 
-    public int writeAbbrevSectionOffset(int offset, byte[] buffer, int pos) {
+    protected int writeAbbrevSectionOffset(int offset, byte[] buffer, int pos) {
         return writeDwarfSectionOffset(offset, buffer, DwarfDebugInfo.DW_ABBREV_SECTION_NAME, pos);
     }
 
-    public int writeStrSectionOffset(int offset, byte[] buffer, int pos) {
+    protected int writeStrSectionOffset(String value, byte[] buffer, int p) {
+        int pos = p;
+        int idx = debugStringIndex(value);
+        return writeStrSectionOffset(idx, buffer, pos);
+    }
+
+    private int writeStrSectionOffset(int offset, byte[] buffer, int pos) {
         return writeDwarfSectionOffset(offset, buffer, DwarfDebugInfo.DW_STR_SECTION_NAME, pos);
     }
 
@@ -476,7 +482,7 @@ public abstract class DwarfSectionImpl extends BasicProgbitsSectionImpl {
         return writeDwarfSectionOffset(offset, buffer, DwarfDebugInfo.DW_LOC_SECTION_NAME, pos);
     }
 
-    public int writeDwarfSectionOffset(int offset, byte[] buffer, String sectionName, int pos) {
+    protected int writeDwarfSectionOffset(int offset, byte[] buffer, String sectionName, int pos) {
         // offsets to abbrev section DIEs need a relocation
         // the linker uses this to update the offset when info sections are merged
         if (buffer != null) {

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfSectionImpl.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfSectionImpl.java
@@ -621,8 +621,8 @@ public abstract class DwarfSectionImpl extends BasicProgbitsSectionImpl {
         return dwarfSections.getTypes().stream();
     }
 
-    protected Iterable<? extends ClassEntry> getPrimaryClasses() {
-        return dwarfSections.getPrimaryClasses();
+    protected Iterable<? extends ClassEntry> getInstanceClasses() {
+        return dwarfSections.getInstanceClasses();
     }
 
     protected int debugStringIndex(String str) {

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/pecoff/cv/CVLineRecordBuilder.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/pecoff/cv/CVLineRecordBuilder.java
@@ -27,7 +27,7 @@
 package com.oracle.objectfile.pecoff.cv;
 
 import com.oracle.objectfile.debugentry.FileEntry;
-import com.oracle.objectfile.debugentry.PrimaryEntry;
+import com.oracle.objectfile.debugentry.CompiledMethodEntry;
 import com.oracle.objectfile.debugentry.Range;
 
 import java.util.Iterator;
@@ -41,7 +41,7 @@ public class CVLineRecordBuilder {
 
     private final CVDebugInfo cvDebugInfo;
     private CVLineRecord lineRecord;
-    private PrimaryEntry primaryEntry;
+    private CompiledMethodEntry compiledEntry;
 
     CVLineRecordBuilder(CVDebugInfo cvDebugInfo) {
         this.cvDebugInfo = cvDebugInfo;
@@ -57,16 +57,16 @@ public class CVLineRecordBuilder {
      * @param entry function to build line number table for
      * @return CVLineRecord containing any entries generated, or null if no entries generated
      */
-    CVLineRecord build(PrimaryEntry entry) {
-        this.primaryEntry = entry;
-        Range primaryRange = primaryEntry.getPrimary();
+    CVLineRecord build(CompiledMethodEntry entry) {
+        this.compiledEntry = entry;
+        Range primaryRange = compiledEntry.getPrimary();
 
         debug("DEBUG_S_LINES linerecord for 0x%05x file: %s:%d", primaryRange.getLo(), primaryRange.getFileName(), primaryRange.getLine());
         this.lineRecord = new CVLineRecord(cvDebugInfo, primaryRange.getSymbolName());
         debug("CVLineRecord.computeContents: processing primary range %s", primaryRange);
 
         processRange(primaryRange);
-        Iterator<Range> iterator = primaryEntry.leafRangeIterator();
+        Iterator<Range> iterator = compiledEntry.leafRangeIterator();
         while (iterator.hasNext()) {
             Range subRange = iterator.next();
             debug("CVLineRecord.computeContents: processing range %s", subRange);
@@ -101,9 +101,9 @@ public class CVLineRecordBuilder {
         }
 
         /* Add line record. */
-        int lineLoAddr = range.getLo() - primaryEntry.getPrimary().getLo();
+        int lineLoAddr = range.getLo() - compiledEntry.getPrimary().getLo();
         int line = Math.max(range.getLine(), 1);
-        debug("  processRange:   addNewLine: 0x%05x-0x%05x %s", lineLoAddr, range.getHi() - primaryEntry.getPrimary().getLo(), line);
+        debug("  processRange:   addNewLine: 0x%05x-0x%05x %s", lineLoAddr, range.getHi() - compiledEntry.getPrimary().getLo(), line);
         lineRecord.addNewLine(lineLoAddr, line);
     }
 }

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/pecoff/cv/CVSymbolSubrecord.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/pecoff/cv/CVSymbolSubrecord.java
@@ -88,7 +88,7 @@ abstract class CVSymbolSubrecord {
         private static String findObjectName(CVDebugInfo cvDebugInfo) {
             /* Infer object filename from first class definition. */
             String fn = null;
-            for (ClassEntry classEntry : cvDebugInfo.getPrimaryClasses()) {
+            for (ClassEntry classEntry : cvDebugInfo.getInstanceClasses()) {
                 if (classEntry.getFileName() != null) {
                     fn = classEntry.getFileEntry().getFileName();
                     if (fn.endsWith(".java")) {
@@ -214,7 +214,7 @@ abstract class CVSymbolSubrecord {
 
         private static String findFirstFile(CVDebugInfo cvDebugInfo) {
             String fn = null;
-            for (ClassEntry classEntry : cvDebugInfo.getPrimaryClasses()) {
+            for (ClassEntry classEntry : cvDebugInfo.getInstanceClasses()) {
                 if (classEntry.getFileName() != null) {
                     fn = classEntry.getFileEntry().getFileName();
                     break;

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/pecoff/cv/CVSymbolSubsectionBuilder.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/pecoff/cv/CVSymbolSubsectionBuilder.java
@@ -56,7 +56,7 @@ final class CVSymbolSubsectionBuilder {
      */
     void build() {
         /* loop over all classes defined in this module. */
-        for (ClassEntry classEntry : cvDebugInfo.getPrimaryClasses()) {
+        for (ClassEntry classEntry : cvDebugInfo.getInstanceClasses()) {
             build(classEntry);
         }
         cvDebugInfo.getCVSymbolSection().addRecord(cvSymbolSubsection);

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/pecoff/cv/CVSymbolSubsectionBuilder.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/pecoff/cv/CVSymbolSubsectionBuilder.java
@@ -69,9 +69,7 @@ final class CVSymbolSubsectionBuilder {
      */
     private void build(ClassEntry classEntry) {
         /* Loop over all functions defined in this class. */
-        for (PrimaryEntry primaryEntry : classEntry.getPrimaryEntries()) {
-            build(primaryEntry);
-        }
+        classEntry.primaryEntries().forEach(primaryEntry -> build(primaryEntry));
     }
 
     /**

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/image/NativeImage.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/image/NativeImage.java
@@ -909,6 +909,10 @@ public abstract class NativeImage extends AbstractImage {
                  * 3. the linkage names given by @CEntryPoint
                  */
 
+                if (SubstrateOptions.DeleteLocalSymbols.getValue()) {
+                    /* add a dummy function symbol at the start of the code section */
+                    objectFile.createDefinedSymbol("__svm_code_section", textSection, 0, 0, true, true);
+                }
                 final Map<String, HostedMethod> methodsBySignature = new HashMap<>();
                 // 1. fq with return type
                 for (Pair<HostedMethod, CompilationResult> pair : codeCache.getOrderedCompilations()) {

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/image/NativeImageDebugInfoProvider.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/image/NativeImageDebugInfoProvider.java
@@ -1744,12 +1744,12 @@ class NativeImageDebugInfoProvider implements DebugInfoProvider {
                     JavaKind storageKind = (slot < frame.numLocals ? frame.getLocalValueKind(slot) : JavaKind.Illegal);
                     debugContext.log(DebugContext.DETAILED_LEVEL, "  =>  %s kind %s", value, storageKind);
                     int bciStart = l.getStartBCI();
-                    int line = (lineNumberTable != null ? lineNumberTable.getLineNumber(bciStart) : -1);
+                    int firstLine = (lineNumberTable != null ? lineNumberTable.getLineNumber(bciStart) : -1);
                     // only add the local if the kinds match
                     if ((storageKind == kind) ||
                                     isIntegralKindPromotion(storageKind, kind) ||
                                     (isPseudoObjectType(type, ownerType) && kind == JavaKind.Object && storageKind == JavaKind.Long)) {
-                        localInfos.add(new NativeImageDebugLocalValueInfo(name, value, framesize, storageKind, type, slot, line));
+                        localInfos.add(new NativeImageDebugLocalValueInfo(name, value, framesize, storageKind, type, slot, firstLine));
                     } else if (storageKind != JavaKind.Illegal) {
                         debugContext.log(DebugContext.DETAILED_LEVEL, "  value kind incompatible with var kind %s!", type.getJavaKind());
                     }
@@ -1764,7 +1764,7 @@ class NativeImageDebugInfoProvider implements DebugInfoProvider {
             ArrayList<DebugLocalValueInfo> localInfos = new ArrayList<>();
             LocalVariableTable table = method.getLocalVariableTable();
             LineNumberTable lineNumberTable = method.getLineNumberTable();
-            int line = (lineNumberTable != null ? lineNumberTable.getLineNumber(0) : -1);
+            int firstLine = (lineNumberTable != null ? lineNumberTable.getLineNumber(0) : -1);
             int slot = 0;
             int localIdx = 0;
             ResolvedJavaType ownerType = method.getDeclaringClass();
@@ -1776,7 +1776,7 @@ class NativeImageDebugInfoProvider implements DebugInfoProvider {
                 NativeImageDebugLocalValue value = locProducer.nextLocation(kind);
                 debugContext.log(DebugContext.DETAILED_LEVEL, "locals[%d] %s type %s slot %d", localIdx, name, ownerType.getName(), slot);
                 debugContext.log(DebugContext.DETAILED_LEVEL, "  =>  %s kind %s", value, storageKind);
-                localInfos.add(new NativeImageDebugLocalValueInfo(name, value, storageKind, ownerType, slot, line));
+                localInfos.add(new NativeImageDebugLocalValueInfo(name, value, storageKind, ownerType, slot, firstLine));
                 slot += storageKind.getSlotCount();
                 localIdx++;
             }
@@ -1789,7 +1789,7 @@ class NativeImageDebugInfoProvider implements DebugInfoProvider {
                 NativeImageDebugLocalValue value = locProducer.nextLocation(kind);
                 debugContext.log(DebugContext.DETAILED_LEVEL, "locals[%d] %s type %s slot %d", localIdx, name, ownerType.getName(), slot);
                 debugContext.log(DebugContext.DETAILED_LEVEL, "  =>  %s kind %s", value, storageKind);
-                localInfos.add(new NativeImageDebugLocalValueInfo(name, value, storageKind, paramType, slot, line));
+                localInfos.add(new NativeImageDebugLocalValueInfo(name, value, storageKind, paramType, slot, firstLine));
                 slot += storageKind.getSlotCount();
                 localIdx++;
             }

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/image/NativeImageDebugInfoProvider.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/image/NativeImageDebugInfoProvider.java
@@ -426,7 +426,7 @@ class NativeImageDebugInfoProvider implements DebugInfoProvider {
         }
     }
 
-    private final static Path fullFilePathFromClassName(HostedInstanceClass hostedInstanceClass) {
+    private static Path fullFilePathFromClassName(HostedInstanceClass hostedInstanceClass) {
         String[] elements = hostedInstanceClass.toJavaName().split("\\.");
         int count = elements.length;
         String name = elements[count - 1];

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/image/NativeImageDebugInfoProvider.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/image/NativeImageDebugInfoProvider.java
@@ -354,6 +354,8 @@ class NativeImageDebugInfoProvider implements DebugInfoProvider {
             try (DebugContext.Scope s = debugContext.scope("DebugFileInfo", hostedType)) {
                 Path filePath = sourceManager.findAndCacheSource(javaType, clazz, debugContext);
                 if (filePath == null && hostedType instanceof HostedInstanceClass) {
+                    // conjure up an appropriate, unique file name to keep tools happy
+                    // even though we cannot find a corresponding source
                     filePath = fullFilePathFromClassName((HostedInstanceClass) hostedType);
                 }
                 fullFilePath = filePath;


### PR DESCRIPTION
This PR implements changes to Linux debug info generation specified in issue #4810. These enable the Linux tool `perf` to display profile information for GraalVM native images.

This patch 'fixes' `perf` modulo from a few small remaining details:

`perf` expects many references from definitions to associated declarations (`specification` or `abstract_origin` attribute values) to be implemented as compile unit (CU) local offsets because it assumes that a single CU owns both the referring and referenced records. There are still a few cases in Java debug info where definitions and declarations need to be in different CUs and so must use an info section global offset. This is no problem for `gdb` but `perf` cannot cope with it.

`perf` does display generated machine code for sampled code addresses. However, it appears to be adding an extra 4K offset to the code address before decompiling, meaning that the wrong code is displayed. I am not clear why this is happening.

`perf` occasionally lists sampled method code addresses as hex numbers (e.g. something like `0x4061ba`) instead of using the fully qualified method name. I am not clear why this is happening. The odd thing is that `perf` delegates to binary `addr2line` to do name, file and line lookup and this program prints the correct name, file, line and even inline frame info for these addresses.