### PR TITLE
Clear options before parsing

### DIFF
--- a/substratevm/src/com.oracle.graal.pointsto/src/com/oracle/graal/pointsto/util/PointsToOptionParser.java
+++ b/substratevm/src/com.oracle.graal.pointsto/src/com/oracle/graal/pointsto/util/PointsToOptionParser.java
@@ -83,6 +83,7 @@ public final class PointsToOptionParser {
     public OptionValues parse(String[] args) {
         List<String> remainingArgs = new ArrayList<>();
         Set<String> errors = new HashSet<>();
+        analysisValues.clear();
         for (String arg : args) {
             boolean isAnalysisOption = false;
             isAnalysisOption |= parseOption(CommonOptionParser.HOSTED_OPTION_PREFIX, allAnalysisOptions, analysisValues, PLUS_MINUS, errors, arg, System.out);


### PR DESCRIPTION
The standalone pointsto analysis can be programmatically invoked multiple times. Each invocation should have its own options which are parsed independently but all invocations can share the same allAnalysisOptions.

This PR is part of the standalone pointsto analysis, see https://github.com/oracle/graal/pull/4375 for details.