### PR TITLE
[GR-40819] Locate sources associated with classes provided as jars in the module path

### DIFF
--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/image/sources/SourceCache.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/image/sources/SourceCache.java
@@ -131,9 +131,9 @@ public class SourceCache {
 
     private void addGraalSources() {
         classPathEntries.stream()
-                .forEach(classPathEntry -> addGraalSourceRoot(classPathEntry, true));
+                        .forEach(classPathEntry -> addGraalSourceRoot(classPathEntry, true));
         modulePathEntries.stream()
-                .forEach(modulePathEntry -> addGraalSourceRoot(modulePathEntry, true));
+                        .forEach(modulePathEntry -> addGraalSourceRoot(modulePathEntry, true));
         sourcePathEntries.stream()
                         .forEach(sourcePathEntry -> addGraalSourceRoot(Paths.get(sourcePathEntry), false));
     }
@@ -188,7 +188,7 @@ public class SourceCache {
         classPathEntries.stream()
                         .forEach(classPathEntry -> addApplicationSourceRoot(classPathEntry, true));
         modulePathEntries.stream()
-                .forEach(modulePathEntry -> addApplicationSourceRoot(modulePathEntry, true));
+                        .forEach(modulePathEntry -> addApplicationSourceRoot(modulePathEntry, true));
         sourcePathEntries.stream()
                         .forEach(sourcePathEntry -> addApplicationSourceRoot(Paths.get(sourcePathEntry), false));
     }
@@ -514,7 +514,7 @@ public class SourceCache {
     }
 
     /**
-     * Add a path to the list of classpath entries.
+     * Add a path to the list of module path entries.
      *
      * @param path The path to add.
      */


### PR DESCRIPTION
This patch is a fix for issue #4863.

It updates `SourceCache` to be aware of jars in the module path and look for associated source files using the paths for those jars.