### PR TITLE
macOS note for Truffle build

### DIFF
--- a/truffle/README.md
+++ b/truffle/README.md
@@ -40,6 +40,8 @@ $ mx build
 $ mx unittest
 ```
 
+> **NOTE:** Install pure `gcc` (e.g. `brew install gcc`) on macOS
+
 The created `./mxbuild/dists` directory contains all necessary jars and source bundles.
 
   - `truffle-api.jar` contains the framework


### PR DESCRIPTION
macOS note for Truffle build

`clang` doesn't support `-print-multi-os-directory` option, `gcc` needs to be used to have a successful build