### PR TITLE
[GR-40820] Ensure section offsets written to DWARF records are relocatable

### DIFF
--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/ELFObjectFile.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/ELFObjectFile.java
@@ -1186,6 +1186,17 @@ public class ELFObjectFile extends ObjectFile {
         newUserDefinedSection(elfARangesSectionImpl.getSectionName(), elfARangesSectionImpl);
         newUserDefinedSection(elfLineSectionImpl.getSectionName(), elfLineSectionImpl);
         /*
+         * Add symbols for the base of all DWARF sections whose content may need to be referenced
+         * using a section global offset. These need to be written using a base relative reloc so
+         * that they get updated if the section is merged with DWARF content from other ELF objects
+         * during image linking.
+         */
+        createDefinedSymbol(elfAbbrevSectionImpl.getSectionName(), elfAbbrevSectionImpl.getElement(), 0, 0, false, false);
+        createDefinedSymbol(elfInfoSectionImpl.getSectionName(), elfInfoSectionImpl.getElement(), 0, 0, false, false);
+        createDefinedSymbol(elfLineSectionImpl.getSectionName(), elfLineSectionImpl.getElement(), 0, 0, false, false);
+        createDefinedSymbol(elfStrSectionImpl.getSectionName(), elfStrSectionImpl.getElement(), 0, 0, false, false);
+        createDefinedSymbol(elfLocSectionImpl.getSectionName(), elfLocSectionImpl.getElement(), 0, 0, false, false);
+        /*
          * The byte[] for each implementation's content are created and written under
          * getOrDecideContent. Doing that ensures that all dependent sections are filled in and then
          * sized according to the declared dependencies. However, if we leave it at that then

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfARangesSectionImpl.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfARangesSectionImpl.java
@@ -185,7 +185,7 @@ public class DwarfARangesSectionImpl extends DwarfSectionImpl {
             pos = writeInt(length, buffer, pos);
             /* DWARF version is always 2. */
             pos = writeShort(DwarfDebugInfo.DW_VERSION_2, buffer, pos);
-            pos = writeInt(cuIndex, buffer, pos);
+            pos = writeInfoSectionOffset(cuIndex, buffer, pos);
             /* Address size is always 8. */
             pos = writeByte((byte) 8, buffer, pos);
             /* Segment size is always 0. */
@@ -238,7 +238,7 @@ public class DwarfARangesSectionImpl extends DwarfSectionImpl {
                 pos = writeInt(length, buffer, pos);
                 /* DWARF version is always 2. */
                 pos = writeShort(DwarfDebugInfo.DW_VERSION_2, buffer, pos);
-                pos = writeInt(cuIndex, buffer, pos);
+                pos = writeInfoSectionOffset(cuIndex, buffer, pos);
                 /* Address size is always 8. */
                 pos = writeByte((byte) 8, buffer, pos);
                 /* Segment size is always 0. */


### PR DESCRIPTION
This patch is a fix for issue  #4856.

It ensures that any section global offsets written into DWARF section records are relocatable.