### PR TITLE
[GR-42531] Debug info memory footprint improvements

### DIFF
--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/ClassEntry.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/ClassEntry.java
@@ -28,13 +28,12 @@ package com.oracle.objectfile.debugentry;
 
 import java.nio.file.Path;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.stream.Stream;
 
 import jdk.vm.ci.meta.ResolvedJavaMethod;
 import jdk.vm.ci.meta.ResolvedJavaType;
+import org.graalvm.collections.EconomicMap;
 import org.graalvm.compiler.debug.DebugContext;
 
 import com.oracle.objectfile.debuginfo.DebugInfoProvider.DebugFieldInfo;
@@ -74,7 +73,7 @@ public class ClassEntry extends StructureTypeEntry {
      * An index of all currently known methods keyed by the unique, associated, identifying
      * ResolvedJavaMethod.
      */
-    private Map<ResolvedJavaMethod, MethodEntry> methodsIndex;
+    private EconomicMap<ResolvedJavaMethod, MethodEntry> methodsIndex;
     /**
      * A list recording details of all normal compiled methods included in this class sorted by
      * ascending address range. Note that the associated address ranges are disjoint and contiguous.
@@ -90,11 +89,11 @@ public class ClassEntry extends StructureTypeEntry {
      * An index identifying ranges for compiled method which have already been encountered, whether
      * normal or deopt fallback methods.
      */
-    private Map<Range, CompiledMethodEntry> compiledMethodIndex;
+    private EconomicMap<Range, CompiledMethodEntry> compiledMethodIndex;
     /**
      * An index of all primary and secondary files referenced from this class's compilation unit.
      */
-    private Map<FileEntry, Integer> localFilesIndex;
+    private EconomicMap<FileEntry, Integer> localFilesIndex;
     /**
      * A list of the same files.
      */
@@ -102,7 +101,7 @@ public class ClassEntry extends StructureTypeEntry {
     /**
      * An index of all primary and secondary dirs referenced from this class's compilation unit.
      */
-    private HashMap<DirEntry, Integer> localDirsIndex;
+    private EconomicMap<DirEntry, Integer> localDirsIndex;
     /**
      * A list of the same dirs.
      */
@@ -114,15 +113,15 @@ public class ClassEntry extends StructureTypeEntry {
         this.fileEntry = fileEntry;
         this.loader = null;
         this.methods = new ArrayList<>();
-        this.methodsIndex = new HashMap<>();
+        this.methodsIndex = EconomicMap.create();
         this.normalCompiledEntries = new ArrayList<>();
         // deopt methods list is created on demand
         this.deoptCompiledEntries = null;
-        this.compiledMethodIndex = new HashMap<>();
+        this.compiledMethodIndex = EconomicMap.create();
         this.localFiles = new ArrayList<>();
-        this.localFilesIndex = new HashMap<>();
+        this.localFilesIndex = EconomicMap.create();
         this.localDirs = new ArrayList<>();
-        this.localDirsIndex = new HashMap<>();
+        this.localDirsIndex = EconomicMap.create();
         if (fileEntry != null) {
             localFiles.add(fileEntry);
             localFilesIndex.put(fileEntry, localFiles.size());

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/DebugInfoBase.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/DebugInfoBase.java
@@ -36,6 +36,7 @@ import java.util.Map;
 
 import com.oracle.objectfile.debuginfo.DebugInfoProvider.DebugFileInfo;
 import jdk.vm.ci.meta.ResolvedJavaType;
+import org.graalvm.collections.EconomicMap;
 import org.graalvm.compiler.debug.DebugContext;
 
 import com.oracle.objectfile.debuginfo.DebugInfoProvider;
@@ -108,7 +109,7 @@ public abstract class DebugInfoBase {
      * Index of all dirs in which files are found to reside either as part of substrate/compiler or
      * user code.
      */
-    private Map<Path, DirEntry> dirsIndex = new HashMap<>();
+    private EconomicMap<Path, DirEntry> dirsIndex = EconomicMap.create();
 
     /**
      * List of all types present in the native image including instance classes, array classes,
@@ -128,7 +129,11 @@ public abstract class DebugInfoBase {
     /**
      * Index of already seen classes.
      */
-    private Map<ResolvedJavaType, ClassEntry> instanceClassesIndex = new HashMap<>();
+    private EconomicMap<ResolvedJavaType, ClassEntry> instanceClassesIndex = EconomicMap.create();
+    /**
+     * Handle on type entry for header structure.
+     */
+    private HeaderTypeEntry headerType;
     /**
      * Handle on class entry for java.lang.Object.
      */
@@ -140,7 +145,7 @@ public abstract class DebugInfoBase {
     /**
      * Index of files which contain primary or secondary ranges keyed by path.
      */
-    private Map<Path, FileEntry> filesIndex = new HashMap<>();
+    private EconomicMap<Path, FileEntry> filesIndex = EconomicMap.create();
 
     /**
      * List of all loaders associated with classes included in the image.
@@ -150,7 +155,7 @@ public abstract class DebugInfoBase {
     /**
      * Index of all loaders associated with classes included in the image.
      */
-    private Map<String, LoaderEntry> loaderIndex = new HashMap<>();
+    private EconomicMap<String, LoaderEntry> loaderIndex = EconomicMap.create();
 
     /**
      * Flag set to true if heap references are stored as addresses relative to a heap base register
@@ -270,7 +275,7 @@ public abstract class DebugInfoBase {
             DebugTypeKind typeKind = debugTypeInfo.typeKind();
 
             debugContext.log(DebugContext.INFO_LEVEL, "Process %s type %s ", typeKind.toString(), typeName);
-            TypeEntry typeEntry = lookupTypeEntry(idType);
+            TypeEntry typeEntry = (idType != null ? lookupTypeEntry(idType) : lookupHeaderType());
             typeEntry.addDebugInfo(this, debugTypeInfo, debugContext);
         }));
 
@@ -296,7 +301,7 @@ public abstract class DebugInfoBase {
              * Record all subranges even if they have no line or file so we at least get a symbol
              * for them and don't see a break in the address range.
              */
-            HashMap<DebugLocationInfo, Range> subRangeIndex = new HashMap<>();
+            EconomicMap<DebugLocationInfo, Range> subRangeIndex = EconomicMap.create();
             debugCodeInfo.locationInfoProvider().forEach(debugLocationInfo -> addSubrange(debugLocationInfo, primaryRange, classEntry, subRangeIndex, debugContext));
         }));
 
@@ -349,11 +354,17 @@ public abstract class DebugInfoBase {
     }
 
     private TypeEntry addTypeEntry(ResolvedJavaType idType, String typeName, String fileName, Path filePath, Path cachePath, int size, DebugTypeKind typeKind) {
-        TypeEntry typeEntry = typesIndex.get(idType);
+        TypeEntry typeEntry = (idType != null ? typesIndex.get(idType) : null);
         if (typeEntry == null) {
             typeEntry = createTypeEntry(typeName, fileName, filePath, cachePath, size, typeKind);
             types.add(typeEntry);
-            typesIndex.put(idType, typeEntry);
+            if (idType != null) {
+                typesIndex.put(idType, typeEntry);
+            }
+            // track object type and header struct
+            if (idType == null) {
+                headerType = (HeaderTypeEntry) typeEntry;
+            }
             if (typeName.equals("java.lang.Object")) {
                 objectClass = (ClassEntry) typeEntry;
             }
@@ -389,6 +400,12 @@ public abstract class DebugInfoBase {
         return classEntry;
     }
 
+    public HeaderTypeEntry lookupHeaderType() {
+        // this should only be looked up after all types have been notified
+        assert headerType != null;
+        return headerType;
+    }
+
     public ClassEntry lookupObjectClass() {
         // this should only be looked up after all types have been notified
         assert objectClass != null;
@@ -407,7 +424,7 @@ public abstract class DebugInfoBase {
      *         primaryRange
      */
     @SuppressWarnings("try")
-    private Range addSubrange(DebugLocationInfo locationInfo, Range primaryRange, ClassEntry classEntry, HashMap<DebugLocationInfo, Range> subRangeIndex, DebugContext debugContext) {
+    private Range addSubrange(DebugLocationInfo locationInfo, Range primaryRange, ClassEntry classEntry, EconomicMap<DebugLocationInfo, Range> subRangeIndex, DebugContext debugContext) {
         /*
          * We still insert subranges for the primary method but they don't actually count as inline.
          * we only need a range so that subranges for inline code can refer to the top level line

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/Range.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/Range.java
@@ -70,7 +70,6 @@ public class Range {
     private static final String CLASS_DELIMITER = ".";
     private final MethodEntry methodEntry;
     private final String fullMethodName;
-    private final String fullMethodNameWithParams;
     private final int lo;
     private int hi;
     private final int line;
@@ -153,7 +152,6 @@ public class Range {
         }
         this.methodEntry = methodEntry;
         this.fullMethodName = isTopLevel ? stringTable.uniqueDebugString(constructClassAndMethodName()) : stringTable.uniqueString(constructClassAndMethodName());
-        this.fullMethodNameWithParams = constructClassAndMethodNameWithParams();
         this.lo = lo;
         this.hi = hi;
         this.line = line;
@@ -227,7 +225,7 @@ public class Range {
     }
 
     public String getFullMethodNameWithParams() {
-        return fullMethodNameWithParams;
+        return constructClassAndMethodNameWithParams();
     }
 
     public boolean isDeoptTarget() {

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/Range.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/Range.java
@@ -67,7 +67,7 @@ import java.util.List;
  * represented by the parent call range at level N.
  */
 public class Range {
-    private final static DebugLocalInfo[] EMPTY_LOCAL_INFOS = new DebugLocalInfo[0];
+    private static final DebugLocalInfo[] EMPTY_LOCAL_INFOS = new DebugLocalInfo[0];
     private static final String CLASS_DELIMITER = ".";
     private final MethodEntry methodEntry;
     private final String fullMethodName;

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/Range.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/Range.java
@@ -67,6 +67,7 @@ import java.util.List;
  * represented by the parent call range at level N.
  */
 public class Range {
+    private final static DebugLocalInfo[] EMPTY_LOCAL_INFOS = new DebugLocalInfo[0];
     private static final String CLASS_DELIMITER = ".";
     private final MethodEntry methodEntry;
     private final String fullMethodName;
@@ -330,7 +331,7 @@ public class Range {
     public void setLocalValueInfo(DebugLocalValueInfo[] localValueInfos) {
         int len = localValueInfos.length;
         this.localValueInfos = localValueInfos;
-        this.localInfos = new DebugLocalInfo[len];
+        this.localInfos = (len > 0 ? new DebugLocalInfo[len] : EMPTY_LOCAL_INFOS);
         // set up mapping from local values to local variables
         for (int i = 0; i < len; i++) {
             localInfos[i] = methodEntry.recordLocal(localValueInfos[i]);

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfDebugInfo.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfDebugInfo.java
@@ -27,7 +27,6 @@
 package com.oracle.objectfile.elf.dwarf;
 
 import java.nio.ByteOrder;
-import java.util.HashMap;
 
 import com.oracle.objectfile.debugentry.ClassEntry;
 import com.oracle.objectfile.debugentry.DebugInfoBase;
@@ -38,6 +37,7 @@ import com.oracle.objectfile.debugentry.StructureTypeEntry;
 import com.oracle.objectfile.debugentry.TypeEntry;
 import com.oracle.objectfile.debuginfo.DebugInfoProvider.DebugLocalInfo;
 import com.oracle.objectfile.elf.ELFMachine;
+import org.graalvm.collections.EconomicMap;
 
 /**
  * A class that models the debug info in an organization that facilitates generation of the required
@@ -334,12 +334,12 @@ public class DwarfDebugInfo extends DebugInfoBase {
      * n.b. this collection includes entries for the structure types used to define the object and
      * array headers which do not have an associated TypeEntry.
      */
-    private HashMap<TypeEntry, DwarfTypeProperties> typePropertiesIndex;
+    private EconomicMap<TypeEntry, DwarfTypeProperties> typePropertiesIndex;
 
     /**
      * A collection of method properties associated with each generated method record.
      */
-    private HashMap<MethodEntry, DwarfMethodProperties> methodPropertiesIndex;
+    private EconomicMap<MethodEntry, DwarfMethodProperties> methodPropertiesIndex;
 
     /**
      * A collection of local variable properties associated with a generated method record,
@@ -347,12 +347,12 @@ public class DwarfDebugInfo extends DebugInfoBase {
      * range).
      */
 
-    private HashMap<MethodEntry, DwarfLocalProperties> methodLocalPropertiesIndex;
+    private EconomicMap<MethodEntry, DwarfLocalProperties> methodLocalPropertiesIndex;
 
     /**
      * A collection of local variable properties associated with an inlined subrange.
      */
-    private HashMap<Range, DwarfLocalProperties> rangeLocalPropertiesIndex;
+    private EconomicMap<Range, DwarfLocalProperties> rangeLocalPropertiesIndex;
 
     public DwarfDebugInfo(ELFMachine elfMachine, ByteOrder byteOrder) {
         super(byteOrder);
@@ -373,10 +373,10 @@ public class DwarfDebugInfo extends DebugInfoBase {
             this.heapbaseRegister = rheapbase_x86;
             this.threadRegister = rthread_x86;
         }
-        typePropertiesIndex = new HashMap<>();
-        methodPropertiesIndex = new HashMap<>();
-        methodLocalPropertiesIndex = new HashMap<>();
-        rangeLocalPropertiesIndex = new HashMap<>();
+        typePropertiesIndex = EconomicMap.create();
+        methodPropertiesIndex = EconomicMap.create();
+        methodLocalPropertiesIndex = EconomicMap.create();
+        rangeLocalPropertiesIndex = EconomicMap.create();
     }
 
     public DwarfStrSectionImpl getStrSectionImpl() {
@@ -505,16 +505,16 @@ public class DwarfDebugInfo extends DebugInfoBase {
         /**
          * Map from field names to info section index for the field declaration.
          */
-        private HashMap<String, Integer> fieldDeclarationIndex;
+        private EconomicMap<String, Integer> fieldDeclarationIndex;
         /**
          * Map from method entries to associated abstract inline method index.
          */
-        private HashMap<MethodEntry, Integer> abstractInlineMethodIndex;
+        private EconomicMap<MethodEntry, Integer> abstractInlineMethodIndex;
 
         /**
          * Map from method entries to associated method local properties index.
          */
-        private HashMap<MethodEntry, DwarfLocalProperties> methodLocalPropertiesIndex;
+        private EconomicMap<MethodEntry, DwarfLocalProperties> methodLocalPropertiesIndex;
 
         DwarfClassProperties(StructureTypeEntry entry) {
             super(entry);
@@ -769,9 +769,9 @@ public class DwarfDebugInfo extends DebugInfoBase {
         DwarfClassProperties classProperties;
         classProperties = lookupClassProperties(entry);
         assert classProperties.getTypeEntry() == entry;
-        HashMap<String, Integer> fieldDeclarationIndex = classProperties.fieldDeclarationIndex;
+        EconomicMap<String, Integer> fieldDeclarationIndex = classProperties.fieldDeclarationIndex;
         if (fieldDeclarationIndex == null) {
-            classProperties.fieldDeclarationIndex = fieldDeclarationIndex = new HashMap<>();
+            classProperties.fieldDeclarationIndex = fieldDeclarationIndex = EconomicMap.create();
         }
         if (fieldDeclarationIndex.get(fieldName) != null) {
             assert fieldDeclarationIndex.get(fieldName) == pos : entry.getTypeName() + fieldName;
@@ -784,7 +784,7 @@ public class DwarfDebugInfo extends DebugInfoBase {
         DwarfClassProperties classProperties;
         classProperties = lookupClassProperties(entry);
         assert classProperties.getTypeEntry() == entry;
-        HashMap<String, Integer> fieldDeclarationIndex = classProperties.fieldDeclarationIndex;
+        EconomicMap<String, Integer> fieldDeclarationIndex = classProperties.fieldDeclarationIndex;
         assert fieldDeclarationIndex != null : fieldName;
         assert fieldDeclarationIndex.get(fieldName) != null : entry.getTypeName() + fieldName;
         return fieldDeclarationIndex.get(fieldName);
@@ -803,9 +803,9 @@ public class DwarfDebugInfo extends DebugInfoBase {
     public void setAbstractInlineMethodIndex(ClassEntry classEntry, MethodEntry methodEntry, int pos) {
         DwarfClassProperties classProperties = lookupClassProperties(classEntry);
         assert classProperties.getTypeEntry() == classEntry;
-        HashMap<MethodEntry, Integer> abstractInlineMethodIndex = classProperties.abstractInlineMethodIndex;
+        EconomicMap<MethodEntry, Integer> abstractInlineMethodIndex = classProperties.abstractInlineMethodIndex;
         if (abstractInlineMethodIndex == null) {
-            classProperties.abstractInlineMethodIndex = abstractInlineMethodIndex = new HashMap<>();
+            classProperties.abstractInlineMethodIndex = abstractInlineMethodIndex = EconomicMap.create();
         }
         if (abstractInlineMethodIndex.get(methodEntry) != null) {
             assert abstractInlineMethodIndex.get(methodEntry) == pos : classEntry.getTypeName() + " & " + methodEntry.getSymbolName();
@@ -817,7 +817,7 @@ public class DwarfDebugInfo extends DebugInfoBase {
     public int getAbstractInlineMethodIndex(ClassEntry classEntry, MethodEntry methodEntry) {
         DwarfClassProperties classProperties = lookupClassProperties(classEntry);
         assert classProperties.getTypeEntry() == classEntry;
-        HashMap<MethodEntry, Integer> abstractInlineMethodIndex = classProperties.abstractInlineMethodIndex;
+        EconomicMap<MethodEntry, Integer> abstractInlineMethodIndex = classProperties.abstractInlineMethodIndex;
         assert abstractInlineMethodIndex != null : classEntry.getTypeName() + " & " + methodEntry.getSymbolName();
         assert abstractInlineMethodIndex.get(methodEntry) != null : classEntry.getTypeName() + " & " + methodEntry.getSymbolName();
         return abstractInlineMethodIndex.get(methodEntry);
@@ -829,10 +829,10 @@ public class DwarfDebugInfo extends DebugInfoBase {
      */
 
     static final class DwarfLocalProperties {
-        private HashMap<DebugLocalInfo, Integer> locals;
+        private EconomicMap<DebugLocalInfo, Integer> locals;
 
         private DwarfLocalProperties() {
-            locals = new HashMap<>();
+            locals = EconomicMap.create();
         }
 
         int getIndex(DebugLocalInfo localInfo) {
@@ -855,7 +855,7 @@ public class DwarfDebugInfo extends DebugInfoBase {
     }
 
     public DwarfLocalProperties lookupLocalProperties(ClassEntry classEntry, MethodEntry methodEntry) {
-        HashMap<MethodEntry, DwarfLocalProperties> map;
+        EconomicMap<MethodEntry, DwarfLocalProperties> map;
         if (classEntry == null) {
             map = methodLocalPropertiesIndex;
         } else {
@@ -863,7 +863,7 @@ public class DwarfDebugInfo extends DebugInfoBase {
             assert classProperties != null;
             map = classProperties.methodLocalPropertiesIndex;
             if (map == null) {
-                map = classProperties.methodLocalPropertiesIndex = new HashMap<>();
+                map = classProperties.methodLocalPropertiesIndex = EconomicMap.create();
             }
         }
         DwarfLocalProperties localProperties = map.get(methodEntry);

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfInfoSectionImpl.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfInfoSectionImpl.java
@@ -549,7 +549,7 @@ public class DwarfInfoSectionImpl extends DwarfSectionImpl {
         } else {
             /* Inherit layout from object header. */
             superName = OBJECT_HEADER_STRUCT_NAME;
-            TypeEntry headerType = lookupType(null);
+            TypeEntry headerType = headerType();
             superTypeOffset = getTypeIndex(headerType);
         }
         /* Now write the child fields. */

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfSectionImpl.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfSectionImpl.java
@@ -49,7 +49,6 @@ import org.graalvm.compiler.debug.DebugContext;
 import java.nio.ByteOrder;
 import java.nio.charset.StandardCharsets;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Stream;
 
@@ -689,9 +688,7 @@ public abstract class DwarfSectionImpl extends BasicProgbitsSectionImpl {
      * @return the unique object header type notified via the DebugTypeInfo API.
      */
     protected HeaderTypeEntry headerType() {
-        Optional<HeaderTypeEntry> optHeader = typeStream().filter(TypeEntry::isHeader).map(entry -> ((HeaderTypeEntry) entry)).findFirst();
-        assert optHeader.isPresent();
-        return optHeader.get();
+        return dwarfSections.lookupHeaderType();
     }
 
     /**
@@ -705,8 +702,8 @@ public abstract class DwarfSectionImpl extends BasicProgbitsSectionImpl {
     }
 
     /**
-     * Retrieve an iterable for all all instance classes, including interfaces and enums, notified
-     * via the DebugTypeInfo API.
+     * Retrieve an iterable for all instance classes, including interfaces and enums, notified via
+     * the DebugTypeInfo API.
      * 
      * @return an iterable for all instance classes notified via the DebugTypeInfo API.
      */
@@ -729,7 +726,7 @@ public abstract class DwarfSectionImpl extends BasicProgbitsSectionImpl {
         return dwarfSections.lookupTypeEntry(type);
     }
 
-    protected TypeEntry lookupObjectClass() {
+    protected ClassEntry lookupObjectClass() {
         return dwarfSections.lookupObjectClass();
     }
 

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/image/NativeImageDebugInfoProvider.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/image/NativeImageDebugInfoProvider.java
@@ -1865,7 +1865,7 @@ class NativeImageDebugInfoProvider implements DebugInfoProvider {
             if (localInfoList != null) {
                 return localInfoList.toArray(new DebugLocalValueInfo[localInfoList.size()]);
             } else {
-                return new DebugLocalValueInfo[0];
+                return EMPTY_LOCAL_VALUE_INFOS;
             }
         }
 
@@ -1933,6 +1933,8 @@ class NativeImageDebugInfoProvider implements DebugInfoProvider {
         }
 
     }
+
+    private static final DebugLocalValueInfo[] EMPTY_LOCAL_VALUE_INFOS = new DebugLocalValueInfo[0];
 
     static final Register[] AARCH64_GPREG = {
                     AArch64.r0,


### PR DESCRIPTION
This PR implements significant improvements to debug info footprint. It only addresses changes local to the debug info generator. Although this is a great improvement the limited scope of the changes means that a large amount of the footprint that results from enabling of debug info is still present (debug info-related output by the compiler and ELF image modelling). An accompanying report (to be attached) identifies these overheads as well as the overheads addressed by this patch and suggests some areas where space savings might perhaps still be achieved in these other components.