### PR TITLE
Object allocation in new TLAB JFR event

### DIFF
--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/JfrEvent.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/JfrEvent.java
@@ -63,6 +63,7 @@ public final class JfrEvent {
     public static final JfrEvent ThreadSleep = create("jdk.ThreadSleep", JDK17OrEarlier.class);
     public static final JfrEvent ThreadPark = create("jdk.ThreadPark");
     public static final JfrEvent JavaMonitorWait = create("jdk.JavaMonitorWait");
+    public static final JfrEvent ObjectAllocationInNewTLAB = create("jdk.ObjectAllocationInNewTLAB");
 
     private final long id;
     private final String name;

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/JfrThreadLocal.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/JfrThreadLocal.java
@@ -203,7 +203,10 @@ public class JfrThreadLocal implements ThreadListener {
         }
         return result;
     }
-
+    @Uninterruptible(reason = "Accesses a JFR buffer.", callerMustBe = true)
+    public boolean JfrThreadLocalInitialized() {
+        return threadId.get() > 0;
+    }
     @Uninterruptible(reason = "Accesses a JFR buffer.", callerMustBe = true)
     public static JfrBuffer getJavaBuffer(IsolateThread thread) {
         assert (VMOperation.isInProgressAtSafepoint());

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/JfrThreadLocal.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/JfrThreadLocal.java
@@ -203,10 +203,12 @@ public class JfrThreadLocal implements ThreadListener {
         }
         return result;
     }
+
     @Uninterruptible(reason = "Accesses a JFR buffer.", callerMustBe = true)
-    public boolean JfrThreadLocalInitialized() {
+    public boolean initialized() {
         return threadId.get() > 0;
     }
+
     @Uninterruptible(reason = "Accesses a JFR buffer.", callerMustBe = true)
     public static JfrBuffer getJavaBuffer(IsolateThread thread) {
         assert (VMOperation.isInProgressAtSafepoint());

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/events/ObjectAllocationInNewTLABEvent.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/events/ObjectAllocationInNewTLABEvent.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2022, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2022, Red Hat Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package com.oracle.svm.core.jfr.events;
+
+import com.oracle.svm.core.Uninterruptible;
+import com.oracle.svm.core.jfr.JfrEvent;
+import com.oracle.svm.core.jfr.JfrNativeEventWriter;
+import com.oracle.svm.core.jfr.JfrNativeEventWriterData;
+import com.oracle.svm.core.jfr.JfrNativeEventWriterDataAccess;
+import com.oracle.svm.core.jfr.JfrTicks;
+import com.oracle.svm.core.jfr.SubstrateJVM;
+import com.oracle.svm.core.jfr.HasJfrSupport;
+import com.oracle.svm.core.jfr.JfrThreadLocal;
+import org.graalvm.nativeimage.StackValue;
+
+public class ObjectAllocationInNewTLABEvent {
+    public static void emit(long startTicks,  Class<?> clazz, long allocationSize, long tlabSize) {
+        if (HasJfrSupport.get()) {
+            emit0(startTicks, clazz, allocationSize, tlabSize);
+        }
+    }
+
+    @Uninterruptible(reason = "Accesses a JFR buffer.")
+    private static void emit0(long startTicks, Class<?> clazz, long allocationSize, long tlabSize) {
+
+        if (SubstrateJVM.isRecording() && SubstrateJVM.get().isEnabled(JfrEvent.ObjectAllocationInNewTLAB)) {
+            JfrThreadLocal jfrThreadLocal = (JfrThreadLocal) SubstrateJVM.getThreadLocal();
+            if (!jfrThreadLocal.JfrThreadLocalInitialized()){
+                return;
+            }
+            JfrNativeEventWriterData data = StackValue.get(JfrNativeEventWriterData.class);
+            JfrNativeEventWriterDataAccess.initializeThreadLocalNativeBuffer(data);
+            JfrNativeEventWriter.beginSmallEvent(data, JfrEvent.ObjectAllocationInNewTLAB);
+            JfrNativeEventWriter.putLong(data, startTicks);
+            JfrNativeEventWriter.putEventThread(data);
+            JfrNativeEventWriter.putLong(data, SubstrateJVM.get().getStackTraceId(JfrEvent.ObjectAllocationInNewTLAB, 0));
+            JfrNativeEventWriter.putClass(data, clazz);
+            JfrNativeEventWriter.putLong(data, allocationSize);
+            JfrNativeEventWriter.putLong(data, tlabSize);
+            JfrNativeEventWriter.endSmallEvent(data);
+        }
+    }
+}

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/events/ObjectAllocationInNewTLABEvent.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/events/ObjectAllocationInNewTLABEvent.java
@@ -31,14 +31,13 @@ import com.oracle.svm.core.jfr.JfrEvent;
 import com.oracle.svm.core.jfr.JfrNativeEventWriter;
 import com.oracle.svm.core.jfr.JfrNativeEventWriterData;
 import com.oracle.svm.core.jfr.JfrNativeEventWriterDataAccess;
-import com.oracle.svm.core.jfr.JfrTicks;
 import com.oracle.svm.core.jfr.SubstrateJVM;
 import com.oracle.svm.core.jfr.HasJfrSupport;
 import com.oracle.svm.core.jfr.JfrThreadLocal;
 import org.graalvm.nativeimage.StackValue;
 
 public class ObjectAllocationInNewTLABEvent {
-    public static void emit(long startTicks,  Class<?> clazz, long allocationSize, long tlabSize) {
+    public static void emit(long startTicks, Class<?> clazz, long allocationSize, long tlabSize) {
         if (HasJfrSupport.get()) {
             emit0(startTicks, clazz, allocationSize, tlabSize);
         }
@@ -49,7 +48,10 @@ public class ObjectAllocationInNewTLABEvent {
 
         if (SubstrateJVM.isRecording() && SubstrateJVM.get().isEnabled(JfrEvent.ObjectAllocationInNewTLAB)) {
             JfrThreadLocal jfrThreadLocal = (JfrThreadLocal) SubstrateJVM.getThreadLocal();
-            if (!jfrThreadLocal.JfrThreadLocalInitialized()){
+
+            // This check is needed to avoid issues upon allocation from the thread that invokes the
+            // Java main method and shutdown.
+            if (!jfrThreadLocal.initialized()) {
                 return;
             }
             JfrNativeEventWriterData data = StackValue.get(JfrNativeEventWriterData.class);


### PR DESCRIPTION
### Description of Changes
This adds support for the JFR event `jdk.ObjectAllocationInNewTLAB`.  This PR resolves the issue https://github.com/oracle/graal/issues/5636

The JFR event`jdk.ObjectAllocationOutsideTLAB` also exists, but does not seem applicable to native images because allocations are always done in new TLABs.  For example, in Hotspot, if an allocation is larger than the largest possible TLAB size, or if TLAB allocation fails, then allocation is done outside of the TLAB. This is also true if the `UseTLAB` option is false. However, in SVM, all the aforementioned scenarios still result in using a new TLAB. 