### PR TITLE
Refactor standalone tests

### DIFF
--- a/substratevm/src/com.oracle.graal.pointsto.standalone.test/src/com/oracle/graal/pointsto/standalone/test/ClassEqualityCase.java
+++ b/substratevm/src/com.oracle.graal.pointsto.standalone.test/src/com/oracle/graal/pointsto/standalone/test/ClassEqualityCase.java
@@ -26,30 +26,19 @@
 
 package com.oracle.graal.pointsto.standalone.test;
 
-import org.junit.Test;
-
-public class StandaloneAnalyzerReachabilityTest {
-
-    @Test
-    public void testPointstoAnalyzer() throws NoSuchFieldException {
-        PointstoAnalyzerTester tester = new PointstoAnalyzerTester(StandaloneAnalyzerReachabilityCase.class);
-        tester.setAnalysisArguments(tester.getTestClassName(),
-                        "-H:AnalysisTargetAppCP=" + tester.getTestClassJar());
-        Class<StandaloneAnalyzerReachabilityCase.C> classC = StandaloneAnalyzerReachabilityCase.C.class;
-        Class<StandaloneAnalyzerReachabilityCase.D> classD = StandaloneAnalyzerReachabilityCase.D.class;
-        tester.setExpectedReachableTypes(classC, StandaloneAnalyzerReachabilityCase.C1.class, StandaloneAnalyzerReachabilityCase.C2.class);
-        tester.setExpectedUnreachableTypes(classD);
-        tester.setExpectedReachableFields(classC.getDeclaredField("val"));
-        tester.setExpectedUnreachableFields(classD.getDeclaredField("val"));
-        tester.runAnalysisAndAssert();
+public class ClassEqualityCase {
+    static class C {
+        public static void foo() {
+        }
     }
 
-    @Test
-    public void testMultipleAnalysis() throws NoSuchFieldException {
-        int times = 5;
-        int i = 0;
-        while (i++ < times) {
-            testPointstoAnalyzer();
+    public static void main(String[] args) {
+        equals(C.class);
+    }
+
+    private static void equals(Class<?> clazz) {
+        if (clazz == C.class) {
+            C.foo();
         }
     }
 }

--- a/substratevm/src/com.oracle.graal.pointsto.standalone.test/src/com/oracle/graal/pointsto/standalone/test/ClassEqualityTest.java
+++ b/substratevm/src/com.oracle.graal.pointsto.standalone.test/src/com/oracle/graal/pointsto/standalone/test/ClassEqualityTest.java
@@ -29,28 +29,14 @@ package com.oracle.graal.pointsto.standalone.test;
 import org.junit.Test;
 
 public class ClassEqualityTest {
-    static class C {
-        public static void foo() {
-        }
-    }
-
-    public static void main(String[] args) {
-        equals(C.class);
-    }
-
-    private static void equals(Class<?> clazz) {
-        if (clazz == C.class) {
-            C.foo();
-        }
-    }
 
     @Test
-    public void test() {
-        PointstoAnalyzerTester tester = new PointstoAnalyzerTester(this.getClass());
+    public void test() throws NoSuchMethodException {
+        PointstoAnalyzerTester tester = new PointstoAnalyzerTester(ClassEqualityCase.class);
         tester.setAnalysisArguments(tester.getTestClassName(),
                         "-H:AnalysisTargetAppCP=" + tester.getTestClassJar());
 
-        tester.setExpectedReachableMethods(C.class.getName() + ".foo()");
+        tester.setExpectedReachableMethods(ClassEqualityCase.C.class.getDeclaredMethod("foo"));
         tester.runAnalysisAndAssert();
     }
 }

--- a/substratevm/src/com.oracle.graal.pointsto.standalone.test/src/com/oracle/graal/pointsto/standalone/test/ConstantFieldTest.java
+++ b/substratevm/src/com.oracle.graal.pointsto.standalone.test/src/com/oracle/graal/pointsto/standalone/test/ConstantFieldTest.java
@@ -40,13 +40,13 @@ import org.junit.Test;
 public class ConstantFieldTest {
 
     @Test
-    public void testConstantField() {
+    public void testConstantField() throws NoSuchMethodException, NoSuchFieldException {
         PointstoAnalyzerTester tester = new PointstoAnalyzerTester(ConstantFieldCase.class);
         tester.setAnalysisArguments(tester.getTestClassName(),
                         "-H:AnalysisTargetAppCP=" + tester.getTestClassJar());
-        tester.setExpectedReachableMethods(ConstantFieldCase.ConstantType.class.getName() + ".foo()",
-                        ConstantFieldCase.class.getName() + ".<clinit>()");
-        tester.setExpectedReachableFields(ConstantFieldCase.class.getName() + ".constantField");
+        tester.setExpectedReachableMethods(ConstantFieldCase.ConstantType.class.getDeclaredMethod("foo"));
+        tester.setExpectedReachableClinits(ConstantFieldCase.class);
+        tester.setExpectedReachableFields(ConstantFieldCase.class.getDeclaredField("constantField"));
         tester.runAnalysisAndAssert();
     }
 }

--- a/substratevm/src/com.oracle.graal.pointsto.standalone.test/src/com/oracle/graal/pointsto/standalone/test/PointstoAnalyzerTester.java
+++ b/substratevm/src/com.oracle.graal.pointsto.standalone.test/src/com/oracle/graal/pointsto/standalone/test/PointstoAnalyzerTester.java
@@ -27,44 +27,74 @@
 package com.oracle.graal.pointsto.standalone.test;
 
 import com.oracle.graal.pointsto.constraints.UnsupportedFeatureException;
+import com.oracle.graal.pointsto.meta.AnalysisElement;
+import com.oracle.graal.pointsto.meta.AnalysisType;
 import com.oracle.graal.pointsto.meta.AnalysisUniverse;
 import com.oracle.graal.pointsto.standalone.PointsToAnalyzer;
+import com.oracle.graal.pointsto.util.AnalysisError;
+import jdk.vm.ci.meta.MetaAccessProvider;
+import jdk.vm.ci.meta.ResolvedJavaField;
+import jdk.vm.ci.meta.ResolvedJavaMethod;
+import jdk.vm.ci.meta.ResolvedJavaType;
+import org.graalvm.nativeimage.hosted.Feature;
 
 import java.io.ByteArrayOutputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.lang.reflect.Executable;
+import java.lang.reflect.Field;
 import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.SimpleFileVisitor;
 import java.nio.file.attribute.BasicFileAttributes;
-import java.util.Collection;
+import java.util.Arrays;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 import java.util.function.Function;
-import java.util.function.Predicate;
+import java.util.stream.Collectors;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 public class PointstoAnalyzerTester {
-    private Set<String> expectedReachableMethods = new HashSet<>();
-    private Set<String> expectedReachableTypes = new HashSet<>();
-    private Set<String> expectedReachableFields = new HashSet<>();
-    private Set<String> expectedUnreachableMethods = new HashSet<>();
-    private Set<String> expectedUnreachableTypes = new HashSet<>();
-    private Set<String> expectedUnreachableFields = new HashSet<>();
+    private Set<Executable> expectedReachableMethods = new HashSet<>();
+    private Set<Class<?>> expectedReachableTypes = new HashSet<>();
+    private Set<Field> expectedReachableFields = new HashSet<>();
+    private Set<Executable> expectedUnreachableMethods = new HashSet<>();
+    private Set<Class<?>> expectedUnreachableTypes = new HashSet<>();
+    private Set<Field> expectedUnreachableFields = new HashSet<>();
+    private Set<Class<?>> expectedReachableClinits = new HashSet<>();
+    private Set<Class<?>> expectedUnreachableClinits = new HashSet<>();
     private String[] arguments;
     private Path tmpDir;
     private String testClassName;
     private String testClassJar;
+    private Class<?> testClass;
 
     public PointstoAnalyzerTester(Class<?> testClass) {
+        this.testClass = testClass;
         testClassJar = testClass.getProtectionDomain().getCodeSource().getLocation().getPath();
         testClassName = testClass.getName();
+    }
+
+    public PointstoAnalyzerTester(String testClassName) {
+        try {
+            testClass = Class.forName(testClassName);
+            testClassJar = testClass.getProtectionDomain().getCodeSource().getLocation().getPath();
+            this.testClassName = testClassName;
+        } catch (ClassNotFoundException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public Class<?> getTestClass() {
+        return testClass;
     }
 
     public String getTestClassName() {
@@ -79,49 +109,49 @@ public class PointstoAnalyzerTester {
         this.arguments = arguments;
     }
 
-    public void setExpectedReachableMethods(String... methodNames) {
-        expectedReachableMethods = new HashSet<>();
-        for (String methodName : methodNames) {
-            expectedReachableMethods.add(methodName);
-        }
+    public void setExpectedReachableMethods(Executable... methods) {
+        expectedReachableMethods.addAll(Arrays.asList(methods));
     }
 
-    public void setExpectedUnreachableMethods(String... methodNames) {
-        expectedUnreachableMethods = new HashSet<>();
-        for (String methodName : methodNames) {
-            expectedUnreachableMethods.add(methodName);
-        }
+    public void setExpectedUnreachableMethods(Executable... methods) {
+        expectedUnreachableMethods.addAll(Arrays.asList(methods));
     }
 
-    public void setExpectedReachableTypes(String... typeNames) {
-        expectedReachableTypes = new HashSet<>();
-        for (String typeName : typeNames) {
-            expectedReachableTypes.add(typeName);
-        }
+    public void setExpectedReachableTypes(Class<?>... types) {
+        expectedReachableTypes.addAll(Arrays.asList(types));
     }
 
-    public void setExpectedUnreachableTypes(String... typeNames) {
-        expectedUnreachableTypes = new HashSet<>();
-        for (String typeName : typeNames) {
-            expectedUnreachableTypes.add(typeName);
-        }
+    public void setExpectedUnreachableTypes(Class<?>... types) {
+        expectedUnreachableTypes.addAll(Arrays.asList(types));
     }
 
-    public void setExpectedReachableFields(String... fieldNames) {
-        expectedReachableFields = new HashSet<>();
-        for (String fieldName : fieldNames) {
-            expectedReachableFields.add(fieldName);
-        }
+    public void setExpectedReachableClinits(Class<?>... types) {
+        expectedReachableClinits.addAll(Arrays.asList(types));
     }
 
-    public void setExpectedUnreachableFields(String... fieldNames) {
-        expectedUnreachableFields = new HashSet<>();
-        for (String fieldName : fieldNames) {
-            expectedUnreachableFields.add(fieldName);
-        }
+    public void setExpectedUnreachableClinits(Class<?>... types) {
+        expectedUnreachableClinits.addAll(Arrays.asList(types));
+    }
+
+    public void setExpectedReachableFields(Field... fields) {
+        expectedReachableFields.addAll(Arrays.asList(fields));
+    }
+
+    public void setExpectedUnreachableFields(Field... fields) {
+        expectedUnreachableFields.addAll(Arrays.asList(fields));
     }
 
     public void runAnalysisAndAssert() {
+        runAnalysisAndAssert(true);
+    }
+
+    /**
+     * Run the analysis and check the results.
+     *
+     * @param expectPass true if the analysis is expected to be successfully finished, false if the
+     *            analysis is supposed to fail.
+     */
+    public void runAnalysisAndAssert(boolean expectPass) {
         PointsToAnalyzer pointstoAnalyzer = PointsToAnalyzer.createAnalyzer(arguments);
         UnsupportedFeatureException unsupportedFeatureException = null;
         try {
@@ -131,13 +161,50 @@ public class PointstoAnalyzerTester {
             } catch (UnsupportedFeatureException e) {
                 unsupportedFeatureException = e;
             }
-            AnalysisUniverse universe = pointstoAnalyzer.getResultUniverse();
+            ClassLoader analysisClassLoader = pointstoAnalyzer.getClassLoader();
+            if (!expectPass) {
+                return;
+            }
+            final AnalysisUniverse universe = pointstoAnalyzer.getResultUniverse();
+            final MetaAccessProvider originalMetaAccess = universe.getOriginalMetaAccess();
             assertNotNull(universe);
 
-            elementsIteration("Method", expectedReachableMethods, expectedUnreachableMethods, universe.getMethods(), m -> m.getQualifiedName(), m -> m.getImplementations().length >= 1);
-            elementsIteration("Type", expectedReachableTypes, expectedUnreachableTypes, universe.getTypes(), t -> t.getJavaClass().getName(), t -> t.isReachable());
-            elementsIteration("Field", expectedReachableFields, expectedUnreachableFields, universe.getFields(), f -> f.getDeclaringClass().getJavaClass().getName() + "." + f.getName(),
-                            f -> f.isAccessed() || f.isRead() || f.isWritten());
+            assertReachable("Method", expectedReachableMethods, expectedUnreachableMethods, reflectionMethod -> {
+                try {
+                    Executable actualMethod = reflectionMethod;
+                    Class<?> declaringClass = reflectionMethod.getDeclaringClass();
+                    if (!analysisClassLoader.equals(declaringClass.getClassLoader())) {
+                        Class<?> c = Class.forName(declaringClass.getName(), false, analysisClassLoader);
+                        actualMethod = c.getDeclaredMethod(reflectionMethod.getName(), reflectionMethod.getParameterTypes());
+                    }
+                    ResolvedJavaMethod m = universe.getOriginalMetaAccess().lookupJavaMethod(actualMethod);
+                    return universe.getMethod(m);
+                } catch (ReflectiveOperationException e) {
+                    throw AnalysisError.shouldNotReachHere(e);
+                }
+            },
+                            reflectionMethod -> reflectionMethod.getDeclaringClass().getName() + "." + reflectionMethod.getName());
+            assertReachable("<clinit>", expectedReachableClinits, expectedUnreachableClinits, clazz -> {
+                AnalysisType t = classToAnalysisType(analysisClassLoader, universe, originalMetaAccess, clazz);
+                return t.getClassInitializer();
+            }, clazz -> clazz.getName() + ".<clinit>");
+            assertReachable("Type", expectedReachableTypes, expectedUnreachableTypes, clazz -> classToAnalysisType(analysisClassLoader, universe, originalMetaAccess, clazz),
+                            clazz -> clazz.getName());
+            assertReachable("Field", expectedReachableFields, expectedUnreachableFields, reflectionField -> {
+                try {
+                    Field actualField = reflectionField;
+                    Class<?> declaringClass = actualField.getDeclaringClass();
+                    if (!analysisClassLoader.equals(declaringClass.getClassLoader())) {
+                        Class<?> c = Class.forName(declaringClass.getName(), false, analysisClassLoader);
+                        actualField = c.getDeclaredField(reflectionField.getName());
+                    }
+                    ResolvedJavaField resolvedJavaField = originalMetaAccess.lookupJavaField(actualField);
+                    return universe.getField(resolvedJavaField);
+                } catch (ReflectiveOperationException e) {
+                    throw AnalysisError.shouldNotReachHere(e);
+                }
+            },
+                            reflectionField -> reflectionField.getDeclaringClass().getName() + "." + reflectionField.getName());
 
             if (unsupportedFeatureException != null) {
                 throw unsupportedFeatureException;
@@ -147,6 +214,39 @@ public class PointstoAnalyzerTester {
                 pointstoAnalyzer.cleanUp();
             }
         }
+    }
+
+    private static AnalysisType classToAnalysisType(ClassLoader analysisClassLoader, AnalysisUniverse universe, MetaAccessProvider originalMetaAccess, Class<?> clazz) {
+        try {
+            Class<?> actualClass = clazz;
+            if (!analysisClassLoader.equals(clazz.getClassLoader())) {
+                actualClass = Class.forName(clazz.getName(), false, analysisClassLoader);
+            }
+            ResolvedJavaType resolvedJavaType = originalMetaAccess.lookupJavaType(actualClass);
+            return universe.optionalLookup(resolvedJavaType);
+        } catch (ReflectiveOperationException e) {
+            throw AnalysisError.shouldNotReachHere(e);
+        }
+    }
+
+    public Object runAnalysisForFeatureResult(Class<? extends Feature> feature) {
+        PointsToAnalyzer pointstoAnalyzer = runAnalysis(true);
+        return pointstoAnalyzer.getResultFromFeature(feature);
+    }
+
+    private PointsToAnalyzer runAnalysis(boolean expectPass) {
+        PointsToAnalyzer pointstoAnalyzer = PointsToAnalyzer.createAnalyzer(arguments);
+        try {
+            int ret = pointstoAnalyzer.run();
+            if (expectPass) {
+                assertEquals("Analysis return code is expected to 0", 0, ret);
+            } else {
+                assertNotEquals("The analysis is expected to fail, but succeeded", 0, ret);
+            }
+        } catch (UnsupportedFeatureException e) {
+            throw e;
+        }
+        return pointstoAnalyzer;
     }
 
     public Path createTestTmpDir() {
@@ -196,25 +296,30 @@ public class PointstoAnalyzerTester {
         });
     }
 
-    private static <T> void elementsIteration(String elementType, Set<String> expectedReachables, Set<String> expectedUnreachables, Collection<T> elements,
-                    Function<T, String> getElementName, Predicate<T> reachablePredicate) {
-        if (expectedReachables != null || expectedUnreachables != null) {
-            for (T element : elements) {
-                String name = getElementName.apply(element);
-                if (expectedReachables != null && expectedReachables.remove(name)) {
-                    assertTrue(elementType + " " + name + " should be reachable.", reachablePredicate.test(element));
-                    continue;
-                }
+    private static <T, R extends AnalysisElement> void assertReachable(String elementType, Set<T> expectedReachables, Set<T> expectedUnreachables,
+                    Function<T, R> getAnalysisElement, Function<T, String> getName) {
+        if (expectedReachables != null && !expectedReachables.isEmpty()) {
+            // Find all the elements that should be reachable but not
+            List<T> shouldReachableButNot = expectedReachables.stream().filter(t -> {
+                R element = getAnalysisElement.apply(t);
+                return !element.isReachable();
+            }).collect(Collectors.toList());
 
-                if (expectedUnreachables != null && expectedUnreachables.remove(name)) {
-                    assertFalse(elementType + " " + name + " should not be reachable.", reachablePredicate.test(element));
-                }
+            if (!shouldReachableButNot.isEmpty()) {
+                StringBuilder sb = new StringBuilder(elementType + " should be reached but not:");
+                shouldReachableButNot.forEach(s -> sb.append(" ").append(getName.apply(s)).append("\n"));
+                fail(sb.toString());
             }
         }
-        if (expectedReachables != null && !expectedReachables.isEmpty()) {
-            StringBuilder sb = new StringBuilder(elementType + " should be reached but not:");
-            expectedReachables.forEach(s -> sb.append(" ").append(s));
-            assertTrue(sb.toString(), expectedReachables.isEmpty());
+
+        if (expectedUnreachables != null && !expectedUnreachables.isEmpty()) {
+            for (T expectedUnreachable : expectedUnreachables) {
+                R element = getAnalysisElement.apply(expectedUnreachable);
+                // element can be null as the unreachable type is not in the universe
+                if (element != null) {
+                    assertFalse(elementType + " " + getName.apply(expectedUnreachable) + " should not be reachable.", element.isReachable());
+                }
+            }
         }
     }
 }

--- a/substratevm/src/com.oracle.graal.pointsto.standalone.test/src/com/oracle/graal/pointsto/standalone/test/StandaloneAnalyzerReachabilityCase.java
+++ b/substratevm/src/com.oracle.graal.pointsto.standalone.test/src/com/oracle/graal/pointsto/standalone/test/StandaloneAnalyzerReachabilityCase.java
@@ -26,30 +26,52 @@
 
 package com.oracle.graal.pointsto.standalone.test;
 
-import org.junit.Test;
-
-public class StandaloneAnalyzerReachabilityTest {
-
-    @Test
-    public void testPointstoAnalyzer() throws NoSuchFieldException {
-        PointstoAnalyzerTester tester = new PointstoAnalyzerTester(StandaloneAnalyzerReachabilityCase.class);
-        tester.setAnalysisArguments(tester.getTestClassName(),
-                        "-H:AnalysisTargetAppCP=" + tester.getTestClassJar());
-        Class<StandaloneAnalyzerReachabilityCase.C> classC = StandaloneAnalyzerReachabilityCase.C.class;
-        Class<StandaloneAnalyzerReachabilityCase.D> classD = StandaloneAnalyzerReachabilityCase.D.class;
-        tester.setExpectedReachableTypes(classC, StandaloneAnalyzerReachabilityCase.C1.class, StandaloneAnalyzerReachabilityCase.C2.class);
-        tester.setExpectedUnreachableTypes(classD);
-        tester.setExpectedReachableFields(classC.getDeclaredField("val"));
-        tester.setExpectedUnreachableFields(classD.getDeclaredField("val"));
-        tester.runAnalysisAndAssert();
+public class StandaloneAnalyzerReachabilityCase {
+    public static void main(String[] args) {
+        Object c;
+        if (args.length > 0) {
+            c = new C1("C1");
+        } else {
+            c = new C2("C2");
+        }
+        c.toString();
     }
 
-    @Test
-    public void testMultipleAnalysis() throws NoSuchFieldException {
-        int times = 5;
-        int i = 0;
-        while (i++ < times) {
-            testPointstoAnalyzer();
+    public abstract static class C {
+        protected String val;
+
+        @Override
+        public abstract String toString();
+    }
+
+    public static class C1 extends C {
+        public C1(String v) {
+            val = v;
+        }
+
+        @Override
+        public String toString() {
+            return val;
+        }
+    }
+
+    public static class C2 extends C {
+        public C2(String v) {
+            val = v;
+        }
+
+        @Override
+        public String toString() {
+            return val;
+        }
+    }
+
+    public static class D {
+        @SuppressWarnings("unused") private String val;
+
+        @Override
+        public String toString() {
+            return val = "D";
         }
     }
 }

--- a/substratevm/src/com.oracle.graal.pointsto.standalone/src/com/oracle/graal/pointsto/standalone/PointsToAnalyzer.java
+++ b/substratevm/src/com.oracle.graal.pointsto.standalone/src/com/oracle/graal/pointsto/standalone/PointsToAnalyzer.java
@@ -308,4 +308,8 @@ public final class PointsToAnalyzer {
         System.err.print("Exception:");
         e.printStackTrace();
     }
+
+    public ClassLoader getClassLoader() {
+        return analysisClassLoader;
+    }
 }

--- a/substratevm/src/com.oracle.graal.pointsto.standalone/src/com/oracle/graal/pointsto/standalone/heap/StandaloneImageHeapScanner.java
+++ b/substratevm/src/com.oracle.graal.pointsto.standalone/src/com/oracle/graal/pointsto/standalone/heap/StandaloneImageHeapScanner.java
@@ -62,7 +62,7 @@ public class StandaloneImageHeapScanner extends ImageHeapScanner {
     @Override
     protected ValueSupplier<JavaConstant> readHostedFieldValue(AnalysisField field, JavaConstant receiver) {
         ValueSupplier<JavaConstant> ret = super.readHostedFieldValue(field, receiver);
-        if (ret.get() == null) {
+        if (ret.get() == null && field.isStatic()) {
             JavaConstant constant = UninitializedStaticFieldValueReader.readUninitializedStaticValue(field, value -> universe.getSnippetReflection().forObject(value));
             return ValueSupplier.eagerValue(constant);
         } else {

--- a/substratevm/src/com.oracle.graal.pointsto/src/com/oracle/graal/pointsto/meta/AnalysisUniverse.java
+++ b/substratevm/src/com.oracle.graal.pointsto/src/com/oracle/graal/pointsto/meta/AnalysisUniverse.java
@@ -539,8 +539,16 @@ public class AnalysisUniverse implements Universe {
         return fields.values();
     }
 
+    public AnalysisField getField(ResolvedJavaField resolvedJavaField) {
+        return fields.get(resolvedJavaField);
+    }
+
     public Collection<AnalysisMethod> getMethods() {
         return methods.values();
+    }
+
+    public AnalysisMethod getMethod(ResolvedJavaMethod resolvedJavaMethod) {
+        return methods.get(resolvedJavaMethod);
     }
 
     public Map<JavaConstant, BytecodePosition> getEmbeddedRoots() {


### PR DESCRIPTION
1.Directly look up fields, methods and types from universe instead of walking through to search when checking the reachability of the given items. It will improve the testing performance.
2.Accept Field, Method and Class type at setting expected (un)reachable time.

This PR is part of https://github.com/oracle/graal/pull/4375.