### PR TITLE
[GR-41098] clear allocated memory after heapdump

### DIFF
--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/heapdump/HeapDumpWriterImpl.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/heapdump/HeapDumpWriterImpl.java
@@ -530,7 +530,10 @@ public class HeapDumpWriterImpl extends HeapDumpWriter {
 
         /* Flush buffer stream and throw it away. */
         out.flush();
+        /* zero out allocated memory in order to be garbage collected */
         out = null;
+        fieldsMap = null;
+        classDataCache = null;
     }
 
     private void writeHeapRecordPrologue() throws IOException {


### PR DESCRIPTION
HeapDumpWriterImpl is shown as global JNI reference, which will not be garbage collected (GC root). When a heapdump is written, some fields are set, which contain a lot of memory. Those fields are not null'ed after the .hprof file has been written. This will result in lost memory, which is quite expensive in some cases. The fields can not be GC'ed, because they are referenced from `HeapDumpWriterImpl` and `HeapDumpWriterImpl` is a GC root, which means it will not be GC'ed. This fix nulls set fields after the .hprof file has been written in order to be GC'ed.

Issue-Id: GR-41098
Issue-Id: #4985

## Testing

I did a quick test with master (HEAD) and this branch and it seems the fields set to null will be GC'ed after the .hprof file is created.

### Bad case
```
// stable at ~50MiB heap before heap dump
[Full GC (CollectOnAllocation) 120960K->54400K, 0.0825642 secs]

// stable at ~80MiB after heap dump
[Full GC (CollectOnAllocation) 158522K->84794K, 0.0976779 secs]
```

## Good case (with fix)
```
// stable at ~50MiB before heap dump is triggered
[Full GC (CollectOnAllocation) 133248K->51328K, 0.0907885 secs]

// trigger heap dump
[Full GC (java.lang.System.gc()) 124032K->51328K, 0.0989828 secs]

// after heap dump is triggered
[Full GC (CollectOnAllocation) 120773K->52165K, 0.0863788 secs]
```