### PR TITLE
[GR-43600] Additional debuginfo memory footprint improvements

### DIFF
--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/ClassEntry.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/ClassEntry.java
@@ -31,6 +31,9 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Stream;
 
+import com.oracle.objectfile.debugentry.range.PrimaryRange;
+import com.oracle.objectfile.debugentry.range.Range;
+import com.oracle.objectfile.debugentry.range.SubRange;
 import jdk.vm.ci.meta.ResolvedJavaMethod;
 import jdk.vm.ci.meta.ResolvedJavaType;
 import org.graalvm.collections.EconomicMap;
@@ -166,7 +169,7 @@ public class ClassEntry extends StructureTypeEntry {
         debugInstanceTypeInfo.methodInfoProvider().forEach(debugMethodInfo -> this.processMethod(debugMethodInfo, debugInfoBase, debugContext));
     }
 
-    public void indexPrimary(Range primary, List<DebugFrameSizeChange> frameSizeInfos, int frameSize) {
+    public void indexPrimary(PrimaryRange primary, List<DebugFrameSizeChange> frameSizeInfos, int frameSize) {
         if (compiledMethodIndex.get(primary) == null) {
             CompiledMethodEntry compiledEntry = new CompiledMethodEntry(primary, frameSizeInfos, frameSize, this);
             compiledMethodIndex.put(primary, compiledEntry);
@@ -187,7 +190,7 @@ public class ClassEntry extends StructureTypeEntry {
         }
     }
 
-    public void indexSubRange(Range subrange) {
+    public void indexSubRange(SubRange subrange) {
         Range primary = subrange.getPrimary();
         /* The subrange should belong to a primary range. */
         assert primary != null;

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/DebugInfoBase.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/DebugInfoBase.java
@@ -34,6 +34,9 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import com.oracle.objectfile.debugentry.range.PrimaryRange;
+import com.oracle.objectfile.debugentry.range.Range;
+import com.oracle.objectfile.debugentry.range.SubRange;
 import com.oracle.objectfile.debuginfo.DebugInfoProvider.DebugFileInfo;
 import jdk.vm.ci.meta.ResolvedJavaType;
 import org.graalvm.collections.EconomicMap;
@@ -299,7 +302,7 @@ public abstract class DebugInfoBase {
             /* Search for a method defining this primary range. */
             ClassEntry classEntry = lookupClassEntry(ownerType);
             MethodEntry methodEntry = classEntry.ensureMethodEntryForDebugRangeInfo(debugCodeInfo, this, debugContext);
-            Range primaryRange = new Range(stringTable, methodEntry, lo, hi, primaryLine);
+            PrimaryRange primaryRange = Range.createPrimary(methodEntry, lo, hi, primaryLine);
             debugContext.log(DebugContext.INFO_LEVEL, "PrimaryRange %s.%s %s %s:%d [0x%x, 0x%x]", ownerType.toJavaName(), methodName, filePath, fileName, primaryLine, lo, hi);
             classEntry.indexPrimary(primaryRange, debugCodeInfo.getFrameSizeChanges(), debugCodeInfo.getFrameSize());
             /*
@@ -427,12 +430,13 @@ public abstract class DebugInfoBase {
      * @param locationInfo
      * @param primaryRange
      * @param classEntry
+     * @param subRangeIndex
      * @param debugContext
      * @return the subrange for {@code locationInfo} linked with all its caller subranges up to the
      *         primaryRange
      */
     @SuppressWarnings("try")
-    private Range addSubrange(DebugLocationInfo locationInfo, Range primaryRange, ClassEntry classEntry, EconomicMap<DebugLocationInfo, Range> subRangeIndex, DebugContext debugContext) {
+    private Range addSubrange(DebugLocationInfo locationInfo, PrimaryRange primaryRange, ClassEntry classEntry, EconomicMap<DebugLocationInfo, Range> subRangeIndex, DebugContext debugContext) {
         /*
          * We still insert subranges for the primary method but they don't actually count as inline.
          * we only need a range so that subranges for inline code can refer to the top level line
@@ -458,7 +462,7 @@ public abstract class DebugInfoBase {
         final int line = locationInfo.line();
         ClassEntry subRangeClassEntry = lookupClassEntry(ownerType);
         MethodEntry subRangeMethodEntry = subRangeClassEntry.ensureMethodEntryForDebugRangeInfo(locationInfo, this, debugContext);
-        Range subRange = new Range(stringTable, subRangeMethodEntry, lo, hi, line, primaryRange, isTopLevel, caller);
+        SubRange subRange = Range.createSubrange(subRangeMethodEntry, lo, hi, line, primaryRange, caller, locationInfo.isLeaf());
         classEntry.indexSubRange(subRange);
         subRangeIndex.put(locationInfo, subRange);
         debugContext.log(DebugContext.DETAILED_LEVEL, "SubRange %s.%s %d %s:%d [0x%x, 0x%x] (%d, %d)",

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/DebugInfoBase.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/DebugInfoBase.java
@@ -309,7 +309,7 @@ public abstract class DebugInfoBase {
              * Record all subranges even if they have no line or file so we at least get a symbol
              * for them and don't see a break in the address range.
              */
-            EconomicMap<DebugLocationInfo, Range> subRangeIndex = EconomicMap.create();
+            EconomicMap<DebugLocationInfo, SubRange> subRangeIndex = EconomicMap.create();
             debugCodeInfo.locationInfoProvider().forEach(debugLocationInfo -> addSubrange(debugLocationInfo, primaryRange, classEntry, subRangeIndex, debugContext));
         }));
 
@@ -436,7 +436,7 @@ public abstract class DebugInfoBase {
      *         primaryRange
      */
     @SuppressWarnings("try")
-    private Range addSubrange(DebugLocationInfo locationInfo, PrimaryRange primaryRange, ClassEntry classEntry, EconomicMap<DebugLocationInfo, Range> subRangeIndex, DebugContext debugContext) {
+    private Range addSubrange(DebugLocationInfo locationInfo, PrimaryRange primaryRange, ClassEntry classEntry, EconomicMap<DebugLocationInfo, SubRange> subRangeIndex, DebugContext debugContext) {
         /*
          * We still insert subranges for the primary method but they don't actually count as inline.
          * we only need a range so that subranges for inline code can refer to the top level line

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/MemberEntry.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/MemberEntry.java
@@ -60,8 +60,7 @@ public abstract class MemberEntry {
         }
     }
 
-    @SuppressWarnings("unused")
-    String getFullFileName() {
+    public String getFullFileName() {
         if (fileEntry != null) {
             return fileEntry.getFullName();
         } else {

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/Range.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/Range.java
@@ -70,7 +70,6 @@ public class Range {
     private static final DebugLocalInfo[] EMPTY_LOCAL_INFOS = new DebugLocalInfo[0];
     private static final String CLASS_DELIMITER = ".";
     private final MethodEntry methodEntry;
-    private final String fullMethodName;
     private final int lo;
     private int hi;
     private final int line;
@@ -152,7 +151,6 @@ public class Range {
             stringTable.uniqueDebugString(methodEntry.fileEntry.getPathName());
         }
         this.methodEntry = methodEntry;
-        this.fullMethodName = isTopLevel ? stringTable.uniqueDebugString(constructClassAndMethodName()) : stringTable.uniqueString(constructClassAndMethodName());
         this.lo = lo;
         this.hi = hi;
         this.line = line;
@@ -222,7 +220,7 @@ public class Range {
     }
 
     public String getFullMethodName() {
-        return fullMethodName;
+        return constructClassAndMethodName();
     }
 
     public String getFullMethodNameWithParams() {

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/range/CallRange.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/range/CallRange.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2022, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2022, Red Hat Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package com.oracle.objectfile.debugentry.range;
+
+import com.oracle.objectfile.debugentry.MethodEntry;
+
+class CallRange extends SubRange {
+    /**
+     * The first direct callee whose range is wholly contained in this range or null if this is a
+     * leaf range.
+     */
+    protected SubRange firstCallee;
+    /**
+     * The last direct callee whose range is wholly contained in this range.
+     */
+    protected SubRange lastCallee;
+
+    protected CallRange(MethodEntry methodEntry, int lo, int hi, int line, PrimaryRange primary, Range caller) {
+        super(methodEntry, lo, hi, line, primary, caller);
+        this.firstCallee = null;
+        this.lastCallee = null;
+    }
+
+    @Override
+    protected void addCallee(SubRange callee) {
+        assert this.lo <= callee.lo;
+        assert this.hi >= callee.hi;
+        assert callee.caller == this;
+        assert callee.siblingCallee == null;
+        if (this.firstCallee == null) {
+            assert this.lastCallee == null;
+            this.firstCallee = this.lastCallee = callee;
+        } else {
+            this.lastCallee.siblingCallee = callee;
+            this.lastCallee = callee;
+        }
+    }
+
+    @Override
+    public SubRange getFirstCallee() {
+        return firstCallee;
+    }
+
+    @Override
+    public boolean isLeaf() {
+        assert firstCallee != null;
+        return false;
+    }
+
+    @Override
+    public boolean includesInlineRanges() {
+        SubRange child = firstCallee;
+        while (child != null && child.isLeaf()) {
+            child = child.siblingCallee;
+        }
+        return child != null;
+    }
+}

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/range/CallRange.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/range/CallRange.java
@@ -70,13 +70,4 @@ class CallRange extends SubRange {
         assert firstCallee != null;
         return false;
     }
-
-    @Override
-    public boolean includesInlineRanges() {
-        SubRange child = firstCallee;
-        while (child != null && child.isLeaf()) {
-            child = child.siblingCallee;
-        }
-        return child != null;
-    }
 }

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/range/LeafRange.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/range/LeafRange.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2022, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2022, Red Hat Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package com.oracle.objectfile.debugentry.range;
+
+import com.oracle.objectfile.debugentry.MethodEntry;
+
+class LeafRange extends SubRange {
+    protected LeafRange(MethodEntry methodEntry, int lo, int hi, int line, PrimaryRange primary, Range caller) {
+        super(methodEntry, lo, hi, line, primary, caller);
+    }
+
+    @Override
+    protected void addCallee(SubRange callee) {
+        assert false : "should never be adding callees to a leaf range!";
+    }
+
+    @Override
+    public SubRange getFirstCallee() {
+        return null;
+    }
+
+    @Override
+    public boolean isLeaf() {
+        return true;
+    }
+
+    @Override
+    public boolean includesInlineRanges() {
+        return false;
+    }
+}

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/range/LeafRange.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/range/LeafRange.java
@@ -47,9 +47,4 @@ class LeafRange extends SubRange {
     public boolean isLeaf() {
         return true;
     }
-
-    @Override
-    public boolean includesInlineRanges() {
-        return false;
-    }
 }

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/range/PrimaryRange.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/range/PrimaryRange.java
@@ -28,10 +28,8 @@ package com.oracle.objectfile.debugentry.range;
 
 import com.oracle.objectfile.debugentry.ClassEntry;
 import com.oracle.objectfile.debugentry.MethodEntry;
-import com.oracle.objectfile.debuginfo.DebugInfoProvider;
 
 public class PrimaryRange extends Range {
-    private static final DebugInfoProvider.DebugLocalInfo[] EMPTY_LOCAL_INFOS = new DebugInfoProvider.DebugLocalInfo[0];
     /**
      * The first subrange in the range covered by this primary or null if this primary as no
      * subranges.

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/range/PrimaryRange.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/range/PrimaryRange.java
@@ -41,21 +41,6 @@ public class PrimaryRange extends Range {
      * The last subrange in the range covered by this primary.
      */
     protected SubRange lastCallee;
-    /**
-     * Values for the associated method's local and parameter variables that are available or,
-     * alternatively, marked as invalid in this range.
-     */
-    private DebugInfoProvider.DebugLocalValueInfo[] localValueInfos;
-    /**
-     * The set of local or parameter variables with which each corresponding local value in field
-     * localValueInfos is associated. Local values which are associated with the same local or
-     * parameter variable will share the same reference in the corresponding array entries. Local
-     * values with which no local variable can be associated will have a null reference in the
-     * corresponding array. The latter case can happen when a local value has an invalid slot or
-     * when a local value that maps to a parameter slot has a different name or type to the
-     * parameter.
-     */
-    private DebugInfoProvider.DebugLocalInfo[] localInfos;
 
     protected PrimaryRange(MethodEntry methodEntry, int lo, int hi, int line) {
         super(methodEntry, lo, hi, line, -1);
@@ -97,51 +82,5 @@ public class PrimaryRange extends Range {
     @Override
     public boolean isLeaf() {
         return firstCallee == null;
-    }
-
-    @Override
-    public boolean includesInlineRanges() {
-        SubRange child = firstCallee;
-        while (child != null && child.isLeaf()) {
-            child = child.siblingCallee;
-        }
-        return child != null;
-    }
-
-    public int getLocalValueCount() {
-        assert !this.isPrimary() : "primary range does not have local values";
-        return localValueInfos.length;
-    }
-
-    public DebugInfoProvider.DebugLocalValueInfo getLocalValue(int i) {
-        assert !this.isPrimary() : "primary range does not have local values";
-        assert i >= 0 && i < localValueInfos.length : "bad index";
-        return localValueInfos[i];
-    }
-
-    public DebugInfoProvider.DebugLocalInfo getLocal(int i) {
-        assert !this.isPrimary() : "primary range does not have local vars";
-        assert i >= 0 && i < localInfos.length : "bad index";
-        return localInfos[i];
-    }
-
-    public void setLocalValueInfo(DebugInfoProvider.DebugLocalValueInfo[] localValueInfos) {
-        int len = localValueInfos.length;
-        this.localValueInfos = localValueInfos;
-        this.localInfos = (len > 0 ? new DebugInfoProvider.DebugLocalInfo[len] : EMPTY_LOCAL_INFOS);
-        // set up mapping from local values to local variables
-        for (int i = 0; i < len; i++) {
-            localInfos[i] = methodEntry.recordLocal(localValueInfos[i]);
-        }
-    }
-
-    public DebugInfoProvider.DebugLocalValueInfo lookupValue(DebugInfoProvider.DebugLocalInfo local) {
-        int localValueCount = getLocalValueCount();
-        for (int i = 0; i < localValueCount; i++) {
-            if (getLocal(i) == local) {
-                return getLocalValue(i);
-            }
-        }
-        return null;
     }
 }

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/range/PrimaryRange.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/range/PrimaryRange.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright (c) 2022, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2022, Red Hat Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package com.oracle.objectfile.debugentry.range;
+
+import com.oracle.objectfile.debugentry.ClassEntry;
+import com.oracle.objectfile.debugentry.MethodEntry;
+import com.oracle.objectfile.debuginfo.DebugInfoProvider;
+
+public class PrimaryRange extends Range {
+    private static final DebugInfoProvider.DebugLocalInfo[] EMPTY_LOCAL_INFOS = new DebugInfoProvider.DebugLocalInfo[0];
+    /**
+     * The first subrange in the range covered by this primary or null if this primary as no
+     * subranges.
+     */
+    protected SubRange firstCallee;
+    /**
+     * The last subrange in the range covered by this primary.
+     */
+    protected SubRange lastCallee;
+    /**
+     * Values for the associated method's local and parameter variables that are available or,
+     * alternatively, marked as invalid in this range.
+     */
+    private DebugInfoProvider.DebugLocalValueInfo[] localValueInfos;
+    /**
+     * The set of local or parameter variables with which each corresponding local value in field
+     * localValueInfos is associated. Local values which are associated with the same local or
+     * parameter variable will share the same reference in the corresponding array entries. Local
+     * values with which no local variable can be associated will have a null reference in the
+     * corresponding array. The latter case can happen when a local value has an invalid slot or
+     * when a local value that maps to a parameter slot has a different name or type to the
+     * parameter.
+     */
+    private DebugInfoProvider.DebugLocalInfo[] localInfos;
+
+    protected PrimaryRange(MethodEntry methodEntry, int lo, int hi, int line) {
+        super(methodEntry, lo, hi, line, -1);
+        this.firstCallee = null;
+        this.lastCallee = null;
+    }
+
+    @Override
+    public int getFileIndex() {
+        ClassEntry owner = methodEntry.ownerType();
+        return owner.localFilesIdx(getFileEntry());
+    }
+
+    @Override
+    public boolean isPrimary() {
+        return true;
+    }
+
+    @Override
+    protected void addCallee(SubRange callee) {
+        assert this.lo <= callee.lo;
+        assert this.hi >= callee.hi;
+        assert callee.caller == this;
+        assert callee.siblingCallee == null;
+        if (this.firstCallee == null) {
+            assert this.lastCallee == null;
+            this.firstCallee = this.lastCallee = callee;
+        } else {
+            this.lastCallee.siblingCallee = callee;
+            this.lastCallee = callee;
+        }
+    }
+
+    @Override
+    public SubRange getFirstCallee() {
+        return firstCallee;
+    }
+
+    @Override
+    public boolean isLeaf() {
+        return firstCallee == null;
+    }
+
+    @Override
+    public boolean includesInlineRanges() {
+        SubRange child = firstCallee;
+        while (child != null && child.isLeaf()) {
+            child = child.siblingCallee;
+        }
+        return child != null;
+    }
+
+    public int getLocalValueCount() {
+        assert !this.isPrimary() : "primary range does not have local values";
+        return localValueInfos.length;
+    }
+
+    public DebugInfoProvider.DebugLocalValueInfo getLocalValue(int i) {
+        assert !this.isPrimary() : "primary range does not have local values";
+        assert i >= 0 && i < localValueInfos.length : "bad index";
+        return localValueInfos[i];
+    }
+
+    public DebugInfoProvider.DebugLocalInfo getLocal(int i) {
+        assert !this.isPrimary() : "primary range does not have local vars";
+        assert i >= 0 && i < localInfos.length : "bad index";
+        return localInfos[i];
+    }
+
+    public void setLocalValueInfo(DebugInfoProvider.DebugLocalValueInfo[] localValueInfos) {
+        int len = localValueInfos.length;
+        this.localValueInfos = localValueInfos;
+        this.localInfos = (len > 0 ? new DebugInfoProvider.DebugLocalInfo[len] : EMPTY_LOCAL_INFOS);
+        // set up mapping from local values to local variables
+        for (int i = 0; i < len; i++) {
+            localInfos[i] = methodEntry.recordLocal(localValueInfos[i]);
+        }
+    }
+
+    public DebugInfoProvider.DebugLocalValueInfo lookupValue(DebugInfoProvider.DebugLocalInfo local) {
+        int localValueCount = getLocalValueCount();
+        for (int i = 0; i < localValueCount; i++) {
+            if (getLocal(i) == local) {
+                return getLocalValue(i);
+            }
+        }
+        return null;
+    }
+}

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/range/Range.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/range/Range.java
@@ -234,7 +234,13 @@ public abstract class Range {
 
     public abstract boolean isLeaf();
 
-    public abstract boolean includesInlineRanges();
+    public boolean includesInlineRanges() {
+        SubRange child = getFirstCallee();
+        while (child != null && child.isLeaf()) {
+            child = child.getSiblingCallee();
+        }
+        return child != null;
+    }
 
     public int getDepth() {
         return depth;

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/range/SubRange.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/range/SubRange.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright (c) 2022, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2022, Red Hat Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package com.oracle.objectfile.debugentry.range;
+
+import com.oracle.objectfile.debugentry.ClassEntry;
+import com.oracle.objectfile.debugentry.MethodEntry;
+import com.oracle.objectfile.debuginfo.DebugInfoProvider;
+
+public abstract class SubRange extends Range {
+    private static final DebugInfoProvider.DebugLocalInfo[] EMPTY_LOCAL_INFOS = new DebugInfoProvider.DebugLocalInfo[0];
+    /**
+     * This is null for a primary range. For sub ranges it holds the root of the call tree they
+     * belong to.
+     */
+    private final PrimaryRange primary;
+    /**
+     * The range for the caller or the primary range when this range if for top level method code.
+     */
+    protected Range caller;
+    /**
+     * A link to a sibling callee, i.e., a range sharing the same caller with this range.
+     */
+    protected SubRange siblingCallee;
+    /**
+     * Values for the associated method's local and parameter variables that are available or,
+     * alternatively, marked as invalid in this range.
+     */
+    private DebugInfoProvider.DebugLocalValueInfo[] localValueInfos;
+    /**
+     * The set of local or parameter variables with which each corresponding local value in field
+     * localValueInfos is associated. Local values which are associated with the same local or
+     * parameter variable will share the same reference in the corresponding array entries. Local
+     * values with which no local variable can be associated will have a null reference in the
+     * corresponding array. The latter case can happen when a local value has an invalid slot or
+     * when a local value that maps to a parameter slot has a different name or type to the
+     * parameter.
+     */
+    private DebugInfoProvider.DebugLocalInfo[] localInfos;
+
+    protected SubRange(MethodEntry methodEntry, int lo, int hi, int line, PrimaryRange primary, Range caller) {
+        super(methodEntry, lo, hi, line, (caller == null ? 0 : caller.depth + 1));
+        this.caller = caller;
+        if (caller != null) {
+            caller.addCallee(this);
+        }
+        this.primary = primary;
+    }
+
+    public Range getPrimary() {
+        return primary;
+    }
+
+    @Override
+    public int getFileIndex() {
+        // the primary range's class entry indexes all files defined by the compilation unit
+        Range primaryRange = (isPrimary() ? this : getPrimary());
+        ClassEntry owner = primaryRange.methodEntry.ownerType();
+        return owner.localFilesIdx(getFileEntry());
+    }
+
+    @Override
+    public boolean isPrimary() {
+        return getPrimary() == null;
+    }
+
+    public Range getCaller() {
+        return caller;
+    }
+
+    @Override
+    public abstract SubRange getFirstCallee();
+
+    @Override
+    public abstract boolean isLeaf();
+
+    public int getLocalValueCount() {
+        assert !this.isPrimary() : "primary range does not have local values";
+        return localValueInfos.length;
+    }
+
+    public DebugInfoProvider.DebugLocalValueInfo getLocalValue(int i) {
+        assert !this.isPrimary() : "primary range does not have local values";
+        assert i >= 0 && i < localValueInfos.length : "bad index";
+        return localValueInfos[i];
+    }
+
+    public DebugInfoProvider.DebugLocalInfo getLocal(int i) {
+        assert !this.isPrimary() : "primary range does not have local vars";
+        assert i >= 0 && i < localInfos.length : "bad index";
+        return localInfos[i];
+    }
+
+    public void setLocalValueInfo(DebugInfoProvider.DebugLocalValueInfo[] localValueInfos) {
+        int len = localValueInfos.length;
+        this.localValueInfos = localValueInfos;
+        this.localInfos = (len > 0 ? new DebugInfoProvider.DebugLocalInfo[len] : EMPTY_LOCAL_INFOS);
+        // set up mapping from local values to local variables
+        for (int i = 0; i < len; i++) {
+            localInfos[i] = methodEntry.recordLocal(localValueInfos[i]);
+        }
+    }
+
+    public DebugInfoProvider.DebugLocalValueInfo lookupValue(DebugInfoProvider.DebugLocalInfo local) {
+        int localValueCount = getLocalValueCount();
+        for (int i = 0; i < localValueCount; i++) {
+            if (getLocal(i) == local) {
+                return getLocalValue(i);
+            }
+        }
+        return null;
+    }
+
+    public SubRange getSiblingCallee() {
+        return siblingCallee;
+    }
+}

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/range/SubRange.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/range/SubRange.java
@@ -33,12 +33,11 @@ import com.oracle.objectfile.debuginfo.DebugInfoProvider;
 public abstract class SubRange extends Range {
     private static final DebugInfoProvider.DebugLocalInfo[] EMPTY_LOCAL_INFOS = new DebugInfoProvider.DebugLocalInfo[0];
     /**
-     * This is null for a primary range. For sub ranges it holds the root of the call tree they
-     * belong to.
+     * The root of the call tree the subrange belongs to.
      */
     private final PrimaryRange primary;
     /**
-     * The range for the caller or the primary range when this range if for top level method code.
+     * The range for the caller or the primary range when this range is for top level method code.
      */
     protected Range caller;
     /**
@@ -67,6 +66,7 @@ public abstract class SubRange extends Range {
         if (caller != null) {
             caller.addCallee(this);
         }
+        assert primary != null;
         this.primary = primary;
     }
 
@@ -77,14 +77,13 @@ public abstract class SubRange extends Range {
     @Override
     public int getFileIndex() {
         // the primary range's class entry indexes all files defined by the compilation unit
-        Range primaryRange = (isPrimary() ? this : getPrimary());
-        ClassEntry owner = primaryRange.methodEntry.ownerType();
+        ClassEntry owner = primary.methodEntry.ownerType();
         return owner.localFilesIdx(getFileEntry());
     }
 
     @Override
     public boolean isPrimary() {
-        return getPrimary() == null;
+        return false;
     }
 
     public Range getCaller() {
@@ -98,18 +97,15 @@ public abstract class SubRange extends Range {
     public abstract boolean isLeaf();
 
     public int getLocalValueCount() {
-        assert !this.isPrimary() : "primary range does not have local values";
         return localValueInfos.length;
     }
 
     public DebugInfoProvider.DebugLocalValueInfo getLocalValue(int i) {
-        assert !this.isPrimary() : "primary range does not have local values";
         assert i >= 0 && i < localValueInfos.length : "bad index";
         return localValueInfos[i];
     }
 
     public DebugInfoProvider.DebugLocalInfo getLocal(int i) {
-        assert !this.isPrimary() : "primary range does not have local vars";
         assert i >= 0 && i < localInfos.length : "bad index";
         return localInfos[i];
     }

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debuginfo/DebugInfoProvider.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debuginfo/DebugInfoProvider.java
@@ -31,6 +31,7 @@ import java.util.List;
 import java.util.function.Consumer;
 import java.util.stream.Stream;
 
+import com.oracle.objectfile.debugentry.range.Range;
 import jdk.vm.ci.meta.JavaConstant;
 import jdk.vm.ci.meta.JavaKind;
 import jdk.vm.ci.meta.ResolvedJavaMethod;
@@ -282,7 +283,7 @@ public interface DebugInfoProvider {
 
     /**
      * Access details of a compiled top level or inline method producing the code in a specific
-     * {@link com.oracle.objectfile.debugentry.Range}.
+     * {@link Range}.
      */
     public interface DebugRangeInfo extends DebugMethodInfo {
 
@@ -357,6 +358,8 @@ public interface DebugInfoProvider {
          *         variables present in the frame of the current range.
          */
         DebugLocalValueInfo[] getLocalValueInfo();
+
+        boolean isLeaf();
     }
 
     /**

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debuginfo/DebugInfoProvider.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debuginfo/DebugInfoProvider.java
@@ -31,7 +31,6 @@ import java.util.List;
 import java.util.function.Consumer;
 import java.util.stream.Stream;
 
-import com.oracle.objectfile.debugentry.range.Range;
 import jdk.vm.ci.meta.JavaConstant;
 import jdk.vm.ci.meta.JavaKind;
 import jdk.vm.ci.meta.ResolvedJavaMethod;
@@ -283,7 +282,7 @@ public interface DebugInfoProvider {
 
     /**
      * Access details of a compiled top level or inline method producing the code in a specific
-     * {@link Range}.
+     * {@link com.oracle.objectfile.debugentry.range.Range}.
      */
     public interface DebugRangeInfo extends DebugMethodInfo {
 

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfARangesSectionImpl.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfARangesSectionImpl.java
@@ -38,7 +38,7 @@ import com.oracle.objectfile.LayoutDecisionMap;
 import com.oracle.objectfile.ObjectFile;
 import com.oracle.objectfile.debugentry.ClassEntry;
 import com.oracle.objectfile.debugentry.CompiledMethodEntry;
-import com.oracle.objectfile.debugentry.Range;
+import com.oracle.objectfile.debugentry.range.Range;
 
 /**
  * Section generator for debug_aranges section.

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfDebugInfo.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfDebugInfo.java
@@ -32,7 +32,7 @@ import com.oracle.objectfile.debugentry.ClassEntry;
 import com.oracle.objectfile.debugentry.DebugInfoBase;
 
 import com.oracle.objectfile.debugentry.MethodEntry;
-import com.oracle.objectfile.debugentry.Range;
+import com.oracle.objectfile.debugentry.range.Range;
 import com.oracle.objectfile.debugentry.StructureTypeEntry;
 import com.oracle.objectfile.debugentry.TypeEntry;
 import com.oracle.objectfile.debuginfo.DebugInfoProvider.DebugLocalInfo;

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfFrameSectionImpl.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfFrameSectionImpl.java
@@ -29,7 +29,7 @@ package com.oracle.objectfile.elf.dwarf;
 import com.oracle.objectfile.LayoutDecision;
 import com.oracle.objectfile.debugentry.ClassEntry;
 import com.oracle.objectfile.debugentry.CompiledMethodEntry;
-import com.oracle.objectfile.debugentry.Range;
+import com.oracle.objectfile.debugentry.range.Range;
 import com.oracle.objectfile.debuginfo.DebugInfoProvider;
 import org.graalvm.compiler.debug.DebugContext;
 

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfInfoSectionImpl.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfInfoSectionImpl.java
@@ -35,7 +35,6 @@ import java.util.List;
 import java.util.stream.Stream;
 import java.util.function.Predicate;
 
-import com.oracle.objectfile.debugentry.range.SubRange;
 import jdk.vm.ci.meta.JavaConstant;
 import jdk.vm.ci.meta.JavaKind;
 import jdk.vm.ci.meta.PrimitiveConstant;
@@ -53,6 +52,7 @@ import com.oracle.objectfile.debugentry.MethodEntry;
 import com.oracle.objectfile.debugentry.CompiledMethodEntry;
 import com.oracle.objectfile.debugentry.PrimitiveTypeEntry;
 import com.oracle.objectfile.debugentry.range.Range;
+import com.oracle.objectfile.debugentry.range.SubRange;
 import com.oracle.objectfile.debugentry.StructureTypeEntry;
 import com.oracle.objectfile.debugentry.TypeEntry;
 import com.oracle.objectfile.debuginfo.DebugInfoProvider.DebugLocalInfo;

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfLineSectionImpl.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfLineSectionImpl.java
@@ -38,7 +38,8 @@ import com.oracle.objectfile.debugentry.ClassEntry;
 import com.oracle.objectfile.debugentry.CompiledMethodEntry;
 import com.oracle.objectfile.debugentry.DirEntry;
 import com.oracle.objectfile.debugentry.FileEntry;
-import com.oracle.objectfile.debugentry.Range;
+import com.oracle.objectfile.debugentry.range.Range;
+import com.oracle.objectfile.debugentry.range.SubRange;
 
 /**
  * Section generator for debug_line section.
@@ -503,14 +504,14 @@ public class DwarfLineSectionImpl extends DwarfSectionImpl {
         /*
          * Now write a row for each subrange lo and hi.
          */
-        Iterator<Range> iterator = compiledEntry.leafRangeIterator();
+        Iterator<SubRange> iterator = compiledEntry.leafRangeIterator();
         if (prologueRange != null) {
             // skip already processed range
-            Range first = iterator.next();
+            SubRange first = iterator.next();
             assert first == prologueRange;
         }
         while (iterator.hasNext()) {
-            Range subrange = iterator.next();
+            SubRange subrange = iterator.next();
             assert subrange.getLo() >= primaryRange.getLo();
             assert subrange.getHi() <= primaryRange.getHi();
             FileEntry subFileEntry = subrange.getFileEntry();
@@ -656,10 +657,10 @@ public class DwarfLineSectionImpl extends DwarfSectionImpl {
         return pos;
     }
 
-    private static Range prologueLeafRange(CompiledMethodEntry compiledEntry) {
-        Iterator<Range> iterator = compiledEntry.leafRangeIterator();
+    private static SubRange prologueLeafRange(CompiledMethodEntry compiledEntry) {
+        Iterator<SubRange> iterator = compiledEntry.leafRangeIterator();
         if (iterator.hasNext()) {
-            Range range = iterator.next();
+            SubRange range = iterator.next();
             if (range.getLo() == compiledEntry.getPrimary().getLo()) {
                 return range;
             }

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfSectionImpl.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfSectionImpl.java
@@ -36,7 +36,7 @@ import com.oracle.objectfile.debugentry.ClassEntry;
 import com.oracle.objectfile.debugentry.HeaderTypeEntry;
 import com.oracle.objectfile.debugentry.MethodEntry;
 import com.oracle.objectfile.debugentry.PrimitiveTypeEntry;
-import com.oracle.objectfile.debugentry.Range;
+import com.oracle.objectfile.debugentry.range.Range;
 import com.oracle.objectfile.debugentry.StructureTypeEntry;
 import com.oracle.objectfile.debugentry.TypeEntry;
 import com.oracle.objectfile.debuginfo.DebugInfoProvider.DebugLocalInfo;

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/pecoff/cv/CVLineRecordBuilder.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/pecoff/cv/CVLineRecordBuilder.java
@@ -28,7 +28,8 @@ package com.oracle.objectfile.pecoff.cv;
 
 import com.oracle.objectfile.debugentry.FileEntry;
 import com.oracle.objectfile.debugentry.CompiledMethodEntry;
-import com.oracle.objectfile.debugentry.Range;
+import com.oracle.objectfile.debugentry.range.Range;
+import com.oracle.objectfile.debugentry.range.SubRange;
 
 import java.util.Iterator;
 
@@ -66,9 +67,9 @@ public class CVLineRecordBuilder {
         debug("CVLineRecord.computeContents: processing primary range %s", primaryRange);
 
         processRange(primaryRange);
-        Iterator<Range> iterator = compiledEntry.leafRangeIterator();
+        Iterator<SubRange> iterator = compiledEntry.leafRangeIterator();
         while (iterator.hasNext()) {
-            Range subRange = iterator.next();
+            SubRange subRange = iterator.next();
             debug("CVLineRecord.computeContents: processing range %s", subRange);
             processRange(subRange);
         }

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/pecoff/cv/CVSymbolSubsectionBuilder.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/pecoff/cv/CVSymbolSubsectionBuilder.java
@@ -30,8 +30,8 @@ import com.oracle.objectfile.SectionName;
 import com.oracle.objectfile.debugentry.ClassEntry;
 import com.oracle.objectfile.debugentry.CompiledMethodEntry;
 import com.oracle.objectfile.debugentry.FieldEntry;
-import com.oracle.objectfile.debugentry.Range;
 import com.oracle.objectfile.debugentry.TypeEntry;
+import com.oracle.objectfile.debugentry.range.Range;
 
 import java.lang.reflect.Modifier;
 

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/image/NativeImageDebugInfoProvider.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/image/NativeImageDebugInfoProvider.java
@@ -2231,7 +2231,6 @@ class NativeImageDebugInfoProvider implements DebugInfoProvider {
             return kind.getSlotCount();
         }
 
-
         @Override
         public JavaKind javaKind() {
             return kind;
@@ -2242,6 +2241,7 @@ class NativeImageDebugInfoProvider implements DebugInfoProvider {
             return line;
         }
     }
+
     public class NativeImageDebugLocalValueInfo extends NativeImageDebugLocalInfo implements DebugLocalValueInfo {
         private final NativeImageDebugLocalValue value;
         private LocalKind localKind;
@@ -2366,7 +2366,7 @@ class NativeImageDebugInfoProvider implements DebugInfoProvider {
     public abstract static class NativeImageDebugLocalValue {
     }
 
-    public static class NativeImageDebugRegisterValue extends NativeImageDebugLocalValue {
+    public static final class NativeImageDebugRegisterValue extends NativeImageDebugLocalValue {
         private static EconomicMap<Integer, NativeImageDebugRegisterValue> registerValues = EconomicMap.create();
         private int number;
 
@@ -2406,7 +2406,7 @@ class NativeImageDebugInfoProvider implements DebugInfoProvider {
         }
     }
 
-    public static class NativeImageDebugStackValue extends NativeImageDebugLocalValue {
+    public static final class NativeImageDebugStackValue extends NativeImageDebugLocalValue {
         private static EconomicMap<Integer, NativeImageDebugStackValue> stackValues = EconomicMap.create();
         private int offset;
 
@@ -2446,7 +2446,7 @@ class NativeImageDebugInfoProvider implements DebugInfoProvider {
         }
     }
 
-    public static class NativeImageDebugConstantValue extends NativeImageDebugLocalValue {
+    public static final class NativeImageDebugConstantValue extends NativeImageDebugLocalValue {
         private static EconomicMap<JavaConstant, NativeImageDebugConstantValue> constantValues = EconomicMap.create();
         private JavaConstant value;
         private long heapoffset;


### PR DESCRIPTION
This is a second round of improvements to debug info footprint. It involves one change to the COMPILER phase and four to the DWARF phase:
### COMPILER phase
1. Each entry in a compiled method's `Infopoint` list includes a leaf `BytecodeFrame` which links an associated linear chain of caller `BytecodeFrame` instances. In many cases the chains in adjacent `Infopoint` instances are either identical or share most ancestors (based on `BytecodeFrame.equals`). Storage can be compressed by merging this list of lists to an equivalent tree where common ancestors are reduced to unique instances. This can be done as a final step during compilation, ensuring that the reduction in memory is delivered incrementally over the compilation phase rather than as one final step.
n.b. It would be preferable to generate the `BytecodeFrame` instances in a tree structure during LIR generation. However, that is not possible with the current compile strategy which is why conversion to a tree is being done when the compilation has completed. There are several reasons for this. A frame chain created during LIR generation of a given `Infopoint`includes an unprocessed `values` array attached to each `BytecodeFrame`. These `values` are initialized in a second pass down the chain. Reuse of existing `BytecodeFrame` ancestors to build a shared tree structure would, at least, require this initialization pass to be merged with the construction pass. However, these `values` may also be updated by subsequent compiler phases, which also assume independent linear `BytecodeFrame` chains. So, the later passes would also need to be modified to process a shared tree and, possibly, restructure it if modifications led to further merge opportunities (this also assumes that earlier merges did not elide nodes that might later need to be distinguished) 

For the HelloWorld app used in to test previous debug info footprint improvements these changes save roughly 8Mb storage for basic debug info generation. However, for full debug info generation (where full local var info implies many more Infpoint instances) it results in a very significant 100Mb saving. The saving is roughly 75% of the memory previously used to record frame information, comprising not just repeated instances of `BytecodeFrame` but also (necessarily for equality) repeats of their associated arrays of type `JavaValue[]` and `JavaKind[]`.

### DWARF phase
1. Full method names were being stored in `Range` objects and redundantly entered into the string table for inclusion in the `.debug_string` section. The first change creates these names on demand, which only happens when performing logging.
2. A single class, `Range`, was being used to model: primary ranges that detail a top level method; leaf ranges that model an instruction range comprising instructions derived from a single caller method (whether primary or inlined) and call ranges that model an instruction range derived from an inlined call, possibly including recursively inlined ranges. The change uses three subclasses to model each type of range more succinctly, allowing each class to omit some field data:
- `PrimaryRange` and `CallRange` employ fields `firstCallee` and `lastCallee` to daisy chain child ranges but these can be omitted from `LeafRange`.
- `CallRange` and `LeafRange` employ fields `caller` and `primary` as a back link to, respectively, their direct caller range and (indirect) primary range but these fields can be omitted from `PrimaryRange`.
- `CallRange` and `LeafRange` employ field `siblingCallee` to daisy chain adjacent `Range` instances sharing the same caller but this can be omitted from `PrimaryRange`.
3.Details of a local or parameter variable value locations were being modelled with distinct instances of classes `NativeImageDebugRegisterValue`,  `NativeImageDebugStackValue` and `NativeImageDebugConstantValue` even though the same register, stack slot and, occasionally but less frequently, constant will be referenced many times. This was changed to reuse instances (across all compilations).
4. A single implementation class, `NativeImageDebugLocalValueInfo` was being used to implement interface `DebugLocalInfo` and extending interface `DebugLocalValueInfo` which model, respectively, details of a local or parameter variable’s name, type etc and details of where the variable’s value is located. Splitting the implementation into a superclass, `NativeImageDebugLocalInfo`, and subclass,  `NativeImageDebugLocalValueInfo`, allows superclass inastances to omit some fields.

For the HelloWorld app used in to test previous debug info footprint improvements these changes save roughly 6/15Mb extra storage for basic/full debug info generation. 

### Updated heap dump stats
For the specific classes affected by these updates
[Footprint3.pdf](https://github.com/oracle/graal/files/10117859/Footprint3.pdf)


