### PR TITLE
Remove most truffle dependencies from `com.oracle.svm.graal`

### DIFF
--- a/sdk/mx.sdk/mx_sdk_vm_impl.py
+++ b/sdk/mx.sdk/mx_sdk_vm_impl.py
@@ -1308,9 +1308,10 @@ class NativePropertiesBuildTask(mx.ProjectBuildTask):
                 '--no-fallback',
                 '-march=compatibility',  # Target maximum portability of all GraalVM images.
                 '-H:+AssertInitializationSpecifiedForAllClasses',
-                '-H:+EnforceMaxRuntimeCompileMethods',
                 '-Dorg.graalvm.version={}'.format(_suite.release_version()),
             ]
+            if has_component('LibGraal'):
+                build_args += ['-H:+EnforceMaxRuntimeCompileMethods']
             if _debug_images():
                 build_args += ['-ea', '-O0', '-H:+PreserveFramePointer', '-H:-DeleteLocalSymbols']
             if _get_svm_support().generate_debug_info(image_config):

--- a/substratevm/mx.substratevm/mx_substratevm.py
+++ b/substratevm/mx.substratevm/mx_substratevm.py
@@ -227,7 +227,9 @@ def vm_executable_path(executable, config=None):
 @contextmanager
 def native_image_context(common_args=None, hosted_assertions=True, native_image_cmd='', config=None, build_if_missing=False):
     common_args = [] if common_args is None else common_args
-    base_args = ['--no-fallback', '-H:+EnforceMaxRuntimeCompileMethods', '-H:+ReportExceptionStackTraces']
+    base_args = ['--no-fallback', '-H:+ReportExceptionStackTraces']
+    if mx_sdk_vm_impl.has_component('LibGraal'):
+        base_args += ['-H:+EnforceMaxRuntimeCompileMethods']
     base_args += ['-H:Path=' + svmbuild_dir()]
     if mx.get_opts().verbose:
         base_args += ['--verbose']

--- a/substratevm/src/com.oracle.svm.driver/src/com/oracle/svm/driver/NativeImage.java
+++ b/substratevm/src/com.oracle.svm.driver/src/com/oracle/svm/driver/NativeImage.java
@@ -544,7 +544,7 @@ public class NativeImage {
             if (libJvmciDir != null) {
                 result.addAll(getJars(libJvmciDir, "graal-sdk", "enterprise-graal"));
             }
-            result.addAll(getJars(rootDir.resolve(Paths.get("lib", "truffle")), "truffle-api", "truffle-compiler", "truffle-runtime", "truffle-enterprise"));
+            result.addAll(getJars(rootDir.resolve(Paths.get("lib", "truffle")), true, "truffle-api", "truffle-compiler", "truffle-runtime", "truffle-enterprise"));
             if (modulePathBuild) {
                 result.addAll(getJars(rootDir.resolve(Paths.get("lib", "svm", "builder"))));
             }
@@ -2044,6 +2044,10 @@ public class NativeImage {
     }
 
     protected static List<Path> getJars(Path dir, String... jarBaseNames) {
+        return getJars(dir, false, jarBaseNames);
+    }
+
+    private static List<Path> getJars(Path dir, boolean optional, String... jarBaseNames) {
         try {
             List<String> baseNameList = Arrays.asList(jarBaseNames);
             return Files.list(dir)
@@ -2061,7 +2065,12 @@ public class NativeImage {
                             })
                             .collect(Collectors.toList());
         } catch (IOException e) {
-            throw showError("Unable to use jar-files from directory " + dir, e);
+            if (optional) {
+                LogUtils.warning("Unable to use jar-files from directory " + dir);
+                return Collections.emptyList();
+            } else {
+                throw showError("Unable to use jar-files from directory " + dir, e);
+            }
         }
     }
 

--- a/substratevm/src/com.oracle.svm.graal/src/com/oracle/svm/graal/isolated/IsolatedCodeInstallBridge.java
+++ b/substratevm/src/com.oracle.svm.graal/src/com/oracle/svm/graal/isolated/IsolatedCodeInstallBridge.java
@@ -33,10 +33,9 @@ import jdk.vm.ci.code.InstalledCode;
 
 /**
  * A helper to pass information for installing code in the compilation client through a Truffle
- * compilation. It does not implement {@link InstalledCode} or {@link OptimizedAssumptionDependency}
- * in any meaningful way.
+ * compilation. It does not implement {@link InstalledCode} in any meaningful way.
  */
-public final class IsolatedCodeInstallBridge extends InstalledCode implements OptimizedAssumptionDependency {
+public class IsolatedCodeInstallBridge extends InstalledCode {
     private final ClientHandle<? extends SubstrateInstalledCode.Factory> factoryHandle;
     private ClientHandle<? extends SubstrateInstalledCode> installedCodeHandle;
 
@@ -58,7 +57,7 @@ public final class IsolatedCodeInstallBridge extends InstalledCode implements Op
         return installedCodeHandle;
     }
 
-    private static final String DO_NOT_CALL_REASON = IsolatedCodeInstallBridge.class.getSimpleName() +
+    protected static final String DO_NOT_CALL_REASON = IsolatedCodeInstallBridge.class.getSimpleName() +
                     " only acts as an accessor for cross-isolate data. None of the implemented methods may be called.";
 
     @Override
@@ -87,17 +86,7 @@ public final class IsolatedCodeInstallBridge extends InstalledCode implements Op
     }
 
     @Override
-    public void onAssumptionInvalidated(Object source, CharSequence reason) {
-        throw VMError.shouldNotReachHere(DO_NOT_CALL_REASON);
-    }
-
-    @Override
     public Object executeVarargs(Object... args) {
-        throw VMError.shouldNotReachHere(DO_NOT_CALL_REASON);
-    }
-
-    @Override
-    public TruffleCompilable getCompilable() {
         throw VMError.shouldNotReachHere(DO_NOT_CALL_REASON);
     }
 

--- a/substratevm/src/com.oracle.svm.truffle/src/com/oracle/svm/truffle/isolated/IsolatedCompilableTruffleAST.java
+++ b/substratevm/src/com.oracle.svm.truffle/src/com/oracle/svm/truffle/isolated/IsolatedCompilableTruffleAST.java
@@ -39,7 +39,6 @@ import com.oracle.svm.graal.isolated.ClientHandle;
 import com.oracle.svm.graal.isolated.ClientIsolateThread;
 import com.oracle.svm.graal.isolated.CompilerHandle;
 import com.oracle.svm.graal.isolated.CompilerIsolateThread;
-import com.oracle.svm.graal.isolated.IsolatedCodeInstallBridge;
 import com.oracle.svm.graal.isolated.IsolatedCompileClient;
 import com.oracle.svm.graal.isolated.IsolatedCompileContext;
 import com.oracle.svm.graal.isolated.IsolatedObjectConstant;
@@ -138,7 +137,7 @@ final class IsolatedCompilableTruffleAST extends IsolatedObjectProxy<SubstrateCo
 
     @Override
     public InstalledCode createPreliminaryInstalledCode() {
-        return new IsolatedCodeInstallBridge(handle);
+        return new IsolatedTruffleCodeInstallBridge(handle);
     }
 
     @Override

--- a/substratevm/src/com.oracle.svm.truffle/src/com/oracle/svm/truffle/isolated/IsolatedTruffleCodeInstallBridge.java
+++ b/substratevm/src/com.oracle.svm.truffle/src/com/oracle/svm/truffle/isolated/IsolatedTruffleCodeInstallBridge.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2022, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2022, Red Hat Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package com.oracle.svm.truffle.isolated;
+
+import com.oracle.svm.core.deopt.SubstrateInstalledCode;
+import com.oracle.svm.core.util.VMError;
+import com.oracle.svm.graal.isolated.ClientHandle;
+import com.oracle.svm.graal.isolated.IsolatedCodeInstallBridge;
+import jdk.vm.ci.code.InstalledCode;
+import org.graalvm.compiler.truffle.common.OptimizedAssumptionDependency;
+import org.graalvm.compiler.truffle.common.TruffleCompilable;
+
+/**
+ * A helper to pass information for installing code in the compilation client through a Truffle
+ * compilation. It does not implement {@link InstalledCode} or {@link OptimizedAssumptionDependency}
+ * in any meaningful way.
+ */
+public final class IsolatedTruffleCodeInstallBridge extends IsolatedCodeInstallBridge implements OptimizedAssumptionDependency {
+    public IsolatedTruffleCodeInstallBridge(ClientHandle<? extends SubstrateInstalledCode.Factory> factoryHandle) {
+        super(factoryHandle);
+    }
+
+    @Override
+    public void onAssumptionInvalidated(Object source, CharSequence reason) {
+        throw VMError.shouldNotReachHere(DO_NOT_CALL_REASON);
+    }
+
+    @Override
+    public TruffleCompilable getCompilable() {
+        throw VMError.shouldNotReachHere(DO_NOT_CALL_REASON);
+    }
+}


### PR DESCRIPTION
This PR tries to completely remove any dependencies on the truffle-api.jar for running `native-image` without runtime compilation support and truffle features.

It:

* Makes flags that depend on LibGraal optional
* Makes the native-image driver dependency on truffle-api.jar optional
* Removes most truffle dependencies from `com.oracle.svm.graal`
  * The last dependency I have not yet managed to properly remove is https://github.com/oracle/graal/blob/2f9a32bbc9fbe53952fa6e85b55979e3754cc70c/substratevm/src/com.oracle.svm.graal/src/com/oracle/svm/graal/meta/RuntimeCodeInstaller.java#L111 (suggestions are welcome)


