### PR TITLE
Word-by-word card table scanning

### DIFF
--- a/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/remset/CardTable.java
+++ b/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/remset/CardTable.java
@@ -74,10 +74,11 @@ import com.oracle.svm.core.util.UnsignedUtils;
 final class CardTable {
     public static final int BYTES_COVERED_BY_ENTRY = 512;
 
-    private static final int ENTRY_SIZE_BYTES = 1;
+    static final int DIRTY_ENTRY = 0;
+    static final int CLEAN_ENTRY = 1;
+    static final UnsignedWord CLEAN_WORD = WordFactory.unsigned(0x0101010101010101L);
 
-    private static final int DIRTY_ENTRY = 0;
-    private static final int CLEAN_ENTRY = 1;
+    private static final int ENTRY_SIZE_BYTES = 1;
 
     private static final CardTableVerificationVisitor CARD_TABLE_VERIFICATION_VISITOR = new CardTableVerificationVisitor();
 
@@ -110,6 +111,14 @@ final class CardTable {
     private static boolean isClean(Pointer table, UnsignedWord index) {
         int entry = readEntry(table, index);
         return entry == CLEAN_ENTRY;
+    }
+
+    public static UnsignedWord readWord(Pointer table, UnsignedWord index) {
+        return table.readWord(indexToTableOffset(index));
+    }
+
+    public static void cleanWord(Pointer table, UnsignedWord index) {
+        table.writeWord(indexToTableOffset(index), CLEAN_WORD, BarrierSnippets.CARD_REMEMBERED_SET_LOCATION);
     }
 
     private static int readEntry(Pointer table, UnsignedWord index) {


### PR DESCRIPTION
This is a port of a [Hotspot fix](https://bugs.openjdk.org/browse/JDK-7068625). The idea is, currently card table is scanned byte by byte. But the majority of cards are clean, so we could move by 8-byte steps as long as none of those 8 cards are marked, and fall back to single-byte steps otherwise.

Testing shows this speeds up things a bit, especially when heap is large. The charts below show length of the `blackenDirtyCardRoots` stage for HyperAlloc running with `OnlyIncrementally` collection policy and different heap sizes.

![HyperAlloc-Xmx1g](https://user-images.githubusercontent.com/16533006/215777279-05a9358d-d305-4878-b557-1907bbb135b7.png)
![HyperAlloc-Xmx32g](https://user-images.githubusercontent.com/16533006/215777323-bc6810b4-17a8-4eb4-8488-2798ce9db568.png)
