### PR TITLE
Return long option from Isolate parameters

### DIFF
--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/IsolateArgumentParser.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/IsolateArgumentParser.java
@@ -198,6 +198,11 @@ public class IsolateArgumentParser {
         return (int) PARSED_OPTION_VALUES[index];
     }
 
+    @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
+    public static long getLongOptionValue(int index) {
+        return PARSED_OPTION_VALUES[index];
+    }
+
     private static Object getOptionValue(int index) {
         Class<?> optionValueType = OPTIONS[index].getDescriptor().getOptionValueType();
         long value = PARSED_OPTION_VALUES[index];


### PR DESCRIPTION
Add an API to return long typed option values (-Xmx,-Xms and -Xmn) that are setting in Isolate parameters.

This PR fixes the issue https://github.com/oracle/graal/issues/4851