### PR TITLE
Fix exception due to unsupported event throttling

### DIFF
--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/SubstrateJVM.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/SubstrateJVM.java
@@ -48,6 +48,8 @@ import com.oracle.svm.core.util.VMError;
 import jdk.jfr.Configuration;
 import jdk.jfr.internal.JVM;
 import jdk.jfr.internal.LogTag;
+import jdk.jfr.internal.LogLevel;
+import jdk.jfr.internal.Logger;
 
 /**
  * Manager class that handles most JFR Java API, see {@link Target_jdk_jfr_internal_JVM}.
@@ -527,6 +529,12 @@ public class SubstrateJVM {
     /** See {@link JVM#setCutoff}. */
     public boolean setCutoff(long eventTypeId, long cutoffTicks) {
         eventSettings[NumUtil.safeToInt(eventTypeId)].setCutoffTicks(cutoffTicks);
+        return true;
+    }
+
+    /** See {@link JVM#setThrottle}. */
+    public boolean setThrottle(long eventTypeId, long eventSampleSize, long periodMs) {
+        Logger.log(LogTag.JFR_SYSTEM_THROTTLE, LogLevel.WARN, "JFR event throttling is not yet supported in native images.");
         return true;
     }
 

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/Target_jdk_jfr_internal_JVM.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/Target_jdk_jfr_internal_JVM.java
@@ -349,6 +349,13 @@ public final class Target_jdk_jfr_internal_JVM {
         return SubstrateJVM.get().setCutoff(eventTypeId, cutoffTicks);
     }
 
+    /** See {@link JVM#setThrottle}. */
+    @Substitute
+    @TargetElement(onlyWith = JDK17OrLater.class)
+    public boolean setThrottle(long eventTypeId, long eventSampleSize, long periodMs) {
+        return SubstrateJVM.get().setThrottle(eventTypeId, eventSampleSize, periodMs);
+    }
+
     /** See {@link JVM#emitOldObjectSamples}. */
     @Substitute
     @TargetElement(onlyWith = JDK11OrEarlier.class) //


### PR DESCRIPTION
See related issue here: https://github.com/oracle/graal/issues/4431

### Problem 
`jdk.jfr.internal.JVM.setThrottle(long, long, long)` was being called. Since event throttling is not yet supported, an exception is thrown and and error is printed to the terminal. This is only an issue with JDK 17+

### Solution
Substitute this method so an exception is not thrown, and then log a descriptive warning explaining throttling feature is not supported yet: "`[warn][jfr,system,throttle] JFR event throttling is not yet supported in native images.`"

However, it might be better to silently do nothing instead of show a warning, similar to how the old object sample feature is handled (`Target_jdk_jfr_internal_JVM.emitOldObjectSamples(long, boolean)`).