### PR TITLE
Add unit tests for standalone pointsto analysis

### DIFF
--- a/substratevm/mx.substratevm/suite.py
+++ b/substratevm/mx.substratevm/suite.py
@@ -507,6 +507,32 @@ suite = {
             "workingSets": "SVM",
         },
 
+        "com.oracle.graal.pointsto.standalone.test": {
+            "subDir": "src",
+            "sourceDirs": ["src"],
+            "dependencies": [
+                "mx:JUNIT_TOOL",
+                "sdk:GRAAL_SDK",
+                "STANDALONE_POINTSTO"
+            ],
+            "requires": [
+                "jdk.unsupported",
+                "java.compiler",
+            ],
+            "requiresConcealed": {
+                "jdk.internal.vm.ci": [
+                    "jdk.vm.ci.meta",
+                ]
+            },
+            "checkstyle": "com.oracle.svm.test",
+            "workingSets": "SVM",
+            "annotationProcessors": [
+                "compiler:GRAAL_PROCESSOR",
+            ],
+            "javaCompliance": "11+",
+            "spotbugs": "false",
+        },
+
         "com.oracle.graal.reachability": {
             "subDir": "src",
             "sourceDirs": ["src"],
@@ -1636,6 +1662,20 @@ suite = {
                     ]
                 }
             },
+        },
+
+        "STANDALONE_POINTSTO_TESTS" : {
+            "subDir": "src",
+            "relpath" : True,
+            "dependencies" : [
+                "com.oracle.graal.pointsto.standalone.test",
+            ],
+            "distDependencies": [
+                "mx:JUNIT_TOOL",
+                "sdk:GRAAL_SDK",
+                "STANDALONE_POINTSTO",
+            ],
+            "testDistribution" : True,
         },
 
         "SVM_TESTS" : {

--- a/substratevm/src/com.oracle.graal.pointsto.standalone.test/src/com/oracle/graal/pointsto/standalone/test/ClassEqualityTest.java
+++ b/substratevm/src/com.oracle.graal.pointsto.standalone.test/src/com/oracle/graal/pointsto/standalone/test/ClassEqualityTest.java
@@ -24,25 +24,33 @@
  * questions.
  */
 
-package com.oracle.graal.pointsto.standalone.meta;
+package com.oracle.graal.pointsto.standalone.test;
 
-import jdk.vm.ci.meta.MetaAccessProvider;
-import jdk.vm.ci.meta.ResolvedJavaField;
-import org.graalvm.compiler.core.common.spi.JavaConstantFieldProvider;
+import org.junit.Test;
 
-public class StandaloneConstantFieldProvider extends JavaConstantFieldProvider {
-
-    public StandaloneConstantFieldProvider(MetaAccessProvider metaAccess) {
-        super(metaAccess);
+public class ClassEqualityTest {
+    static class C {
+        public static void foo() {
+        }
     }
 
-    /**
-     * In standalone mode, all classes are runtime initialized. We take all fields as not final, so
-     * that it doesn't read field value from current environment. Test
-     * com.oracle.graal.pointsto.test.ConstantFieldTest verifies this method.
-     **/
-    @Override
-    public boolean isFinalField(ResolvedJavaField field, ConstantFieldTool<?> tool) {
-        return false;
+    public static void main(String[] args) {
+        equals(C.class);
+    }
+
+    private static void equals(Class<?> clazz) {
+        if (clazz == C.class) {
+            C.foo();
+        }
+    }
+
+    @Test
+    public void test() {
+        PointstoAnalyzerTester tester = new PointstoAnalyzerTester(this.getClass());
+        tester.setAnalysisArguments(tester.getTestClassName(),
+                        "-H:AnalysisTargetAppCP=" + tester.getTestClassJar());
+
+        tester.setExpectedReachableMethods(C.class.getName() + ".foo()");
+        tester.runAnalysisAndAssert();
     }
 }

--- a/substratevm/src/com.oracle.graal.pointsto.standalone.test/src/com/oracle/graal/pointsto/standalone/test/PointstoAnalyzerTester.java
+++ b/substratevm/src/com.oracle.graal.pointsto.standalone.test/src/com/oracle/graal/pointsto/standalone/test/PointstoAnalyzerTester.java
@@ -1,0 +1,220 @@
+/*
+ * Copyright (c) 2022, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2022, Alibaba Group Holding Limited. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package com.oracle.graal.pointsto.standalone.test;
+
+import com.oracle.graal.pointsto.constraints.UnsupportedFeatureException;
+import com.oracle.graal.pointsto.meta.AnalysisUniverse;
+import com.oracle.graal.pointsto.standalone.PointsToAnalyzer;
+
+import java.io.ByteArrayOutputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.function.Predicate;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+public class PointstoAnalyzerTester {
+    private Set<String> expectedReachableMethods = new HashSet<>();
+    private Set<String> expectedReachableTypes = new HashSet<>();
+    private Set<String> expectedReachableFields = new HashSet<>();
+    private Set<String> expectedUnreachableMethods = new HashSet<>();
+    private Set<String> expectedUnreachableTypes = new HashSet<>();
+    private Set<String> expectedUnreachableFields = new HashSet<>();
+    private String[] arguments;
+    private Path tmpDir;
+    private String testClassName;
+    private String testClassJar;
+
+    public PointstoAnalyzerTester(Class<?> testClass) {
+        testClassJar = testClass.getProtectionDomain().getCodeSource().getLocation().getPath();
+        testClassName = testClass.getName();
+    }
+
+    public String getTestClassName() {
+        return testClassName;
+    }
+
+    public String getTestClassJar() {
+        return testClassJar;
+    }
+
+    public void setAnalysisArguments(String... arguments) {
+        this.arguments = arguments;
+    }
+
+    public void setExpectedReachableMethods(String... methodNames) {
+        expectedReachableMethods = new HashSet<>();
+        for (String methodName : methodNames) {
+            expectedReachableMethods.add(methodName);
+        }
+    }
+
+    public void setExpectedUnreachableMethods(String... methodNames) {
+        expectedUnreachableMethods = new HashSet<>();
+        for (String methodName : methodNames) {
+            expectedUnreachableMethods.add(methodName);
+        }
+    }
+
+    public void setExpectedReachableTypes(String... typeNames) {
+        expectedReachableTypes = new HashSet<>();
+        for (String typeName : typeNames) {
+            expectedReachableTypes.add(typeName);
+        }
+    }
+
+    public void setExpectedUnreachableTypes(String... typeNames) {
+        expectedUnreachableTypes = new HashSet<>();
+        for (String typeName : typeNames) {
+            expectedUnreachableTypes.add(typeName);
+        }
+    }
+
+    public void setExpectedReachableFields(String... fieldNames) {
+        expectedReachableFields = new HashSet<>();
+        for (String fieldName : fieldNames) {
+            expectedReachableFields.add(fieldName);
+        }
+    }
+
+    public void setExpectedUnreachableFields(String... fieldNames) {
+        expectedUnreachableFields = new HashSet<>();
+        for (String fieldName : fieldNames) {
+            expectedUnreachableFields.add(fieldName);
+        }
+    }
+
+    public void runAnalysisAndAssert() {
+        PointsToAnalyzer pointstoAnalyzer = PointsToAnalyzer.createAnalyzer(arguments);
+        UnsupportedFeatureException unsupportedFeatureException = null;
+        try {
+            try {
+                int ret = pointstoAnalyzer.run();
+                assertEquals("Analysis return code is expected to 0", 0, ret);
+            } catch (UnsupportedFeatureException e) {
+                unsupportedFeatureException = e;
+            }
+            AnalysisUniverse universe = pointstoAnalyzer.getResultUniverse();
+            assertNotNull(universe);
+
+            elementsIteration("Method", expectedReachableMethods, expectedUnreachableMethods, universe.getMethods(), m -> m.getQualifiedName(), m -> m.getImplementations().length >= 1);
+            elementsIteration("Type", expectedReachableTypes, expectedUnreachableTypes, universe.getTypes(), t -> t.getJavaClass().getName(), t -> t.isReachable());
+            elementsIteration("Field", expectedReachableFields, expectedUnreachableFields, universe.getFields(), f -> f.getDeclaringClass().getJavaClass().getName() + "." + f.getName(),
+                            f -> f.isAccessed() || f.isRead() || f.isWritten());
+
+            if (unsupportedFeatureException != null) {
+                throw unsupportedFeatureException;
+            }
+        } finally {
+            if (pointstoAnalyzer != null) {
+                pointstoAnalyzer.cleanUp();
+            }
+        }
+    }
+
+    public Path createTestTmpDir() {
+        try {
+            tmpDir = Files.createTempDirectory("Pointsto-test-");
+        } catch (IOException e) {
+            e.printStackTrace();
+            tmpDir = null;
+        }
+        return tmpDir;
+    }
+
+    public Path saveFileFromResource(String resourceName, Path outputFilePath) throws IOException {
+        InputStream fileStream = this.getClass().getResourceAsStream(resourceName);
+        if (fileStream == null) {
+            return null;
+        }
+
+        Path outputDir = outputFilePath.getParent();
+        Files.createDirectories(outputDir);
+
+        try (FileOutputStream outputStream = new FileOutputStream(outputFilePath.toFile());) {
+            ByteArrayOutputStream baos = new ByteArrayOutputStream();
+            byte[] buffer = new byte[1024];
+            int numOfRead;
+            while ((numOfRead = fileStream.read(buffer)) != -1) {
+                baos.write(buffer, 0, numOfRead);
+            }
+            outputStream.write(baos.toByteArray());
+        }
+        return outputFilePath;
+    }
+
+    public void deleteTestTmpDir() throws IOException {
+        Files.walkFileTree(tmpDir, new SimpleFileVisitor<>() {
+            @Override
+            public FileVisitResult visitFile(Path file, BasicFileAttributes attributes) throws IOException {
+                Files.delete(file);
+                return FileVisitResult.CONTINUE;
+            }
+
+            @Override
+            public FileVisitResult postVisitDirectory(Path dir, IOException exc) throws IOException {
+                Files.delete(dir);
+                return FileVisitResult.CONTINUE;
+            }
+        });
+    }
+
+    private static <T> void elementsIteration(String elementType, Set<String> expectedReachables, Set<String> expectedUnreachables, Collection<T> elements,
+                    Function<T, String> getElementName, Predicate<T> reachablePredicate) {
+        if (expectedReachables != null || expectedUnreachables != null) {
+            for (T element : elements) {
+                String name = getElementName.apply(element);
+                if (expectedReachables != null && expectedReachables.remove(name)) {
+                    assertTrue(elementType + " " + name + " should be reachable.", reachablePredicate.test(element));
+                    continue;
+                }
+
+                if (expectedUnreachables != null && expectedUnreachables.remove(name)) {
+                    assertFalse(elementType + " " + name + " should not be reachable.", reachablePredicate.test(element));
+                }
+            }
+        }
+        if (expectedReachables != null && !expectedReachables.isEmpty()) {
+            StringBuilder sb = new StringBuilder(elementType + " should be reached but not:");
+            expectedReachables.forEach(s -> sb.append(" ").append(s));
+            assertTrue(sb.toString(), expectedReachables.isEmpty());
+        }
+    }
+}

--- a/substratevm/src/com.oracle.graal.pointsto.standalone.test/src/com/oracle/graal/pointsto/standalone/test/StandaloneAnalyzerReachabilityTest.java
+++ b/substratevm/src/com.oracle.graal.pointsto.standalone.test/src/com/oracle/graal/pointsto/standalone/test/StandaloneAnalyzerReachabilityTest.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2022, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2022, Alibaba Group Holding Limited. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package com.oracle.graal.pointsto.standalone.test;
+
+import org.junit.Test;
+
+public class StandaloneAnalyzerReachabilityTest {
+
+    public static void main(String[] args) {
+        Object c;
+        if (args.length > 0) {
+            c = new C1("C1");
+        } else {
+            c = new C2("C2");
+        }
+        c.toString();
+    }
+
+    public abstract static class C {
+        protected String val;
+
+        @Override
+        public abstract String toString();
+    }
+
+    public static class C1 extends C {
+        public C1(String v) {
+            val = v;
+        }
+
+        @Override
+        public String toString() {
+            return val;
+        }
+    }
+
+    public static class C2 extends C {
+        public C2(String v) {
+            val = v;
+        }
+
+        @Override
+        public String toString() {
+            return val;
+        }
+    }
+
+    public static class D {
+        @SuppressWarnings("unused") private String val;
+
+        @Override
+        public String toString() {
+            return val = "D";
+        }
+    }
+
+    @Test
+    public void testPointstoAnalyzer() {
+        PointstoAnalyzerTester tester = new PointstoAnalyzerTester(this.getClass());
+        tester.setAnalysisArguments(tester.getTestClassName(),
+                        "-H:AnalysisTargetAppCP=" + tester.getTestClassJar());
+        String classC = C.class.getName();
+        String classC1 = C1.class.getName();
+        String classC2 = C2.class.getName();
+        String classD = D.class.getName();
+        tester.setExpectedReachableTypes(classC, classC1, classC2);
+        tester.setExpectedUnreachableTypes(classD);
+        tester.setExpectedReachableFields(classC + ".val");
+        tester.setExpectedUnreachableFields(classD + ".val");
+        tester.runAnalysisAndAssert();
+    }
+
+    @Test
+    public void testMultipleAnalysis() {
+        int times = 5;
+        int i = 0;
+        while (i++ < times) {
+            testPointstoAnalyzer();
+        }
+    }
+}

--- a/substratevm/src/com.oracle.graal.pointsto/src/com/oracle/graal/pointsto/util/PointsToOptionParser.java
+++ b/substratevm/src/com.oracle.graal.pointsto/src/com/oracle/graal/pointsto/util/PointsToOptionParser.java
@@ -83,6 +83,12 @@ public final class PointsToOptionParser {
     public OptionValues parse(String[] args) {
         List<String> remainingArgs = new ArrayList<>();
         Set<String> errors = new HashSet<>();
+        /*
+         * The standalone pointsto analysis can be programmatically invoked multiple times. Each
+         * invocation should have its own options which are parsed independently, but all
+         * invocations can share with the same allAnalysisOptions.
+         */
+        analysisValues.clear();
         for (String arg : args) {
             boolean isAnalysisOption = false;
             isAnalysisOption |= parseOption(CommonOptionParser.HOSTED_OPTION_PREFIX, allAnalysisOptions, analysisValues, PLUS_MINUS, errors, arg, System.out);


### PR DESCRIPTION
Adding unit tests and a tester framework to run standalone pointsto analysis and verifies the results.

This PR is part of the standalone pointsto analysis, see https://github.com/oracle/graal/pull/4375 for details.