### PR TITLE
GitHub Workflows security hardening

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,6 +39,9 @@ env:
   JDT: builtin
   MX_PATH: ${{ github.workspace }}/mx
 
+permissions:
+  contents: read # to fetch code (actions/checkout)
+
 jobs:
   build-graalvm:
     name: ${{ matrix.env.JDK }} ${{ matrix.env.GATE }} ${{ matrix.env.PRIMARY }} ${{ matrix.env.WITHOUT_VCS }}

--- a/.github/workflows/quarkus.yml
+++ b/.github/workflows/quarkus.yml
@@ -25,8 +25,12 @@ env:
   QUARKUS_PATH: ${{ github.workspace }}/quarkus
   GRAALVM_HOME: ${{ github.workspace }}/graalvm
 
+permissions: {}
 jobs:
   build-quarkus-and-graalvm:
+    permissions:
+      contents: read # to fetch code (actions/checkout)
+
     name: Nightly quarkus and GraalVM build
     runs-on: ubuntu-20.04
     outputs:


### PR DESCRIPTION
This PR adds explicit [permissions section](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions) to workflows. This is a security best practice because by default workflows run with [extended set of permissions](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token) (except from `on: pull_request` [from external forks](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)). By specifying any permission explicitly all others are set to none. By using the principle of least privilege the damage a compromised workflow can do (because of an [injection](https://securitylab.github.com/research/github-actions-untrusted-input/) or compromised third party tool or action) is restricted.
It is recommended to have [most strict permissions on the top level](https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions) and grant write permissions on [job level](https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs) case by case.