### PR TITLE
Populate SystemProperties for SVM runtime

### DIFF
--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/VM.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/VM.java
@@ -24,7 +24,6 @@
  */
 package com.oracle.svm.core;
 
-import org.graalvm.compiler.serviceprovider.JavaVersionUtil;
 import org.graalvm.nativeimage.Platform;
 import org.graalvm.nativeimage.Platforms;
 
@@ -33,14 +32,20 @@ import com.oracle.svm.core.util.VMError;
 public final class VM {
 
     public final String version;
+    public final String vendor;
+    public final String vendorUrl;
+    public final String runtimeName;
 
     @Platforms(Platform.HOSTED_ONLY.class)
     public VM(String config) {
         String versionStr = System.getProperty("org.graalvm.version");
         VMError.guarantee(versionStr != null);
         versionStr = "GraalVM " + versionStr;
-        versionStr += " Java " + JavaVersionUtil.JAVA_SPEC;
+        versionStr += " Java " + Runtime.version().toString();
         versionStr += " " + config;
         version = versionStr;
+        vendor = System.getProperty("org.graalvm.vendor", "Oracle Corporation");
+        vendorUrl = System.getProperty("org.graalvm.vendorurl", "https://www.graalvm.org/");
+        runtimeName = System.getProperty("java.runtime.name", "Unknown Runtime Environment");
     }
 }

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/SystemPropertiesSupport.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/SystemPropertiesSupport.java
@@ -103,10 +103,12 @@ public abstract class SystemPropertiesSupport {
         }
 
         initializeProperty("java.vm.name", "Substrate VM");
-        initializeProperty("java.vm.vendor", "Oracle Corporation");
+        initializeProperty("java.runtime.name", ImageSingletons.lookup(VM.class).runtimeName);
+        initializeProperty("java.vm.vendor", ImageSingletons.lookup(VM.class).vendor);
         initializeProperty("java.vm.version", ImageSingletons.lookup(VM.class).version);
-        initializeProperty("java.vendor", "Oracle Corporation");
-        initializeProperty("java.vendor.url", "https://www.graalvm.org/");
+        initializeProperty("java.runtime.version", ImageSingletons.lookup(VM.class).version);
+        initializeProperty("java.vendor", ImageSingletons.lookup(VM.class).vendor);
+        initializeProperty("java.vendor.url", ImageSingletons.lookup(VM.class).vendorUrl);
 
         initializeProperty("java.class.path", "");
         initializeProperty("java.endorsed.dirs", "");

--- a/substratevm/src/com.oracle.svm.driver/src/com/oracle/svm/driver/NativeImage.java
+++ b/substratevm/src/com.oracle.svm.driver/src/com/oracle/svm/driver/NativeImage.java
@@ -109,6 +109,8 @@ public class NativeImage {
 
     static final String graalvmVersion = System.getProperty("org.graalvm.version", "dev");
     static final String graalvmConfig = System.getProperty("org.graalvm.config", "CE");
+    static final String graalvmVendor = System.getProperty("org.graalvm.vendor", "Oracle Corporation");
+    static final String graalvmVendorUrl = System.getProperty("org.graalvm.vendorurl", "https://www.graalvm.org/");
 
     private static Map<String, String[]> getCompilerFlags() {
         Map<String, String[]> result = new HashMap<>();
@@ -785,6 +787,8 @@ public class NativeImage {
         /* Prevent JVM that runs the image builder to steal focus */
         addImageBuilderJavaArgs("-Djava.awt.headless=true");
         addImageBuilderJavaArgs("-Dorg.graalvm.version=" + graalvmVersion);
+        addImageBuilderJavaArgs("-Dorg.graalvm.vendor=" + graalvmVendor);
+        addImageBuilderJavaArgs("-Dorg.graalvm.vendorurl=" + graalvmVendorUrl);
         if (!NativeImage.IS_AOT) {
             addImageBuilderJavaArgs("-Dorg.graalvm.config=" + graalvmConfig);
         }


### PR DESCRIPTION
Certain monitoring tools that rely on sys props, e.g. [Micrometer](https://github.com/micrometer-metrics/micrometer/blob/main/micrometer-core/src/main/java/io/micrometer/core/instrument/binder/jvm/JvmInfoMetrics.java), might report unpopulated fields when operating with native-image built apps, e.g.

[Quarkus Micrometer Quickstart](https://github.com/quarkusio/quarkus-quickstarts/tree/main/micrometer-quickstart) reports in native mode:

```
jvm_info_total{runtime="unknown",vendor="Oracle Corporation",version="unknown",} 1.0
```

while it works correctly in HotSpot, JVM mode:

```
jvm_info_total{runtime="OpenJDK Runtime Environment",vendor="Eclipse Adoptium",version="17.0.5+8",} 1.0
```

With this patch, we have both more meaningful values and a way to affect them if needed (e.g. vendor url etc.).

See with this patch:

```
jvm_info_total{runtime="Substrate VM",vendor="Oracle Corporation",version="GraalVM 23.0.0-dev71c7f0d86e29 Java 17 Mandrel Distribution",} 1.0
```
**EDIT:**
~(`version` field not showing the whole JDK version used is a bug in Mandrel build script, unrelated to this PR)~

Well, it seems reporting just the feature version was intentional. I'd like to change that, I think this makes more sense (added in a separate commit 96963cb01):

```
jvm_info_total{runtime="Substrate VM",vendor="Oracle Corporation",version="GraalVM 23.0.0-dev422cfafa4fd6 Java 17.0.4+8 Mandrel Distribution",} 1.0
```