### PR TITLE
Throw metadata exception resources

### DIFF
--- a/substratevm/src/com.oracle.svm.agent/src/com/oracle/svm/agent/BreakpointInterceptor.java
+++ b/substratevm/src/com.oracle.svm.agent/src/com/oracle/svm/agent/BreakpointInterceptor.java
@@ -618,39 +618,25 @@ final class BreakpointInterceptor {
 
     private static boolean findResource(JNIEnvironment jni, JNIObjectHandle thread, Breakpoint bp, InterceptedState state) {
         JNIObjectHandle callerClass = state.getDirectCallerClass();
-        JNIObjectHandle self = getReceiver(thread);
         JNIObjectHandle module = getObjectArgument(thread, 1);
         JNIObjectHandle name = getObjectArgument(thread, 2);
-        JNIObjectHandle result = Support.callObjectMethodLL(jni, self, bp.method, module, name);
-        if (clearException(jni)) {
-            result = nullHandle();
-        }
-        traceReflectBreakpoint(jni, nullHandle(), nullHandle(), callerClass, bp.specification.methodName, result.notEqual(nullHandle()), state.getFullStackTraceOrNull(),
+        traceReflectBreakpoint(jni, nullHandle(), nullHandle(), callerClass, bp.specification.methodName, true, state.getFullStackTraceOrNull(),
                         fromJniString(jni, module), fromJniString(jni, name));
         return true;
     }
 
     private static boolean getResource(JNIEnvironment jni, JNIObjectHandle thread, Breakpoint bp, InterceptedState state) {
-        return handleGetResources(jni, thread, bp, false, state);
+        return handleGetResources(jni, thread, bp, state);
     }
 
     private static boolean getResources(JNIEnvironment jni, JNIObjectHandle thread, Breakpoint bp, InterceptedState state) {
-        return handleGetResources(jni, thread, bp, true, state);
+        return handleGetResources(jni, thread, bp, state);
     }
 
-    private static boolean handleGetResources(JNIEnvironment jni, JNIObjectHandle thread, Breakpoint bp, boolean returnsEnumeration, InterceptedState state) {
+    private static boolean handleGetResources(JNIEnvironment jni, JNIObjectHandle thread, Breakpoint bp, InterceptedState state) {
         JNIObjectHandle callerClass = state.getDirectCallerClass();
         JNIObjectHandle self = getReceiver(thread);
         JNIObjectHandle name = getObjectArgument(thread, 1);
-        boolean result;
-        JNIObjectHandle returnValue = Support.callObjectMethodL(jni, self, bp.method, name);
-        result = returnValue.notEqual(nullHandle());
-        if (clearException(jni)) {
-            result = false;
-        }
-        if (result && returnsEnumeration) {
-            result = hasEnumerationElements(jni, returnValue);
-        }
         JNIObjectHandle selfClazz = nullHandle(); // self is java.lang.ClassLoader, get its class
         if (self.notEqual(nullHandle())) {
             selfClazz = jniFunctions().getGetObjectClass().invoke(jni, self);
@@ -658,38 +644,22 @@ final class BreakpointInterceptor {
                 selfClazz = nullHandle();
             }
         }
-        traceReflectBreakpoint(jni, selfClazz, nullHandle(), callerClass, bp.specification.methodName, result, state.getFullStackTraceOrNull(), fromJniString(jni, name));
+        traceReflectBreakpoint(jni, selfClazz, nullHandle(), callerClass, bp.specification.methodName, true, state.getFullStackTraceOrNull(), fromJniString(jni, name));
         return true;
     }
 
-    private static boolean hasEnumerationElements(JNIEnvironment jni, JNIObjectHandle obj) {
-        boolean hasElements = Support.callBooleanMethod(jni, obj, agent.handles().javaUtilEnumerationHasMoreElements);
-        if (clearException(jni)) {
-            hasElements = false;
-        }
-        return hasElements;
-    }
-
     private static boolean getSystemResource(JNIEnvironment jni, JNIObjectHandle thread, Breakpoint bp, InterceptedState state) {
-        return handleGetSystemResources(jni, thread, bp, false, state);
+        return handleGetSystemResources(jni, thread, bp, state);
     }
 
     private static boolean getSystemResources(JNIEnvironment jni, JNIObjectHandle thread, Breakpoint bp, InterceptedState state) {
-        return handleGetSystemResources(jni, thread, bp, true, state);
+        return handleGetSystemResources(jni, thread, bp, state);
     }
 
-    private static boolean handleGetSystemResources(JNIEnvironment jni, JNIObjectHandle thread, Breakpoint bp, boolean returnsEnumeration, InterceptedState state) {
+    private static boolean handleGetSystemResources(JNIEnvironment jni, JNIObjectHandle thread, Breakpoint bp, InterceptedState state) {
         JNIObjectHandle callerClass = state.getDirectCallerClass();
         JNIObjectHandle name = getReceiver(thread);
-        JNIObjectHandle returnValue = Support.callStaticObjectMethodL(jni, bp.clazz, bp.method, name);
-        boolean result = returnValue.notEqual(nullHandle());
-        if (clearException(jni)) {
-            result = false;
-        }
-        if (result && returnsEnumeration) {
-            result = hasEnumerationElements(jni, returnValue);
-        }
-        traceReflectBreakpoint(jni, nullHandle(), nullHandle(), callerClass, bp.specification.methodName, result, state.getFullStackTraceOrNull(), fromJniString(jni, name));
+        traceReflectBreakpoint(jni, nullHandle(), nullHandle(), callerClass, bp.specification.methodName, true, state.getFullStackTraceOrNull(), fromJniString(jni, name));
         return true;
     }
 
@@ -751,13 +721,11 @@ final class BreakpointInterceptor {
         JNIObjectHandle control = getObjectArgument(thread, 3);
         JNIObjectHandle result = Support.callStaticObjectMethodLLLL(jni, bp.clazz, bp.method, baseName, locale, loader, control);
         BundleInfo bundleInfo = BundleInfo.NONE;
-        if (clearException(jni)) {
-            result = nullHandle();
-        } else {
+        if (!clearException(jni)) {
             bundleInfo = extractBundleInfo(jni, result);
         }
-        traceReflectBreakpoint(jni, nullHandle(), nullHandle(), callerClass, "getBundleImplJDK8OrEarlier", result.notEqual(nullHandle()),
-                        state.getFullStackTraceOrNull(), fromJniString(jni, baseName), Tracer.UNKNOWN_VALUE, Tracer.UNKNOWN_VALUE, Tracer.UNKNOWN_VALUE, bundleInfo.classNames, bundleInfo.locales);
+        traceReflectBreakpoint(jni, nullHandle(), nullHandle(), callerClass, "getBundleImplJDK8OrEarlier", true, state.getFullStackTraceOrNull(),
+                        fromJniString(jni, baseName), Tracer.UNKNOWN_VALUE, Tracer.UNKNOWN_VALUE, Tracer.UNKNOWN_VALUE, bundleInfo.classNames, bundleInfo.locales);
         return true;
     }
 
@@ -778,14 +746,11 @@ final class BreakpointInterceptor {
         JNIObjectHandle control = getObjectArgument(thread, 4);
         JNIObjectHandle result = Support.callStaticObjectMethodLLLLL(jni, bp.clazz, bp.method, callerModule, module, baseName, locale, control);
         BundleInfo bundleInfo = BundleInfo.NONE;
-        if (clearException(jni)) {
-            result = nullHandle();
-        } else {
+        if (!clearException(jni)) {
             bundleInfo = extractBundleInfo(jni, result);
         }
-        traceReflectBreakpoint(jni, nullHandle(), nullHandle(), callerClass, "getBundleImplJDK11OrLater", result.notEqual(nullHandle()),
-                        state.getFullStackTraceOrNull(), Tracer.UNKNOWN_VALUE, Tracer.UNKNOWN_VALUE, fromJniString(jni, baseName), Tracer.UNKNOWN_VALUE, Tracer.UNKNOWN_VALUE, bundleInfo.classNames,
-                        bundleInfo.locales);
+        traceReflectBreakpoint(jni, nullHandle(), nullHandle(), callerClass, "getBundleImplJDK11OrLater", true, state.getFullStackTraceOrNull(),
+                        Tracer.UNKNOWN_VALUE, Tracer.UNKNOWN_VALUE, fromJniString(jni, baseName), Tracer.UNKNOWN_VALUE, Tracer.UNKNOWN_VALUE, bundleInfo.classNames, bundleInfo.locales);
         return true;
     }
 

--- a/substratevm/src/com.oracle.svm.agent/src/com/oracle/svm/agent/NativeImageAgentJNIHandleSet.java
+++ b/substratevm/src/com.oracle.svm.agent/src/com/oracle/svm/agent/NativeImageAgentJNIHandleSet.java
@@ -84,6 +84,9 @@ public class NativeImageAgentJNIHandleSet extends JNIHandleSet {
 
     final JNIFieldId javaLangInvokeSerializedLambdaCapturingClass;
 
+    final JNIObjectHandle javaNioFilePath;
+    final JNIMethodId javaNioFilePathToString;
+
     NativeImageAgentJNIHandleSet(JNIEnvironment env) {
         super(env);
         javaLangClass = newClassGlobalRef(env, "java/lang/Class");
@@ -120,6 +123,9 @@ public class NativeImageAgentJNIHandleSet extends JNIHandleSet {
 
         JNIObjectHandle serializedLambda = findClass(env, "java/lang/invoke/SerializedLambda");
         javaLangInvokeSerializedLambdaCapturingClass = getFieldId(env, serializedLambda, "capturingClass", "Ljava/lang/Class;", false);
+
+        javaNioFilePath = newClassGlobalRef(env, "java/nio/file/Path");
+        javaNioFilePathToString = getMethodId(env, javaNioFilePath, "toString", "()Ljava/lang/String;", false);
     }
 
     JNIMethodId getJavaLangReflectExecutableGetParameterTypes(JNIEnvironment env) {

--- a/substratevm/src/com.oracle.svm.configure/src/com/oracle/svm/configure/trace/ReflectionProcessor.java
+++ b/substratevm/src/com.oracle.svm.configure/src/com/oracle/svm/configure/trace/ReflectionProcessor.java
@@ -81,6 +81,25 @@ class ReflectionProcessor extends AbstractProcessor {
             case "getSystemResourceAsStream":
             case "getResources":
             case "getSystemResources":
+            case "newInputStream":
+            case "newOutputStream":
+            case "newByteChannel":
+            case "newDirectoryStream":
+            case "createDirectory":
+            case "createDirectories":
+            case "delete":
+            case "deleteIfExists":
+            case "copy":
+            case "move":
+            case "getFileStore":
+            case "readAttributes":
+            case "setAttribute":
+            case "isAccessible":
+            case "walkFileTree":
+            case "walk":
+            case "find":
+            case "lines":
+            case "open":
                 String literal = singleElement(args);
                 String regex = Pattern.quote(literal);
                 resourceConfiguration.addResourcePattern(condition, regex);

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/ClassLoaderSupport.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/ClassLoaderSupport.java
@@ -56,6 +56,8 @@ public abstract class ClassLoaderSupport {
         void addResource(String moduleName, String resourceName, InputStream resourceStream, boolean fromJar);
 
         void addDirectoryResource(String moduleName, String dir, String content, boolean fromJar);
+
+        void registerNegativeQuery(String moduleName, String resourceName);
     }
 
     public abstract void collectResources(ResourceCollector resourceCollector);

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/ClassLoaderSupport.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/ClassLoaderSupport.java
@@ -24,6 +24,7 @@
  */
 package com.oracle.svm.core;
 
+import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
 import java.util.List;
@@ -58,6 +59,8 @@ public abstract class ClassLoaderSupport {
         void addDirectoryResource(String moduleName, String dir, String content, boolean fromJar);
 
         void registerNegativeQuery(String moduleName, String resourceName);
+
+        void registerIOException(String moduleName, String resourceName, IOException e);
     }
 
     public abstract void collectResources(ResourceCollector resourceCollector);

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/hub/DynamicHub.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/hub/DynamicHub.java
@@ -739,7 +739,7 @@ public final class DynamicHub implements AnnotatedElement, java.lang.reflect.Typ
     public InputStream getResourceAsStream(String resourceName) {
         String moduleName = module == null ? null : module.getName();
         String resolvedName = resolveName(resourceName);
-        return Resources.createInputStream(moduleName, resolvedName);
+        return Resources.singleton().createInputStream(moduleName, resolvedName);
     }
 
     @KeepOriginal

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/Resources.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/Resources.java
@@ -197,6 +197,13 @@ public final class Resources {
         }
     }
 
+    public static void registerNegativeQueryRuntime(String resourceName) {
+        var resources = singleton().resources;
+        synchronized (resources) {
+            addEntry(null, resourceName, NEGATIVE_QUERY, resources);
+        }
+    }
+
     @Platforms(Platform.HOSTED_ONLY.class)
     public static void registerNegativeQuery(String resourceName) {
         registerNegativeQuery(null, resourceName);

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/Resources.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/Resources.java
@@ -183,6 +183,21 @@ public final class Resources {
     }
 
     @Platforms(Platform.HOSTED_ONLY.class)
+    public static void registerIOException(String resourceName, IOException e) {
+        registerIOException(null, resourceName, e);
+    }
+
+    @Platforms(Platform.HOSTED_ONLY.class)
+    public static void registerIOException(String moduleName, String resourceName, IOException e) {
+        Pair<String, String> key = Pair.create(moduleName, resourceName);
+        var resources = singleton().resources;
+        synchronized (resources) {
+            updateTimeStamp();
+            resources.put(key, e);
+        }
+    }
+
+    @Platforms(Platform.HOSTED_ONLY.class)
     public static void registerNegativeQuery(String resourceName) {
         registerNegativeQuery(null, resourceName);
     }
@@ -272,6 +287,9 @@ public final class Resources {
             } else {
                 return null;
             }
+        }
+        if (entry instanceof IOException) {
+            throw new RuntimeException((IOException) entry);
         }
         if (entry == NEGATIVE_QUERY) {
             return null;

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/ResourcesHelper.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/ResourcesHelper.java
@@ -61,7 +61,7 @@ public class ResourcesHelper {
     }
 
     public static <T> Enumeration<T> nameToResources(String resourceName) {
-        Enumeration<URL> urls = Resources.createURLs(resourceName);
+        Enumeration<URL> urls = Resources.singleton().createURLs(resourceName);
         List<T> resourceURLs = new ArrayList<>();
         while (urls.hasMoreElements()) {
             resourceURLs.add(urlToResource(resourceName, urls.nextElement()));
@@ -70,11 +70,11 @@ public class ResourcesHelper {
     }
 
     public static URL nameToResourceURL(String resourceName) {
-        return Resources.createURL(resourceName);
+        return Resources.singleton().createURL(resourceName);
     }
 
     public static URL nameToResourceURL(String moduleName, String resourceName) {
-        return Resources.createURL(moduleName, resourceName);
+        return Resources.singleton().createURL(moduleName, resourceName);
     }
 
     public static InputStream nameToResourceInputStream(String resourceName) throws IOException {
@@ -83,7 +83,7 @@ public class ResourcesHelper {
     }
 
     public static List<URL> nameToResourceListURLs(String resourcesName) {
-        Enumeration<URL> urls = Resources.createURLs(resourcesName);
+        Enumeration<URL> urls = Resources.singleton().createURLs(resourcesName);
         List<URL> resourceURLs = new ArrayList<>();
         while (urls.hasMoreElements()) {
             resourceURLs.add(urls.nextElement());

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/Target_java_lang_ClassLoader.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/Target_java_lang_ClassLoader.java
@@ -36,7 +36,6 @@ import java.util.Vector;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Stream;
 
-import jdk.internal.loader.ClassLoaderValue;
 import org.graalvm.nativeimage.hosted.FieldValueTransformer;
 
 import com.oracle.svm.core.SubstrateUtil;
@@ -51,6 +50,8 @@ import com.oracle.svm.core.hub.ClassForNameSupport;
 import com.oracle.svm.core.hub.PredefinedClassesSupport;
 import com.oracle.svm.core.util.LazyFinalReference;
 import com.oracle.svm.core.util.VMError;
+
+import jdk.internal.loader.ClassLoaderValue;
 
 @TargetClass(className = "jdk.internal.loader.Resource")
 @SuppressWarnings("unused")
@@ -108,12 +109,12 @@ public final class Target_java_lang_ClassLoader {
 
     @Substitute
     public InputStream getResourceAsStream(String name) {
-        return Resources.createInputStream(name);
+        return Resources.singleton().createInputStream(name);
     }
 
     @Substitute
     public static InputStream getSystemResourceAsStream(String name) {
-        return Resources.createInputStream(name);
+        return Resources.singleton().createInputStream(name);
     }
 
     @Substitute

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/Target_java_lang_Module.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/Target_java_lang_Module.java
@@ -49,8 +49,8 @@ final class Target_java_lang_Module {
         if (resName.startsWith("/")) {
             resName = resName.substring(1);
         }
-        ResourceStorageEntry res = Resources.get(name, resName);
-        return res == null ? null : new ByteArrayInputStream(res.getData().get(0));
+        Object res = Resources.get(name, resName, true);
+        return res == null ? null : new ByteArrayInputStream(((ResourceStorageEntry) res).getData().get(0));
     }
 
     @Substitute //

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/Target_java_lang_Module.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/Target_java_lang_Module.java
@@ -49,7 +49,7 @@ final class Target_java_lang_Module {
         if (resName.startsWith("/")) {
             resName = resName.substring(1);
         }
-        Object res = Resources.get(name, resName, true);
+        Object res = Resources.singleton().get(name, resName, true);
         return res == null ? null : new ByteArrayInputStream(((ResourceStorageEntry) res).getData().get(0));
     }
 

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/Target_java_net_URLClassLoader.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/Target_java_net_URLClassLoader.java
@@ -80,6 +80,6 @@ final class Target_java_net_URLClassLoader {
 
     @Substitute
     public InputStream getResourceAsStream(String name) throws IOException {
-        return Resources.createInputStream(name);
+        return Resources.singleton().createInputStream(name);
     }
 }

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/resources/MissingResourceMetadataException.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/resources/MissingResourceMetadataException.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2023, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package com.oracle.svm.core.jdk.resources;
+
+import org.graalvm.compiler.options.Option;
+import org.graalvm.compiler.options.OptionType;
+
+import com.oracle.svm.core.option.HostedOptionKey;
+import com.oracle.svm.core.util.ExitStatus;
+
+public final class MissingResourceMetadataException extends RuntimeException {
+    private static final long serialVersionUID = 1L;
+
+    public static class Options {
+        @Option(help = "Enable termination caused by missing metadata.")//
+        public static final HostedOptionKey<Boolean> ExitOnMissingMetadata = new HostedOptionKey<>(false);
+
+        @Option(help = "Simulate exiting the program with an exception instead of calling System.exit() (for testing)")//
+        public static final HostedOptionKey<Boolean> ExitWithException = new HostedOptionKey<>(false);
+
+        @Option(help = "Throw Native Image-specific exceptions when encountering an unregistered reflection call.", type = OptionType.User)//
+        public static final HostedOptionKey<Boolean> ThrowMissingMetadataExceptions = new HostedOptionKey<>(false);
+    }
+
+    private MissingResourceMetadataException(String message) {
+        super(message);
+    }
+
+    public static MissingResourceMetadataException missingResource(String resourcePath) {
+        MissingResourceMetadataException exception = new MissingResourceMetadataException(
+                        "Resource at path " + resourcePath + " has not been registered as reachable. To ensure this resource is available at run time, you need to add it to the resource metadata.");
+        if (MissingResourceMetadataException.Options.ExitOnMissingMetadata.getValue()) {
+            exitOnMissingMetadata(exception);
+        }
+        return exception;
+    }
+
+    private static void exitOnMissingMetadata(MissingResourceMetadataException exception) {
+        if (Options.ExitWithException.getValue()) {
+            throw new ExitException(exception);
+        } else {
+            exception.printStackTrace(System.out);
+            System.exit(ExitStatus.MISSING_METADATA.getValue());
+        }
+    }
+
+    public static final class ExitException extends Error {
+        private static final long serialVersionUID = 1L;
+
+        private ExitException(Throwable cause) {
+            super(cause);
+        }
+    }
+}

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/resources/NativeImageResourceFileSystem.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/resources/NativeImageResourceFileSystem.java
@@ -119,7 +119,7 @@ public class NativeImageResourceFileSystem extends FileSystem {
     private final ReadWriteLock rwlock = new ReentrantReadWriteLock();
 
     private static final byte[] ROOT_PATH = new byte[]{'/'};
-    private final IndexNode lookupKey = new IndexNode(null, true);
+    private final IndexNode lookupKey = new IndexNode(null, true, false);
     private final LinkedHashMap<IndexNode, IndexNode> inodes = new LinkedHashMap<>(10);
 
     public NativeImageResourceFileSystem(NativeImageResourceFileSystemProvider provider, Path resourcePath, Map<String, ?> env) {
@@ -305,7 +305,7 @@ public class NativeImageResourceFileSystem extends FileSystem {
                 if (inode == null) {
                     return null;
                 }
-                entry = new Entry(inode.name, inode.isDir);
+                entry = new Entry(inode.name, inode.isDir, inode.isComplete);
                 entry.lastModifiedTime = entry.lastAccessTime = entry.createTime = defaultTimestamp;
             }
         } finally {
@@ -351,7 +351,7 @@ public class NativeImageResourceFileSystem extends FileSystem {
                     throw new NoSuchFileException(getString(path));
                 }
                 checkParents(path);
-                return new EntryOutputChannel(new Entry(path, false));
+                return new EntryOutputChannel(new Entry(path, false, false));
             } finally {
                 endRead();
             }
@@ -439,7 +439,7 @@ public class NativeImageResourceFileSystem extends FileSystem {
                 throw new FileAlreadyExistsException(getString(dir));
             }
             checkParents(dir);
-            Entry e = new Entry(dir, true);
+            Entry e = new Entry(dir, true, false);
             update(e);
         } finally {
             endWrite();
@@ -571,7 +571,12 @@ public class NativeImageResourceFileSystem extends FileSystem {
         if (path == null) {
             throw new NullPointerException("Path is null!");
         }
-        return inodes.get(IndexNode.keyOf(path));
+        IndexNode indexNode = inodes.get(IndexNode.keyOf(path));
+        if (indexNode == null && MissingResourceMetadataException.Options.ThrowMissingMetadataExceptions.getValue()) {
+            // Try to access the resource to see if the metadata is present
+            Resources.singleton().get(getString(path), true);
+        }
+        return indexNode;
     }
 
     Entry getEntry(byte[] path) {
@@ -582,7 +587,7 @@ public class NativeImageResourceFileSystem extends FileSystem {
         if (inode == null) {
             return null;
         }
-        return new Entry(inode.name, inode.isDir);
+        return new Entry(inode.name, inode.isDir, inode.isComplete);
     }
 
     static byte[] getParent(byte[] path) {
@@ -652,10 +657,13 @@ public class NativeImageResourceFileSystem extends FileSystem {
     private void readAllEntries() {
         MapCursor<Pair<String, String>, Object> entries = Resources.singleton().resources().getEntries();
         while (entries.advance()) {
-            byte[] name = getBytes(entries.getKey().getRight());
+            String stringName = entries.getKey().getRight();
+            byte[] name = getBytes(stringName);
             Object entry = entries.getValue();
             if (entry != Resources.NEGATIVE_QUERY && !((ResourceStorageEntry) entry).isDirectory()) {
-                IndexNode newIndexNode = new IndexNode(name, false);
+                IndexNode newIndexNode = new IndexNode(name, false, true);
+                // Mark the resources as accessible from null module because it is dropped
+                Resources.registerNegativeQueryRuntime(stringName);
                 inodes.put(newIndexNode, newIndexNode);
             }
         }
@@ -667,7 +675,7 @@ public class NativeImageResourceFileSystem extends FileSystem {
         try {
             IndexNode rootIndex = inodes.get(lookupKey.as(ROOT_PATH));
             if (rootIndex == null) {
-                rootIndex = new IndexNode(ROOT_PATH, true);
+                rootIndex = new IndexNode(ROOT_PATH, true, false);
             } else {
                 inodes.remove(rootIndex);
             }
@@ -692,7 +700,7 @@ public class NativeImageResourceFileSystem extends FileSystem {
                         break;
                     }
                     // Add new pseudo directory entry.
-                    parent = new IndexNode(Arrays.copyOf(node.name, off), true);
+                    parent = new IndexNode(Arrays.copyOf(node.name, off), true, false);
                     inodes.put(parent, parent);
                     node.sibling = parent.child;
                     parent.child = node;
@@ -803,7 +811,7 @@ public class NativeImageResourceFileSystem extends FileSystem {
                     throw new NoSuchFileException(getString(path));
                 }
                 checkParents(path);
-                return getOutputStream(new Entry(path, false));
+                return getOutputStream(new Entry(path, false, false));
             }
         } finally {
             endRead();
@@ -837,7 +845,7 @@ public class NativeImageResourceFileSystem extends FileSystem {
             final boolean isFCH = (e != null && e.type == Entry.FILE_CH);
             final Path tmpFile = isFCH ? e.file : getTempPathForEntry(path);
             final FileChannel fch = tmpFile.getFileSystem().provider().newFileChannel(tmpFile, options, attrs);
-            final Entry target = isFCH ? e : new Entry(path, tmpFile, Entry.FILE_CH);
+            final Entry target = isFCH ? e : new Entry(path, tmpFile, Entry.FILE_CH, false);
             return new FileChannel() {
 
                 @Override
@@ -981,6 +989,7 @@ public class NativeImageResourceFileSystem extends FileSystem {
         byte[] name;
         int hashcode;
         boolean isDir;
+        boolean isComplete;
 
         IndexNode child;
         IndexNode sibling;
@@ -992,9 +1001,10 @@ public class NativeImageResourceFileSystem extends FileSystem {
             name(n);
         }
 
-        IndexNode(byte[] n, boolean isDir) {
+        IndexNode(byte[] n, boolean isDir, boolean isComplete) {
             name(n);
             this.isDir = isDir;
+            this.isComplete = isComplete;
         }
 
         static IndexNode keyOf(byte[] n) {
@@ -1099,8 +1109,8 @@ public class NativeImageResourceFileSystem extends FileSystem {
         private byte[] bytes;
         public Path file;
 
-        Entry(byte[] name, Path file, int type) {
-            this(name, type, false);
+        Entry(byte[] name, Path file, int type, boolean isComplete) {
+            this(name, type, false, isComplete);
             this.file = file;
         }
 
@@ -1109,12 +1119,14 @@ public class NativeImageResourceFileSystem extends FileSystem {
         }
 
         void initData() {
-            this.bytes = NativeImageResourceFileSystemUtil.getBytes(getString(name), true);
-            this.size = !isDir ? this.bytes.length : 0;
+            if (isComplete) {
+                this.bytes = NativeImageResourceFileSystemUtil.getBytes(getString(name), true);
+                this.size = !isDir ? this.bytes.length : 0;
+            }
         }
 
         byte[] getBytes(boolean readOnly) {
-            if (!readOnly) {
+            if (!readOnly && isComplete) {
                 // Copy On Write technique.
                 if (!copyOnWrite) {
                     copyOnWrite = true;
@@ -1124,18 +1136,20 @@ public class NativeImageResourceFileSystem extends FileSystem {
             return this.bytes;
         }
 
-        Entry(byte[] name, boolean isDir) {
+        Entry(byte[] name, boolean isDir, boolean isComplete) {
             name(name);
             this.type = Entry.NEW;
             this.isDir = isDir;
+            this.isComplete = isComplete;
             initData();
             initTimes();
         }
 
-        Entry(byte[] name, int type, boolean isDir) {
+        Entry(byte[] name, int type, boolean isDir, boolean isComplete) {
             name(name);
             this.type = type;
             this.isDir = isDir;
+            this.isComplete = isComplete;
             initData();
             initTimes();
         }
@@ -1146,6 +1160,7 @@ public class NativeImageResourceFileSystem extends FileSystem {
             this.lastAccessTime = other.lastAccessTime;
             this.createTime = other.createTime;
             this.isDir = other.isDir;
+            this.isComplete = other.isComplete;
             this.size = other.size;
             this.bytes = other.bytes;
             this.type = type;

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/resources/NativeImageResourceFileSystem.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/resources/NativeImageResourceFileSystem.java
@@ -663,7 +663,7 @@ public class NativeImageResourceFileSystem extends FileSystem {
             if (entry != Resources.NEGATIVE_QUERY && !((ResourceStorageEntry) entry).isDirectory()) {
                 IndexNode newIndexNode = new IndexNode(name, false, true);
                 // Mark the resources as accessible from null module because it is dropped
-                Resources.registerNegativeQueryRuntime(stringName);
+                Resources.singleton().registerNegativeQueryRuntime(stringName);
                 inodes.put(newIndexNode, newIndexNode);
             }
         }

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/resources/NativeImageResourceFileSystem.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/resources/NativeImageResourceFileSystem.java
@@ -650,10 +650,11 @@ public class NativeImageResourceFileSystem extends FileSystem {
     }
 
     private void readAllEntries() {
-        MapCursor<Pair<String, String>, ResourceStorageEntry> entries = Resources.singleton().resources().getEntries();
+        MapCursor<Pair<String, String>, Object> entries = Resources.singleton().resources().getEntries();
         while (entries.advance()) {
             byte[] name = getBytes(entries.getKey().getRight());
-            if (!entries.getValue().isDirectory()) {
+            Object entry = entries.getValue();
+            if (entry != Resources.NEGATIVE_QUERY && !((ResourceStorageEntry) entry).isDirectory()) {
                 IndexNode newIndexNode = new IndexNode(name, false);
                 inodes.put(newIndexNode, newIndexNode);
             }

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/resources/NativeImageResourceFileSystemUtil.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/resources/NativeImageResourceFileSystemUtil.java
@@ -36,7 +36,7 @@ public final class NativeImageResourceFileSystemUtil {
     }
 
     public static byte[] getBytes(String resourceName, boolean readOnly) {
-        Object entry = Resources.get(resourceName, true);
+        Object entry = Resources.singleton().get(resourceName, true);
         if (entry == null) {
             return new byte[0];
         }
@@ -49,7 +49,7 @@ public final class NativeImageResourceFileSystemUtil {
     }
 
     public static int getSize(String resourceName) {
-        Object entry = Resources.get(resourceName, true);
+        Object entry = Resources.singleton().get(resourceName, true);
         if (entry == null) {
             return 0;
         } else {

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/resources/NativeImageResourceFileSystemUtil.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/resources/NativeImageResourceFileSystemUtil.java
@@ -36,11 +36,11 @@ public final class NativeImageResourceFileSystemUtil {
     }
 
     public static byte[] getBytes(String resourceName, boolean readOnly) {
-        ResourceStorageEntry entry = Resources.get(resourceName);
+        Object entry = Resources.get(resourceName, true);
         if (entry == null) {
             return new byte[0];
         }
-        byte[] bytes = entry.getData().get(0);
+        byte[] bytes = ((ResourceStorageEntry) entry).getData().get(0);
         if (readOnly) {
             return bytes;
         } else {
@@ -49,11 +49,11 @@ public final class NativeImageResourceFileSystemUtil {
     }
 
     public static int getSize(String resourceName) {
-        ResourceStorageEntry entry = Resources.get(resourceName);
+        Object entry = Resources.get(resourceName, true);
         if (entry == null) {
             return 0;
         } else {
-            return entry.getData().get(0).length;
+            return ((ResourceStorageEntry) entry).getData().get(0).length;
         }
     }
 

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/resources/ResourceURLConnection.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/resources/ResourceURLConnection.java
@@ -58,9 +58,9 @@ public final class ResourceURLConnection extends URLConnection {
             throw new IllegalArgumentException("Empty URL path not allowed in " + JavaNetSubstitutions.RESOURCE_PROTOCOL + " URL");
         }
         String resourceName = urlPath.substring(1);
-        ResourceStorageEntry entry = Resources.get(hostNameOrNull, resourceName);
+        Object entry = Resources.get(hostNameOrNull, resourceName, true);
         if (entry != null) {
-            List<byte[]> bytes = entry.getData();
+            List<byte[]> bytes = ((ResourceStorageEntry) entry).getData();
             String urlRef = url.getRef();
             int index = 0;
             if (urlRef != null) {

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/resources/ResourceURLConnection.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/resources/ResourceURLConnection.java
@@ -58,7 +58,7 @@ public final class ResourceURLConnection extends URLConnection {
             throw new IllegalArgumentException("Empty URL path not allowed in " + JavaNetSubstitutions.RESOURCE_PROTOCOL + " URL");
         }
         String resourceName = urlPath.substring(1);
-        Object entry = Resources.get(hostNameOrNull, resourceName, true);
+        Object entry = Resources.singleton().get(hostNameOrNull, resourceName, true);
         if (entry != null) {
             List<byte[]> bytes = ((ResourceStorageEntry) entry).getData();
             String urlRef = url.getRef();

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/ClassLoaderSupportImpl.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/ClassLoaderSupportImpl.java
@@ -132,6 +132,7 @@ public class ClassLoaderSupportImpl extends ClassLoaderSupport {
             for (String resName : foundResources) {
                 Optional<InputStream> content = moduleReader.open(resName);
                 if (content.isEmpty()) {
+                    resourceCollector.registerNegativeQuery(moduleName, resName);
                     continue;
                 }
                 try (InputStream is = content.get()) {
@@ -187,6 +188,8 @@ public class ClassLoaderSupportImpl extends ClassLoaderSupport {
             List<String> dirContent = matchedDirectoryResources.get(key);
             if (dirContent != null && !dirContent.contains(entry)) {
                 dirContent.add(entry.substring(last + 1));
+            } else if (dirContent == null) {
+                collector.registerNegativeQuery(null, key);
             }
         }
 

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/ProgressReporter.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/ProgressReporter.java
@@ -416,7 +416,7 @@ public class ProgressReporter {
         String format = "%9s (%5.2f%%) for ";
         l().a(format, ByteFormattingUtil.bytesToHuman(codeAreaSize), codeAreaSize / (double) imageFileSize * 100)
                         .doclink("code area", "#glossary-code-area").a(":%,10d compilation units", numCompilations).println();
-        EconomicMap<Pair<String, String>, ResourceStorageEntry> resources = Resources.singleton().resources();
+        EconomicMap<Pair<String, String>, Object> resources = Resources.singleton().resources();
         int numResources = resources.size();
         recordJsonMetric(ImageDetailKey.IMAGE_HEAP_RESOURCE_COUNT, numResources);
         l().a(format, ByteFormattingUtil.bytesToHuman(imageHeapSize), imageHeapSize / (double) imageFileSize * 100)
@@ -525,9 +525,12 @@ public class ProgressReporter {
                 remainingBytes -= metadataByteLength;
             }
             long resourcesByteLength = 0;
-            for (ResourceStorageEntry resourceList : Resources.singleton().resources().getValues()) {
-                for (byte[] resource : resourceList.getData()) {
-                    resourcesByteLength += resource.length;
+            for (Object value : Resources.singleton().resources().getValues()) {
+                if (value != Resources.NEGATIVE_QUERY) {
+                    ResourceStorageEntry resourceList = (ResourceStorageEntry) value;
+                    for (byte[] resource : resourceList.getData()) {
+                        resourcesByteLength += resource.length;
+                    }
                 }
             }
             recordJsonMetric(ImageDetailKey.RESOURCE_SIZE_BYTES, resourcesByteLength);

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/ResourcesFeature.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/ResourcesFeature.java
@@ -27,6 +27,7 @@ package com.oracle.svm.hosted;
 
 import static com.oracle.svm.core.jdk.Resources.RESOURCES_INTERNAL_PATH_SEPARATOR;
 
+import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
 import java.nio.file.FileSystem;
@@ -301,6 +302,11 @@ public final class ResourcesFeature implements InternalFeature {
         @Override
         public void registerNegativeQuery(String moduleName, String resourceName) {
             Resources.registerNegativeQuery(moduleName, resourceName);
+        }
+
+        @Override
+        public void registerIOException(String moduleName, String resourceName, IOException e) {
+            Resources.registerIOException(moduleName, resourceName, e);
         }
 
         private void collectModuleName(String moduleName) {

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/ResourcesFeature.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/ResourcesFeature.java
@@ -298,6 +298,11 @@ public final class ResourcesFeature implements InternalFeature {
             registerDirectoryResource(debugContext, moduleName, dir, content, fromJar);
         }
 
+        @Override
+        public void registerNegativeQuery(String moduleName, String resourceName) {
+            Resources.registerNegativeQuery(moduleName, resourceName);
+        }
+
         private void collectModuleName(String moduleName) {
             if (moduleName != null) {
                 includedResourcesModules.add(moduleName);
@@ -316,7 +321,13 @@ public final class ResourcesFeature implements InternalFeature {
 
         DuringAnalysisAccessImpl duringAnalysisAccess = ((DuringAnalysisAccessImpl) access);
         ResourcePattern[] includePatterns = compilePatterns(resourcePatternWorkSet);
+        for (ResourcePattern resourcePattern : includePatterns) {
+            Resources.registerIncludePattern(resourcePattern.moduleName, resourcePattern.pattern);
+        }
         ResourcePattern[] excludePatterns = compilePatterns(excludedResourcePatterns);
+        for (ResourcePattern resourcePattern : excludePatterns) {
+            Resources.registerExcludePattern(resourcePattern.moduleName, resourcePattern.pattern);
+        }
         DebugContext debugContext = duringAnalysisAccess.getDebugContext();
         ResourceCollectorImpl collector = new ResourceCollectorImpl(debugContext, includePatterns, excludePatterns, includedResourcesModules, duringAnalysisAccess.bb.getHeartbeatCallback());
         try {

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/ResourcesFeature.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/ResourcesFeature.java
@@ -142,7 +142,7 @@ public final class ResourcesFeature implements InternalFeature {
         @Override
         public void injectResource(Module module, String resourcePath, byte[] resourceContent) {
             var moduleName = module.isNamed() ? module.getName() : null;
-            Resources.registerResource(moduleName, resourcePath, resourceContent);
+            Resources.singleton().registerResource(moduleName, resourcePath, resourceContent);
         }
 
         @Override
@@ -301,12 +301,12 @@ public final class ResourcesFeature implements InternalFeature {
 
         @Override
         public void registerNegativeQuery(String moduleName, String resourceName) {
-            Resources.registerNegativeQuery(moduleName, resourceName);
+            Resources.singleton().registerNegativeQuery(moduleName, resourceName);
         }
 
         @Override
         public void registerIOException(String moduleName, String resourceName, IOException e) {
-            Resources.registerIOException(moduleName, resourceName, e);
+            Resources.singleton().registerIOException(moduleName, resourceName, e);
         }
 
         private void collectModuleName(String moduleName) {
@@ -328,11 +328,11 @@ public final class ResourcesFeature implements InternalFeature {
         DuringAnalysisAccessImpl duringAnalysisAccess = ((DuringAnalysisAccessImpl) access);
         ResourcePattern[] includePatterns = compilePatterns(resourcePatternWorkSet);
         for (ResourcePattern resourcePattern : includePatterns) {
-            Resources.registerIncludePattern(resourcePattern.moduleName, resourcePattern.pattern);
+            Resources.singleton().registerIncludePattern(resourcePattern.moduleName, resourcePattern.pattern);
         }
         ResourcePattern[] excludePatterns = compilePatterns(excludedResourcePatterns);
         for (ResourcePattern resourcePattern : excludePatterns) {
-            Resources.registerExcludePattern(resourcePattern.moduleName, resourcePattern.pattern);
+            Resources.singleton().registerExcludePattern(resourcePattern.moduleName, resourcePattern.pattern);
         }
         DebugContext debugContext = duringAnalysisAccess.getDebugContext();
         ResourceCollectorImpl collector = new ResourceCollectorImpl(debugContext, includePatterns, excludePatterns, includedResourcesModules, duringAnalysisAccess.bb.getHeartbeatCallback());
@@ -411,7 +411,7 @@ public final class ResourcesFeature implements InternalFeature {
         try (DebugContext.Scope s = debugContext.scope("registerResource")) {
             String moduleNamePrefix = moduleName == null ? "" : moduleName + ":";
             debugContext.log(DebugContext.VERBOSE_LEVEL, "ResourcesFeature: registerResource: %s%s", moduleNamePrefix, resourceName);
-            Resources.registerResource(moduleName, resourceName, resourceStream, fromJar);
+            Resources.singleton().registerResource(moduleName, resourceName, resourceStream, fromJar);
         }
     }
 
@@ -420,7 +420,7 @@ public final class ResourcesFeature implements InternalFeature {
         try (DebugContext.Scope s = debugContext.scope("registerResource")) {
             String moduleNamePrefix = moduleName == null ? "" : moduleName + ":";
             debugContext.log(DebugContext.VERBOSE_LEVEL, "ResourcesFeature: registerResource: %s%s", moduleNamePrefix, moduleName, dir);
-            Resources.registerDirectoryResource(moduleName, dir, content, fromJar);
+            Resources.singleton().registerDirectoryResource(moduleName, dir, content, fromJar);
         }
     }
 }

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/ServiceLoaderFeature.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/ServiceLoaderFeature.java
@@ -258,7 +258,7 @@ public class ServiceLoaderFeature implements InternalFeature {
              * No service implementations registered in the resources. Since we check all classes
              * that the static analysis finds, this case is very likely.
              */
-            Resources.registerNegativeQuery(null, serviceResourceLocation);
+            Resources.singleton().registerNegativeQuery(null, serviceResourceLocation);
             return false;
         }
 
@@ -359,7 +359,7 @@ public class ServiceLoaderFeature implements InternalFeature {
         try (DebugContext.Scope s = debugContext.scope("registerResource")) {
             debugContext.log("ServiceLoaderFeature: registerResource: %s", serviceResourceLocation);
         }
-        Resources.registerResource(null, serviceResourceLocation, new ByteArrayInputStream(newResourceValue.toString().getBytes(StandardCharsets.UTF_8)), false);
+        Resources.singleton().registerResource(null, serviceResourceLocation, new ByteArrayInputStream(newResourceValue.toString().getBytes(StandardCharsets.UTF_8)), false);
 
         /* Ensure that the static analysis runs again for the new implementation classes. */
         access.requireAnalysisIteration();

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/ServiceLoaderFeature.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/ServiceLoaderFeature.java
@@ -258,6 +258,7 @@ public class ServiceLoaderFeature implements InternalFeature {
              * No service implementations registered in the resources. Since we check all classes
              * that the static analysis finds, this case is very likely.
              */
+            Resources.registerNegativeQuery(null, serviceResourceLocation);
             return false;
         }
 

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/image/ImageHeapConnectedComponentsPrinter.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/image/ImageHeapConnectedComponentsPrinter.java
@@ -148,12 +148,14 @@ public class ImageHeapConnectedComponentsPrinter {
     }
 
     private static void markResources(NativeImageHeap heap) {
-        EconomicMap<Pair<String, String>, ResourceStorageEntry> resources = Resources.singleton().resources();
-        for (ResourceStorageEntry value : resources.getValues()) {
-            for (byte[] arr : value.getData()) {
-                ObjectInfo info = heap.getObjectInfo(arr);
-                if (info != null) {
-                    heap.objectReachabilityInfo.get(info).addReason(HeapInclusionReason.Resource);
+        EconomicMap<Pair<String, String>, Object> resources = Resources.singleton().resources();
+        for (Object value : resources.getValues()) {
+            if (value != Resources.NEGATIVE_QUERY) {
+                for (byte[] arr : ((ResourceStorageEntry) value).getData()) {
+                    ObjectInfo info = heap.getObjectInfo(arr);
+                    if (info != null) {
+                        heap.objectReachabilityInfo.get(info).addReason(HeapInclusionReason.Resource);
+                    }
                 }
             }
         }

--- a/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/NativeImageResourceFileSystemProviderTest.java
+++ b/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/NativeImageResourceFileSystemProviderTest.java
@@ -34,6 +34,8 @@ import static com.oracle.svm.test.NativeImageResourceUtils.resourceNameToURI;
 import static com.oracle.svm.test.NativeImageResourceUtils.resourceNameToURL;
 
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
 import java.net.URI;
 import java.net.URL;
 import java.net.URLConnection;
@@ -69,6 +71,7 @@ import org.junit.Test;
 public class NativeImageResourceFileSystemProviderTest {
 
     private static final String NEW_DIRECTORY = RESOURCE_DIR + "/tmp";
+    private static final String NEW_FILE = NEW_DIRECTORY + "/newFile";
 
     private static final int TIME_SPAN = 1_000_000;
 
@@ -259,13 +262,7 @@ public class NativeImageResourceFileSystemProviderTest {
         }
 
         try (SeekableByteChannel channel = Files.newByteChannel(resourceFile1, StandardOpenOption.READ, StandardOpenOption.WRITE)) {
-            ByteBuffer byteBuffer = ByteBuffer.wrap("test string#".getBytes());
-            channel.write(byteBuffer);
-            ByteBuffer byteBuffer2 = ByteBuffer.allocate((int) channel.size());
-            channel.read(byteBuffer2);
-            String content = new String(byteBuffer.array());
-            Assert.assertTrue("Nothing has been writen into file!", content.length() > 0);
-            Assert.assertTrue("Content has been writen into file improperly!", content.startsWith("test string#"));
+            writeInChannelAndCheck(channel);
         } catch (IOException ioException) {
             Assert.fail("Exception occurs during writing into file!");
         }
@@ -327,13 +324,7 @@ public class NativeImageResourceFileSystemProviderTest {
         }
 
         try (SeekableByteChannel channel = provider.newFileChannel(resourceFile1, readWritePermissions)) {
-            ByteBuffer byteBuffer = ByteBuffer.wrap("test string#".getBytes());
-            channel.write(byteBuffer);
-            ByteBuffer byteBuffer2 = ByteBuffer.allocate((int) channel.size());
-            channel.read(byteBuffer2);
-            String content = new String(byteBuffer.array());
-            Assert.assertTrue("Nothing has been writen into file!", content.length() > 0);
-            Assert.assertTrue("Content has been writen into file improperly!", content.startsWith("test string#"));
+            writeInChannelAndCheck(channel);
         } catch (IOException ioException) {
             Assert.fail("Exception occurs during writing into file!");
         }
@@ -361,30 +352,13 @@ public class NativeImageResourceFileSystemProviderTest {
         Path resourceFile2 = resourceNameToPath(RESOURCE_FILE_2, true);
 
         // 1. Creating new directory.
-        Path newDirectory = fileSystem.getPath(NEW_DIRECTORY);
-        try {
-            Files.createDirectory(newDirectory);
-        } catch (IOException ioException) {
-            Assert.fail("Exception occurs during creating new directory!");
-        }
+        Path newDirectory = createDirectory();
 
         // 2. Copy file to newly create directory.
-        Path destination = fileSystem.getPath(newDirectory.toString(),
-                        resourceFile1.getName(resourceFile1.getNameCount() - 1).toString());
-        try {
-            Files.copy(resourceFile1, destination, StandardCopyOption.REPLACE_EXISTING);
-            try (SeekableByteChannel channel = Files.newByteChannel(resourceFile1, StandardOpenOption.READ)) {
-                ByteBuffer byteBuffer = ByteBuffer.allocate((int) channel.size());
-                channel.read(byteBuffer);
-                String content = new String(byteBuffer.array());
-                Assert.assertTrue("Nothing has been read from new file!", content.length() > 0);
-            }
-        } catch (IOException ioException) {
-            Assert.fail("Exception occurs during copying file into new directory!");
-        }
+        copyFile(resourceFile1, newDirectory);
 
         // 3. Moving file to newly create directory.
-        destination = fileSystem.getPath(newDirectory.toString(),
+        Path destination = fileSystem.getPath(newDirectory.toString(),
                         resourceFile2.getName(resourceFile2.getNameCount() - 1).toString());
         try {
             Files.move(resourceFile2, destination, StandardCopyOption.REPLACE_EXISTING);
@@ -431,6 +405,148 @@ public class NativeImageResourceFileSystemProviderTest {
         } catch (IOException ignored) {
             Assert.fail("Exception occurs during file deletion!");
         }
+    }
+
+    @Test
+    public void writingNewFileFileChannel() {
+        // 1. Creating new directory.
+        createDirectory();
+
+        // 2. Creating and writing in a new file.
+        Path newResource = fileSystem.getPath(NEW_FILE);
+        try (SeekableByteChannel channel = Files.newByteChannel(newResource, StandardOpenOption.READ, StandardOpenOption.WRITE, StandardOpenOption.CREATE)) {
+            writeInChannelAndCheck(channel);
+        } catch (IOException ioException) {
+            Assert.fail("Exception occurs during writing into file!");
+        }
+    }
+
+    @Test
+    public void writingCopyFileFileChannel() {
+        Path resourceFile1 = resourceNameToPath(RESOURCE_FILE_1, true);
+
+        // 1. Creating new directory.
+        createDirectory();
+
+        // 2. Copy file to newly create directory.
+        Path newFile = fileSystem.getPath(NEW_FILE);
+        Path destination = copyFile(resourceFile1, newFile);
+
+        // 3. Writing in the copied file.
+        try (SeekableByteChannel channel = Files.newByteChannel(destination, StandardOpenOption.READ, StandardOpenOption.WRITE)) {
+            writeInChannelAndCheck(channel);
+        } catch (IOException ioException) {
+            Assert.fail("Exception occurs during writing into file!");
+        }
+    }
+
+    @Test
+    public void writingNewFileByteChannel() {
+        // 1. Creating new directory.
+        createDirectory();
+
+        // 2. Creating and writing in a new file.
+        Path newResource = fileSystem.getPath(NEW_FILE);
+
+        FileSystemProvider provider = fileSystem.provider();
+
+        Set<StandardOpenOption> permissions = new HashSet<>(Collections.emptySet());
+        permissions.add(StandardOpenOption.READ);
+        permissions.add(StandardOpenOption.WRITE);
+        permissions.add(StandardOpenOption.CREATE);
+
+        try (SeekableByteChannel channel = provider.newFileChannel(newResource, permissions)) {
+            writeInChannelAndCheck(channel);
+        } catch (IOException ioException) {
+            Assert.fail("Exception occurs during writing into file!");
+        }
+    }
+
+    @Test
+    public void writingCopyFileByteChannel() {
+        Path resourceFile1 = resourceNameToPath(RESOURCE_FILE_1, true);
+
+        // 1. Creating new directory.
+        createDirectory();
+
+        // 2. Copy file to newly create directory.
+        Path newFile = fileSystem.getPath(NEW_FILE);
+        Path destination = copyFile(resourceFile1, newFile);
+
+        // 3. Writing in the copied file.
+        FileSystemProvider provider = fileSystem.provider();
+
+        Set<StandardOpenOption> permissions = new HashSet<>(Collections.emptySet());
+        permissions.add(StandardOpenOption.READ);
+        permissions.add(StandardOpenOption.WRITE);
+
+        try (SeekableByteChannel channel = provider.newFileChannel(destination, permissions)) {
+            writeInChannelAndCheck(channel);
+        } catch (IOException ioException) {
+            Assert.fail("Exception occurs during writing into file!");
+        }
+    }
+
+    @Test
+    public void writingNewFileOutputStream() {
+        // 1. Creating new directory.
+        createDirectory();
+
+        // 2. Creating and writing in a new file.
+        Path newResource = fileSystem.getPath(NEW_FILE);
+        try (OutputStream outputStream = Files.newOutputStream(newResource, StandardOpenOption.WRITE, StandardOpenOption.CREATE_NEW)) {
+            outputStream.write("test string#".getBytes());
+            outputStream.flush();
+        } catch (IOException ioException) {
+            Assert.fail("Exception occurs during writing into file!");
+        }
+
+        // 3. Reading in the new file.
+        try (InputStream inputStream = Files.newInputStream(newResource, StandardOpenOption.READ)) {
+            String content = new String(inputStream.readAllBytes());
+            Assert.assertTrue("Nothing has been writen into file!", content.length() > 0);
+            Assert.assertTrue("Content has been writen into file improperly!", content.startsWith("test string#"));
+        } catch (IOException ioException) {
+            Assert.fail("Exception occurs during writing into file!");
+        }
+    }
+
+    private Path createDirectory() {
+        Path newDirectory = fileSystem.getPath(NEW_DIRECTORY);
+        try {
+            Files.createDirectory(newDirectory);
+        } catch (IOException ioException) {
+            Assert.fail("Exception occurs during creating new directory!");
+        }
+        return newDirectory;
+    }
+
+    private static void writeInChannelAndCheck(SeekableByteChannel channel) throws IOException {
+        ByteBuffer byteBuffer = ByteBuffer.wrap("test string#".getBytes());
+        channel.write(byteBuffer);
+        ByteBuffer byteBuffer2 = ByteBuffer.allocate((int) channel.size());
+        channel.position(0);
+        channel.read(byteBuffer2);
+        String content = new String(byteBuffer2.array());
+        Assert.assertTrue("Nothing has been writen into file!", content.length() > 0);
+        Assert.assertTrue("Content has been writen into file improperly!", content.startsWith("test string#"));
+    }
+
+    private Path copyFile(Path resourceFile1, Path newDirectory) {
+        Path destination = fileSystem.getPath(newDirectory.toString(),
+                        resourceFile1.getName(resourceFile1.getNameCount() - 1).toString());
+        try {
+            Files.copy(resourceFile1, destination, StandardCopyOption.REPLACE_EXISTING);
+            try (SeekableByteChannel channel = Files.newByteChannel(resourceFile1, StandardOpenOption.READ)) {
+                ByteBuffer byteBuffer = ByteBuffer.allocate((int) channel.size());
+                channel.read(byteBuffer);
+                String content = new String(byteBuffer.array());
+                Assert.assertTrue("Nothing has been read from new file!", content.length() > 0);
+            }
+        } catch (IOException ioException) {
+            Assert.fail("Exception occurs during copying file into new directory!");
+        }
+        return destination;
     }
 
     /**


### PR DESCRIPTION
This PR allows to throw `MissingResourceMetadataException` when the metadata for a resource the user tries to access is not included in the image.

Additionally, it retains the `IOException` that occurred when accessing resources during build time and throw them later at runtime, when the resource is assigned again,

The goal is to match this proposal: https://github.com/graalvm/taming-build-time-initialization/blob/main/metadata-exceptions/Exceptions%20proposal.md.