### PR TITLE
Support delegating SVM's feature

### DIFF
--- a/substratevm/mx.substratevm/suite.py
+++ b/substratevm/mx.substratevm/suite.py
@@ -490,6 +490,7 @@ suite = {
             "sourceDirs": ["src"],
             "dependencies": [
                 "com.oracle.graal.pointsto",
+                "sdk:GRAAL_SDK",
             ],
             "requires" : [
                 "jdk.unsupported" # sun.misc.Unsafe
@@ -1680,6 +1681,7 @@ suite = {
                 "mx:JUNIT_TOOL",
                 "sdk:GRAAL_SDK",
                 "STANDALONE_POINTSTO",
+                "SVM"
             ],
             "testDistribution" : True,
         },

--- a/substratevm/src/com.oracle.graal.pointsto.standalone.test/src/com/oracle/graal/pointsto/standalone/test/DelegateSVMFeatureTest.java
+++ b/substratevm/src/com.oracle.graal.pointsto.standalone.test/src/com/oracle/graal/pointsto/standalone/test/DelegateSVMFeatureTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2022, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2022, Alibaba Group Holding Limited. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package com.oracle.graal.pointsto.standalone.test;
+
+import org.junit.Test;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.Assert.assertTrue;
+
+/**
+ * This test verifies the functionality of invoking compatible SVM feature from standalone pointsto
+ * analyzer. This test takes the com.oracle.svm.hosted.dashboard.DashboardDumpFeature as test case,
+ * so requires svm.jar on the classpath.
+ */
+public class DelegateSVMFeatureTest {
+
+    public static void main(String[] args) {
+
+    }
+
+    @Test
+    public void test() throws IOException {
+        PointstoAnalyzerTester tester = new PointstoAnalyzerTester(this.getClass());
+        Path testTmpDir = tester.createTestTmpDir();
+        try {
+            Path outputPath = testTmpDir.resolve("reports");
+            String dumpFileName = "dumpRet";
+            tester.setAnalysisArguments(tester.getTestClassName(),
+                            "-H:AnalysisTargetAppCP=" + tester.getTestClassJar(),
+                            "-H:DumpDashboardPointsto=" + outputPath.resolve(dumpFileName).normalize().toString());
+            tester.runAnalysisAndAssert();
+            assertTrue(Files.exists(outputPath.resolve(dumpFileName + ".dump")));
+        } finally {
+            tester.deleteTestTmpDir();
+        }
+    }
+}

--- a/substratevm/src/com.oracle.graal.pointsto.standalone/src/com/oracle/graal/pointsto/standalone/PointsToAnalyzer.java
+++ b/substratevm/src/com.oracle.graal.pointsto.standalone/src/com/oracle/graal/pointsto/standalone/PointsToAnalyzer.java
@@ -277,6 +277,9 @@ public final class PointsToAnalyzer {
 
     private void registerFeatures() {
         standaloneAnalysisFeatureManager.registerFeaturesFromOptions();
+        // Register DashboardDump feature by default, user can enable the feature by setting
+        // -H:+DumpAnalysisReports
+        standaloneAnalysisFeatureManager.registerFeature("com.oracle.graal.pointsto.standalone.features.DashboardDumpDelegate$Feature");
     }
 
     private void registerEntryMethod() {

--- a/substratevm/src/com.oracle.graal.pointsto.standalone/src/com/oracle/graal/pointsto/standalone/StandaloneSingletonsSupportImpl.java
+++ b/substratevm/src/com.oracle.graal.pointsto.standalone/src/com/oracle/graal/pointsto/standalone/StandaloneSingletonsSupportImpl.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2021, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2021, Alibaba Group Holding Limited. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package com.oracle.graal.pointsto.standalone;
+
+import com.oracle.graal.pointsto.util.AnalysisError;
+import org.graalvm.nativeimage.impl.ImageSingletonsSupport;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class StandaloneSingletonsSupportImpl extends ImageSingletonsSupport {
+
+    static {
+        ImageSingletonsSupport.installSupport(new StandaloneSingletonsSupportImpl());
+    }
+
+    private Map<Class<?>, Object> configObjects = new ConcurrentHashMap<>();
+
+    public static ImageSingletonsSupport get() {
+        return ImageSingletonsSupport.get();
+    }
+
+    @Override
+    public <T> void add(Class<T> key, T value) {
+        configObjects.put(key, value);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public <T> T lookup(Class<T> key) {
+        Object ret = configObjects.get(key);
+        if (ret == null) {
+            throw AnalysisError.shouldNotReachHere(String.format("ImageSingletons do not contain key %s", key.getTypeName()));
+        }
+        return (T) ret;
+    }
+
+    @Override
+    public boolean contains(Class<?> key) {
+        return configObjects.containsKey(key);
+    }
+}

--- a/substratevm/src/com.oracle.graal.pointsto.standalone/src/com/oracle/graal/pointsto/standalone/features/DashboardDumpDelegate.java
+++ b/substratevm/src/com.oracle.graal.pointsto.standalone/src/com/oracle/graal/pointsto/standalone/features/DashboardDumpDelegate.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2022, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2022, Alibaba Group Holding Limited. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package com.oracle.graal.pointsto.standalone.features;
+
+import com.oracle.graal.pointsto.BigBang;
+import com.oracle.graal.pointsto.util.AnalysisError;
+import org.graalvm.collections.EconomicMap;
+import org.graalvm.compiler.options.Option;
+import org.graalvm.compiler.options.OptionKey;
+import org.graalvm.compiler.options.OptionValues;
+import org.graalvm.compiler.options.OptionsParser;
+
+import java.lang.reflect.Method;
+
+public class DashboardDumpDelegate {
+
+    /**
+     * Options must not be declared inside subclass of
+     * {@link org.graalvm.nativeimage.hosted.Feature}, because it may lead to native-image build
+     * error. When an application calls {@link OptionsParser#getOptionsLoader()} is native-image
+     * built, the pointsto analysis will get {@link org.graalvm.nativeimage.hosted.Feature} as
+     * reachable if Options class is an inner class of Feature class. But
+     * {@link org.graalvm.nativeimage.hosted.Feature} is annotated as HostedOnly, so an
+     * UnsupportedFeatureException will be thrown. An instance is Libgraal.
+     */
+    public static class Options {
+        @Option(help = "Dump pointsto analysis results for GraalVM dashboard to a json file, as a combination of -H:DashboardDump= and -H:+DashboardPointsTo and -H:+DashboardJson.")
+//
+        public static final OptionKey<String> DumpDashboardPointsto = new OptionKey<>(null) {
+            @Override
+            protected void onValueUpdate(EconomicMap<OptionKey<?>, Object> values, String oldValue, String newValue) {
+                Class<?> dashBoardOptionsClazz = null;
+                try {
+                    dashBoardOptionsClazz = Class.forName("com.oracle.svm.hosted.dashboard.DashboardOptions");
+                } catch (ClassNotFoundException e) {
+                    AnalysisError.dependencyNotExist("class DashboardOptions ", "svm.jar", e);
+                }
+                HostedOptionValueUpdater.registerHostedOptionUpdate(new HostedOptionValueUpdater.HostedOptionValue(newValue, dashBoardOptionsClazz, "DashboardDump"),
+                                new HostedOptionValueUpdater.HostedOptionValue(true, dashBoardOptionsClazz, "DashboardPointsTo"),
+                                new HostedOptionValueUpdater.HostedOptionValue(true, dashBoardOptionsClazz, "DashboardJson"));
+            }
+        };
+    }
+
+    @DelegateSVMFeature("com.oracle.svm.hosted.dashboard.DashboardDumpFeature")
+    public static class Feature extends DelegateFeature {
+
+        public Feature(OptionValues options) {
+            super(options);
+        }
+
+        @Override
+        protected boolean isEnabled(OptionValues options) {
+            return Options.DumpDashboardPointsto.getValue(options) != null;
+        }
+
+        @Override
+        public void beforeAnalysis(BeforeAnalysisAccess access) {
+            StandaloneAnalysisFeatureImpl.BeforeAnalysisAccessImpl a = (StandaloneAnalysisFeatureImpl.BeforeAnalysisAccessImpl) access;
+            BigBang bb = a.getBigBang();
+
+            try {
+                Method setBBMethod = original.getClass().getDeclaredMethod("setBB", BigBang.class);
+                setBBMethod.invoke(original, bb);
+            } catch (ReflectiveOperationException e) {
+                AnalysisError.dependencyNotExist("DashboardDumpFeature", "svm.jar", e);
+            }
+        }
+
+        @Override
+        public void onAnalysisExit(OnAnalysisExitAccess access) {
+            original.onAnalysisExit(access);
+        }
+    }
+}

--- a/substratevm/src/com.oracle.graal.pointsto.standalone/src/com/oracle/graal/pointsto/standalone/features/DelegateFeature.java
+++ b/substratevm/src/com.oracle.graal.pointsto.standalone/src/com/oracle/graal/pointsto/standalone/features/DelegateFeature.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2022, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2022, Alibaba Group Holding Limited. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package com.oracle.graal.pointsto.standalone.features;
+
+import com.oracle.graal.pointsto.util.AnalysisError;
+import com.oracle.svm.util.ReflectionUtil;
+import org.graalvm.compiler.options.OptionValues;
+import org.graalvm.nativeimage.AnnotationAccess;
+import org.graalvm.nativeimage.hosted.Feature;
+
+/**
+ * This class supports invoking SVM Features from standalone pointsto analysis. Some SVM features
+ * are useful in standalone pointsto analysis, but difficult to extract into the common place. For
+ * example, com.oracle.svm.hosted.dashboard.DashboardDumpFeature can dump pointsto results for
+ * further visualized analysis. We introduce the Feature delegating mechanism to reuse the features
+ * defined in SVM. User can extend this class to delegate an SVM feature.
+ * <p>
+ * The subclasses must be annotated with @{@link DelegateSVMFeature} to specify which SVM feature is
+ * delegated.
+ * <p>
+ * Sometimes, the SVM feature may need to set its functions via HostedOptionKey which is
+ * inaccessible from pointsto. We use {@link HostedOptionValueUpdater.HostedOptionValue} to store
+ * the option and reflectively update the option value before analysis starts.
+ * <p>
+ * An example usage of this class is {@link DashboardDumpDelegate.Feature}. Please refer it for more
+ * details.
+ */
+public abstract class DelegateFeature implements Feature {
+    protected Feature original;
+
+    @SuppressWarnings("unchecked")
+    public DelegateFeature(OptionValues options) {
+        DelegateSVMFeature annotation = AnnotationAccess.getAnnotation(this.getClass(), DelegateSVMFeature.class);
+        if (annotation == null) {
+            String annotationName = DelegateSVMFeature.class.getName();
+            AnalysisError.shouldNotReachHere("Annotation " + annotationName + " is not found on class " + this.getClass().getName() + "\n. The subtype of " + DelegateFeature.class.getName() +
+                            " must have annotation " + annotationName + " to specify which original SVM feature is delegated.");
+        }
+        // Stop initialization if the feature is not enabled.
+        if (!isEnabled(options)) {
+            throw new FeatureNotEnabledException();
+        }
+        String originalFeatureName = annotation.value();
+        try {
+            Class<? extends Feature> originalFeatureClass = (Class<? extends Feature>) Class.forName(originalFeatureName);
+            original = ReflectionUtil.lookupConstructor(originalFeatureClass).newInstance();
+        } catch (ReflectiveOperationException e) {
+            AnalysisError.dependencyNotExist(originalFeatureName, "svm.jar", e);
+        }
+    }
+
+    /**
+     * The Feature instance of this class wouldn't get created if this method returns false.
+     * 
+     * @param options options
+     * @return true if the feature is enabled.
+     */
+    protected abstract boolean isEnabled(OptionValues options);
+}

--- a/substratevm/src/com.oracle.graal.pointsto.standalone/src/com/oracle/graal/pointsto/standalone/features/DelegateSVMFeature.java
+++ b/substratevm/src/com.oracle.graal.pointsto.standalone/src/com/oracle/graal/pointsto/standalone/features/DelegateSVMFeature.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2022, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2022, Alibaba Group Holding Limited. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package com.oracle.graal.pointsto.standalone.features;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * This annotation must be added on subclasses of {@link DelegateFeature} to specify which original
+ * SVM feature is delegated.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE})
+public @interface DelegateSVMFeature {
+    String value(); // The qualified name of original SVM feature class to be delegated
+}

--- a/substratevm/src/com.oracle.graal.pointsto.standalone/src/com/oracle/graal/pointsto/standalone/features/FeatureNotEnabledException.java
+++ b/substratevm/src/com.oracle.graal.pointsto.standalone/src/com/oracle/graal/pointsto/standalone/features/FeatureNotEnabledException.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2022, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2022, Alibaba Group Holding Limited. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package com.oracle.graal.pointsto.standalone.features;
+
+public class FeatureNotEnabledException extends RuntimeException {
+    private static final long serialVersionUID = 2692592390489416901L;
+}

--- a/substratevm/src/com.oracle.graal.pointsto.standalone/src/com/oracle/graal/pointsto/standalone/features/HostedOptionValueUpdater.java
+++ b/substratevm/src/com.oracle.graal.pointsto.standalone/src/com/oracle/graal/pointsto/standalone/features/HostedOptionValueUpdater.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2022, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2022, Alibaba Group Holding Limited. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package com.oracle.graal.pointsto.standalone.features;
+
+import com.oracle.graal.pointsto.util.AnalysisError;
+import com.oracle.svm.util.ReflectionUtil;
+import org.graalvm.compiler.options.OptionKey;
+import org.graalvm.collections.EconomicMap;
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.List;
+
+public class HostedOptionValueUpdater {
+    public static final String HOSTED_OPTION_VALUES_CLASS = "com.oracle.svm.core.option.HostedOptionValues";
+
+    private static List<HostedOptionValue> hostedOptionUpdates = new ArrayList<>();
+
+    public static List<HostedOptionValue> getHostedOptionUpdates() {
+        return hostedOptionUpdates;
+    }
+
+    public static class HostedOptionValue {
+        Object newValue;
+        Class<?> optionClass;
+        String optionName;
+
+        public HostedOptionValue(Object newValue, Class<?> optionClass, String optionName) {
+            this.newValue = newValue;
+            this.optionClass = optionClass;
+            this.optionName = optionName;
+        }
+
+        public void update(EconomicMap<OptionKey<?>, Object> values) {
+            try {
+                Field optionField = ReflectionUtil.lookupField(optionClass, optionName);
+                OptionKey<?> optionKey = (OptionKey<?>) optionField.get(null);
+                optionKey.update(values, newValue);
+            } catch (ReflectiveOperationException e) {
+                AnalysisError.dependencyNotExist("option " + optionName, "svm.jar", e);
+            }
+        }
+    }
+
+    /**
+     * Register one or more HostedOptions that are necessary to run the original SVM feature.
+     *
+     * @param updaters
+     */
+    public static void registerHostedOptionUpdate(HostedOptionValue... updaters) {
+        for (HostedOptionValue hostedOptionValueUpdater : updaters) {
+            hostedOptionUpdates.add(hostedOptionValueUpdater);
+        }
+    }
+}

--- a/substratevm/src/com.oracle.graal.pointsto/src/com/oracle/graal/pointsto/util/AnalysisError.java
+++ b/substratevm/src/com.oracle.graal.pointsto/src/com/oracle/graal/pointsto/util/AnalysisError.java
@@ -143,6 +143,10 @@ public class AnalysisError extends Error {
         InterruptAnalysis(String msg) {
             super(msg);
         }
+
+        InterruptAnalysis(Exception e, String msg) {
+            super(msg, e);
+        }
     }
 
     public static TypeNotFoundError typeNotFound(ResolvedJavaType type) {
@@ -191,5 +195,14 @@ public class AnalysisError extends Error {
 
     public static RuntimeException interruptAnalysis(String msg) {
         throw new InterruptAnalysis(msg);
+    }
+
+    public static RuntimeException interruptAnalysis(String msg, Exception e) {
+        throw new InterruptAnalysis(e, msg);
+    }
+
+    public static void dependencyNotExist(String dependency, String jarName, Exception e) {
+        String errMsg = "Can't find the " + dependency + ", please make sure the " + jarName + " is on the classpath.";
+        AnalysisError.interruptAnalysis(errMsg, e);
     }
 }

--- a/substratevm/src/com.oracle.graal.pointsto/src/com/oracle/graal/pointsto/util/PointsToOptionParser.java
+++ b/substratevm/src/com.oracle.graal.pointsto/src/com/oracle/graal/pointsto/util/PointsToOptionParser.java
@@ -120,7 +120,8 @@ public final class PointsToOptionParser {
                 Class<?> clazz = optionKey.getClass();
                 // All classes from com.oracle.graal.pointsto.api.PointstoOptions are taken as
                 // non-hosted options.
-                if (clazz.getName().startsWith("com.oracle.graal.pointsto.api.PointstoOptions")) {
+                if (clazz.getName().startsWith("com.oracle.graal.pointsto.api.PointstoOptions") ||
+                                clazz.getName().startsWith("com.oracle.graal.pointsto.standalone")) {
                     return false;
                 }
                 if (!clazz.equals(OptionKey.class) && OptionKey.class.isAssignableFrom(clazz)) {

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/dashboard/PointsToJsonObject.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/dashboard/PointsToJsonObject.java
@@ -165,7 +165,7 @@ import jdk.vm.ci.code.BytecodePosition;
  */
 class PointsToJsonObject extends JsonObject {
 
-    private final OnAnalysisExitAccess access;
+    private final BigBang bigBang;
     private boolean built = false;
 
     static class InflatableArrayList<T> extends ArrayList<T> {
@@ -186,8 +186,13 @@ class PointsToJsonObject extends JsonObject {
     private final BitSet known = new BitSet();
     private List<AnalysisWrapper> flows = new InflatableArrayList<>();
 
+    PointsToJsonObject(BigBang bigBang) {
+        this.bigBang = bigBang;
+    }
+
     PointsToJsonObject(OnAnalysisExitAccess access) {
-        this.access = access;
+        FeatureImpl.OnAnalysisExitAccessImpl config = (FeatureImpl.OnAnalysisExitAccessImpl) access;
+        bigBang = config.getBigBang();
     }
 
     @Override
@@ -482,11 +487,8 @@ class PointsToJsonObject extends JsonObject {
         if (built) {
             return;
         }
-        FeatureImpl.OnAnalysisExitAccessImpl config = (FeatureImpl.OnAnalysisExitAccessImpl) access;
-        BigBang bb = config.getBigBang();
-        VMError.guarantee(bb instanceof PointsToAnalysis, "Printing points-to statistics only make sense when point-to analysis is on.");
-        serializeMethods(bb);
-        connectFlowsToEnclosingMethods(bb);
+        serializeMethods(bigBang);
+        connectFlowsToEnclosingMethods(bigBang);
         matchInputsAndUses();
         built = true;
     }


### PR DESCRIPTION
Using DelegateFeature to delegate a compatible SVM feature in standalone pointsto, so that the existing SVM feature can be reused.

DashboardDumpFeature is also modified for invoking from standalone pointsto.

This PR is part of https://github.com/oracle/graal/pull/4375