### PR TITLE
Read entrypoints from file

### DIFF
--- a/substratevm/src/com.oracle.graal.pointsto.standalone.test/src/com/oracle/graal/pointsto/standalone/test/AnalysisEntryPointsFileTest.java
+++ b/substratevm/src/com.oracle.graal.pointsto.standalone.test/src/com/oracle/graal/pointsto/standalone/test/AnalysisEntryPointsFileTest.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2022, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2022, Alibaba Group Holding Limited. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package com.oracle.graal.pointsto.standalone.test;
+
+import org.junit.Test;
+
+import java.io.IOException;
+import java.nio.file.Path;
+
+import static org.junit.Assert.assertNotNull;
+
+/**
+ * This test verifies reading analysis entry points from file via -H:AnalysisEntryPointsFile.
+ */
+public class AnalysisEntryPointsFileTest {
+    static class C {
+        static {
+            doC();
+        }
+
+        private static void doC() {
+        }
+    }
+
+    public static void foo() {
+        doFoo();
+    }
+
+    private static void doFoo() {
+    }
+
+    @SuppressWarnings("unused")
+    public static void bar(String s) {
+        doBar1();
+    }
+
+    private static void doBar1() {
+    }
+
+    @SuppressWarnings("unused")
+    public static void bar(String s, int i) {
+        doBar2();
+    }
+
+    private static void doBar2() {
+    }
+
+    public void foo1() {
+        doFoo1();
+    }
+
+    private void doFoo1() {
+    }
+
+    @Test
+    public void test() throws IOException, ReflectiveOperationException {
+        PointstoAnalyzerTester tester = new PointstoAnalyzerTester(this.getClass());
+        Path outPutDirectory = tester.createTestTmpDir();
+        Path entryFilePath = tester.saveFileFromResource("/resources/entrypoints", outPutDirectory.resolve("entrypoints").normalize());
+        assertNotNull("Fail to create entrypoints file.", entryFilePath);
+        try {
+            tester.setAnalysisArguments("-H:AnalysisEntryPointsFile=" + entryFilePath.toString(),
+                            "-H:AnalysisTargetAppCP=" + tester.getTestClassJar());
+            Class<?> classC = C.class;
+            tester.setExpectedReachableMethods(classC.getDeclaredMethod("doC"),
+                            tester.getTestClass().getDeclaredMethod("doFoo"),
+                            tester.getTestClass().getDeclaredMethod("doFoo1"),
+                            tester.getTestClass().getDeclaredMethod("doBar1"));
+            tester.setExpectedUnreachableMethods(tester.getTestClass().getDeclaredMethod("doBar2"));
+            tester.runAnalysisAndAssert();
+        } finally {
+            tester.deleteTestTmpDir();
+        }
+    }
+}

--- a/substratevm/src/com.oracle.graal.pointsto.standalone.test/src/resources/entrypoints
+++ b/substratevm/src/com.oracle.graal.pointsto.standalone.test/src/resources/entrypoints
@@ -1,0 +1,4 @@
+com.oracle.graal.pointsto.standalone.test.AnalysisEntryPointsFileTest$C.<clinit>
+com.oracle.graal.pointsto.standalone.test.AnalysisEntryPointsFileTest.foo
+com.oracle.graal.pointsto.standalone.test.AnalysisEntryPointsFileTest.foo1
+com.oracle.graal.pointsto.standalone.test.AnalysisEntryPointsFileTest.bar(String)

--- a/substratevm/src/com.oracle.graal.pointsto.standalone/src/com/oracle/graal/pointsto/standalone/MethodConfigReader.java
+++ b/substratevm/src/com.oracle.graal.pointsto.standalone/src/com/oracle/graal/pointsto/standalone/MethodConfigReader.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright (c) 2022, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2022, Alibaba Group Holding Limited. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package com.oracle.graal.pointsto.standalone;
+
+import com.oracle.graal.pointsto.BigBang;
+import com.oracle.graal.pointsto.meta.AnalysisMethod;
+import com.oracle.graal.pointsto.util.AnalysisError;
+import jdk.vm.ci.meta.MetaAccessProvider;
+import jdk.vm.ci.meta.ResolvedJavaMethod;
+import jdk.vm.ci.meta.ResolvedJavaType;
+import org.graalvm.compiler.debug.DebugContext;
+import org.graalvm.compiler.debug.DebugOptions;
+import org.graalvm.compiler.debug.MethodFilter;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+
+/**
+ * This class reads the configuration file that complies to the following rules:
+ * <ol>
+ * <li>The configuration file is a plain text file.</li>
+ * <li>Each line represents one method.</li>
+ * <li>The method is described in the format defined by {@link MethodFilter}</li>
+ * </ol>
+ */
+public class MethodConfigReader {
+
+    private static final String READ_ENTRY_POINTS = "ReadEntryPoints";
+
+    /**
+     * Read methods from the specified file. For each parsed method, execute the specified action.
+     *
+     * @param file the configuration file to read.
+     * @param bigbang
+     * @param classLoader analysis classloader
+     * @param actionForEachMethod the action to take for each resolved method.
+     */
+    public static void readMethodFromFile(String file, BigBang bigbang, ClassLoader classLoader, Consumer<AnalysisMethod> actionForEachMethod) {
+        List<String> methodNameList = new ArrayList<>();
+        Path entryFilePath = Paths.get(file);
+        File entryFile = entryFilePath.toFile();
+        try (FileInputStream fis = new FileInputStream(entryFile);
+                        BufferedReader br = new BufferedReader(new InputStreamReader(fis))) {
+            String line;
+            while ((line = br.readLine()) != null) {
+                methodNameList.add(line);
+            }
+        } catch (IOException e) {
+            AnalysisError.shouldNotReachHere(e);
+        }
+        int totalSize = methodNameList.size();
+        int num = forMethodList(bigbang.getDebug(), methodNameList, bigbang, classLoader, actionForEachMethod);
+        StringBuilder sb = new StringBuilder();
+        sb.append("==Reading analysis entry points status==\n");
+        sb.append(num).append(" out of ").append(totalSize).append(" methods are read from ").append(file).append("\n");
+        if (num < totalSize) {
+            sb.append("To see the details about the missing methods, please append option -H:").append(DebugOptions.Log.getName()).append("=").append(READ_ENTRY_POINTS).append(":3").append("\n");
+        }
+        System.out.println(sb.toString());
+    }
+
+    @SuppressWarnings("try")
+    public static int forMethodList(DebugContext debug, List<String> methods, BigBang bigbang, ClassLoader classLoader, Consumer<AnalysisMethod> actionForEachMethod) {
+        AtomicInteger validMethodsNum = new AtomicInteger(0);
+        try (DebugContext.Scope s = debug.scope(READ_ENTRY_POINTS)) {
+            methods.stream().forEach(method -> {
+                if (!method.isBlank()) {
+                    try {
+                        workWithMethod(method, bigbang, classLoader, actionForEachMethod);
+                        validMethodsNum.incrementAndGet();
+                    } catch (Throwable t) {
+                        debug.log(DebugContext.VERBOSE_LEVEL, "Warning: Can't add method " + method + " as analysis root method. Reason: " + t.getMessage());
+                    }
+                }
+            });
+        }
+        return validMethodsNum.get();
+    }
+
+    private static void workWithMethod(String method, BigBang bigbang, ClassLoader classLoader, Consumer<AnalysisMethod> actionForEachMethod) throws ClassNotFoundException {
+        int pos = method.indexOf('(');
+        int dotAfterClassNamePos;
+        if (pos == -1) {
+            dotAfterClassNamePos = method.lastIndexOf('.');
+        } else {
+            dotAfterClassNamePos = method.lastIndexOf('.', pos);
+        }
+        if (dotAfterClassNamePos == -1) {
+            AnalysisError.shouldNotReachHere("The the given method's name " + method + " doesn't contain the declaring class name.");
+        }
+        String className = method.substring(0, dotAfterClassNamePos);
+        Class<?> c = Class.forName(className, false, classLoader);
+        // MethodFilter.parse requires ResolvedJavaMethod as input
+        MetaAccessProvider originalMetaAccess = bigbang.getUniverse().getOriginalMetaAccess();
+        List<ResolvedJavaMethod> methodCandidates = Arrays.stream(c.getDeclaredMethods()).map(m -> originalMetaAccess.lookupJavaMethod(m)).filter(m -> !m.isNative()).collect(Collectors.toList());
+        methodCandidates.addAll(Arrays.stream(c.getDeclaredConstructors()).map(m -> originalMetaAccess.lookupJavaMethod(m)).collect(Collectors.toList()));
+        ResolvedJavaType t = originalMetaAccess.lookupJavaType(c);
+        if (t.getClassInitializer() != null) {
+            methodCandidates.add(t.getClassInitializer());
+        }
+        MethodFilter filter = MethodFilter.parse(method);
+        ResolvedJavaMethod found = methodCandidates.stream().filter(filter::matches).findFirst().orElseThrow(
+                        () -> new NoSuchMethodError(method));
+        actionForEachMethod.accept(bigbang.getUniverse().lookup(found));
+    }
+}

--- a/substratevm/src/com.oracle.graal.pointsto.standalone/src/com/oracle/graal/pointsto/standalone/PointsToAnalyzer.java
+++ b/substratevm/src/com.oracle.graal.pointsto.standalone/src/com/oracle/graal/pointsto/standalone/PointsToAnalyzer.java
@@ -31,6 +31,8 @@ import java.lang.reflect.Method;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLClassLoader;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ForkJoinPool;
@@ -57,6 +59,7 @@ import com.oracle.graal.pointsto.heap.ImageHeap;
 import com.oracle.graal.pointsto.infrastructure.SubstitutionProcessor;
 import com.oracle.graal.pointsto.meta.AnalysisMetaAccess;
 import com.oracle.graal.pointsto.meta.AnalysisMetaAccessExtensionProvider;
+import com.oracle.graal.pointsto.meta.AnalysisType;
 import com.oracle.graal.pointsto.meta.AnalysisUniverse;
 import com.oracle.graal.pointsto.meta.HostedProviders;
 import com.oracle.graal.pointsto.meta.PointsToAnalysisFactory;
@@ -102,7 +105,9 @@ public final class PointsToAnalyzer {
     private final ClassLoader analysisClassLoader;
     private final DebugContext debugContext;
     private StandaloneAnalysisFeatureImpl.OnAnalysisExitAccessImpl onAnalysisExitAccess;
-    private final String analysisTargetMainClass;
+    private final String analysisName;
+    private boolean entrypointsAreSet;
+    private boolean mainEntryIsSet;
 
     @SuppressWarnings("try")
     private PointsToAnalyzer(String mainEntryClass, OptionValues options) {
@@ -144,11 +149,11 @@ public final class PointsToAnalyzer {
                         originalProviders.getForeignCalls(), originalProviders.getLowerer(), originalProviders.getReplacements(),
                         originalProviders.getStampProvider(), snippetReflection, new WordTypes(aMetaAccess, wordKind),
                         originalProviders.getPlatformConfigurationProvider(), aMetaAccessExtensionProvider, originalProviders.getLoopsDataProvider());
-        analysisTargetMainClass = mainEntryClass;
+        analysisName = getAnalysisName(mainEntryClass, options);
         bigbang = new StandalonePointsToAnalysis(options, aUniverse, aProviders, standaloneHost, executor, () -> {
             /* do nothing */
         }, new TimerCollection());
-        standaloneHost.setImageName(analysisTargetMainClass);
+        standaloneHost.setImageName(analysisName);
         aUniverse.setBigBang(bigbang);
         ImageHeap heap = new ImageHeap();
         StandaloneImageHeapScanner heapScanner = new StandaloneImageHeapScanner(bigbang, heap, aMetaAccess,
@@ -195,6 +200,28 @@ public final class PointsToAnalyzer {
         }
     }
 
+    private String getAnalysisName(String entryClass, OptionValues options) {
+        String entryPointsFile = StandaloneOptions.AnalysisEntryPointsFile.getValue(options);
+        String entryPointsFileOptionName = StandaloneOptions.AnalysisEntryPointsFile.getName();
+        mainEntryIsSet = entryClass != null && !entryClass.isBlank();
+        entrypointsAreSet = entryPointsFile != null && entryPointsFile.length() != 0;
+        if (!mainEntryIsSet && !entrypointsAreSet) {
+            AnalysisError.shouldNotReachHere(
+                            "No analysis entry are specified. Must set entry class or -H:" + entryPointsFileOptionName + " to specify the analysis entries.");
+        }
+        if (mainEntryIsSet) {
+            return entryClass;
+        } else {
+            Path entryFilePath = Paths.get(entryPointsFile);
+            Path fileName = entryFilePath.getFileName();
+            if (fileName == null) {
+                return "Null";
+            } else {
+                return fileName.toString();
+            }
+        }
+    }
+
     private static int getWordSize() {
         int wordSize;
         String archModel = System.getProperty("sun.arch.data.model");
@@ -235,12 +262,12 @@ public final class PointsToAnalyzer {
 
     @SuppressWarnings("try")
     public int run() {
-        registerEntryMethod();
+        registerEntryMethods();
         registerFeatures();
         int exitCode = 0;
         Feature.BeforeAnalysisAccess beforeAnalysisAccess = new StandaloneAnalysisFeatureImpl.BeforeAnalysisAccessImpl(standaloneAnalysisFeatureManager, analysisClassLoader, bigbang, debugContext);
         standaloneAnalysisFeatureManager.forEachFeature(feature -> feature.beforeAnalysis(beforeAnalysisAccess));
-        try (Timer t = new Timer("analysis", "standalone pointsto analysis")) {
+        try (Timer t = new Timer("analysis", analysisName)) {
             StandaloneAnalysisFeatureImpl.DuringAnalysisAccessImpl config = new StandaloneAnalysisFeatureImpl.DuringAnalysisAccessImpl(standaloneAnalysisFeatureManager, analysisClassLoader, bigbang,
                             debugContext);
             bigbang.runAnalysis(debugContext, (analysisUniverse) -> {
@@ -278,20 +305,37 @@ public final class PointsToAnalyzer {
         standaloneAnalysisFeatureManager.registerFeaturesFromOptions();
     }
 
-    private void registerEntryMethod() {
-        if (analysisTargetMainClass == null) {
-            throw new RuntimeException("No analysis entry main class is specified.");
-        } else {
+    /**
+     * Register analysis entry points.
+     */
+    public void registerEntryMethods() {
+        OptionValues options = bigbang.getOptions();
+        if (mainEntryIsSet) {
+            String entryClass = analysisName;
             try {
-                Class<?> analysisMainClass = Class.forName(analysisTargetMainClass, false, analysisClassLoader);
+                Class<?> analysisMainClass = Class.forName(entryClass, false, analysisClassLoader);
                 Method main = analysisMainClass.getDeclaredMethod("main", String[].class);
                 // main method is static, whatever the invokeSpecial is it is ignored.
                 bigbang.addRootMethod(main, true);
             } catch (ClassNotFoundException e) {
-                throw new RuntimeException("Can't find the specified analysis main class " + analysisTargetMainClass, e);
+                throw new RuntimeException("Can't find the specified analysis main class " + entryClass, e);
             } catch (NoSuchMethodException e) {
-                throw new RuntimeException("Can't find the main method in the analysis main class " + analysisTargetMainClass, e);
+                throw new RuntimeException("Can't find the main method in the analysis main class " + analysisName, e);
             }
+        }
+
+        if (entrypointsAreSet) {
+            String entryPointsFile = StandaloneOptions.AnalysisEntryPointsFile.getValue(options);
+            MethodConfigReader.readMethodFromFile(entryPointsFile, bigbang, analysisClassLoader, m -> {
+                // We need to start analyzing from any method given by user, even it is a virtual
+                // method.
+                boolean isInvokeSpecial = m.isConstructor() || m.isFinal();
+                AnalysisType t = m.getDeclaringClass();
+                if (!t.isAbstract()) {
+                    t.registerAsInHeap("Root class.");
+                }
+                bigbang.addRootMethod(m, isInvokeSpecial);
+            });
         }
     }
 

--- a/substratevm/src/com.oracle.graal.pointsto.standalone/src/com/oracle/graal/pointsto/standalone/StandaloneOptions.java
+++ b/substratevm/src/com.oracle.graal.pointsto.standalone/src/com/oracle/graal/pointsto/standalone/StandaloneOptions.java
@@ -33,4 +33,7 @@ public class StandaloneOptions {
 
     @Option(help = "File system splitor separated classpath for the analysis target application.")//
     public static final OptionKey<String> AnalysisTargetAppCP = new OptionKey<>(null);
+
+    @Option(help = "file:doc-files/AnalysisEntryPointsFileHelp.txt")//
+    public static final OptionKey<String> AnalysisEntryPointsFile = new OptionKey<>(null);
 }

--- a/substratevm/src/com.oracle.graal.pointsto.standalone/src/com/oracle/graal/pointsto/standalone/StandalonePointsToAnalysis.java
+++ b/substratevm/src/com.oracle.graal.pointsto.standalone/src/com/oracle/graal/pointsto/standalone/StandalonePointsToAnalysis.java
@@ -70,7 +70,7 @@ public class StandalonePointsToAnalysis extends PointsToAnalysis {
     public void onTypeInitialized(AnalysisType type) {
         AnalysisMethod clinitMethod = type.getClassInitializer();
         if (clinitMethod != null && !addedClinits.contains(clinitMethod)) {
-            addRootMethod(clinitMethod, true).registerAsImplementationInvoked(type);
+            addRootMethod(clinitMethod, true).registerAsImplementationInvoked("static root method");
             addedClinits.add(clinitMethod);
         }
     }

--- a/substratevm/src/com.oracle.graal.pointsto.standalone/src/com/oracle/graal/pointsto/standalone/doc-files/AnalysisEntryPointsFileHelp.txt
+++ b/substratevm/src/com.oracle.graal.pointsto.standalone/src/com/oracle/graal/pointsto/standalone/doc-files/AnalysisEntryPointsFileHelp.txt
@@ -1,0 +1,8 @@
+Use a file to specify the analysis entry point methods. These methods will be added as root methods for analysis besides
+the main entry method (if set). At least one of this option and the main entry method must be set.
+Each line of the file represents an entry point method. See MethodFilter option for method format details.
+To specify a class initialization method, using <clinit> as the method name. E.g. C.<clinit> matches Class C's initialization
+method.
+Notice:
+Although this option allows to specify any method, only direct methods can work as expected. Virtual call need allocation
+information to bound to the actual implementations. But the allocation may be missed when the virtual call is the entry point.


### PR DESCRIPTION
In many static analysis scenarios, users need to set more analysis entry points than Main method. This PR supports such requirement by adding option `-H:AnalysisEntryPointFile=` to set a file where all entry point methods are listed. The method names are matched by `org.graalvm.compiler.debug.MethodFilter`.
This PR is part of https://github.com/oracle/graal/pull/4375