### PR TITLE
Fix GetDirectBufferCapacity() implementation

### DIFF
--- a/substratevm/mx.substratevm/suite.py
+++ b/substratevm/mx.substratevm/suite.py
@@ -226,6 +226,7 @@ suite = {
                 "java.base" : [
                     "sun.invoke.util",
                     "sun.net",
+                    "sun.nio.ch",
                     "sun.reflect.annotation",
                     "sun.reflect.generics.factory",
                     "sun.reflect.generics.reflectiveObjects",


### PR DESCRIPTION
[GetDirectBufferCapacity()](https://docs.oracle.com/en/java/javase/11/docs/specs/jni/functions.html#getdirectbuffercapacity) JNI must return -1 if the given object is not a direct java.nio.Buffer.

This is a continuation of #4715.
