### PR TITLE
LLVM Source Level debug info support

### DIFF
--- a/substratevm/src/com.oracle.svm.core.graal.llvm/src/com/oracle/svm/core/graal/llvm/NodeLLVMBuilder.java
+++ b/substratevm/src/com.oracle.svm.core.graal.llvm/src/com/oracle/svm/core/graal/llvm/NodeLLVMBuilder.java
@@ -35,6 +35,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import com.oracle.svm.core.graal.llvm.util.LLVMOptions;
 import org.graalvm.compiler.code.CompilationResult;
 import org.graalvm.compiler.core.common.NumUtil;
 import org.graalvm.compiler.core.common.calc.Condition;
@@ -796,6 +797,12 @@ public class NodeLLVMBuilder implements NodeLIRBuilderTool, SubstrateNodeLIRBuil
                         "value type doesn't match node stamp (" + node.stamp(NodeView.DEFAULT).toString() + ")", llvmOperand.get());
 
         gen.getDebugInfoPrinter().setValueName(llvmOperand, node);
+        if (LLVMOptions.IncludeLLVMSourceDebugInfo.getValue()) {
+            if (llvmOperand.get() instanceof LLVMValueRef) {
+                LLVMValueRef instr = llvmOperand.get();
+                builder.buildDebugInfoForInstr(node, instr);
+            }
+        }
         valueMap.put(node, llvmOperand);
         return operand;
     }

--- a/substratevm/src/com.oracle.svm.core.graal.llvm/src/com/oracle/svm/core/graal/llvm/SubstrateLLVMBackend.java
+++ b/substratevm/src/com.oracle.svm.core.graal.llvm/src/com/oracle/svm/core/graal/llvm/SubstrateLLVMBackend.java
@@ -28,7 +28,9 @@ import static com.oracle.svm.core.util.VMError.unimplemented;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.locks.ReentrantLock;
 
+import com.oracle.svm.hosted.image.sources.SourceManager;
 import org.graalvm.compiler.code.CompilationResult;
 import org.graalvm.compiler.core.common.CompilationIdentifier;
 import org.graalvm.compiler.debug.CounterKey;
@@ -61,10 +63,12 @@ import jdk.vm.ci.meta.JavaConstant;
 import jdk.vm.ci.meta.JavaKind;
 import jdk.vm.ci.meta.ResolvedJavaMethod;
 import jdk.vm.ci.meta.VMConstant;
+import org.graalvm.nativeimage.ImageSingletons;
 
 public class SubstrateLLVMBackend extends SubstrateBackend {
     private static final TimerKey EmitLLVM = DebugContext.timer("EmitLLVM").doc("Time spent generating LLVM from HIR.");
     private static final TimerKey BackEnd = DebugContext.timer("BackEnd").doc("Time spent in EmitLLVM and Populate.");
+    private ReentrantLock imageSingletonesLock = new ReentrantLock();
 
     public SubstrateLLVMBackend(Providers providers) {
         super(providers);
@@ -121,6 +125,14 @@ public class SubstrateLLVMBackend extends SubstrateBackend {
             NodeLLVMBuilder nodeBuilder = newNodeLLVMBuilder(graph, generator);
 
             /* LLVM generation */
+            if (LLVMOptions.IncludeLLVMSourceDebugInfo.getValue()) {
+                //TODO: Avoid this lock if possible
+                imageSingletonesLock.lock();
+                if (ImageSingletons.contains(SourceManager.class) == false) {
+                    ImageSingletons.add(SourceManager.class, new SourceManager());
+                }
+                imageSingletonesLock.unlock();
+            }
             generate(nodeBuilder, graph);
             byte[] bitcode = generator.getBitcode();
             result.setTargetCode(bitcode, bitcode.length);

--- a/substratevm/src/com.oracle.svm.core.graal.llvm/src/com/oracle/svm/core/graal/llvm/util/LLVMDebugLineInfo.java
+++ b/substratevm/src/com.oracle.svm.core.graal.llvm/src/com/oracle/svm/core/graal/llvm/util/LLVMDebugLineInfo.java
@@ -1,0 +1,205 @@
+/*
+ * Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package com.oracle.svm.core.graal.llvm.util;
+
+import com.oracle.graal.pointsto.infrastructure.OriginalClassProvider;
+import com.oracle.graal.pointsto.infrastructure.WrappedJavaMethod;
+import com.oracle.graal.pointsto.meta.AnalysisType;
+import com.oracle.svm.core.SubstrateOptions;
+import com.oracle.svm.hosted.annotation.CustomSubstitutionMethod;
+import com.oracle.svm.hosted.annotation.CustomSubstitutionType;
+import com.oracle.svm.hosted.image.NativeImage;
+import com.oracle.svm.hosted.image.sources.SourceManager;
+import com.oracle.svm.hosted.lambda.LambdaSubstitutionType;
+import com.oracle.svm.hosted.meta.HostedMethod;
+import com.oracle.svm.hosted.meta.HostedType;
+import com.oracle.svm.hosted.substitute.InjectedFieldsType;
+import com.oracle.svm.hosted.substitute.SubstitutionMethod;
+import com.oracle.svm.hosted.substitute.SubstitutionType;
+import jdk.vm.ci.meta.LineNumberTable;
+import jdk.vm.ci.meta.ResolvedJavaMethod;
+import jdk.vm.ci.meta.ResolvedJavaType;
+import org.graalvm.compiler.debug.DebugContext;
+import org.graalvm.compiler.graph.NodeSourcePosition;
+import org.graalvm.nativeimage.ImageSingletons;
+
+import java.nio.file.Path;
+
+import static org.graalvm.compiler.debug.GraalError.unimplemented;
+
+// Similar to NativeImageDebugLineInfo from previous releases
+public class LLVMDebugLineInfo {
+    private final int bci;
+    private final ResolvedJavaMethod method;
+    private final DebugContext debugContext;
+    private Path cachePath;
+    private Path fullFilePath;
+
+    LLVMDebugLineInfo(DebugContext debugContext, NodeSourcePosition position) {
+        int posbci = position.getBCI();
+        this.bci = (posbci >= 0 ? posbci : 0);
+        this.method = position.getMethod();
+        this.cachePath = SubstrateOptions.getDebugInfoSourceCacheRoot();
+        this.debugContext = debugContext;
+        computeFullFilePath();
+    }
+
+    private static ResolvedJavaType getOriginal(ResolvedJavaType javaType) {
+        if (javaType instanceof SubstitutionType) {
+            return ((SubstitutionType) javaType).getOriginal();
+        } else if (javaType instanceof CustomSubstitutionType<?, ?>) {
+            return ((CustomSubstitutionType<?, ?>) javaType).getOriginal();
+        } else if (javaType instanceof LambdaSubstitutionType) {
+            return ((LambdaSubstitutionType) javaType).getOriginal();
+        } else if (javaType instanceof InjectedFieldsType) {
+            return ((InjectedFieldsType) javaType).getOriginal();
+        }
+        return null;
+    }
+
+    protected static ResolvedJavaType getJavaType(HostedMethod hostedMethod, boolean wantOriginal) {
+        if (wantOriginal) {
+            /* Check for wholesale replacement of the original class. */
+            HostedType hostedType = hostedMethod.getDeclaringClass();
+            ResolvedJavaType javaType = hostedType.getWrapped().getWrappedWithoutResolve();
+            ResolvedJavaType originalType = getOriginal(javaType);
+            if (originalType != null) {
+                return originalType;
+            }
+            /* Check for replacement of the original method only. */
+            ResolvedJavaMethod javaMethod = hostedMethod.getWrapped().getWrapped();
+            if (javaMethod instanceof SubstitutionMethod) {
+                return ((SubstitutionMethod) javaMethod).getOriginal().getDeclaringClass();
+            } else if (javaMethod instanceof CustomSubstitutionMethod) {
+                return ((CustomSubstitutionMethod) javaMethod).getOriginal().getDeclaringClass();
+            }
+            return hostedType.getWrapped().getWrapped();
+        }
+        ResolvedJavaMethod javaMethod = hostedMethod.getWrapped().getWrapped();
+        return javaMethod.getDeclaringClass();
+    }
+
+    public String fileName() {
+        if (fullFilePath != null) {
+            Path fileName = fullFilePath.getFileName();
+            if (fileName != null) {
+                return fileName.toString();
+            }
+        }
+        return null;
+    }
+
+    public Path filePath() {
+        if (fullFilePath != null) {
+            return fullFilePath.getParent();
+        }
+        return null;
+    }
+
+    public Path cachePath() {
+        return cachePath;
+    }
+
+    public String className() {
+        return method.format("%H");
+    }
+
+    public String methodName() {
+        ResolvedJavaMethod targetMethod = method;
+        while (targetMethod instanceof WrappedJavaMethod) {
+            targetMethod = ((WrappedJavaMethod) targetMethod).getWrapped();
+        }
+        if (targetMethod instanceof SubstitutionMethod) {
+            targetMethod = ((SubstitutionMethod) targetMethod).getOriginal();
+        } else if (targetMethod instanceof CustomSubstitutionMethod) {
+            targetMethod = ((CustomSubstitutionMethod) targetMethod).getOriginal();
+        }
+        String name = targetMethod.getName();
+        if (name.equals("<init>")) {
+            if (method instanceof HostedMethod) {
+                name = getJavaType((HostedMethod) method, true).toJavaName();
+                if (name.indexOf('.') >= 0) {
+                    name = name.substring(name.lastIndexOf('.') + 1);
+                }
+                if (name.indexOf('$') >= 0) {
+                    name = name.substring(name.lastIndexOf('$') + 1);
+                }
+            } else {
+                name = targetMethod.format("%h");
+                if (name.indexOf('$') >= 0) {
+                    name = name.substring(name.lastIndexOf('$') + 1);
+                }
+            }
+        }
+        return name;
+    }
+
+    public String symbolNameForMethod() {
+        return NativeImage.localSymbolNameForMethod(method);
+    }
+
+    public int addressLo() {
+        throw unimplemented();
+    }
+
+    public int addressHi() {
+        throw unimplemented();
+    }
+
+    public int line() {
+        LineNumberTable lineNumberTable = method.getLineNumberTable();
+        if (lineNumberTable != null) {
+            return lineNumberTable.getLineNumber(bci);
+        }
+        return 0;
+    }
+
+    @SuppressWarnings("try")
+    public void computeFullFilePath() {
+        ResolvedJavaType declaringClass = method.getDeclaringClass();
+        Class<?> clazz = null;
+        if (declaringClass instanceof OriginalClassProvider) {
+            clazz = ((OriginalClassProvider) declaringClass).getJavaClass();
+        }
+        /*
+         * HostedType wraps an AnalysisType and both HostedType and AnalysisType punt calls to
+         * getSourceFilename to the wrapped class so for consistency we need to do the path
+         * lookup relative to the doubly unwrapped HostedType or singly unwrapped AnalysisType.
+         */
+        if (declaringClass instanceof HostedType) {
+            declaringClass = ((HostedType) declaringClass).getWrapped();
+        }
+        if (declaringClass instanceof AnalysisType) {
+            declaringClass = ((AnalysisType) declaringClass).getWrapped();
+        }
+        SourceManager sourceManager = ImageSingletons.lookup(SourceManager.class);
+        try (DebugContext.Scope s = debugContext.scope("DebugCodeInfo", declaringClass)) {
+            fullFilePath = sourceManager.findAndCacheSource(declaringClass, clazz, debugContext);
+        } catch (Throwable e) {
+            throw debugContext.handle(e);
+        }
+    }
+}
+

--- a/substratevm/src/com.oracle.svm.core.graal.llvm/src/com/oracle/svm/core/graal/llvm/util/LLVMOptions.java
+++ b/substratevm/src/com.oracle.svm.core.graal.llvm/src/com/oracle/svm/core/graal/llvm/util/LLVMOptions.java
@@ -49,5 +49,8 @@ public class LLVMOptions {
     @Option(help = "Enable LLVM bitcode optimizations")//
     public static final HostedOptionKey<Boolean> BitcodeOptimizations = new HostedOptionKey<>(false);
 
+    @Option(help = "Include source code level debug info in the output LLVM IR", type = OptionType.Debug)//
+    public static final HostedOptionKey<Boolean> IncludeLLVMSourceDebugInfo = new HostedOptionKey<>(false);
+
     public static final List<HostedOptionKey<?>> allOptions = Arrays.asList(IncludeLLVMDebugInfo, DumpLLVMStackMap, LLVMMaxFunctionsPerBatch, CustomLD, BitcodeOptimizations);
 }

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/image/NativeImage.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/image/NativeImage.java
@@ -470,7 +470,9 @@ public abstract class NativeImage extends AbstractImage {
             if (SubstrateOptions.GenerateDebugInfo.getValue(HostedOptionValues.singleton()) > 0) {
                 Timer timer = TimerCollection.singleton().get(TimerCollection.Registry.DEBUG_INFO);
                 try (Timer.StopTimer t = timer.start()) {
-                    ImageSingletons.add(SourceManager.class, new SourceManager());
+                    if (ImageSingletons.contains(SourceManager.class) == false) {
+                        ImageSingletons.add(SourceManager.class, new SourceManager());
+                    }
                     DebugInfoProvider provider = new NativeImageDebugInfoProvider(debug, codeCache, heap, metaAccess);
                     objectFile.installDebugInfo(provider);
                 }


### PR DESCRIPTION
(1) the change or feature is needed

Graal substratevm has support for an LLVM backend but it is not possible to associate source level location information (e.g. line number, filename) with the output IR. That is what this commit aims to do, adding an option called "IncludeLLVMSourceDebugInfo" which includes source level debug information in the output IR built using the LLVM DI Builder interface . This information in the IR can be helpful for debugging purposes and performing static analysis on the IR. 

(2) how it is implemented

GraalVM SubstrateVM currently uses JavaCPP's JNI functions for llvm to build the LLVM IR. I am using the JNI methods of the LLVM DIBuilder class to create location information with corresponding line number, subprogram and filename. This location information is associated to the corresponding LLVM Instruction, function or basic block using the `LLVMSetCurrentDebugLocation2` and `LLVMSetInstDebugLocation` functions. The line number, method name and file name information is derived using a new class called LLVMDebugLineInfo which is synonymous to the NativeImageDebugLineInfo class from previous GraalVM releases (21.1.0).

The debug location is attached to an IR instruction by calling `buildDebugInfoForInstr()` from inside the setResult() method in NodeLLVMBuilder class. `buildDebugInfoForInstr()` is defined inside the LLVMIRBuilder class and uses the methods of the LLVM DIBuilder to generate the source level location information.

(3) Notes
1. I needed to use the `SourceManager` class to obtain the file and directory information associated with the node. Once `SourceManager` was defined, I added to the `ImageSingletons` map inside `emitLLVM()`. But the problem is that `emitLLVM()` seems to be run by multiple threads which would cause multiple additions of the `SourceManager` to `ImageSingletons`. I've currently sidestepped the problem by enclosing the addition to `ImageSingletons` within a lock but ideally I would like to perform this addition before the multiple threads are launched but I am not sure where exactly that is? 

2. When using the `-O0` flag to generate the native-image with an LLVM backend, I get an error saying "the LLVM backend doesn't support debug info generation" called from inside `visitFullInfoPointNode` in NodeLLVMBuilder and I am not sure how to avoid this problem. This problem was not present when I implemented this feature in Graal 21.1.0. 

3. I have tested the feature to compile Hadoop to output LLVM IR with location information using GraalVM 21.1.0. But for the latest build, I have only tested it with toy examples.
 
The flags required to obtain location information are `-g` and `-H=+IncludeLLVMSourceDebugInfo`.

This PR is hopefully just some startup code so that I can receive feedback and comments to understand how the code needs to structured and any other requirements that might me needed.
