### PR TITLE
HostObject interop with wrapping TruffleObject

### DIFF
--- a/sdk/src/org.graalvm.polyglot/src/org/graalvm/polyglot/impl/AbstractPolyglotImpl.java
+++ b/sdk/src/org.graalvm.polyglot/src/org/graalvm/polyglot/impl/AbstractPolyglotImpl.java
@@ -705,6 +705,8 @@ public abstract class AbstractPolyglotImpl {
 
         public abstract Object toGuestValue(Object internalContext, Object hostValue);
 
+        public abstract Object toGuestValue(Object polyglotContext, Object hostValue, Object hostLibrary);
+
         public abstract <T> List<T> toList(Object internalContext, Object guestValue, boolean implementFunction, Class<T> elementClass, Type elementType);
 
         public abstract <K, V> Map<K, V> toMap(Object internalContext, Object foreignObject, boolean implementsFunction, Class<K> keyClass, Type keyType, Class<V> valueClass, Type valueType);
@@ -773,7 +775,9 @@ public abstract class AbstractPolyglotImpl {
 
         public abstract void addToHostClassPath(Object context, Object truffleFile);
 
-        public abstract Object toGuestValue(Object context, Object hostValue, boolean asValue);
+        public abstract Object createHostLibrary(int limit);
+
+        public abstract Object toGuestValue(Object context, Object hostValue, boolean asValue, Object hostLibrary);
 
         public abstract Object asHostDynamicClass(Object context, Class<?> value);
 
@@ -815,7 +819,7 @@ public abstract class AbstractPolyglotImpl {
 
         public abstract int findNextGuestToHostStackTraceElement(StackTraceElement firstElement, StackTraceElement[] hostStack, int nextElementIndex);
 
-        public abstract Object migrateValue(Object hostContext, Object value, Object valueContext);
+        public abstract Object migrateValue(Object hostContext, Object value, Object valueContext, Object hostLibrary);
 
         public abstract void pin(Object receiver);
 

--- a/truffle/src/com.oracle.truffle.api.test/src/com/oracle/truffle/api/test/polyglot/HostObjectWrappedTest.java
+++ b/truffle/src/com.oracle.truffle.api.test/src/com/oracle/truffle/api/test/polyglot/HostObjectWrappedTest.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or
+ * data (collectively the "Software"), free of charge and under any and all
+ * copyright rights in the Software, and any and all patent rights owned or
+ * freely licensable by each licensor hereunder covering either (i) the
+ * unmodified Software as contributed to or provided by such licensor, or (ii)
+ * the Larger Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ *
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ *
+ * The above copyright notice and either this complete permission notice or at a
+ * minimum a reference to the UPL must be included in all copies or substantial
+ * portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.oracle.truffle.api.test.polyglot;
+
+import org.graalvm.polyglot.Context;
+import org.graalvm.polyglot.HostAccess;
+import org.graalvm.polyglot.Value;
+import static org.junit.Assert.assertEquals;
+import org.junit.Test;
+
+import com.oracle.truffle.api.interop.TruffleObject;
+import com.oracle.truffle.api.library.CachedLibrary;
+import com.oracle.truffle.api.library.ExportLibrary;
+import com.oracle.truffle.api.library.ExportMessage;
+import com.oracle.truffle.api.library.Message;
+import com.oracle.truffle.api.library.ReflectionLibrary;
+import java.lang.reflect.Field;
+import java.math.BigInteger;
+
+public class HostObjectWrappedTest {
+    /**
+     * Enso language supports <em>values with warnings</em>. They are
+     * implemented as a {@link TruffleObject} that wraps original object,
+     * holds the warnings and delegates all messages via {@link ReflectionLibrary} to the original object. 
+     * Find more details in the
+     * <a href="https://github.com/enso-org/enso/commit/f6340361a0d82047c56b59f8f2d20a209ba6c0b7#diff-d784205295fc228b108d6ca365bf8371e6fa2337bd8f2c38e7a3bdac721f3a30R14">implementation</a>.
+     * <p>
+     * This {@code WrapInt} mimics that behavior and tries to perform
+     * <em>host interop</em>. That fails in 21.3 version and needs additional
+     * fixes to work.
+     */
+    @ExportLibrary(ReflectionLibrary.class)
+    public static final class WrapObject implements TruffleObject {
+        private final TruffleObject delegate;
+
+        private WrapObject(TruffleObject delegate) {
+            this.delegate = delegate;
+        }
+
+        @ExportMessage
+        Object send(Message message, Object[] args, @CachedLibrary(limit="3") ReflectionLibrary reflect) throws Exception {
+            return reflect.send(delegate, message, args);
+        }
+
+        public static Value wrap(Value i) throws Exception {
+            Field f = i.getClass().getSuperclass().getDeclaredField("receiver");
+            f.setAccessible(true);
+            TruffleObject o = (TruffleObject) f.get(i);
+            WrapObject wrap = new WrapObject(o);
+            return i.getContext().asValue(wrap);
+        }
+    }
+
+    @Test
+    public void testHostInteropWithWrapper() throws Exception {
+        HostAccess accessPolicy = HostAccess.newBuilder(HostAccess.ALL).allowPublicAccess(true).build();
+        try (Context context = Context.newBuilder().allowHostAccess(accessPolicy).build()) {
+            Value bigIntClass = context.asValue(BigInteger.class).getMember("static");
+            Value four = bigIntClass.invokeMember("valueOf", 444L);
+            Value five = bigIntClass.invokeMember("valueOf", 555L);
+
+            Value simplePlus = four.invokeMember("add", five);
+            assertEquals(444L + 555L, simplePlus.invokeMember("longValue").asLong());
+
+            Value wrapFive = WrapObject.wrap(five);
+
+            Value wrapPlus = four.invokeMember("add", wrapFive);
+            assertEquals(444L + 555L, wrapPlus.invokeMember("longValue").asLong());
+
+            Value wrapPlusCommutative = wrapFive.invokeMember("add", four);
+            assertEquals(444L + 555L, wrapPlusCommutative.invokeMember("longValue").asLong());
+        }
+    }
+}

--- a/truffle/src/com.oracle.truffle.api.test/src/com/oracle/truffle/api/test/wrapper/GuestToHostLanguageService.java
+++ b/truffle/src/com.oracle.truffle.api.test/src/com/oracle/truffle/api/test/wrapper/GuestToHostLanguageService.java
@@ -73,9 +73,13 @@ public class GuestToHostLanguageService extends AbstractHostLanguageService {
     }
 
     @Override
-    public Object toGuestValue(Object context, Object hostValue, boolean asValue) {
-
+    public Object toGuestValue(Object context, Object hostValue, boolean asValue, Object hostLibrary) {
         return hostValue;
+    }
+
+    @Override
+    public Object createHostLibrary(int limit) {
+        return null;
     }
 
     @Override
@@ -171,7 +175,7 @@ public class GuestToHostLanguageService extends AbstractHostLanguageService {
     }
 
     @Override
-    public Object migrateValue(Object hostContext, Object value, Object valueContext) {
+    public Object migrateValue(Object hostContext, Object value, Object valueContext, Object hostLibrary) {
         return null;
     }
 

--- a/truffle/src/com.oracle.truffle.api/src/com/oracle/truffle/api/TruffleLanguage.java
+++ b/truffle/src/com.oracle.truffle.api/src/com/oracle/truffle/api/TruffleLanguage.java
@@ -2083,6 +2083,7 @@ public abstract class TruffleLanguage<C> {
          * @param hostObject the host object to convert
          * @since 19.0
          */
+        @TruffleBoundary
         public Object asGuestValue(Object hostObject) {
             try {
                 return LanguageAccessor.engineAccess().toGuestValue(null, hostObject, polyglotLanguageContext);

--- a/truffle/src/com.oracle.truffle.host/src/com/oracle/truffle/host/HostAccessor.java
+++ b/truffle/src/com.oracle.truffle.host/src/com/oracle/truffle/host/HostAccessor.java
@@ -102,22 +102,22 @@ final class HostAccessor extends Accessor {
 
         @Override
         public boolean isDisconnectedHostProxy(Object value) {
-            return HostProxy.isProxyGuestObject(null, value);
+            return HostProxy.isProxyGuestObject(null, HostLibrary.getUncached(), value);
         }
 
         @Override
         public boolean isDisconnectedHostObject(Object obj) {
-            return HostObject.isInstance(null, obj);
+            return HostObject.isInstance(null, HostLibrary.getUncached(), obj);
         }
 
         @Override
         public Object unboxDisconnectedHostObject(Object hostValue) {
-            return HostObject.valueOf(null, hostValue);
+            return HostObject.valueOf(null, HostLibrary.getUncached(), hostValue);
         }
 
         @Override
         public Object unboxDisconnectedHostProxy(Object hostValue) {
-            return HostProxy.toProxyHostObject(null, hostValue);
+            return HostProxy.toProxyHostObject(null, HostLibrary.getUncached(), hostValue);
         }
 
         @Override

--- a/truffle/src/com.oracle.truffle.host/src/com/oracle/truffle/host/HostException.java
+++ b/truffle/src/com.oracle.truffle.host/src/com/oracle/truffle/host/HostException.java
@@ -49,7 +49,7 @@ import com.oracle.truffle.api.library.ExportLibrary;
  */
 @SuppressWarnings("serial")
 @ExportLibrary(value = InteropLibrary.class, delegateTo = "delegate")
-final class HostException extends AbstractTruffleException {
+final class HostException extends AbstractTruffleException implements HostInstance {
 
     private final Throwable original;
     final HostObject delegate;

--- a/truffle/src/com.oracle.truffle.host/src/com/oracle/truffle/host/HostFunction.java
+++ b/truffle/src/com.oracle.truffle.host/src/com/oracle/truffle/host/HostFunction.java
@@ -54,7 +54,7 @@ import com.oracle.truffle.api.library.ExportMessage;
 import com.oracle.truffle.api.utilities.TriState;
 
 @ExportLibrary(InteropLibrary.class)
-final class HostFunction implements TruffleObject {
+final class HostFunction implements TruffleObject, HostInstance {
 
     final Object obj;
     final HostMethodDesc method;
@@ -66,12 +66,12 @@ final class HostFunction implements TruffleObject {
         this.context = context;
     }
 
-    public static boolean isInstance(HostLanguage language, TruffleObject obj) {
-        return isInstance(language, (Object) obj);
+    public static boolean isInstance(HostLanguage language, HostLibrary library, TruffleObject obj) {
+        return isInstance(language, library, (Object) obj);
     }
 
-    public static boolean isInstance(HostLanguage language, Object obj) {
-        return HostLanguage.unwrapIfScoped(language, obj) instanceof HostFunction;
+    public static boolean isInstance(HostLanguage language, HostLibrary library, Object obj) {
+        return HostLanguage.unwrapIfScoped(language, library, obj) instanceof HostFunction;
     }
 
     @SuppressWarnings("static-method")

--- a/truffle/src/com.oracle.truffle.host/src/com/oracle/truffle/host/HostInstance.java
+++ b/truffle/src/com.oracle.truffle.host/src/com/oracle/truffle/host/HostInstance.java
@@ -1,0 +1,6 @@
+package com.oracle.truffle.host;
+
+/** Marker interface to recognize all host objects.
+ */
+interface HostInstance {
+}

--- a/truffle/src/com.oracle.truffle.host/src/com/oracle/truffle/host/HostLanguage.java
+++ b/truffle/src/com.oracle.truffle.host/src/com/oracle/truffle/host/HostLanguage.java
@@ -90,11 +90,12 @@ final class HostLanguage extends TruffleLanguage<HostContext> {
         return new HostContext(this, env);
     }
 
-    static Object unwrapIfScoped(HostLanguage language, Object o) {
+    static Object unwrapIfScoped(HostLanguage language, HostLibrary library, Object o) {
+        HostInstance host = library.asHostInstance(o);
         if (language == null || !language.methodScopingEnabled) {
-            return o;
+            return host;
         }
-        return language.unwrapIfScoped(o);
+        return language.unwrapIfScoped(host);
     }
 
     @Override

--- a/truffle/src/com.oracle.truffle.host/src/com/oracle/truffle/host/HostLanguageService.java
+++ b/truffle/src/com.oracle.truffle.host/src/com/oracle/truffle/host/HostLanguageService.java
@@ -163,7 +163,7 @@ public class HostLanguageService extends AbstractHostLanguageService {
 
     @Override
     public boolean isHostValue(Object value) {
-        Object obj = HostLanguage.unwrapIfScoped(language, value);
+        Object obj = HostLanguage.unwrapIfScoped(language, HostLibrary.getUncached(), value);
         return (obj instanceof HostObject) ||
                         (obj instanceof HostFunction) ||
                         (obj instanceof HostException) ||
@@ -172,12 +172,12 @@ public class HostLanguageService extends AbstractHostLanguageService {
 
     @Override
     public Object unboxHostObject(Object hostValue) {
-        return HostObject.valueOf(language, hostValue);
+        return HostObject.valueOf(language, HostLibrary.getUncached(), hostValue);
     }
 
     @Override
     public Object unboxProxyObject(Object hostValue) {
-        return HostProxy.toProxyHostObject(language, hostValue);
+        return HostProxy.toProxyHostObject(language, HostLibrary.getUncached(), hostValue);
     }
 
     @Override
@@ -206,22 +206,22 @@ public class HostLanguageService extends AbstractHostLanguageService {
 
     @Override
     public boolean isHostFunction(Object value) {
-        return HostFunction.isInstance(language, value);
+        return HostFunction.isInstance(language, HostLibrary.getUncached(), value);
     }
 
     @Override
     public boolean isHostObject(Object value) {
-        return HostObject.isInstance(language, value);
+        return HostObject.isInstance(language, HostLibrary.getUncached(), value);
     }
 
     @Override
     public boolean isHostProxy(Object value) {
-        return HostProxy.isProxyGuestObject(language, value);
+        return HostProxy.isProxyGuestObject(language, HostLibrary.getUncached(), value);
     }
 
     @Override
     public boolean isHostSymbol(Object obj) {
-        Object o = HostLanguage.unwrapIfScoped(language, obj);
+        Object o = HostLanguage.unwrapIfScoped(language, HostLibrary.getUncached(), obj);
         if (o instanceof HostObject) {
             return ((HostObject) o).isStaticClass();
         }
@@ -262,8 +262,8 @@ public class HostLanguageService extends AbstractHostLanguageService {
         assert targetContext != valueContext;
         if (value instanceof TruffleObject) {
             assert value instanceof TruffleObject;
-            if (HostObject.isInstance(language, value)) {
-                return HostObject.withContext(language, value, (HostContext) HostAccessor.ENGINE.getHostContext(targetContext));
+            if (HostObject.isInstance(language, HostLibrary.getUncached(), value)) {
+                return HostObject.withContext(language, HostLibrary.getUncached(), value, (HostContext) HostAccessor.ENGINE.getHostContext(targetContext));
             } else if (value instanceof HostProxy) {
                 return HostProxy.withContext(value, (HostContext) HostAccessor.ENGINE.getHostContext(targetContext));
             } else if (valueContext == null) {

--- a/truffle/src/com.oracle.truffle.host/src/com/oracle/truffle/host/HostLibrary.java
+++ b/truffle/src/com.oracle.truffle.host/src/com/oracle/truffle/host/HostLibrary.java
@@ -1,0 +1,23 @@
+package com.oracle.truffle.host;
+
+import com.oracle.truffle.api.library.GenerateLibrary;
+import com.oracle.truffle.api.library.Library;
+import com.oracle.truffle.api.library.LibraryFactory;
+
+@GenerateLibrary(receiverType = HostInstance.class)
+abstract class HostLibrary extends Library {
+    private static final LibraryFactory<HostLibrary> FACTORY = HostLibraryGen.resolve(HostLibrary.class);
+    private static final HostLibrary UNCACHED = FACTORY.getUncached();
+
+    static HostLibrary getUncached() {
+        return UNCACHED;
+    }
+    
+    static LibraryFactory<HostLibrary> getFactory() {
+        return FACTORY;
+    }
+    
+    public HostInstance asHostInstance(Object obj) {
+        return obj instanceof HostInstance ? (HostInstance) obj : null;
+    }
+}

--- a/truffle/src/com.oracle.truffle.host/src/com/oracle/truffle/host/HostLibrary.java
+++ b/truffle/src/com.oracle.truffle.host/src/com/oracle/truffle/host/HostLibrary.java
@@ -1,5 +1,6 @@
 package com.oracle.truffle.host;
 
+import com.oracle.truffle.api.CompilerAsserts;
 import com.oracle.truffle.api.library.GenerateLibrary;
 import com.oracle.truffle.api.library.Library;
 import com.oracle.truffle.api.library.LibraryFactory;
@@ -10,6 +11,7 @@ abstract class HostLibrary extends Library {
     private static final HostLibrary UNCACHED = FACTORY.getUncached();
 
     static HostLibrary getUncached() {
+        CompilerAsserts.neverPartOfCompilation("HostLibrary needs to be fast on fast-path");
         return UNCACHED;
     }
     

--- a/truffle/src/com.oracle.truffle.host/src/com/oracle/truffle/host/HostMethodScope.java
+++ b/truffle/src/com.oracle.truffle.host/src/com/oracle/truffle/host/HostMethodScope.java
@@ -185,19 +185,24 @@ final class HostMethodScope {
     }
 
     @ExportLibrary(value = InteropLibrary.class, delegateTo = "delegate")
-    static final class PinnedObject implements TruffleObject {
-
+    @ExportLibrary(HostLibrary.class)
+    static final class PinnedObject implements TruffleObject, HostInstance {
         final Object delegate;
 
         PinnedObject(Object delegate) {
             this.delegate = delegate;
         }
 
+        @ExportMessage
+        HostInstance asHostInstance(@CachedLibrary(limit = "3") HostLibrary library) {
+            return library.asHostInstance(delegate);
+        }
     }
 
     @SuppressWarnings("deprecation")
     @ExportLibrary(ReflectionLibrary.class)
-    static final class ScopedObject implements TruffleObject {
+    @ExportLibrary(HostLibrary.class)
+    static final class ScopedObject implements TruffleObject, HostInstance {
 
         static final Object OTHER_VALUE = new Object();
         static final ReflectionLibrary OTHER_VALUE_UNCACHED = ReflectionLibrary.getFactory().getUncached(OTHER_VALUE);
@@ -253,6 +258,11 @@ final class HostMethodScope {
             } else {
                 return returnValue;
             }
+        }
+        
+        @ExportMessage
+        HostInstance asHostInstance(@CachedLibrary(limit="3") HostLibrary library) {
+            return library.asHostInstance(delegate);
         }
 
         @TruffleBoundary

--- a/truffle/src/com.oracle.truffle.host/src/com/oracle/truffle/host/HostProxy.java
+++ b/truffle/src/com.oracle.truffle.host/src/com/oracle/truffle/host/HostProxy.java
@@ -88,7 +88,7 @@ import com.oracle.truffle.api.utilities.TriState;
 
 @SuppressWarnings("deprecation")
 @ExportLibrary(InteropLibrary.class)
-final class HostProxy implements TruffleObject {
+final class HostProxy implements TruffleObject, HostInstance {
 
     static final int LIMIT = 5;
 
@@ -734,17 +734,17 @@ final class HostProxy implements TruffleObject {
         return System.identityHashCode(receiver.proxy);
     }
 
-    public static boolean isProxyGuestObject(HostLanguage language, TruffleObject value) {
-        return isProxyGuestObject(language, (Object) value);
+    public static boolean isProxyGuestObject(HostLanguage language, HostLibrary library, TruffleObject value) {
+        return isProxyGuestObject(language, library, (Object) value);
     }
 
-    public static boolean isProxyGuestObject(HostLanguage language, Object value) {
-        Object unwrapped = HostLanguage.unwrapIfScoped(language, value);
+    public static boolean isProxyGuestObject(HostLanguage language, HostLibrary library, Object value) {
+        Object unwrapped = HostLanguage.unwrapIfScoped(language, library, value);
         return unwrapped instanceof HostProxy;
     }
 
-    public static Proxy toProxyHostObject(HostLanguage language, Object value) {
-        Object v = HostLanguage.unwrapIfScoped(language, value);
+    public static Proxy toProxyHostObject(HostLanguage language, HostLibrary library, Object value) {
+        Object v = HostLanguage.unwrapIfScoped(language, library, value);
         return ((HostProxy) v).proxy;
     }
 

--- a/truffle/src/com.oracle.truffle.host/src/com/oracle/truffle/host/HostTargetMappingNode.java
+++ b/truffle/src/com.oracle.truffle.host/src/com/oracle/truffle/host/HostTargetMappingNode.java
@@ -49,6 +49,7 @@ import com.oracle.truffle.api.dsl.Cached;
 import com.oracle.truffle.api.dsl.GenerateUncached;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.interop.InteropLibrary;
+import com.oracle.truffle.api.library.CachedLibrary;
 import com.oracle.truffle.api.nodes.ExplodeLoop;
 import com.oracle.truffle.api.nodes.Node;
 import com.oracle.truffle.api.profiles.ConditionProfile;
@@ -149,12 +150,13 @@ abstract class HostTargetMappingNode extends Node {
         protected Object doDefault(Object receiver, @SuppressWarnings("unused") HostTargetMapping cachedMapping,
                         HostContext context, InteropLibrary interop, boolean checkOnly,
                         @Cached ConditionProfile acceptsProfile,
+                        @CachedLibrary(limit="3") HostLibrary library,
                         @Cached(value = "allowsImplementation(context, cachedMapping.sourceType)", allowUncached = true) boolean allowsImplementation,
                         @Cached HostToTypeNode toHostRecursive) {
             CompilerAsserts.partialEvaluationConstant(checkOnly);
             Object convertedValue = NO_RESULT;
             if (acceptsProfile.profile(HostToTypeNode.canConvert(receiver, cachedMapping.sourceType, cachedMapping.sourceType,
-                            allowsImplementation, context, HostToTypeNode.LOWEST, interop, null))) {
+                            allowsImplementation, context, HostToTypeNode.LOWEST, interop, null, library))) {
                 if (!checkOnly || cachedMapping.accepts != null) {
                     convertedValue = toHostRecursive.execute(context, receiver, cachedMapping.sourceType, cachedMapping.sourceType, false);
                 }

--- a/truffle/src/com.oracle.truffle.nfi.backend.libffi/src/com/oracle/truffle/nfi/backend/libffi/SerializeArgumentNode.java
+++ b/truffle/src/com.oracle.truffle.nfi.backend.libffi/src/com/oracle/truffle/nfi/backend/libffi/SerializeArgumentNode.java
@@ -601,10 +601,12 @@ abstract class SerializeArgumentNode extends Node {
             }
         }
 
+        @CompilerDirectives.TruffleBoundary
         final boolean isHostObject(Object value) {
             return LibFFIContext.get(this).env.isHostObject(value);
         }
 
+        @CompilerDirectives.TruffleBoundary
         final Object asHostObject(Object value) {
             return LibFFIContext.get(this).env.asHostObject(value);
         }


### PR DESCRIPTION
Enso language supports _values with warnings_. They are implemented as a `TruffleObject` that wraps original object, holds the warnings and delegates all messages via `ReflectionLibrary` to the original object. Find more details in the [implementation](https://github.com/enso-org/enso/commit/f6340361a0d82047c56b59f8f2d20a209ba6c0b7#diff-d784205295fc228b108d6ca365bf8371e6fa2337bd8f2c38e7a3bdac721f3a30R14).

This PR provides a [test showing the use-case](https://github.com/oracle/graal/pull/4916/commits/6b9dfae0ef8157a09510dcea9d1860e1411755b2) and demonstrating the failure as the first commit. Additional commits follow showing possible implementation making the test work: [629d3df](https://github.com/oracle/graal/pull/4916/commits/629d3df50769d3ca329d505dfdc6c0105ed46c8d)
