### PR TITLE
Record reflection exceptions in native image agent

### DIFF
--- a/substratevm/src/com.oracle.svm.agent/src/com/oracle/svm/agent/tracing/core/Tracer.java
+++ b/substratevm/src/com.oracle.svm.agent/src/com/oracle/svm/agent/tracing/core/Tracer.java
@@ -117,5 +117,13 @@ public abstract class Tracer {
         traceEntry(entry);
     }
 
+    public void traceException(String clazzName, String exceptionTypeName) {
+        Map<String, Object> entry = new HashMap<>();
+        entry.put("tracer", "exception");
+        entry.put("class", clazzName);
+        entry.put("exception", exceptionTypeName);
+        traceEntry(entry);
+    }
+
     protected abstract void traceEntry(Map<String, Object> entry);
 }

--- a/substratevm/src/com.oracle.svm.configure.test/src/com/oracle/svm/configure/test/config/OmitPreviousConfigTests.java
+++ b/substratevm/src/com.oracle.svm.configure.test/src/com/oracle/svm/configure/test/config/OmitPreviousConfigTests.java
@@ -100,6 +100,7 @@ public class OmitPreviousConfigTests {
         assertTrue(config.getResourceConfiguration().isEmpty());
         assertTrue(config.getSerializationConfiguration().isEmpty());
         assertTrue(config.getPredefinedClassesConfiguration().isEmpty());
+        assertTrue(config.getExceptionConfiguration().isEmpty());
     }
 
     @Test

--- a/substratevm/src/com.oracle.svm.configure/src/com/oracle/svm/configure/ConfigurationTool.java
+++ b/substratevm/src/com.oracle.svm.configure/src/com/oracle/svm/configure/ConfigurationTool.java
@@ -343,6 +343,11 @@ public class ConfigurationTool {
                 configurationSet.getPredefinedClassesConfiguration().printJson(writer);
             }
         }
+        for (URI uri : outputCollection.getExceptionConfigPaths()) {
+            try (JsonWriter writer = new JsonWriter(Paths.get(uri))) {
+                configurationSet.getExceptionConfiguration().printJson(writer);
+            }
+        }
     }
 
     private static Path getOrCreateDirectory(String current, String value) throws IOException {

--- a/substratevm/src/com.oracle.svm.configure/src/com/oracle/svm/configure/config/ConfigurationSet.java
+++ b/substratevm/src/com.oracle.svm.configure/src/com/oracle/svm/configure/config/ConfigurationSet.java
@@ -49,25 +49,28 @@ public class ConfigurationSet {
     private final ProxyConfiguration proxyConfiguration;
     private final SerializationConfiguration serializationConfiguration;
     private final PredefinedClassesConfiguration predefinedClassesConfiguration;
+    private final ExceptionConfiguration exceptionConfiguration;
 
     public ConfigurationSet(TypeConfiguration reflectionConfiguration, TypeConfiguration jniConfiguration, ResourceConfiguration resourceConfiguration, ProxyConfiguration proxyConfiguration,
-                    SerializationConfiguration serializationConfiguration, PredefinedClassesConfiguration predefinedClassesConfiguration) {
+                    SerializationConfiguration serializationConfiguration, PredefinedClassesConfiguration predefinedClassesConfiguration,
+                    ExceptionConfiguration exceptionConfiguration) {
         this.reflectionConfiguration = reflectionConfiguration;
         this.jniConfiguration = jniConfiguration;
         this.resourceConfiguration = resourceConfiguration;
         this.proxyConfiguration = proxyConfiguration;
         this.serializationConfiguration = serializationConfiguration;
         this.predefinedClassesConfiguration = predefinedClassesConfiguration;
+        this.exceptionConfiguration = exceptionConfiguration;
     }
 
     public ConfigurationSet(ConfigurationSet other) {
         this(other.reflectionConfiguration.copy(), other.jniConfiguration.copy(), other.resourceConfiguration.copy(), other.proxyConfiguration.copy(), other.serializationConfiguration.copy(),
-                        other.predefinedClassesConfiguration.copy());
+                        other.predefinedClassesConfiguration.copy(), other.exceptionConfiguration.copy());
     }
 
     public ConfigurationSet() {
         this(new TypeConfiguration(), new TypeConfiguration(), new ResourceConfiguration(), new ProxyConfiguration(), new SerializationConfiguration(),
-                        new PredefinedClassesConfiguration(new Path[0], hash -> false));
+                        new PredefinedClassesConfiguration(new Path[0], hash -> false), new ExceptionConfiguration());
     }
 
     private ConfigurationSet mutate(ConfigurationSet other, Mutator mutator) {
@@ -77,7 +80,8 @@ public class ConfigurationSet {
         ProxyConfiguration proxyConfig = mutator.apply(this.proxyConfiguration, other.proxyConfiguration);
         SerializationConfiguration serializationConfig = mutator.apply(this.serializationConfiguration, other.serializationConfiguration);
         PredefinedClassesConfiguration predefinedClassesConfig = mutator.apply(this.predefinedClassesConfiguration, other.predefinedClassesConfiguration);
-        return new ConfigurationSet(reflectionConfig, jniConfig, resourceConfig, proxyConfig, serializationConfig, predefinedClassesConfig);
+        ExceptionConfiguration exceptionConfig = mutator.apply(this.exceptionConfiguration, other.exceptionConfiguration);
+        return new ConfigurationSet(reflectionConfig, jniConfig, resourceConfig, proxyConfig, serializationConfig, predefinedClassesConfig, exceptionConfiguration);
     }
 
     public ConfigurationSet copyAndMerge(ConfigurationSet other) {
@@ -99,7 +103,8 @@ public class ConfigurationSet {
         ProxyConfiguration proxyConfig = this.proxyConfiguration.copyAndFilter(filter);
         SerializationConfiguration serializationConfig = this.serializationConfiguration.copyAndFilter(filter);
         PredefinedClassesConfiguration predefinedClassesConfig = this.predefinedClassesConfiguration.copyAndFilter(filter);
-        return new ConfigurationSet(reflectionConfig, jniConfig, resourceConfig, proxyConfig, serializationConfig, predefinedClassesConfig);
+        ExceptionConfiguration exceptionConfig = this.exceptionConfiguration.copyAndFilter(filter);
+        return new ConfigurationSet(reflectionConfig, jniConfig, resourceConfig, proxyConfig, serializationConfig, predefinedClassesConfig, exceptionConfiguration);
     }
 
     public TypeConfiguration getReflectionConfiguration() {
@@ -126,6 +131,10 @@ public class ConfigurationSet {
         return predefinedClassesConfiguration;
     }
 
+    public ExceptionConfiguration getExceptionConfiguration() {
+        return exceptionConfiguration;
+    }
+
     @SuppressWarnings("unchecked")
     public <T extends ConfigurationBase<T, ?>> T getConfiguration(ConfigurationFile configurationFile) {
         switch (configurationFile) {
@@ -141,6 +150,8 @@ public class ConfigurationSet {
                 return (T) serializationConfiguration;
             case PREDEFINED_CLASSES_NAME:
                 return (T) predefinedClassesConfiguration;
+            case EXCEPTION:
+                return (T) exceptionConfiguration;
             default:
                 throw VMError.shouldNotReachHere("Unsupported configuration in configuration container: " + configurationFile);
         }
@@ -165,6 +176,6 @@ public class ConfigurationSet {
 
     public boolean isEmpty() {
         return reflectionConfiguration.isEmpty() && jniConfiguration.isEmpty() && resourceConfiguration.isEmpty() && proxyConfiguration.isEmpty() && serializationConfiguration.isEmpty() &&
-                        predefinedClassesConfiguration.isEmpty();
+                        predefinedClassesConfiguration.isEmpty() && exceptionConfiguration.isEmpty();
     }
 }

--- a/substratevm/src/com.oracle.svm.configure/src/com/oracle/svm/configure/config/ExceptionConfiguration.java
+++ b/substratevm/src/com.oracle.svm.configure/src/com/oracle/svm/configure/config/ExceptionConfiguration.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2022, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2022, Alibaba Group Holding Limited. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package com.oracle.svm.configure.config;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+import org.graalvm.nativeimage.impl.ConfigurationCondition;
+
+import com.oracle.svm.configure.ConfigurationBase;
+import com.oracle.svm.core.configure.ConfigurationParser;
+import com.oracle.svm.core.configure.ExceptionConfigurationParser;
+import com.oracle.svm.configure.json.JsonWriter;
+
+public class ExceptionConfiguration extends ConfigurationBase<ExceptionConfiguration, ExceptionConfiguration.Predicate> {
+    private final ConcurrentMap<String, List<String>> exceptions = new ConcurrentHashMap<>();
+
+    public ExceptionConfiguration() {
+    }
+
+    public ExceptionConfiguration(ExceptionConfiguration other) {
+        exceptions.putAll(other.exceptions);
+    }
+
+    public void add(String clazz, String exception) {
+        List<String> exceptionsOfClass = exceptions.computeIfAbsent(clazz, key -> new ArrayList<>());
+        exceptionsOfClass.add(exception);
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return exceptions.isEmpty();
+    }
+
+    @Override
+    public ExceptionConfiguration copy() {
+        return new ExceptionConfiguration(this);
+    }
+
+    @Override
+    protected void merge(ExceptionConfiguration other) {
+        exceptions.putAll(other.exceptions);
+    }
+
+    @Override
+    public void mergeConditional(ConfigurationCondition condition, ExceptionConfiguration other) {
+    }
+
+    @Override
+    public ConfigurationParser createParser() {
+        return new ExceptionConfigurationParser(true);
+    }
+
+    @Override
+    protected void subtract(ExceptionConfiguration other) {
+        exceptions.keySet().removeAll(other.exceptions.keySet());
+    }
+
+    @Override
+    protected void intersect(ExceptionConfiguration other) {
+        exceptions.keySet().retainAll(other.exceptions.keySet());
+    }
+
+    @Override
+    protected void removeIf(Predicate predicate) {
+        exceptions.keySet().removeIf(predicate::testExceptionType);
+    }
+
+    @Override
+    public void printJson(JsonWriter writer) throws IOException {
+        writer.append('[').indent().newline();
+        writer.append('{').indent();
+        String prefix = "";
+        for (Map.Entry<String, List<String>> entry : exceptions.entrySet()) {
+            writer.append(prefix).newline();
+            writer.quote("class").append(":").quote(entry.getKey()).append(",").newline();
+            writer.quote("exceptions").append(":[").indent();
+            prefix = "";
+            for (String exception : entry.getValue()) {
+                writer.append(prefix).newline().quote(exception);
+                prefix = ",";
+            }
+            writer.unindent().newline().append(']');
+            prefix = ",";
+        }
+        writer.unindent().newline().append('}');
+        writer.unindent().newline().append(']').newline();
+    }
+
+    public interface Predicate {
+        public boolean testExceptionType(String className);
+    }
+}

--- a/substratevm/src/com.oracle.svm.configure/src/com/oracle/svm/configure/config/conditional/ConditionalConfigurationPredicate.java
+++ b/substratevm/src/com.oracle.svm.configure/src/com/oracle/svm/configure/config/conditional/ConditionalConfigurationPredicate.java
@@ -29,6 +29,7 @@ import java.util.regex.Pattern;
 
 import com.oracle.svm.configure.config.ConfigurationPredefinedClass;
 import com.oracle.svm.configure.config.ConfigurationType;
+import com.oracle.svm.configure.config.ExceptionConfiguration;
 import com.oracle.svm.configure.config.PredefinedClassesConfiguration;
 import com.oracle.svm.configure.config.ProxyConfiguration;
 import com.oracle.svm.configure.config.ResourceConfiguration;
@@ -40,7 +41,8 @@ import com.oracle.svm.configure.filters.ComplexFilter;
 import com.oracle.svm.core.configure.ConditionalElement;
 
 public class ConditionalConfigurationPredicate implements TypeConfiguration.Predicate, ProxyConfiguration.Predicate,
-                ResourceConfiguration.Predicate, SerializationConfiguration.Predicate, PredefinedClassesConfiguration.Predicate {
+                ResourceConfiguration.Predicate, SerializationConfiguration.Predicate, PredefinedClassesConfiguration.Predicate,
+                ExceptionConfiguration.Predicate {
 
     private final ComplexFilter filter;
 
@@ -81,5 +83,10 @@ public class ConditionalConfigurationPredicate implements TypeConfiguration.Pred
     @Override
     public boolean testPredefinedClass(ConfigurationPredefinedClass clazz) {
         return clazz.getNameInfo() != null && !filter.includes(clazz.getNameInfo());
+    }
+
+    @Override
+    public boolean testExceptionType(String className) {
+        return true;
     }
 }

--- a/substratevm/src/com.oracle.svm.configure/src/com/oracle/svm/configure/trace/ExceptionProcessor.java
+++ b/substratevm/src/com.oracle.svm.configure/src/com/oracle/svm/configure/trace/ExceptionProcessor.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2022, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2022, Alibaba Group Holding Limited. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package com.oracle.svm.configure.trace;
+
+import java.util.Map;
+
+import com.oracle.svm.configure.config.ConfigurationSet;
+import com.oracle.svm.configure.config.ExceptionConfiguration;
+
+public class ExceptionProcessor extends AbstractProcessor {
+    @Override
+    public void processEntry(Map<String, ?> entry, ConfigurationSet configurationSet) {
+        ExceptionConfiguration exceptionConfig = configurationSet.getExceptionConfiguration();
+        String clazz = (String) entry.get("class");
+        String exception = (String) entry.get("exception");
+        if (clazz != null && exception != null) {
+            exceptionConfig.add(clazz, exception);
+        }
+    }
+}

--- a/substratevm/src/com.oracle.svm.configure/src/com/oracle/svm/configure/trace/TraceProcessor.java
+++ b/substratevm/src/com.oracle.svm.configure/src/com/oracle/svm/configure/trace/TraceProcessor.java
@@ -40,6 +40,7 @@ public class TraceProcessor extends AbstractProcessor {
     private final ReflectionProcessor reflectionProcessor;
     private final SerializationProcessor serializationProcessor;
     private final ClassLoadingProcessor classLoadingProcessor;
+    private final ExceptionProcessor exceptionProcessor;
 
     public TraceProcessor(AccessAdvisor accessAdvisor) {
         advisor = accessAdvisor;
@@ -47,6 +48,7 @@ public class TraceProcessor extends AbstractProcessor {
         reflectionProcessor = new ReflectionProcessor(this.advisor);
         serializationProcessor = new SerializationProcessor(this.advisor);
         classLoadingProcessor = new ClassLoadingProcessor();
+        exceptionProcessor = new ExceptionProcessor();
     }
 
     @SuppressWarnings("unchecked")
@@ -90,6 +92,9 @@ public class TraceProcessor extends AbstractProcessor {
                     break;
                 case "classloading":
                     classLoadingProcessor.processEntry(entry, configurationSet);
+                    break;
+                case "exception":
+                    exceptionProcessor.processEntry(entry, configurationSet);
                     break;
                 default:
                     logWarning("Unknown tracer, ignoring: " + tracer);

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/configure/ConfigurationFile.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/configure/ConfigurationFile.java
@@ -33,7 +33,8 @@ public enum ConfigurationFile {
     REFLECTION("reflect", true),
     SERIALIZATION("serialization", true),
     SERIALIZATION_DENY("serialization-deny", false),
-    PREDEFINED_CLASSES_NAME("predefined-classes", true);
+    PREDEFINED_CLASSES_NAME("predefined-classes", true),
+    EXCEPTION("exception", true);
 
     public static final String DEFAULT_FILE_NAME_SUFFIX = "-config.json";
     private final String name;

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/configure/ExceptionConfigurationParser.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/configure/ExceptionConfigurationParser.java
@@ -1,0 +1,13 @@
+package com.oracle.svm.core.configure;
+
+import java.net.URI;
+
+public class ExceptionConfigurationParser extends ConfigurationParser {
+    public ExceptionConfigurationParser(boolean strictConfiguration) {
+        super(strictConfiguration);
+    }
+
+    @Override
+    public void parseAndRegister(Object json, URI origin) {
+    }
+}


### PR DESCRIPTION
# Feature description
It helps to record reflection exceptions happened during execution based on native image agent, such as `java.lang.ClassNotFoundExcetion`, `java.lang.NoClassDefFoundError`, etc. And those records will be written to config file in json format together with other config files.

# Background
While conducting pointsto analysis before building native-image , reflection configuration registry is needed for close world. But the key is that we have no idea about whether those exceptions happened during reflection registry are normal.   With the help of these exception configurations recorded during execution on JVM, the uncertainty could be eliminated.

# Implementation
After executing reflection methods such as `Class.forName` in breakpoint, which is designed to record reflection configuration, unhandled exception check will be conducted. If there exists, record them in configuration set and write them to configuration file.