### PR TITLE
Windows Debug Information for local variables - prerequisite record definitions

### DIFF
--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/pecoff/cv/CVConstants.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/pecoff/cv/CVConstants.java
@@ -36,12 +36,106 @@ public abstract class CVConstants {
     /* CodeView section header signature */
     static final int CV_SIGNATURE_C13 = 4;
 
-    static final int CV_AMD64_R8 = 336;
-    static final int CV_AMD64_R9 = 337;
-    static final int CV_AMD64_R10 = 338;
-    static final int CV_AMD64_R11 = 339;
-    static final int CV_AMD64_R12 = 340;
-    static final int CV_AMD64_R13 = 341;
-    static final int CV_AMD64_R14 = 342;
-    static final int CV_AMD64_R15 = 343;
+    /* Register definitions */
+
+    /* 8 bit registers. */
+    static final short CV_AMD64_R8B = 344;
+    static final short CV_AMD64_R9B = 345;
+    static final short CV_AMD64_R10B = 346;
+    static final short CV_AMD64_R11B = 347;
+    static final short CV_AMD64_R12B = 348;
+    static final short CV_AMD64_R13B = 349;
+    static final short CV_AMD64_R14B = 350;
+    static final short CV_AMD64_R15B = 351;
+
+    static final short CV_AMD64_AL = 1;
+    static final short CV_AMD64_CL = 2;
+    static final short CV_AMD64_DL = 3;
+    static final short CV_AMD64_BL = 4;
+
+    static final short CV_AMD64_SIL = 324;
+    static final short CV_AMD64_DIL = 325;
+    static final short CV_AMD64_BPL = 326;
+    static final short CV_AMD64_SPL = 327;
+
+    /* 16 bit registers. */
+    static final short CV_AMD64_R8W = 352;
+    static final short CV_AMD64_R9W = 353;
+    static final short CV_AMD64_R10W = 354;
+    static final short CV_AMD64_R11W = 355;
+    static final short CV_AMD64_R12W = 356;
+    static final short CV_AMD64_R13W = 357;
+    static final short CV_AMD64_R14W = 358;
+    static final short CV_AMD64_R15W = 359;
+
+    static final short CV_AMD64_AX = 9;
+    static final short CV_AMD64_CX = 10;
+    static final short CV_AMD64_DX = 11;
+    static final short CV_AMD64_BX = 12;
+    static final short CV_AMD64_SP = 13;
+    static final short CV_AMD64_BP = 14;
+    static final short CV_AMD64_SI = 15;
+    static final short CV_AMD64_DI = 16;
+
+    /* 32 bit registers. */
+    static final short CV_AMD64_R8D = 360;
+    static final short CV_AMD64_R9D = 361;
+    static final short CV_AMD64_R10D = 362;
+    static final short CV_AMD64_R11D = 363;
+    static final short CV_AMD64_R12D = 364;
+    static final short CV_AMD64_R13D = 365;
+    static final short CV_AMD64_R14D = 366;
+    static final short CV_AMD64_R15D = 367;
+
+    static final short CV_AMD64_EAX = 17;
+    static final short CV_AMD64_ECX = 18;
+    static final short CV_AMD64_EDX = 19;
+    static final short CV_AMD64_EBX = 20;
+    static final short CV_AMD64_ESP = 21;
+    static final short CV_AMD64_EBP = 22;
+    static final short CV_AMD64_ESI = 23;
+    static final short CV_AMD64_EDI = 24;
+
+    /* 64 bit registers. */
+    static final short CV_AMD64_RAX = 328;
+    static final short CV_AMD64_RBX = 329;
+    static final short CV_AMD64_RCX = 330;
+    static final short CV_AMD64_RDX = 331;
+    static final short CV_AMD64_RSI = 332;
+    static final short CV_AMD64_RDI = 333;
+    static final short CV_AMD64_RBP = 334;
+    static final short CV_AMD64_RSP = 335;
+
+    static final short CV_AMD64_R8 = 336;
+    static final short CV_AMD64_R9 = 337;
+    static final short CV_AMD64_R10 = 338;
+    static final short CV_AMD64_R11 = 339;
+    static final short CV_AMD64_R12 = 340;
+    static final short CV_AMD64_R13 = 341;
+    static final short CV_AMD64_R14 = 342;
+    static final short CV_AMD64_R15 = 343;
+
+    /* FP registers. */
+    static final short CV_AMD64_XMM0 = 154;
+    static final short CV_AMD64_XMM1 = 155;
+    static final short CV_AMD64_XMM2 = 156;
+    static final short CV_AMD64_XMM3 = 157;
+    static final short CV_AMD64_XMM4 = 158;
+    static final short CV_AMD64_XMM5 = 159;
+    static final short CV_AMD64_XMM6 = 160;
+    static final short CV_AMD64_XMM7 = 161;
+
+    static final short CV_AMD64_XMM0L = 194;
+    static final short CV_AMD64_XMM1L = 195;
+    static final short CV_AMD64_XMM2L = 196;
+    static final short CV_AMD64_XMM3L = 197;
+    static final short CV_AMD64_XMM4L = 198;
+    static final short CV_AMD64_XMM5L = 199;
+    static final short CV_AMD64_XMM6L = 200;
+    static final short CV_AMD64_XMM7L = 201;
+
+    static final short CV_AMD64_XMM0_0 = 162;
+    static final short CV_AMD64_XMM1_0 = 166;
+    static final short CV_AMD64_XMM2_0 = 170;
+    static final short CV_AMD64_XMM3_0 = 174;
 }

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/pecoff/cv/CVDebugConstants.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/pecoff/cv/CVDebugConstants.java
@@ -49,10 +49,10 @@ public abstract class CVDebugConstants {
     static final short S_ENVBLOCK = 0x113d;
     static final short S_LOCAL = 0x113e;
     static final short S_DEFRANGE = 0x113f;
-    // static final short S_DEFRANGE_SUBFIELD = 0x1140;
+    static final short S_DEFRANGE_SUBFIELD = 0x1140;
     static final short S_DEFRANGE_REGISTER = 0x1141;
     static final short S_DEFRANGE_FRAMEPOINTER_REL = 0x1142;
-    // static final short S_DEFRANGE_SUBFIELD_REGISTER = 0x1143;
+    static final short S_DEFRANGE_SUBFIELD_REGISTER = 0x1143;
     static final short S_DEFRANGE_FRAMEPOINTER_REL_FULL_SCOPE = 0x1144;
     static final short S_DEFRANGE_REGISTER_REL = 0x1145;
 }

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/pecoff/cv/CVDebugConstants.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/pecoff/cv/CVDebugConstants.java
@@ -37,11 +37,22 @@ public abstract class CVDebugConstants {
     static final short S_END = 0x0006;
     static final short S_FRAMEPROC = 0x1012;
     static final short S_OBJNAME = 0x1101;
-    static final short S_UDT = 0x1108;
+    static final short S_BLOCK32 = 0x1103;
+    static final short S_REGISTER = 0x1106; /* Register variable. */
+    static final short S_CONSTANT = 0x1107; /* Constant. */
+    static final short S_UDT = 0x1108; /* User defined type. */
     static final short S_LDATA32 = 0x110c; /* Local static. */
     static final short S_GDATA32 = 0x110d; /* Global static. */
     static final short S_GPROC32 = 0x1110; /* Global procedure. */
     static final short S_REGREL32 = 0x1111;
     static final short S_COMPILE3 = 0x113c;
     static final short S_ENVBLOCK = 0x113d;
+    static final short S_LOCAL = 0x113e;
+    static final short S_DEFRANGE = 0x113f;
+    // static final short S_DEFRANGE_SUBFIELD = 0x1140;
+    static final short S_DEFRANGE_REGISTER = 0x1141;
+    static final short S_DEFRANGE_FRAMEPOINTER_REL = 0x1142;
+    // static final short S_DEFRANGE_SUBFIELD_REGISTER = 0x1143;
+    static final short S_DEFRANGE_FRAMEPOINTER_REL_FULL_SCOPE = 0x1144;
+    static final short S_DEFRANGE_REGISTER_REL = 0x1145;
 }

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/pecoff/cv/CVSymbolSubrecord.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/pecoff/cv/CVSymbolSubrecord.java
@@ -304,7 +304,7 @@ abstract class CVSymbolSubrecord {
         }
     }
 
-
+    @SuppressWarnings("unused")
     public static class CVSymbolRegisterRecord extends CVSymbolSubrecord {
 
         private final String name;
@@ -379,6 +379,7 @@ abstract class CVSymbolSubrecord {
 
         void addGap() {
             /* TODO */
+            GraalError.shouldNotReachHere("addGap() not implemented");
         }
 
         int computeRange(byte[] buffer, int initialPos) {
@@ -391,7 +392,7 @@ abstract class CVSymbolSubrecord {
         }
 
         int computeGaps(@SuppressWarnings("unused") byte[] buffer, int initialPos) {
-            /* Emit gaps. Not Yet implemented. */
+            /* Emit gaps. Not yet implemented. */
             assert gapCount == 0;
             return initialPos;
         }
@@ -447,6 +448,7 @@ abstract class CVSymbolSubrecord {
         }
     }
 
+    @SuppressWarnings("unused")
     public static class CVSymbolDefRangeRegisterRel extends CVSymbolDefRangeBase {
 
         private final short baseRegister;
@@ -509,6 +511,7 @@ abstract class CVSymbolSubrecord {
         }
     }
 
+    @SuppressWarnings("unused")
     public static class CVSymbolDefRangeFramepointerRel extends CVSymbolDefRangeBase {
 
         private final int fpOffset;
@@ -531,6 +534,7 @@ abstract class CVSymbolSubrecord {
         }
     }
 
+    @SuppressWarnings("unused")
     public static class CVSymbolBlock32Record extends CVSymbolSubrecord {
         // K32 name= parent=0x0 end=0x0 len=0x8 codeoffset=0x0:70
         // reloc addr=0x0008e5 type=11 sym=main IMAGE_REL_AMD64_SECREL(0x0b)
@@ -545,7 +549,7 @@ abstract class CVSymbolSubrecord {
         CVSymbolBlock32Record(CVDebugInfo cvDebugInfo, String procName) {
             super(cvDebugInfo, S_BLOCK32);
             this.procName = procName;
-            /* TODO probably need to implement procOffset here, too. */
+            /* TODO - may need to implement procOffset here. */
         }
 
         @Override
@@ -622,7 +626,7 @@ abstract class CVSymbolSubrecord {
 
     public static final class CVSymbolFrameProcRecord extends CVSymbolSubrecord {
 
-        /* TODO: This may change in the presence of isolates. */
+        /* This may change in the presence of isolates. */
 
         /* Async exception handling (vc++ uses 1, clang uses 0). */
         public static final int FRAME_ASYNC_EH = 1 << 9;

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/pecoff/cv/CVSymbolSubsectionBuilder.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/pecoff/cv/CVSymbolSubsectionBuilder.java
@@ -30,15 +30,63 @@ import com.oracle.objectfile.SectionName;
 import com.oracle.objectfile.debugentry.ClassEntry;
 import com.oracle.objectfile.debugentry.CompiledMethodEntry;
 import com.oracle.objectfile.debugentry.FieldEntry;
+import com.oracle.objectfile.debugentry.MethodEntry;
 import com.oracle.objectfile.debugentry.Range;
 import com.oracle.objectfile.debugentry.TypeEntry;
+import org.graalvm.compiler.debug.GraalError;
 
 import java.lang.reflect.Modifier;
+import java.util.ArrayList;
 
+import static com.oracle.objectfile.pecoff.cv.CVConstants.CV_AMD64_CL;
+import static com.oracle.objectfile.pecoff.cv.CVConstants.CV_AMD64_CX;
+import static com.oracle.objectfile.pecoff.cv.CVConstants.CV_AMD64_DI;
+import static com.oracle.objectfile.pecoff.cv.CVConstants.CV_AMD64_DIL;
+import static com.oracle.objectfile.pecoff.cv.CVConstants.CV_AMD64_DL;
+import static com.oracle.objectfile.pecoff.cv.CVConstants.CV_AMD64_DX;
+import static com.oracle.objectfile.pecoff.cv.CVConstants.CV_AMD64_ECX;
+import static com.oracle.objectfile.pecoff.cv.CVConstants.CV_AMD64_EDI;
+import static com.oracle.objectfile.pecoff.cv.CVConstants.CV_AMD64_EDX;
+import static com.oracle.objectfile.pecoff.cv.CVConstants.CV_AMD64_ESI;
 import static com.oracle.objectfile.pecoff.cv.CVConstants.CV_AMD64_R8;
+import static com.oracle.objectfile.pecoff.cv.CVConstants.CV_AMD64_R8B;
+import static com.oracle.objectfile.pecoff.cv.CVConstants.CV_AMD64_R8D;
+import static com.oracle.objectfile.pecoff.cv.CVConstants.CV_AMD64_R8W;
+import static com.oracle.objectfile.pecoff.cv.CVConstants.CV_AMD64_R9;
+import static com.oracle.objectfile.pecoff.cv.CVConstants.CV_AMD64_R9B;
+import static com.oracle.objectfile.pecoff.cv.CVConstants.CV_AMD64_R9D;
+import static com.oracle.objectfile.pecoff.cv.CVConstants.CV_AMD64_R9W;
+import static com.oracle.objectfile.pecoff.cv.CVConstants.CV_AMD64_RCX;
+import static com.oracle.objectfile.pecoff.cv.CVConstants.CV_AMD64_RDI;
+import static com.oracle.objectfile.pecoff.cv.CVConstants.CV_AMD64_RDX;
+import static com.oracle.objectfile.pecoff.cv.CVConstants.CV_AMD64_RSI;
+import static com.oracle.objectfile.pecoff.cv.CVConstants.CV_AMD64_SI;
+import static com.oracle.objectfile.pecoff.cv.CVConstants.CV_AMD64_SIL;
+import static com.oracle.objectfile.pecoff.cv.CVConstants.CV_AMD64_XMM0L;
+import static com.oracle.objectfile.pecoff.cv.CVConstants.CV_AMD64_XMM0_0;
+import static com.oracle.objectfile.pecoff.cv.CVConstants.CV_AMD64_XMM1L;
+import static com.oracle.objectfile.pecoff.cv.CVConstants.CV_AMD64_XMM1_0;
+import static com.oracle.objectfile.pecoff.cv.CVConstants.CV_AMD64_XMM2L;
+import static com.oracle.objectfile.pecoff.cv.CVConstants.CV_AMD64_XMM2_0;
+import static com.oracle.objectfile.pecoff.cv.CVConstants.CV_AMD64_XMM3L;
+import static com.oracle.objectfile.pecoff.cv.CVConstants.CV_AMD64_XMM3_0;
+import static com.oracle.objectfile.pecoff.cv.CVSymbolSubrecord.CVSymbolFrameProcRecord.FRAME_ASYNC_EH;
+import static com.oracle.objectfile.pecoff.cv.CVSymbolSubrecord.CVSymbolFrameProcRecord.FRAME_LOCAL_BP;
+import static com.oracle.objectfile.pecoff.cv.CVSymbolSubrecord.CVSymbolFrameProcRecord.FRAME_PARAM_BP;
+import static com.oracle.objectfile.pecoff.cv.CVTypeConstants.T_REAL32;
+import static com.oracle.objectfile.pecoff.cv.CVTypeConstants.T_REAL64;
 import static com.oracle.objectfile.pecoff.cv.CVTypeConstants.MAX_PRIMITIVE;
 
 final class CVSymbolSubsectionBuilder {
+
+    private static final short[] javaGP64registers = {CV_AMD64_RDX, CV_AMD64_R8, CV_AMD64_R9, CV_AMD64_RDI, CV_AMD64_RSI, CV_AMD64_RCX};
+    private static final short[] javaGP32registers = {CV_AMD64_EDX, CV_AMD64_R8D, CV_AMD64_R9D, CV_AMD64_EDI, CV_AMD64_ESI, CV_AMD64_ECX};
+    private static final short[] javaGP16registers = {CV_AMD64_DX, CV_AMD64_R8W, CV_AMD64_R9W, CV_AMD64_DI, CV_AMD64_SI, CV_AMD64_CX};
+    private static final short[] javaGP8registers = {CV_AMD64_DL, CV_AMD64_R8B, CV_AMD64_R9B, CV_AMD64_DIL, CV_AMD64_SIL, CV_AMD64_CL};
+    // private static final short[] javaFP128registers = {CV_AMD64_XMM0, CV_AMD64_XMM1,
+    // CV_AMD64_XMM2, CV_AMD64_XMM3};
+    private static final short[] javaFP64registers = {CV_AMD64_XMM0L, CV_AMD64_XMM1L, CV_AMD64_XMM2L, CV_AMD64_XMM3L};
+    private static final short[] javaFP32registers = {CV_AMD64_XMM0_0, CV_AMD64_XMM1_0, CV_AMD64_XMM2_0, CV_AMD64_XMM3_0};
 
     private final CVDebugInfo cvDebugInfo;
     private final CVSymbolSubsection cvSymbolSubsection;
@@ -127,29 +175,137 @@ final class CVSymbolSubsectionBuilder {
         final String externalName = primaryRange.getSymbolName();
 
         /* S_PROC32 add function definition. */
-        int functionTypeIndex = addTypeRecords(compiledEntry);
-        byte funcFlags = 0;
+        final int functionTypeIndex = addTypeRecords(compiledEntry);
+        final byte funcFlags = 0;
         CVSymbolSubrecord.CVSymbolGProc32Record proc32 = new CVSymbolSubrecord.CVSymbolGProc32Record(cvDebugInfo, externalName, debuggerName, 0, 0, 0, primaryRange.getHi() - primaryRange.getLo(), 0,
                         0, functionTypeIndex, (short) 0, funcFlags);
         addSymbolRecord(proc32);
 
-        /* S_FRAMEPROC add frame definitions. */
-        int asynceh = 1 << 9; /* Async exception handling (vc++ uses 1, clang uses 0). */
-        /* TODO: This may change in the presence of isolates. */
-        int localBP = 1 << 14; /* Local base pointer = SP (0=none, 1=sp, 2=bp 3=r13). */
-        int paramBP = 1 << 16; /* Param base pointer = SP. */
-        int frameFlags = asynceh + localBP + paramBP; /* NB: LLVM uses 0x14000. */
+        /* NB: LLVM uses 0x14000. */
+        final int frameFlags = FRAME_ASYNC_EH + FRAME_LOCAL_BP + FRAME_PARAM_BP;
         addSymbolRecord(new CVSymbolSubrecord.CVSymbolFrameProcRecord(cvDebugInfo, compiledEntry.getFrameSize(), frameFlags));
 
-        /* TODO: add parameter definitions (types have been added already). */
-        /* TODO: add local variables, and their types. */
-        /* TODO: add block definitions. */
+        addLocals(compiledEntry);
 
         /* S_END add end record. */
         addSymbolRecord(new CVSymbolSubrecord.CVSymbolEndRecord(cvDebugInfo));
 
         /* Add line number records. */
         addLineNumberRecords(compiledEntry);
+    }
+
+
+    void addLocals(CompiledMethodEntry primaryEntry) {
+        final Range primaryRange = primaryEntry.getPrimary();
+        /* The name as exposed to the linker. */
+        final String externalName = primaryRange.getSymbolName();
+
+        /* Add register parameters - only valid for the first instruction or two. */
+        // addToSymbolSubsection(new CVSymbolSubrecord.CVSymbolBlock32Record(cvDebugInfo,
+        // externalName));
+
+        MethodEntry method = primaryRange.getMethodEntry();
+        ArrayList<CVSymbolSubrecord> regRelRecords = new ArrayList<>(method.getParamCount() + 1);
+        int gpRegisterIndex = 0;
+        int fpRegisterIndex = 0;
+
+        /* define 'this' as a local just as we define other object pointers */
+        if (!Modifier.isStatic(method.getModifiers())) {
+            final TypeEntry thisType = primaryEntry.getClassEntry();
+            final int typeIndex = cvDebugInfo.getCVTypeSection().getIndexForPointer(thisType);
+            addSymbolRecord(new CVSymbolSubrecord.CVSymbolLocalRecord(cvDebugInfo, "this", typeIndex, 1));
+            addSymbolRecord(new CVSymbolSubrecord.CVSymbolDefRangeRegisterRecord(cvDebugInfo, javaGP64registers[gpRegisterIndex], externalName, 0, 8));
+            addSymbolRecord(new CVSymbolSubrecord.CVSymbolDefRangeFramepointerRelFullScope(cvDebugInfo, 0));
+            gpRegisterIndex++;
+        }
+
+        /* define function parameters accoording to the calling convention */
+        for (int i = 0; i < method.getParamCount(); i++) {
+            final TypeEntry paramType = method.getParamType(i);
+            final int typeIndex = cvDebugInfo.getCVTypeSection().addTypeRecords(paramType).getSequenceNumber();
+            final String paramName = "p" + (i + 1);
+            if (typeIndex == T_REAL64 || typeIndex == T_REAL32) {
+                /* floating point primitive */
+                if (fpRegisterIndex < javaFP64registers.length) {
+                    final short register = typeIndex == T_REAL64 ? javaFP64registers[fpRegisterIndex] : javaFP32registers[fpRegisterIndex];
+                    addSymbolRecord(new CVSymbolSubrecord.CVSymbolLocalRecord(cvDebugInfo, paramName, typeIndex, 1));
+                    // addSymbolRecord(new CVSymbolSubrecord.CVSymbolRegisterRecord(cvDebugInfo,
+                    // paramName, typeIndex, javaFPregisters[fpRegisterIndex]));
+                    addSymbolRecord(new CVSymbolSubrecord.CVSymbolDefRangeRegisterRecord(cvDebugInfo, register, externalName, 0, 8));
+                    // addSymbolRecord(new
+                    // CVSymbolSubrecord.CVSymbolDefRangeFramepointerRel(cvDebugInfo, "main", 8,
+                    // (short) 8, 32));
+                    addSymbolRecord(new CVSymbolSubrecord.CVSymbolDefRangeFramepointerRelFullScope(cvDebugInfo, 0));
+                    // regRelRecords.add(new
+                    // CVSymbolSubrecord.CVSymbolRegRel32Record(cvDebugInfo, paramName,
+                    // typeIndex, 0, javaFPregisters[fpRegisterIndex]));
+                    fpRegisterIndex++;
+                } else {
+                    /* TODO: stack parameter; keep track of stack offset, etc. */
+                    break;
+                }
+            } else if (paramType.isPrimitive()) {
+                /* simple primitive */
+                if (gpRegisterIndex < javaGP64registers.length) {
+                    final short register;
+                    if (paramType.getSize() == 8) {
+                        register = javaGP64registers[gpRegisterIndex];
+                    } else if (paramType.getSize() == 4) {
+                        register = javaGP32registers[gpRegisterIndex];
+                    } else if (paramType.getSize() == 2) {
+                        register = javaGP16registers[gpRegisterIndex];
+                    } else if (paramType.getSize() == 1) {
+                        register = javaGP8registers[gpRegisterIndex];
+                    } else {
+                        register = 0; /* Avoid warning. */
+                        GraalError.shouldNotReachHere("Unknown primitive (type" + paramType.getTypeName() + ") size:" + paramType.getSize());
+                    }
+                    addSymbolRecord(new CVSymbolSubrecord.CVSymbolLocalRecord(cvDebugInfo, paramName, typeIndex, 1));
+                    // addSymbolRecord(new
+                    // CVSymbolSubrecord.CVSymbolRegisterRecord(cvDebugInfo, paramName,
+                    // typeIndex, javaGPregisters[gpRegisterIndex]));
+                    addSymbolRecord(new CVSymbolSubrecord.CVSymbolDefRangeRegisterRecord(cvDebugInfo, register, externalName, 0, 8));
+                    // addSymbolRecord(new
+                    // CVSymbolSubrecord.CVSymbolDefRangeFramepointerRel(cvDebugInfo,
+                    // "main", 8, (short) 8, 32));
+                    addSymbolRecord(new CVSymbolSubrecord.CVSymbolDefRangeFramepointerRelFullScope(cvDebugInfo, 8));
+                    // regRelRecords.add(new
+                    // CVSymbolSubrecord.CVSymbolRegRel32Record(cvDebugInfo, paramName,
+                    // typeIndex, 0, javaGPregisters[gpRegisterIndex]));
+                    gpRegisterIndex++;
+                } else {
+                    /* TODO: stack parameter; keep track of stack offset, etc. */
+                    break;
+                }
+            } else {
+                /* Java object. */
+                if (gpRegisterIndex < javaGP64registers.length) {
+                    // int pointerIndex =
+                    // cvDebugInfo.getCVTypeSection().getIndexForPointer(paramType);
+                    // define as offset from register addSymbolRecord(new
+                    // CVSymbolSubrecord.CVSymbolRegRel32Record(cvDebugInfo, paramName,
+                    // typeIndex, 0, javaGPregisters[gpRegisterIndex]));
+                    addSymbolRecord(new CVSymbolSubrecord.CVSymbolLocalRecord(cvDebugInfo, paramName, typeIndex, 1));
+                    addSymbolRecord(new CVSymbolSubrecord.CVSymbolDefRangeRegisterRecord(cvDebugInfo, javaGP64registers[gpRegisterIndex], externalName, 0, 8));
+                    addSymbolRecord(new CVSymbolSubrecord.CVSymbolDefRangeFramepointerRelFullScope(cvDebugInfo, 0));
+                    // regRelRecords.add(new
+                    // CVSymbolSubrecord.CVSymbolRegRel32Record(cvDebugInfo, paramName,
+                    // typeIndex, 0, javaGPregisters[gpRegisterIndex]));
+                    gpRegisterIndex++;
+                } else {
+                    // TODO: stack parameter; keep track of stack offset, etc.
+                    break;
+                }
+            }
+        }
+        for (CVSymbolSubrecord record : regRelRecords) {
+            addSymbolRecord(record);
+        }
+        /* TODO: add entries for stack parameters. */
+        // addToSymbolSubsection(new CVSymbolSubrecord.CVSymbolEndRecord(cvDebugInfo));
+
+        /* TODO: add local variables, and their types. */
+        /* TODO: add block definitions. */
     }
 
     private void addLineNumberRecords(CompiledMethodEntry compiledEntry) {

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/pecoff/cv/CVTypeRecord.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/pecoff/cv/CVTypeRecord.java
@@ -35,20 +35,27 @@ import static com.oracle.objectfile.pecoff.cv.CVTypeConstants.FUNC_IS_CONSTRUCTO
 import static com.oracle.objectfile.pecoff.cv.CVTypeConstants.LF_ARGLIST;
 import static com.oracle.objectfile.pecoff.cv.CVTypeConstants.LF_ARRAY;
 import static com.oracle.objectfile.pecoff.cv.CVTypeConstants.LF_BCLASS;
+import static com.oracle.objectfile.pecoff.cv.CVTypeConstants.LF_BITFIELD;
 import static com.oracle.objectfile.pecoff.cv.CVTypeConstants.LF_CLASS;
+import static com.oracle.objectfile.pecoff.cv.CVTypeConstants.LF_ENUM;
+import static com.oracle.objectfile.pecoff.cv.CVTypeConstants.LF_ENUMERATE;
 import static com.oracle.objectfile.pecoff.cv.CVTypeConstants.LF_FIELDLIST;
 import static com.oracle.objectfile.pecoff.cv.CVTypeConstants.LF_INDEX;
+import static com.oracle.objectfile.pecoff.cv.CVTypeConstants.LF_INTERFACE;
 import static com.oracle.objectfile.pecoff.cv.CVTypeConstants.LF_MEMBER;
 import static com.oracle.objectfile.pecoff.cv.CVTypeConstants.LF_METHOD;
 import static com.oracle.objectfile.pecoff.cv.CVTypeConstants.LF_METHODLIST;
 import static com.oracle.objectfile.pecoff.cv.CVTypeConstants.LF_MFUNCTION;
+import static com.oracle.objectfile.pecoff.cv.CVTypeConstants.LF_MODIFIER;
 import static com.oracle.objectfile.pecoff.cv.CVTypeConstants.LF_ONEMETHOD;
 import static com.oracle.objectfile.pecoff.cv.CVTypeConstants.LF_PAD1;
 import static com.oracle.objectfile.pecoff.cv.CVTypeConstants.LF_PAD2;
 import static com.oracle.objectfile.pecoff.cv.CVTypeConstants.LF_PAD3;
 import static com.oracle.objectfile.pecoff.cv.CVTypeConstants.LF_POINTER;
+import static com.oracle.objectfile.pecoff.cv.CVTypeConstants.LF_PROCEDURE;
 import static com.oracle.objectfile.pecoff.cv.CVTypeConstants.LF_STMEMBER;
 import static com.oracle.objectfile.pecoff.cv.CVTypeConstants.LF_STRING_ID;
+import static com.oracle.objectfile.pecoff.cv.CVTypeConstants.LF_STRUCTURE;
 import static com.oracle.objectfile.pecoff.cv.CVTypeConstants.LF_UDT_SRC_LINE;
 import static com.oracle.objectfile.pecoff.cv.CVTypeConstants.MPROP_ABSTRACT;
 import static com.oracle.objectfile.pecoff.cv.CVTypeConstants.MPROP_COMPGENX;
@@ -354,6 +361,113 @@ abstract class CVTypeRecord {
             }
             CVTypeStringIdRecord other = (CVTypeStringIdRecord) obj;
             return this.string.equals(other.string) && this.substringListIndex == other.substringListIndex;
+        }
+    }
+
+    @SuppressWarnings("unused")
+    static final class CVTypeModifierRecord extends CVTypeRecord {
+
+        private final int typeIndex;
+        private final short attrs;
+
+        CVTypeModifierRecord(int typeIndex, short attrs) {
+            super(LF_MODIFIER);
+            this.typeIndex = typeIndex;
+            this.attrs = attrs;
+        }
+
+        CVTypeModifierRecord(int typeIndex, boolean isConst, boolean isVolatile, boolean isUnaligned) {
+            this(typeIndex, (short) ((isConst ? 1 : 0) + (isVolatile ? 2 : 0) + (isUnaligned ? 4 : 0)));
+        }
+
+        @Override
+        public int computeContents(byte[] buffer, int initialPos) {
+            int pos = CVUtil.putInt(typeIndex, buffer, initialPos);
+            return CVUtil.putShort(attrs, buffer, pos);
+        }
+
+        @Override
+        public String toString() {
+            boolean isConst = (attrs & 0x0001) == 0x0001;
+            boolean isVolatile = (attrs & 0x0002) == 0x0002;
+            boolean isUnaligned = (attrs & 0x0004) == 0x0004;
+            return String.format("LF_MODIFIER 0x%04x attr=0x%x%s%s%s pointTo=0x%04x", getSequenceNumber(), attrs, isConst ? " const" : "", isVolatile ? " volatile" : "",
+                            isUnaligned ? " unaligned" : "", typeIndex);
+        }
+
+        @Override
+        public int hashCode() {
+            int h = type;
+            h = 31 * h + typeIndex;
+            h = 31 * h + attrs;
+            return h;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (!super.equals(obj)) {
+                return false;
+            }
+            CVTypeModifierRecord other = (CVTypeModifierRecord) obj;
+            return this.typeIndex == other.typeIndex && this.attrs == other.attrs;
+        }
+    }
+
+    static final class CVTypeProcedureRecord extends CVTypeRecord {
+
+        private int returnType = -1;
+        private CVTypeArglistRecord argList = null;
+
+        CVTypeProcedureRecord() {
+            super(LF_PROCEDURE);
+        }
+
+        public CVTypeProcedureRecord setReturnType(int leaf) {
+            this.returnType = leaf;
+            return this;
+        }
+
+        public CVTypeProcedureRecord setReturnType(CVTypeRecord leaf) {
+            this.returnType = leaf.getSequenceNumber();
+            return this;
+        }
+
+        CVTypeProcedureRecord setArgList(CVTypeArglistRecord leaf) {
+            this.argList = leaf;
+            return this;
+        }
+
+        @Override
+        public int computeContents(byte[] buffer, int initialPos) {
+            int pos = CVUtil.putInt(returnType, buffer, initialPos);
+            pos = CVUtil.putByte((byte) CV_CALL_NEAR_C, buffer, pos);
+            pos = CVUtil.putByte((byte) 0, buffer, pos); /* TODO funcAttr */
+            pos = CVUtil.putShort((short) argList.getSize(), buffer, pos);
+            pos = CVUtil.putInt(argList.getSequenceNumber(), buffer, pos);
+            return pos;
+        }
+
+        @Override
+        public String toString() {
+            return String.format("LF_PROCEDURE 0x%04x ret=0x%04x arg=0x%04x ", getSequenceNumber(), returnType, argList.getSequenceNumber());
+        }
+
+        @Override
+        public int hashCode() {
+            int h = type;
+            h = 31 * h + returnType;
+            h = 31 * h + argList.hashCode();
+            /* callType and funcAttr are always the same so do not add them to the hash */
+            return h;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (!super.equals(obj)) {
+                return false;
+            }
+            CVTypeProcedureRecord other = (CVTypeProcedureRecord) obj;
+            return this.returnType == other.returnType && this.argList == other.argList;
         }
     }
 
@@ -1034,6 +1148,18 @@ abstract class CVTypeRecord {
         }
     }
 
+    @SuppressWarnings("unused")
+    static final class CVStructRecord extends CVClassRecord {
+        CVStructRecord(short count, short attrs, int fieldIndex, int derivedFromIndex, int vshape, long size, String name) {
+            super(LF_STRUCTURE, count, attrs, fieldIndex, derivedFromIndex, vshape, size, name, null);
+        }
+
+        @Override
+        public String toString() {
+            return toString("LF_STRUCT");
+        }
+    }
+
     static final class CVFieldListRecord extends CVTypeRecord {
 
         static final int INITIAL_CAPACITY = 10;
@@ -1051,6 +1177,10 @@ abstract class CVTypeRecord {
             /* Keep a running total. */
             estimatedSize += CVUtil.align4(m.computeSize());
             members.add(m);
+        }
+
+        int count() {
+            return members.size();
         }
 
         int getEstimatedSize() {
@@ -1086,6 +1216,169 @@ abstract class CVTypeRecord {
         @Override
         public String toString() {
             return String.format("LF_FIELDLIST idx=0x%x count=%d", getSequenceNumber(), members.size());
+        }
+    }
+
+    /*
+     * Unused in Graal - enums are actually implemented as classes, and enumerations are static
+     * instances.
+     */
+    @SuppressWarnings("unused")
+    static final class CVEnumerateRecord extends FieldRecord {
+
+        private final long value;
+
+        CVEnumerateRecord(short attrs, long value, String name) {
+            super(LF_ENUMERATE, attrs, name);
+            this.value = value;
+        }
+
+        @Override
+        public int computeContents(byte[] buffer, int initialPos) {
+            int pos = CVUtil.putShort(type, buffer, initialPos);
+            pos = CVUtil.putShort(attrs, buffer, pos);
+            pos = CVUtil.putLfNumeric(value, buffer, pos);
+            pos = CVUtil.putUTF8StringBytes(name, buffer, pos);
+            return pos;
+        }
+
+        @Override
+        public String toString() {
+            return String.format("LF_ENUMERATE 0x%04x attr=0x%x(%s) val=0x%x %s", type, attrs, attrString(attrs), value, name);
+        }
+
+        @Override
+        public int hashCode() {
+            int h = super.hashCode();
+            h = 31 * h + (int) value;
+            h = 31 * h + name.hashCode();
+            return h;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (!super.equals(obj)) {
+                return false;
+            }
+            CVEnumerateRecord other = (CVEnumerateRecord) obj;
+            return this.value == other.value;
+        }
+    }
+
+    /*
+     * Unused in Graal - enums are actually implemented as classes, and enumerations are static
+     * instances.
+     */
+    @SuppressWarnings("unused")
+    static final class CVEnumRecord extends CVTypeRecord {
+
+        private final String name;
+        private final int attrs;
+        private final int underlyingTypeIndex;
+        private final CVFieldListRecord fieldRecord;
+
+        CVEnumRecord(short attrs, int underlyingTypeIndex, CVFieldListRecord fieldRecord, String name) {
+            super(LF_ENUM);
+            this.attrs = attrs;
+            this.underlyingTypeIndex = underlyingTypeIndex;
+            this.fieldRecord = fieldRecord;
+            this.name = name;
+        }
+
+        @Override
+        protected int computeContents(byte[] buffer, int initialPos) {
+            int pos = CVUtil.putShort((short) attrs, buffer, initialPos);
+            pos = CVUtil.putInt(underlyingTypeIndex, buffer, pos);
+            pos = CVUtil.putInt(fieldRecord.getSequenceNumber(), buffer, pos);
+            pos = CVUtil.putUTF8StringBytes(name, buffer, pos);
+            return pos;
+        }
+
+        @Override
+        public int hashCode() {
+            int hash = type;
+            hash = 31 * hash + name.hashCode();
+            hash = 31 * hash + attrs;
+            hash = 31 * hash + underlyingTypeIndex;
+            hash = 31 * hash + fieldRecord.hashCode();
+            return hash;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (!super.equals(obj)) {
+                return false;
+            }
+            CVEnumRecord other = (CVEnumRecord) obj;
+            return attrs == other.attrs && fieldRecord.equals(other.fieldRecord) && underlyingTypeIndex == other.underlyingTypeIndex && name.equals(other.name);
+        }
+
+        @Override
+        public String toString() {
+            return String.format("LF_ENUM attrs=0x%x(%s) count=%d %s", attrs, propertyString(attrs), fieldRecord.count(), name);
+        }
+    }
+
+    @SuppressWarnings("unused")
+    static final class CVInterfaceRecord extends CVClassRecord {
+        CVInterfaceRecord(short count, short attrs, int fieldIndex, int derivedFromIndex, int vshape, String name) {
+            super(LF_INTERFACE, count, attrs, fieldIndex, derivedFromIndex, vshape, 0, name, null);
+        }
+
+        @Override
+        public String toString() {
+            return toString("LF_INTERFACE");
+        }
+    }
+
+    @SuppressWarnings("unused")
+    static final class CVTypeBitfieldRecord extends CVTypeRecord {
+
+        private final byte length;
+        private final byte position;
+        private final int typeIndex;
+
+        CVTypeBitfieldRecord(int length, int position, int typeIndex) {
+            super(LF_BITFIELD);
+            this.length = (byte) length;
+            this.position = (byte) position;
+            this.typeIndex = typeIndex;
+        }
+
+        @Override
+        public int computeSize(int initialPos) {
+            return initialPos + Integer.BYTES + Byte.BYTES + Byte.BYTES;
+        }
+
+        @Override
+        public int computeContents(byte[] buffer, int initialPos) {
+            int pos = CVUtil.putInt(typeIndex, buffer, initialPos);
+            pos = CVUtil.putByte(length, buffer, pos);
+            pos = CVUtil.putByte(position, buffer, pos);
+            return pos;
+        }
+
+        @Override
+        public String toString() {
+            return String.format("LF_BITFIELD 0x%04x, type=0x%04x len=%d pos=%d", getSequenceNumber(), typeIndex, length, position);
+        }
+
+        @Override
+        public int hashCode() {
+            int h = type;
+            h = 31 * h + position;
+            h = 31 * h + length;
+            h = 31 * h + typeIndex;
+            return h;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (!super.equals(obj)) {
+                return false;
+            }
+            CVTypeBitfieldRecord other = (CVTypeBitfieldRecord) obj;
+            return this.position == other.position && this.length == other.length && this.typeIndex == other.typeIndex;
         }
     }
 


### PR DESCRIPTION
This PR implements issue #5635 by adding Windows CodeView records support to define local variables.  

Method parameter variables (including 'this') are defined as a demonstration.  No other local variable information is implemented by this PR as this PR is not aware of the lifetime of variables or stack frame information.  Method parameter variables are available to the debugger only upon entry to a method.

There is a body of unused code (symbol record definitions) in this PR - it will be required for local variable definition in the followup PR.