### PR TITLE
Use JFR at build time if JFR is included in the native image

### DIFF
--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/Target_jdk_jfr_internal_instrument_JDKEvents.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/Target_jdk_jfr_internal_instrument_JDKEvents.java
@@ -30,17 +30,32 @@ import com.oracle.svm.core.annotate.TargetClass;
 
 import jdk.jfr.events.ActiveRecordingEvent;
 import jdk.jfr.events.ActiveSettingEvent;
+import jdk.jfr.events.FileForceEvent;
+import jdk.jfr.events.FileReadEvent;
+import jdk.jfr.events.FileWriteEvent;
+import jdk.jfr.events.SocketReadEvent;
+import jdk.jfr.events.SocketWriteEvent;
 
 @TargetClass(className = "jdk.jfr.internal.instrument.JDKEvents", onlyWith = HasJfrSupport.class)
 final class Target_jdk_jfr_internal_instrument_JDKEvents {
 
-    @Alias @RecomputeFieldValue(kind = RecomputeFieldValue.Kind.FromAlias, isFinal = true) private static Class<?>[] eventClasses = {
+    @Alias
+    @RecomputeFieldValue(kind = RecomputeFieldValue.Kind.FromAlias, isFinal = true) private static Class<?>[] eventClasses = {
+                    FileForceEvent.class,
+                    FileReadEvent.class,
+                    FileWriteEvent.class,
+                    SocketReadEvent.class,
+                    SocketWriteEvent.class,
                     ActiveSettingEvent.class,
                     ActiveRecordingEvent.class
     };
 
     // This is a list of the classes with instrumentation code that should be applied.
-    @Alias @RecomputeFieldValue(kind = RecomputeFieldValue.Kind.FromAlias, isFinal = true) private static Class<?>[] instrumentationClasses = new Class<?>[]{};
+    // Instrumentation code should have already been applied when JFR was enabled during image
+    // build.
+    @Alias
+    @RecomputeFieldValue(kind = RecomputeFieldValue.Kind.FromAlias, isFinal = true) private static Class<?>[] instrumentationClasses = new Class<?>[]{};
 
-    @Alias @RecomputeFieldValue(kind = RecomputeFieldValue.Kind.FromAlias, isFinal = true) private static Class<?>[] mirrorEventClasses = new Class<?>[]{};
+    @Alias
+    @RecomputeFieldValue(kind = RecomputeFieldValue.Kind.FromAlias, isFinal = true) private static Class<?>[] mirrorEventClasses = new Class<?>[]{};
 }

--- a/substratevm/src/com.oracle.svm.driver/src/com/oracle/svm/driver/NativeImage.java
+++ b/substratevm/src/com.oracle.svm.driver/src/com/oracle/svm/driver/NativeImage.java
@@ -1800,6 +1800,9 @@ public class NativeImage {
         }
         for (String arg : config.getBuildArgs()) {
             argsProcessor.accept(arg);
+            if (arg.matches("--enable-monitoring=(.*,)*(jfr|all)(,.*)*\\Z")) {
+                imageBuilderJavaArgs.add("-XX:StartFlightRecording"); // use JFR at image build time
+            }
         }
         return argsProcessor.apply(false);
     }

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/jfr/JfrEventSubstitution.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/jfr/JfrEventSubstitution.java
@@ -24,9 +24,6 @@
  */
 package com.oracle.svm.hosted.jfr;
 
-import java.lang.reflect.Field;
-import java.lang.reflect.Method;
-import java.lang.reflect.Modifier;
 import java.util.concurrent.ConcurrentHashMap;
 
 import org.graalvm.nativeimage.Platform;
@@ -39,7 +36,6 @@ import com.oracle.svm.core.jfr.JfrEventWriterAccess;
 import com.oracle.svm.core.jfr.JfrJavaEvents;
 import com.oracle.svm.core.util.VMError;
 
-import jdk.internal.misc.Unsafe;
 import jdk.jfr.Event;
 import jdk.jfr.internal.JVM;
 import jdk.jfr.internal.SecuritySupport;
@@ -64,7 +60,6 @@ public class JfrEventSubstitution extends SubstitutionProcessor {
     JfrEventSubstitution(MetaAccessProvider metaAccess) {
         jdkJfrEvent = metaAccess.lookupJavaType(Event.class);
         ResolvedJavaType jdkJfrEventWriter = metaAccess.lookupJavaType(JfrEventWriterAccess.getEventWriterClass());
-        changeWriterResetMethod(jdkJfrEventWriter);
         typeSubstitution = new ConcurrentHashMap<>();
         methodSubstitutions = new ConcurrentHashMap<>();
         fieldSubstitutions = new ConcurrentHashMap<>();
@@ -156,53 +151,5 @@ public class JfrEventSubstitution extends SubstitutionProcessor {
 
     private boolean needsClassRedefinition(ResolvedJavaType type) {
         return !type.isAbstract() && jdkJfrEvent.isAssignableFrom(type) && !jdkJfrEvent.equals(type);
-    }
-
-    /**
-     * The method EventWriter.reset() is private but it is called by the EventHandler classes, which
-     * are generated automatically. To prevent bytecode parsing issues, we patch the visibility of
-     * that method using the hacky way below.
-     */
-    private static void changeWriterResetMethod(ResolvedJavaType eventWriterType) {
-        for (ResolvedJavaMethod m : eventWriterType.getDeclaredMethods()) {
-            if (m.getName().equals("reset")) {
-                setPublicModifier(m);
-            }
-        }
-    }
-
-    private static void setPublicModifier(ResolvedJavaMethod m) {
-        try {
-            Class<?> hotspotMethodClass = m.getClass();
-            Method metaspaceMethodM = getMethodToFetchMetaspaceMethod(hotspotMethodClass);
-            metaspaceMethodM.setAccessible(true);
-            long metaspaceMethod = (Long) metaspaceMethodM.invoke(m);
-            VMError.guarantee(metaspaceMethod != 0);
-            Class<?> hotSpotVMConfigC = Class.forName("jdk.vm.ci.hotspot.HotSpotVMConfig");
-            Method configM = hotSpotVMConfigC.getDeclaredMethod("config");
-            configM.setAccessible(true);
-            Field methodAccessFlagsOffsetF = hotSpotVMConfigC.getDeclaredField("methodAccessFlagsOffset");
-            methodAccessFlagsOffsetF.setAccessible(true);
-            Object hotSpotVMConfig = configM.invoke(null);
-            int methodAccessFlagsOffset = methodAccessFlagsOffsetF.getInt(hotSpotVMConfig);
-            int modifiers = Unsafe.getUnsafe().getInt(metaspaceMethod + methodAccessFlagsOffset);
-            int newModifiers = modifiers & ~Modifier.PRIVATE | Modifier.PUBLIC;
-            Unsafe.getUnsafe().putInt(metaspaceMethod + methodAccessFlagsOffset, newModifiers);
-        } catch (Exception ex) {
-            throw VMError.shouldNotReachHere(ex);
-        }
-    }
-
-    private static Method getMethodToFetchMetaspaceMethod(Class<?> method) throws NoSuchMethodException {
-        // The exact method depends on the JVMCI version.
-        try {
-            return method.getDeclaredMethod("getMethodPointer");
-        } catch (NoSuchMethodException e) {
-            try {
-                return method.getDeclaredMethod("getMetaspaceMethod");
-            } catch (NoSuchMethodException e2) {
-                return method.getDeclaredMethod("getMetaspacePointer");
-            }
-        }
     }
 }


### PR DESCRIPTION
This PR adds changes that enforce JFR is used at build time when it is going to be included in the native image. 
This will include support for JFR events that are supported by byte code instrumentation. These events include jdk.SocketRead, jdk.SocketWrite, jdk.FileRead, jdk.FileWrite, and jdk.FileForce. 
