### PR TITLE
Fix typo in toc_group

### DIFF
--- a/truffle/docs/LanguageTutorial.md
+++ b/truffle/docs/LanguageTutorial.md
@@ -1,6 +1,6 @@
 ---
 layout: docs
-toc_group: truffles
+toc_group: truffle
 link_title: Implementing a New Language with Truffle
 permalink: /graalvm-as-a-platform/language-implementation-framework/LanguageTutorial/
 ---


### PR DESCRIPTION
There is a typo in toc_group. It have to be `truffle`, not the `truffles`.
This causes the sidebar toc to disappear. Fixed it.

![image](https://user-images.githubusercontent.com/10591327/200354969-e782b7f1-145b-47f3-9f3c-d628a2349167.png)
