### PR TITLE
Do not load java.awt.Component and java.beans.Customizer classes when they are not used in Java Beans

### DIFF
--- a/substratevm/mx.substratevm/suite.py
+++ b/substratevm/mx.substratevm/suite.py
@@ -267,6 +267,7 @@ suite = {
                 "java.desktop": [
                     "sun.java2d",
                     "sun.java2d.pipe",
+                    "com.sun.beans.finder",
                 ],
                 "java.management": [
                     "com.sun.jmx.mbeanserver",

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/JavaBeansSubstitutions.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/JavaBeansSubstitutions.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2022, BELLSOFT. All rights reserved.
+ * Copyright (c) 2022, 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package com.oracle.svm.core.jdk;
+
+import com.oracle.svm.core.annotate.Substitute;
+import com.oracle.svm.core.annotate.TargetClass;
+import com.sun.beans.finder.ClassFinder;
+
+@SuppressWarnings({"static-method", "unused"})
+public final class JavaBeansSubstitutions {
+    // Checkstyle: stop
+
+    // Do not make string final to avoid class name interception
+    // in Class.forName(...) call
+    private static String COMPONENT_CLASS = "java.awt.Component";
+    private static String CUSTOMIZER_CLASS = "java.beans.Customizer";
+
+    @TargetClass(className = "java.beans.Introspector")
+    static final class Target_java_beans_Introspector {
+
+        // Do not load java.awt.Component and java.beans.Customizer classes
+        // when they are not used
+        @Substitute
+        private static Class<?> findCustomizerClass(Class<?> type) {
+            String name = type.getName() + "Customizer";
+            try {
+                type = ClassFinder.findClass(name, type.getClassLoader());
+                if (Class.forName(COMPONENT_CLASS).isAssignableFrom(type)
+                        && Class.forName(CUSTOMIZER_CLASS).isAssignableFrom(type)) {
+                    return type;
+                }
+            } catch (Exception exception) {
+                // ignore any exceptions
+            }
+            return null;
+        }
+    }
+    // Checkstyle: resume
+}

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/JavaBeansSubstitutions.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/JavaBeansSubstitutions.java
@@ -41,8 +41,10 @@ public final class JavaBeansSubstitutions {
     @TargetClass(className = "java.beans.Introspector")
     static final class Target_java_beans_Introspector {
 
-        // Do not load java.awt.Component and java.beans.Customizer classes
-        // when they are not used
+        /**
+         * Do not load java.awt.Component and java.beans.Customizer classes
+         * when they are not used
+         */
         @Substitute
         private static Class<?> findCustomizerClass(Class<?> type) {
             String name = type.getName() + "Customizer";

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/JavaBeansSupport.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/JavaBeansSupport.java
@@ -74,10 +74,6 @@ public final class JavaBeansSupport {
         return ImageSingletons.lookup(JavaBeansSupport.class).COMPONENT_CLASS;
     }
 
-    private Class<?> getComponentClass() {
-        return COMPONENT_CLASS;
-    }
-
     @Platforms(Platform.HOSTED_ONLY.class)
     public static void enableComponentClass() {
         ImageSingletons.lookup(JavaBeansSupport.class).COMPONENT_CLASS = Component.class;

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/JavaBeansFeature.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/JavaBeansFeature.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2022, BELLSOFT. All rights reserved.
+ * Copyright (c) 2022, 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package com.oracle.svm.hosted;
+
+import org.graalvm.nativeimage.ImageSingletons;
+import org.graalvm.nativeimage.Platform;
+import org.graalvm.nativeimage.Platforms;
+
+import com.oracle.svm.core.jdk.JavaBeansSupport;
+import com.oracle.svm.core.feature.InternalFeature;
+import com.oracle.svm.core.feature.AutomaticallyRegisteredFeature;
+import com.oracle.svm.hosted.FeatureImpl.DuringAnalysisAccessImpl;
+import com.oracle.svm.hosted.FeatureImpl.DuringSetupAccessImpl;
+
+import java.beans.Introspector;
+import java.lang.reflect.Field;
+
+@AutomaticallyRegisteredFeature
+final class JavaBeansFeature implements InternalFeature {
+
+    private Field componentClassField;
+
+    @Override
+    public void afterRegistration(AfterRegistrationAccess access) {
+        ImageSingletons.add(JavaBeansSupport.class, new JavaBeansSupport());
+    }
+
+    @Override
+    public void duringSetup(DuringSetupAccess a) {
+        DuringSetupAccessImpl access = (DuringSetupAccessImpl) a;
+        componentClassField = access.findField(JavaBeansSupport.class, "COMPONENT_CLASS");
+    }
+
+    @Override
+    public void beforeAnalysis(BeforeAnalysisAccess access) {
+        access.registerReachabilityHandler(this::enableComponentClass, access.findClassByName("java.awt.Component"));
+    }
+
+    @Platforms(Platform.HOSTED_ONLY.class)
+    void enableComponentClass(DuringAnalysisAccess a) {
+        DuringAnalysisAccessImpl access = (DuringAnalysisAccessImpl) a;
+        JavaBeansSupport.enableComponentClass();
+        access.rescanField(ImageSingletons.lookup(JavaBeansSupport.class), componentClassField);
+        if (!access.concurrentReachabilityHandlers()) {
+            access.requireAnalysisIteration();
+        }
+    }
+}


### PR DESCRIPTION
  GraalVM includes java.awt.Component and derived classes into native image even a Java Beans application does not use them.

Steps to reproduce:
  Compile the  [BeanSample.java](http://cr.openjdk.java.net/~alexsch/samples/javabeans/introspector/BeanSample.java) class which does not define a bean customizer, create a reflection configuration file by the native-image-agent,  generate a native image with the config file and --diagnostics-mode option to check classes included into the native image:
```
  > javac BeanSample.java
  > java -agentlib:native-image-agent=config-output-dir=conf-dir BeanSample
  > native-image --no-fallback --diagnostics-mode -H:ReflectionConfigurationFiles=conf-dir/reflect-config.json BeanSample
```

  The class_initialization_report_date.csv file reports some unused java.awt classes: java.awt.Component, java.awt.Container, ava.awt.EventQueue, and others.

Suggested solution:
  Avoid direct java.awt.Component class usage in [Introspector.findCustomizerClass()](https://github.com/openjdk/jdk/blob/844a95b907aaf6ef67d7e4b1ed0998945a6152d2/src/java.desktop/share/classes/java/beans/Introspector.java#L1128) method. Change explicit `Component.class.isAssignableFrom(type)` method call to  reflection `Class.forName("java.awt.Component").isAssignableFrom(type)`.

The fix proposes  Introspector.findCustomizerClass() substitution method:
- `Component.class.isAssignableFrom(type)` and `Customizer.class.isAssignableFrom(type)` calls are are substituted by their reflection counterparts `Class.forName(COMPONENT_CLASS).isAssignableFrom(type)` and `Class.forName(CUSTOMIZER_CLASS).isAssignableFrom(type)`
- `COMPONENT_CLASS` and `CUSTOMIZER_CLASS` fields are made private static but not final to avoid class name interception by GraalVM.

With the fix the class_initialization_report_date.csv does not contain java.awt.Component and derived classes for the BeanSample.

The [BeanSampleCustomizer](http://cr.openjdk.java.net/~alexsch/samples/javabeans/introspector/BeanSampleCustomizer.java) sample shows that the fix works as well for the case when Java Beans Customizer is used and necesary java.awt.Component classes are included into the native image:
```
> native-image --no-fallback --diagnostics-mode -H:ReflectionConfigurationFiles=conf-dir/reflect-config.json BeanSampleCustomizer
```