### PR TITLE
Add StandaloneClassInitializationFeature

### DIFF
--- a/substratevm/src/com.oracle.graal.pointsto.standalone.test/src/com/oracle/graal/pointsto/standalone/test/ConstantFieldCase.java
+++ b/substratevm/src/com.oracle.graal.pointsto.standalone.test/src/com/oracle/graal/pointsto/standalone/test/ConstantFieldCase.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2022, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2022, Alibaba Group Holding Limited. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package com.oracle.graal.pointsto.standalone.test;
+
+public class ConstantFieldCase {
+    public static final ConstantType constantField = new ConstantType();
+
+    public static void main(String[] args) {
+        constantField.foo();
+    }
+
+    static class ConstantType {
+        public void foo() {
+        }
+    }
+}

--- a/substratevm/src/com.oracle.graal.pointsto.standalone.test/src/com/oracle/graal/pointsto/standalone/test/ConstantFieldTest.java
+++ b/substratevm/src/com.oracle.graal.pointsto.standalone.test/src/com/oracle/graal/pointsto/standalone/test/ConstantFieldTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2022, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2022, Alibaba Group Holding Limited. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package com.oracle.graal.pointsto.standalone.test;
+
+import org.junit.Test;
+
+/**
+ * This test can test 2 facts for standalone pointsto analysis:
+ * <ol>
+ * <li>The clinit method is taken as analysis target instead of being executed to initialize the
+ * class.</li>
+ * <li>The static final field is not taken as final in the analysis, i.e. it is not considered as
+ * constant at analysis time.</li>
+ * </ol>
+ */
+public class ConstantFieldTest {
+
+    @Test
+    public void testConstantField() {
+        PointstoAnalyzerTester tester = new PointstoAnalyzerTester(ConstantFieldCase.class);
+        tester.setAnalysisArguments(tester.getTestClassName(),
+                        "-H:AnalysisTargetAppCP=" + tester.getTestClassJar());
+        tester.setExpectedReachableMethods(ConstantFieldCase.ConstantType.class.getName() + ".foo()",
+                        ConstantFieldCase.class.getName() + ".<clinit>()");
+        tester.setExpectedReachableFields(ConstantFieldCase.class.getName() + ".constantField");
+        tester.runAnalysisAndAssert();
+    }
+}

--- a/substratevm/src/com.oracle.graal.pointsto.standalone/src/com/oracle/graal/pointsto/standalone/PointsToAnalyzer.java
+++ b/substratevm/src/com.oracle.graal.pointsto.standalone/src/com/oracle/graal/pointsto/standalone/PointsToAnalyzer.java
@@ -47,8 +47,8 @@ import com.oracle.graal.pointsto.standalone.meta.StandaloneConstantFieldProvider
 import com.oracle.graal.pointsto.standalone.meta.StandaloneConstantReflectionProvider;
 import com.oracle.graal.pointsto.standalone.util.Timer;
 import com.oracle.graal.pointsto.typestate.DefaultAnalysisPolicy;
-import com.oracle.graal.pointsto.util.GraalAccess;
 import com.oracle.graal.pointsto.util.AnalysisError;
+import com.oracle.graal.pointsto.util.GraalAccess;
 import com.oracle.graal.pointsto.util.PointsToOptionParser;
 import com.oracle.graal.pointsto.util.TimerCollection;
 import com.oracle.svm.util.ModuleSupport;
@@ -71,7 +71,6 @@ import org.graalvm.nativeimage.hosted.Feature;
 
 import java.io.File;
 import java.lang.reflect.Method;
-
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLClassLoader;

--- a/substratevm/src/com.oracle.graal.pointsto.standalone/src/com/oracle/graal/pointsto/standalone/StandalonePointsToAnalysis.java
+++ b/substratevm/src/com.oracle.graal.pointsto.standalone/src/com/oracle/graal/pointsto/standalone/StandalonePointsToAnalysis.java
@@ -29,15 +29,20 @@ package com.oracle.graal.pointsto.standalone;
 import com.oracle.graal.pointsto.PointsToAnalysis;
 import com.oracle.graal.pointsto.api.HostVM;
 import com.oracle.graal.pointsto.constraints.UnsupportedFeatures;
+import com.oracle.graal.pointsto.meta.AnalysisMethod;
 import com.oracle.graal.pointsto.meta.AnalysisType;
 import com.oracle.graal.pointsto.meta.AnalysisUniverse;
 import com.oracle.graal.pointsto.meta.HostedProviders;
 import com.oracle.graal.pointsto.util.TimerCollection;
 import org.graalvm.compiler.options.OptionValues;
 
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ForkJoinPool;
 
 public class StandalonePointsToAnalysis extends PointsToAnalysis {
+    private Set<AnalysisMethod> addedClinits = ConcurrentHashMap.newKeySet();
+
     public StandalonePointsToAnalysis(OptionValues options, AnalysisUniverse universe, HostedProviders providers, HostVM hostVM, ForkJoinPool executorService, Runnable heartbeatCallback,
                     TimerCollection timerCollection) {
         super(options, universe, providers, hostVM, executorService, heartbeatCallback, new UnsupportedFeatures(), timerCollection, true);
@@ -52,10 +57,20 @@ public class StandalonePointsToAnalysis extends PointsToAnalysis {
         });
         universe.getMethods().clear();
         universe.getFields().clear();
+        addedClinits.clear();
     }
 
     @Override
     public void initializeMetaData(AnalysisType type) {
 
+    }
+
+    @Override
+    public void onTypeInitialized(AnalysisType type) {
+        AnalysisMethod clinitMethod = type.getClassInitializer();
+        if (clinitMethod != null && !addedClinits.contains(clinitMethod)) {
+            addRootMethod(clinitMethod, true).registerAsImplementationInvoked();
+            addedClinits.add(clinitMethod);
+        }
     }
 }


### PR DESCRIPTION
All clinit methods should be taken as root methods for standalone pointsto analysis.
Adding a new StandaloneClassInitializationFeature to register all discovered clinit method during analysis.

This PR is part of the standalone pointsto analysis, see https://github.com/oracle/graal/pull/4375 for details.