### PR TITLE
[GR-41851] Support thread sleep as a mirror event in JDK 19

### DIFF
--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/JfrEvent.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/JfrEvent.java
@@ -60,7 +60,7 @@ public final class JfrEvent {
     public static final JfrEvent SafepointEnd = create("jdk.SafepointEnd");
     public static final JfrEvent ExecuteVMOperation = create("jdk.ExecuteVMOperation");
     public static final JfrEvent JavaMonitorEnter = create("jdk.JavaMonitorEnter");
-    public static final JfrEvent ThreadSleep = create("jdk.ThreadSleep", JDK17OrEarlier.class);
+    public static final JfrEvent ThreadSleep = create("jdk.ThreadSleep");
     public static final JfrEvent ThreadPark = create("jdk.ThreadPark");
     public static final JfrEvent JavaMonitorWait = create("jdk.JavaMonitorWait");
 

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/JfrEvent.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/JfrEvent.java
@@ -24,6 +24,8 @@
  */
 package com.oracle.svm.core.jfr;
 
+import java.util.HashSet;
+import java.util.Set;
 import java.util.function.BooleanSupplier;
 
 import org.graalvm.nativeimage.Platform;
@@ -65,6 +67,13 @@ public final class JfrEvent {
 
     private final long id;
     private final String name;
+    private static Set<Long> mirrorEvents = new HashSet<>();
+    public static boolean isMirrorEvent(long id) {
+        return mirrorEvents.contains(id);
+    }
+    public static boolean addMirrorEvent(long id) {
+        return mirrorEvents.add(id);
+    }
 
     @Platforms(Platform.HOSTED_ONLY.class)
     private static JfrEvent create(String name) {

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/JfrEvent.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/JfrEvent.java
@@ -31,7 +31,6 @@ import org.graalvm.nativeimage.Platforms;
 
 import com.oracle.svm.core.Uninterruptible;
 import com.oracle.svm.core.annotate.TargetClass;
-import com.oracle.svm.core.jdk.JDK17OrEarlier;
 import com.oracle.svm.util.ReflectionUtil;
 
 /**

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/JfrMetadataTypeLibrary.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/JfrMetadataTypeLibrary.java
@@ -42,6 +42,7 @@ import jdk.jfr.internal.PlatformEventType;
 import jdk.jfr.internal.Type;
 import jdk.jfr.internal.TypeLibrary;
 import com.oracle.svm.core.annotate.TargetClass;
+
 /**
  * This class caches all JFR metadata types. This is mainly necessary because
  * {@link TypeLibrary#getTypes()} isn't multi-threading safe.
@@ -52,7 +53,7 @@ public class JfrMetadataTypeLibrary {
     private static final TypeLibrary typeLibrary = TypeLibrary.getInstance();
     private static List<Long> mirrorEvents = new ArrayList<>();
 
-    private static void addMirrorEvent(Class<?> svmClass, Class<?> internalClass){
+    private static void addMirrorEvent(Class<?> svmClass, Class<?> internalClass) {
         PlatformEventType et = (PlatformEventType) TypeLibrary.createType(svmClass, Collections.emptyList(), Collections.emptyList());
         long id = Type.getTypeId(internalClass);
         et.setId(id);
@@ -60,16 +61,17 @@ public class JfrMetadataTypeLibrary {
         mirrorEvents.add(id);
     }
 
-    private static void addMirrorEvents(){
-        if(JavaVersionUtil.JAVA_SPEC > 17){
+    private static void addMirrorEvents() {
+        if (JavaVersionUtil.JAVA_SPEC > 17) {
             addMirrorEvent(com.oracle.svm.core.jfr.events.ThreadSleepEvent.class, Target_jdk_internal_event_ThreadSleepEvent.class);
         }
     }
 
-    public static void removeType(long id){
+    public static void removeType(long id) {
         typeLibrary.removeType(id);
     }
-    public static List<Long> getMirrorEvents(){
+
+    public static List<Long> getMirrorEvents() {
         return mirrorEvents;
     }
 

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/JfrMetadataTypeLibrary.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/JfrMetadataTypeLibrary.java
@@ -50,25 +50,19 @@ import com.oracle.svm.core.annotate.TargetClass;
 @Platforms(Platform.HOSTED_ONLY.class)
 public class JfrMetadataTypeLibrary {
     private static final HashMap<String, Type> types = new HashMap<>();
-    private static final TypeLibrary typeLibrary = TypeLibrary.getInstance();
     private static List<Long> mirrorEvents = new ArrayList<>();
 
     private static void addMirrorEvent(Class<?> svmClass, Class<?> internalClass) {
         PlatformEventType et = (PlatformEventType) TypeLibrary.createType(svmClass, Collections.emptyList(), Collections.emptyList());
-        long id = Type.getTypeId(internalClass);
-        et.setId(id);
+        et.setId(Type.getTypeId(internalClass));
         types.put(et.getName(), et);
-        mirrorEvents.add(id);
+        mirrorEvents.add(et.getId());
     }
 
     private static void addMirrorEvents() {
         if (JavaVersionUtil.JAVA_SPEC > 17) {
             addMirrorEvent(com.oracle.svm.core.jfr.events.ThreadSleepEvent.class, Target_jdk_internal_event_ThreadSleepEvent.class);
         }
-    }
-
-    public static void removeType(long id) {
-        typeLibrary.removeType(id);
     }
 
     public static List<Long> getMirrorEvents() {

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/SubstrateJVM.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/SubstrateJVM.java
@@ -92,8 +92,6 @@ public class SubstrateJVM {
             eventSettings[i] = new JfrNativeEventSetting();
         }
 
-        handleMirrorEvents();
-
         symbolRepo = new JfrSymbolRepository();
         typeRepo = new JfrTypeRepository();
         threadRepo = new JfrThreadRepository();
@@ -116,12 +114,6 @@ public class SubstrateJVM {
         initialized = false;
         recording = false;
         metadataDescriptor = null;
-    }
-
-    private void handleMirrorEvents() {
-        for (long id : com.oracle.svm.core.jfr.JfrMetadataTypeLibrary.getMirrorEvents()) {
-            setEnabled(id, true);
-        }
     }
 
     @Fold

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/SubstrateJVM.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/SubstrateJVM.java
@@ -92,6 +92,8 @@ public class SubstrateJVM {
             eventSettings[i] = new JfrNativeEventSetting();
         }
 
+        handleMirrorEvents();
+
         symbolRepo = new JfrSymbolRepository();
         typeRepo = new JfrTypeRepository();
         threadRepo = new JfrThreadRepository();
@@ -114,6 +116,13 @@ public class SubstrateJVM {
         initialized = false;
         recording = false;
         metadataDescriptor = null;
+    }
+
+    private void handleMirrorEvents(){
+        for (long id : com.oracle.svm.core.jfr.JfrMetadataTypeLibrary.getMirrorEvents()){
+            JfrMetadataTypeLibrary.removeType(id);
+            setEnabled(id,true);
+        }
     }
 
     @Fold

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/SubstrateJVM.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/SubstrateJVM.java
@@ -120,7 +120,6 @@ public class SubstrateJVM {
 
     private void handleMirrorEvents() {
         for (long id : com.oracle.svm.core.jfr.JfrMetadataTypeLibrary.getMirrorEvents()) {
-            JfrMetadataTypeLibrary.removeType(id);
             setEnabled(id, true);
         }
     }

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/SubstrateJVM.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/SubstrateJVM.java
@@ -118,10 +118,10 @@ public class SubstrateJVM {
         metadataDescriptor = null;
     }
 
-    private void handleMirrorEvents(){
-        for (long id : com.oracle.svm.core.jfr.JfrMetadataTypeLibrary.getMirrorEvents()){
+    private void handleMirrorEvents() {
+        for (long id : com.oracle.svm.core.jfr.JfrMetadataTypeLibrary.getMirrorEvents()) {
             JfrMetadataTypeLibrary.removeType(id);
-            setEnabled(id,true);
+            setEnabled(id, true);
         }
     }
 

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/events/ThreadSleepEvent.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/events/ThreadSleepEvent.java
@@ -26,6 +26,8 @@
 
 package com.oracle.svm.core.jfr.events;
 
+
+import jdk.jfr.Event;
 import org.graalvm.nativeimage.StackValue;
 
 import com.oracle.svm.core.Uninterruptible;
@@ -35,8 +37,18 @@ import com.oracle.svm.core.jfr.JfrNativeEventWriterData;
 import com.oracle.svm.core.jfr.JfrNativeEventWriterDataAccess;
 import com.oracle.svm.core.jfr.JfrTicks;
 import com.oracle.svm.core.jfr.SubstrateJVM;
+import jdk.jfr.Category;
+import jdk.jfr.Label;
+import jdk.jfr.Name;
+import jdk.jfr.Timespan;
 
-public class ThreadSleepEvent {
+@Category("Java Application")
+@Label("Java Thread Sleep")
+@Name("jdk.ThreadSleep")
+public class ThreadSleepEvent extends Event {
+    @Label("Sleep Time")
+    @Timespan()
+    public long time;
 
     public static void emit(long time, long startTicks) {
         if (com.oracle.svm.core.jfr.HasJfrSupport.get()) {

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/events/ThreadSleepEvent.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/events/ThreadSleepEvent.java
@@ -26,7 +26,6 @@
 
 package com.oracle.svm.core.jfr.events;
 
-
 import jdk.jfr.Event;
 import org.graalvm.nativeimage.StackValue;
 
@@ -47,8 +46,7 @@ import jdk.jfr.Timespan;
 @Name("jdk.ThreadSleep")
 public class ThreadSleepEvent extends Event {
     @Label("Sleep Time")
-    @Timespan()
-    public long time;
+    @Timespan() public long time;
 
     public static void emit(long time, long startTicks) {
         if (com.oracle.svm.core.jfr.HasJfrSupport.get()) {


### PR DESCRIPTION
### Summary of bug:
Currently a null pointer exception is thrown at runtime if the thread sleep event is emitted (with JDK19).  This is because jdk.ThreadSleep is only added as an event  if the JDK version is <17. This is a recent change in SVM that was done because in JDK19, ThreadSleep is now a mirror event and is not longer in metadata.xml. This means it doesn't get added to `JfrMetadataTypeLibrary`, and so an NPE is eventually thrown when we try to emit the event in uninterruptible code. A solution to this could be to not attempt to emit  thread sleep events if jdk version is over 17. This PR instead tries to add support for thread sleep as a mirror event. 

This is the error:
`Exception in thread "Thread-2" java.lang.NullPointerException: [no exception stack trace available because exception is thrown from code that must be allocation free]
`

To reproduce:

1. Build graal with jdk19
2. Compile this [sample app](https://github.com/roberttoyonaga/jfr-tests/blob/addJavaMonitorEnterTests/src/main/java/com/redhat/jfr/tests/event/TestJavaMonitorWaitEvents.java) with jdk 19. Any java app that uses Thread.sleep() could be used.
3. Build with JFR included in the image `mx native-image --no-fallback -H:+AllowVMInspection -cp /jfr-tests/target/classes com.redhat.jfr.tests.event.TestJavaMonitorWaitEvents`
4. Run with starting flight recorder `./com.redhat.jfr.tests.event.testjavamonitorwaitevents  -XX:+FlightRecorder -XX:StartFlightRecording=filename=testjavamonitorwaitevents.jfr`

### Summary of changes
To solve this, special handling of jdk.ThreadSleep as a mirror event is added (only if jdk version is 19). In the future, support for new mirror events could possibly be done in a similar way.