### PR TITLE
[GR-42601] Model class constants in debug info

### DIFF
--- a/docs/reference-manual/native-image/DebugInfo.md
+++ b/docs/reference-manual/native-image/DebugInfo.md
@@ -140,6 +140,7 @@ The currently supported features include:
   - access through object networks via path expressions
   - reference by name to methods and static field data
   - reference by name to values bound to parameter and local vars
+  - reference by name to class constants
 
 Note that single stepping within a compiled method includes file and line number info for inlined code, including inlined GraalVM methods.
 So, GDB may switch files even though you are still in the same compiled method.
@@ -392,6 +393,46 @@ end
 
 (gdb) hubname $1
 0x8779c8:	"[Ljava.lang.String;"
+```
+
+The native image heap contains a unique hub object (i.e. instance of
+`java.lang.Class`) for every Java type that is included in the
+image. It is possible to refer to these class constants using the
+standard Java class literal syntax:
+
+```
+(gdb) print 'Hello.class'
+$6 = {
+  <java.lang.Object> = {
+    <_objhdr> = {
+      hub = 0xaabd00,
+      idHash = 1589947226
+    }, <No data fields>}, 
+  members of java.lang.Class:
+  typeCheckStart = 13,
+  name = 0xbd57f0,
+  ...
+```
+
+Unfortunately it is necessary to quote the class constant literal to
+avoid gdb interpreting the embedded `.` character as a field access.
+
+Note that the type of a class constant literal is `java.lang.Class`
+rather than `java.lang.Class *`.
+
+Class constants exist for Java instance classes, interfaces, array
+classes and arrays, including primitive arrays:
+
+```
+(gdb)  print 'java.util.List.class'.name
+$7 = (java.lang.String *) 0xb1f698
+(gdb) print 'java.lang.String[].class'.name->value->data
+$8 = 0x8e6d78 "[Ljava.lang.String;"
+(gdb) print 'long.class'.name->value->data
+$9 = 0xc87b78 "long"
+(gdb) x/s  'byte[].class'.name->value->data
+0x925a00:	"[B"
+(gdb) 
 ```
 
 Interface layouts are modelled as C++ union types.

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/ArrayTypeEntry.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/ArrayTypeEntry.java
@@ -48,6 +48,7 @@ public class ArrayTypeEntry extends StructureTypeEntry {
 
     @Override
     public void addDebugInfo(DebugInfoBase debugInfoBase, DebugTypeInfo debugTypeInfo, DebugContext debugContext) {
+        super.addDebugInfo(debugInfoBase, debugTypeInfo, debugContext);
         DebugArrayTypeInfo debugArrayTypeInfo = (DebugArrayTypeInfo) debugTypeInfo;
         ResolvedJavaType eltType = debugArrayTypeInfo.elementType();
         this.elementType = debugInfoBase.lookupTypeEntry(eltType);

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/ClassEntry.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/ClassEntry.java
@@ -141,6 +141,7 @@ public class ClassEntry extends StructureTypeEntry {
 
     @Override
     public void addDebugInfo(DebugInfoBase debugInfoBase, DebugTypeInfo debugTypeInfo, DebugContext debugContext) {
+        super.addDebugInfo(debugInfoBase, debugTypeInfo, debugContext);
         assert debugTypeInfo.typeName().equals(typeName);
         DebugInstanceTypeInfo debugInstanceTypeInfo = (DebugInstanceTypeInfo) debugTypeInfo;
         /* Add details of super and interface classes */

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/DebugInfoBase.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/DebugInfoBase.java
@@ -182,7 +182,7 @@ public abstract class DebugInfoBase {
      */
     private int oopAlignShift;
     /**
-     * The type entry for java.lang.Class
+     * The type entry for java.lang.Class.
      */
     private ClassEntry hubClassEntry;
 

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/DebugInfoBase.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/DebugInfoBase.java
@@ -181,6 +181,10 @@ public abstract class DebugInfoBase {
      * Number of bits in oop which are guaranteed 0 by virtue of alignment.
      */
     private int oopAlignShift;
+    /**
+     * The type entry for java.lang.Class
+     */
+    private ClassEntry hubClassEntry;
 
     public DebugInfoBase(ByteOrder byteOrder) {
         this.byteOrder = byteOrder;
@@ -191,6 +195,7 @@ public abstract class DebugInfoBase {
         this.pointerSize = 0;
         this.oopAlignment = 0;
         this.oopAlignShift = 0;
+        this.hubClassEntry = null;
     }
 
     /**
@@ -317,6 +322,9 @@ public abstract class DebugInfoBase {
             case INSTANCE: {
                 FileEntry fileEntry = addFileEntry(fileName, filePath, cachePath);
                 typeEntry = new ClassEntry(typeName, fileEntry, size);
+                if (typeEntry.getTypeName().equals(DwarfDebugInfo.HUB_TYPE_NAME)) {
+                    hubClassEntry = (ClassEntry) typeEntry;
+                }
                 break;
             }
             case INTERFACE: {
@@ -622,5 +630,9 @@ public abstract class DebugInfoBase {
             return DwarfDebugInfo.DW_ABBREV_CODE_class_layout2;
         }
         return DwarfDebugInfo.DW_ABBREV_CODE_class_layout1;
+    }
+
+    public ClassEntry getHubClassEntry() {
+        return hubClassEntry;
     }
 }

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/HeaderTypeEntry.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/HeaderTypeEntry.java
@@ -45,6 +45,7 @@ public class HeaderTypeEntry extends StructureTypeEntry {
 
     @Override
     public void addDebugInfo(DebugInfoBase debugInfoBase, DebugTypeInfo debugTypeInfo, DebugContext debugContext) {
+        super.addDebugInfo(debugInfoBase, debugTypeInfo, debugContext);
         assert debugTypeInfo.typeName().equals(typeName);
         DebugHeaderTypeInfo debugHeaderTypeInfo = (DebugHeaderTypeInfo) debugTypeInfo;
         debugHeaderTypeInfo.fieldInfoProvider().forEach(debugFieldInfo -> this.processField(debugFieldInfo, debugInfoBase, debugContext));

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/PrimitiveTypeEntry.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/PrimitiveTypeEntry.java
@@ -54,6 +54,7 @@ public class PrimitiveTypeEntry extends TypeEntry {
 
     @Override
     public void addDebugInfo(DebugInfoBase debugInfoBase, DebugTypeInfo debugTypeInfo, DebugContext debugContext) {
+        super.addDebugInfo(debugInfoBase, debugTypeInfo, debugContext);
         DebugPrimitiveTypeInfo debugPrimitiveTypeInfo = (DebugPrimitiveTypeInfo) debugTypeInfo;
         flags = debugPrimitiveTypeInfo.flags();
         typeChar = debugPrimitiveTypeInfo.typeChar();

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/TypeEntry.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/TypeEntry.java
@@ -106,7 +106,7 @@ public abstract class TypeEntry {
         return isClass() || isHeader();
     }
 
-    public void addDebugInfo(DebugInfoBase debugInfoBase, DebugTypeInfo debugTypeInfo, DebugContext debugContext) {
+    public void addDebugInfo(@SuppressWarnings("unused") DebugInfoBase debugInfoBase, DebugTypeInfo debugTypeInfo, @SuppressWarnings("unused") DebugContext debugContext) {
         /* Record the location of the Class instance in the heap if there is one */
         this.classOffset = debugTypeInfo.classOffset();
     }

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/TypeEntry.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/TypeEntry.java
@@ -44,6 +44,12 @@ public abstract class TypeEntry {
     protected String typeName;
 
     /**
+     * The offset of the java.lang.Class instance for this class in the image heap or -1
+     * if no such object exists.
+     */
+    private long classOffset;
+
+    /**
      * The size of an occurrence of this type in bytes.
      */
     protected int size;
@@ -51,6 +57,11 @@ public abstract class TypeEntry {
     protected TypeEntry(String typeName, int size) {
         this.typeName = typeName;
         this.size = size;
+        this.classOffset = -1;
+    }
+
+    public long getClassOffset() {
+        return classOffset;
     }
 
     public int getSize() {
@@ -95,5 +106,8 @@ public abstract class TypeEntry {
         return isClass() || isHeader();
     }
 
-    public abstract void addDebugInfo(DebugInfoBase debugInfoBase, DebugTypeInfo debugTypeInfo, DebugContext debugContext);
+    public void addDebugInfo(DebugInfoBase debugInfoBase, DebugTypeInfo debugTypeInfo, DebugContext debugContext) {
+        /* Record the location of the Class instance in the heap if there is one */
+        this.classOffset = debugTypeInfo.classOffset();
+    }
 }

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/TypeEntry.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/TypeEntry.java
@@ -44,8 +44,8 @@ public abstract class TypeEntry {
     protected String typeName;
 
     /**
-     * The offset of the java.lang.Class instance for this class in the image heap or -1
-     * if no such object exists.
+     * The offset of the java.lang.Class instance for this class in the image heap or -1 if no such
+     * object exists.
      */
     private long classOffset;
 

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debuginfo/DebugInfoProvider.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debuginfo/DebugInfoProvider.java
@@ -132,6 +132,14 @@ public interface DebugInfoProvider {
 
         DebugTypeKind typeKind();
 
+        /**
+         * returns the offset in the heap at which the java.lang.Class instance which models
+         * this class is located or -1 if no such instance exists for this class.
+         *
+         * @return the offset of the java.lang.Class instance which models this class or -1.
+         */
+        long classOffset();
+
         int size();
     }
 

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debuginfo/DebugInfoProvider.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debuginfo/DebugInfoProvider.java
@@ -133,8 +133,8 @@ public interface DebugInfoProvider {
         DebugTypeKind typeKind();
 
         /**
-         * returns the offset in the heap at which the java.lang.Class instance which models
-         * this class is located or -1 if no such instance exists for this class.
+         * returns the offset in the heap at which the java.lang.Class instance which models this
+         * class is located or -1 if no such instance exists for this class.
          *
          * @return the offset of the java.lang.Class instance which models this class or -1.
          */

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfAbbrevSectionImpl.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfAbbrevSectionImpl.java
@@ -1216,7 +1216,7 @@ public class DwarfAbbrevSectionImpl extends DwarfSectionImpl {
         return pos;
     }
 
-    private int writeClassConstantAbbrev(DebugContext context, byte[] buffer, int p) {
+    private int writeClassConstantAbbrev(@SuppressWarnings("unused") DebugContext context, byte[] buffer, int p) {
         int pos = p;
         pos = writeAbbrevCode(DwarfDebugInfo.DW_ABBREV_CODE_class_constant, buffer, pos);
         pos = writeTag(DwarfDebugInfo.DW_TAG_constant, buffer, pos);

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfAbbrevSectionImpl.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfAbbrevSectionImpl.java
@@ -870,6 +870,7 @@ public class DwarfAbbrevSectionImpl extends DwarfSectionImpl {
         pos = writeClassReferenceAbbrev(context, buffer, pos);
         pos = writeMethodDeclarationAbbrevs(context, buffer, pos);
         pos = writeFieldDeclarationAbbrevs(context, buffer, pos);
+        pos = writeClassConstantAbbrev(context, buffer, pos);
         pos = writeArrayLayoutAbbrev(context, buffer, pos);
         pos = writeArrayReferenceAbbrev(context, buffer, pos);
         pos = writeInterfaceLayoutAbbrev(context, buffer, pos);
@@ -1207,6 +1208,32 @@ public class DwarfAbbrevSectionImpl extends DwarfSectionImpl {
             pos = writeAttrType(DwarfDebugInfo.DW_AT_declaration, buffer, pos);
             pos = writeAttrForm(DwarfDebugInfo.DW_FORM_flag, buffer, pos);
         }
+        /*
+         * Now terminate.
+         */
+        pos = writeAttrType(DwarfDebugInfo.DW_AT_null, buffer, pos);
+        pos = writeAttrForm(DwarfDebugInfo.DW_FORM_null, buffer, pos);
+        return pos;
+    }
+
+    private int writeClassConstantAbbrev(DebugContext context, byte[] buffer, int p) {
+        int pos = p;
+        pos = writeAbbrevCode(DwarfDebugInfo.DW_ABBREV_CODE_class_constant, buffer, pos);
+        pos = writeTag(DwarfDebugInfo.DW_TAG_constant, buffer, pos);
+        pos = writeFlag(DwarfDebugInfo.DW_CHILDREN_no, buffer, pos);
+        pos = writeAttrType(DwarfDebugInfo.DW_AT_name, buffer, pos);
+        pos = writeAttrForm(DwarfDebugInfo.DW_FORM_strp, buffer, pos);
+        /* We may not have a file and line for a field. */
+        pos = writeAttrType(DwarfDebugInfo.DW_AT_type, buffer, pos);
+        pos = writeAttrForm(DwarfDebugInfo.DW_FORM_ref_addr, buffer, pos);
+        pos = writeAttrType(DwarfDebugInfo.DW_AT_accessibility, buffer, pos);
+        pos = writeAttrForm(DwarfDebugInfo.DW_FORM_data1, buffer, pos);
+        pos = writeAttrType(DwarfDebugInfo.DW_AT_external, buffer, pos);
+        pos = writeAttrForm(DwarfDebugInfo.DW_FORM_flag, buffer, pos);
+        pos = writeAttrType(DwarfDebugInfo.DW_AT_declaration, buffer, pos);
+        pos = writeAttrForm(DwarfDebugInfo.DW_FORM_flag, buffer, pos);
+        pos = writeAttrType(DwarfDebugInfo.DW_AT_location, buffer, pos);
+        pos = writeAttrForm(DwarfDebugInfo.DW_FORM_expr_loc, buffer, pos);
         /*
          * Now terminate.
          */

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfDebugInfo.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfDebugInfo.java
@@ -98,6 +98,7 @@ public class DwarfDebugInfo extends DebugInfoBase {
     public static final int DW_ABBREV_CODE_field_declaration2 = 24;
     public static final int DW_ABBREV_CODE_field_declaration3 = 25;
     public static final int DW_ABBREV_CODE_field_declaration4 = 26;
+    public static final int DW_ABBREV_CODE_class_constant = 42;
     public static final int DW_ABBREV_CODE_header_field = 27;
     public static final int DW_ABBREV_CODE_array_data_type = 28;
     public static final int DW_ABBREV_CODE_super_reference = 29;
@@ -130,6 +131,7 @@ public class DwarfDebugInfo extends DebugInfoBase {
     public static final int DW_TAG_union_type = 0x17;
     public static final int DW_TAG_inheritance = 0x1c;
     public static final int DW_TAG_base_type = 0x24;
+    public static final int DW_TAG_constant = 0x27;
     public static final int DW_TAG_subprogram = 0x2e;
     public static final int DW_TAG_variable = 0x34;
     public static final int DW_TAG_namespace = 0x39;

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfInfoSectionImpl.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfInfoSectionImpl.java
@@ -216,6 +216,12 @@ public class DwarfInfoSectionImpl extends DwarfSectionImpl {
 
         pos = writeHeaderType(context, headerType(), buffer, pos);
 
+        /* write class constants for primitive type classes */
+
+        pos = primitiveTypeStream().reduce(pos,
+                (pos1, primitiveTypeEntry) -> writeClassConstantDeclaration(context, primitiveTypeEntry, buffer, pos1),
+                (oldpos, newpos) -> newpos);
+
         /* Terminate with null entry. */
 
         pos = writeAttrNull(buffer, pos);

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfInfoSectionImpl.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfInfoSectionImpl.java
@@ -387,7 +387,6 @@ public class DwarfInfoSectionImpl extends DwarfSectionImpl {
             pos = writeClassType(context, classEntry, buffer, pos);
         }
 
-        int classObjectDeclarationOffset = pos;
         /* Write a declaration for the special Class object pseudo-static field */
         pos = writeClassConstantDeclaration(context, classEntry, buffer, pos);
 
@@ -478,7 +477,6 @@ public class DwarfInfoSectionImpl extends DwarfSectionImpl {
             pos = writeClassType(context, classEntry, buffer, pos);
         }
 
-        int classObjectDeclarationOffset = pos;
         /* Write a declaration for the special Class object pseudo-static field */
         pos = writeClassConstantDeclaration(context, classEntry, buffer, pos);
 

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfInfoSectionImpl.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfInfoSectionImpl.java
@@ -219,8 +219,8 @@ public class DwarfInfoSectionImpl extends DwarfSectionImpl {
         /* write class constants for primitive type classes */
 
         pos = primitiveTypeStream().reduce(pos,
-                (pos1, primitiveTypeEntry) -> writeClassConstantDeclaration(context, primitiveTypeEntry, buffer, pos1),
-                (oldpos, newpos) -> newpos);
+                        (pos1, primitiveTypeEntry) -> writeClassConstantDeclaration(context, primitiveTypeEntry, buffer, pos1),
+                        (oldpos, newpos) -> newpos);
 
         /* Terminate with null entry. */
 
@@ -388,7 +388,7 @@ public class DwarfInfoSectionImpl extends DwarfSectionImpl {
         }
 
         int classObjectDeclarationOffset = pos;
-        /*  Write a declaration for the special Class object pseudo-static field */
+        /* Write a declaration for the special Class object pseudo-static field */
         pos = writeClassConstantDeclaration(context, classEntry, buffer, pos);
 
         /* For a non-compiled class there are no method definitions to write. */
@@ -479,7 +479,7 @@ public class DwarfInfoSectionImpl extends DwarfSectionImpl {
         }
 
         int classObjectDeclarationOffset = pos;
-        /*  Write a declaration for the special Class object pseudo-static field */
+        /* Write a declaration for the special Class object pseudo-static field */
         pos = writeClassConstantDeclaration(context, classEntry, buffer, pos);
 
         /* Write all method locations. */
@@ -540,22 +540,22 @@ public class DwarfInfoSectionImpl extends DwarfSectionImpl {
         log(context, "  [0x%08x]     name  0x%x (%s)", pos, debugStringIndex(name), name);
         pos = writeStrSectionOffset(name, buffer, pos);
         /*
-         * This is a direct reference to the object rather than a compressed oop reference.
-         * So, we need to use the direct layout type for hub class to type it.
+         * This is a direct reference to the object rather than a compressed oop reference. So, we
+         * need to use the direct layout type for hub class to type it.
          */
         ClassEntry valueType = dwarfSections.getHubClassEntry();
         int typeIdx = (valueType == null ? -1 : getLayoutIndex(valueType));
         log(context, "  [0x%08x]     type  0x%x (<hub type>)", pos, typeIdx);
         pos = writeInfoSectionOffset(typeIdx, buffer, pos);
         log(context, "  [0x%08x]     accessibility public static final", pos);
-        pos = writeAttrAccessibility(Modifier.PUBLIC|Modifier.STATIC|Modifier.FINAL, buffer, pos);
+        pos = writeAttrAccessibility(Modifier.PUBLIC | Modifier.STATIC | Modifier.FINAL, buffer, pos);
         log(context, "  [0x%08x]     external(true)", pos);
         pos = writeFlag((byte) 1, buffer, pos);
         log(context, "  [0x%08x]     definition(true)", pos);
         pos = writeFlag((byte) 1, buffer, pos);
         /*
-         * We need to force encoding of this location as a heap base relative relocatable address rather
-         * than an offset from the heapbase register.
+         * We need to force encoding of this location as a heap base relative relocatable address
+         * rather than an offset from the heapbase register.
          */
         log(context, "  [0x%08x]     location  heapbase + 0x%x (class constant)", pos, offset);
         pos = writeHeapLocationExprLoc(offset, false, buffer, pos);
@@ -1232,7 +1232,7 @@ public class DwarfInfoSectionImpl extends DwarfSectionImpl {
         }
         pos = writeArrayTypes(context, arrayTypeEntry, layoutIdx, indirectLayoutIdx, buffer, pos);
 
-        /*  Write a declaration for the special Class object pseudo-static field */
+        /* Write a declaration for the special Class object pseudo-static field */
         pos = writeClassConstantDeclaration(context, arrayTypeEntry, buffer, pos);
 
         /*

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfInfoSectionImpl.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfInfoSectionImpl.java
@@ -539,9 +539,12 @@ public class DwarfInfoSectionImpl extends DwarfSectionImpl {
         String name = uniqueDebugString(typeEntry.getTypeName() + ".class");
         log(context, "  [0x%08x]     name  0x%x (%s)", pos, debugStringIndex(name), name);
         pos = writeStrSectionOffset(name, buffer, pos);
-        /* use the indirect layout type for hub class to type the class constant */
+        /*
+         * This is a direct reference to the object rather than a compressed oop reference.
+         * So, we need to use the direct layout type for hub class to type it.
+         */
         ClassEntry valueType = dwarfSections.getHubClassEntry();
-        int typeIdx = (valueType == null ? -1 : getIndirectLayoutIndex(valueType));
+        int typeIdx = (valueType == null ? -1 : getLayoutIndex(valueType));
         log(context, "  [0x%08x]     type  0x%x (<hub type>)", pos, typeIdx);
         pos = writeInfoSectionOffset(typeIdx, buffer, pos);
         log(context, "  [0x%08x]     accessibility public static final", pos);
@@ -550,9 +553,12 @@ public class DwarfInfoSectionImpl extends DwarfSectionImpl {
         pos = writeFlag((byte) 1, buffer, pos);
         log(context, "  [0x%08x]     definition(true)", pos);
         pos = writeFlag((byte) 1, buffer, pos);
-        /* Field offset needs to be relocated relative to static object base. */
+        /*
+         * We need to force encoding of this location as a heap base relative relocatable address rather
+         * than an offset from the heapbase register.
+         */
         log(context, "  [0x%08x]     location  heapbase + 0x%x (class constant)", pos, offset);
-        pos = writeHeapLocationExprLoc(offset, buffer, pos);
+        pos = writeHeapLocationExprLoc(offset, false, buffer, pos);
         return pos;
     }
 

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfSectionImpl.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfSectionImpl.java
@@ -499,10 +499,10 @@ public abstract class DwarfSectionImpl extends BasicProgbitsSectionImpl {
 
     /*
      * Write a heap location expression preceded by a ULEB block size count as appropriate for an
-     * attribute with FORM exprloc. If a heapbase register is in use the generated expression computes
-     * the location as a constant offset from the runtime heap base register. If a heapbase register is
-     * not in use it computes the location as a fixed, relocatable offset from the link-time heap base
-     * address.
+     * attribute with FORM exprloc. If a heapbase register is in use the generated expression
+     * computes the location as a constant offset from the runtime heap base register. If a heapbase
+     * register is not in use it computes the location as a fixed, relocatable offset from the
+     * link-time heap base address.
      */
     protected int writeHeapLocationExprLoc(long offset, byte[] buffer, int p) {
         return writeHeapLocationExprLoc(offset, dwarfSections.useHeapBase(), buffer, p);
@@ -511,8 +511,8 @@ public abstract class DwarfSectionImpl extends BasicProgbitsSectionImpl {
     /*
      * Write a heap location expression preceded by a ULEB block size count as appropriate for an
      * attribute with FORM exprloc. If useHeapBase is true the generated expression computes the
-     * location as a constant offset from the runtime heap base register. If useHeapBase is false
-     * it computes the location as a fixed, relocatable offset from the link-time heap base address.
+     * location as a constant offset from the runtime heap base register. If useHeapBase is false it
+     * computes the location as a fixed, relocatable offset from the link-time heap base address.
      */
     protected int writeHeapLocationExprLoc(long offset, boolean useHeapBase, byte[] buffer, int p) {
         int pos = p;
@@ -530,9 +530,9 @@ public abstract class DwarfSectionImpl extends BasicProgbitsSectionImpl {
     /*
      * Write a heap location expression preceded by a ULEB block size count as appropriate for
      * location list in the debug_loc section. If a heapbase register is in use the generated
-     * expression computes the location as a constant offset from the runtime heap base register.
-     * If a heapbase register is not in use it computes the location as a fixed, relocatable
-     * offset from the link-time heap base address.
+     * expression computes the location as a constant offset from the runtime heap base register. If
+     * a heapbase register is not in use it computes the location as a fixed, relocatable offset
+     * from the link-time heap base address.
      */
     protected int writeHeapLocationLocList(long offset, byte[] buffer, int p) {
         int pos = p;
@@ -549,8 +549,8 @@ public abstract class DwarfSectionImpl extends BasicProgbitsSectionImpl {
     }
 
     /*
-     * Write a bare heap location expression as appropriate for a single location. If useHeapBase
-     * is true the generated expression computes the location as a constant offset from the runtime
+     * Write a bare heap location expression as appropriate for a single location. If useHeapBase is
+     * true the generated expression computes the location as a constant offset from the runtime
      * heap base register. If useHeapBase is false it computes the location as a fixed, relocatable
      * offset from the link-time heap base address.
      */

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/image/NativeImageDebugInfoProvider.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/image/NativeImageDebugInfoProvider.java
@@ -477,6 +477,15 @@ class NativeImageDebugInfoProvider implements DebugInfoProvider {
         }
 
         @Override
+        public long classOffset() {
+            ObjectInfo objectInfo = heap.getObjectInfo(hostedType.getHub());
+            if (objectInfo != null) {
+                return objectInfo.getOffset();
+            }
+            return -1;
+        }
+
+        @Override
         public int size() {
             if (hostedType instanceof HostedInstanceClass) {
                 /* We know the actual instance size in bytes. */
@@ -551,6 +560,11 @@ class NativeImageDebugInfoProvider implements DebugInfoProvider {
         @Override
         public Path cachePath() {
             return null;
+        }
+
+        @Override
+        public long classOffset() {
+            return -1;
         }
 
         @Override


### PR DESCRIPTION
This PR exposes the location of java.lang.Class (aka DynamicHub) instances located in the image heap to debug info generators, allowing them to be encoded into debug info using the standard class name as an identifier for the corresponding object.

It includes a modification to the Linux debug info generator that encodes details of the class constant object in the info section as a DWARF constant DIE. The implementation enables reference to the class constants using symbolic names like

```
  hello.Hello.class
  java.util.List.class
  java.long.String[].class
  long.class
  byte[].class
```

The type of all the above constants is `class java.lang.Class` (i.e. they identify the underlying object layout rather than an oop).

These symbols are not currently entered into the symbol table as local symbols. That might be desirable for a follow up PR.
