### PR TITLE
Fix indefinite articles for URL in Javadoc and error messages

### DIFF
--- a/sdk/src/org.graalvm.polyglot/src/org/graalvm/polyglot/Source.java
+++ b/sdk/src/org.graalvm.polyglot/src/org/graalvm/polyglot/Source.java
@@ -69,7 +69,7 @@ import org.graalvm.polyglot.io.ByteSequence;
  *
  * The starting point is {@link Source#newBuilder(String, java.io.File)} method.
  *
- * <h3>Read from an URL</h3>
+ * <h3>Read from a URL</h3>
  *
  * One can read remote or in JAR resources using the {@link Source#newBuilder(String, java.net.URL)}
  * factory: <br>
@@ -124,9 +124,9 @@ import org.graalvm.polyglot.io.ByteSequence;
  *
  * @see Context#eval(Source) To evaluate sources.
  * @see Source#findLanguage(File) To detect a language using a File
- * @see Source#findLanguage(URL) To detect a language using an URL.
+ * @see Source#findLanguage(URL) To detect a language using a URL.
  * @see Source#findMimeType(File) To detect a MIME type using a File.
- * @see Source#findMimeType(URL) To detect a MIME type using an URL.
+ * @see Source#findMimeType(URL) To detect a MIME type using a URL.
  * @since 19.0
  */
 public final class Source {
@@ -634,7 +634,7 @@ public final class Source {
      * Returns the probed MIME type for a given url, or <code>null</code> if no MIME type could be
      * resolved. Typically the MIME type is identified using the file extension, connection
      * meta-data and/or using it contents. Returns <code>null</code> if the language of the given
-     * file could not be detected. Probing the language of an URL may require to open a new URL
+     * file could not be detected. Probing the language of a URL may require to open a new URL
      * connection.
      *
      * @throws IOException if an error opening the url occurred.

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/JavaNetSubstitutions.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/JavaNetSubstitutions.java
@@ -224,11 +224,11 @@ public final class JavaNetSubstitutions {
         URLStreamHandler result = URLProtocolsSupport.get(protocol);
         if (result == null) {
             if (onDemandProtocols.contains(protocol)) {
-                unsupported("Accessing an URL protocol that was not enabled. The URL protocol " + protocol +
+                unsupported("Accessing a URL protocol that was not enabled. The URL protocol " + protocol +
                                 " is supported but not enabled by default. It must be enabled by adding the " + enableProtocolsOption + protocol +
                                 " option to the native-image command.");
             } else {
-                unsupported("Accessing an URL protocol that was not enabled. The URL protocol " + protocol +
+                unsupported("Accessing a URL protocol that was not enabled. The URL protocol " + protocol +
                                 " is not tested and might not work as expected. It can be enabled by adding the " + enableProtocolsOption + protocol +
                                 " option to the native-image command.");
             }

--- a/truffle/src/com.oracle.truffle.api/src/com/oracle/truffle/api/source/Source.java
+++ b/truffle/src/com.oracle.truffle.api/src/com/oracle/truffle/api/source/Source.java
@@ -84,7 +84,7 @@ import com.oracle.truffle.api.nodes.LanguageInfo;
  *
  * The starting point is {@link Source#newBuilder(String, TruffleFile)} method.
  *
- * <h3>Read from an URL</h3>
+ * <h3>Read from a URL</h3>
  *
  * One can read remote or in JAR resources using the {@link Source#newBuilder(String, java.net.URL)}
  * factory: <br>

--- a/vm/src/org.graalvm.component.installer/src/org/graalvm/component/installer/CommonConstants.java
+++ b/vm/src/org.graalvm.component.installer/src/org/graalvm/component/installer/CommonConstants.java
@@ -135,7 +135,7 @@ public class CommonConstants {
     public static final String BUILTIN_INSTALLATION_DIR = "/usr/lib/graalvm"; // NOI18N
 
     /**
-     * Origin of the component. An URL. Used only in directory-based registry of installed
+     * Origin of the component. A URL. Used only in directory-based registry of installed
      * components.
      */
     public static final String BUNDLE_ORIGIN_URL = "x-GraalVM-Component-Origin"; // NOI18N

--- a/vm/src/org.graalvm.component.installer/src/org/graalvm/component/installer/SoftwareChannel.java
+++ b/vm/src/org.graalvm.component.installer/src/org/graalvm/component/installer/SoftwareChannel.java
@@ -69,7 +69,7 @@ public interface SoftwareChannel {
     interface Factory {
         /**
          * True, if the channel is willing to handle the URL. URL is passed as a String so that
-         * custom protocols may be used without registering an URLStreamHandlerFactory.
+         * custom protocols may be used without registering a URLStreamHandlerFactory.
          * 
          * @param source the definition of the channel including label
          * @param input input parameters

--- a/vm/src/org.graalvm.component.installer/src/org/graalvm/component/installer/SystemUtils.java
+++ b/vm/src/org.graalvm.component.installer/src/org/graalvm/component/installer/SystemUtils.java
@@ -820,7 +820,7 @@ public class SystemUtils {
      * as relative.
      * 
      * @param pathOrURL path or URL to check.
-     * @return true, if the path is actually an URL.
+     * @return true, if the path is actually a URL.
      */
     public static boolean isRemotePath(String pathOrURL) {
         try {

--- a/vm/src/org.graalvm.component.installer/src/org/graalvm/component/installer/remote/GraalEditionList.java
+++ b/vm/src/org.graalvm.component.installer/src/org/graalvm/component/installer/remote/GraalEditionList.java
@@ -58,7 +58,7 @@ import org.graalvm.component.installer.persist.DirectoryStorage;
  * <ol>
  * <li>{@link #overrideCatalogSpec}, which should be set from {@code -C} or GRAALVM_CATALOG_URL
  * environment variable by installer launcher.
- * <li>catalog related properties from the release file; each software sources has an URL
+ * <li>catalog related properties from the release file; each software sources has a URL
  * (mandatory), label and potentially parameters.
  * <li>component_catalog property, which defines all the software sources in a single property
  * </ol>


### PR DESCRIPTION
This PR fixes indefinite articles for URL in Javadoc and error messages.