### PR TITLE
Fix JMX issue with VisualVM

### DIFF
--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/management/SubstrateThreadMXBean.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/management/SubstrateThreadMXBean.java
@@ -40,14 +40,10 @@ import com.oracle.svm.core.Uninterruptible;
 import com.oracle.svm.core.jdk.UninterruptibleUtils.AtomicInteger;
 import com.oracle.svm.core.jdk.UninterruptibleUtils.AtomicLong;
 import com.oracle.svm.core.thread.PlatformThreads;
-import com.oracle.svm.core.util.VMError;
 
 import sun.management.Util;
 
 public final class SubstrateThreadMXBean implements com.sun.management.ThreadMXBean {
-
-    private static final String MSG = "ThreadMXBean methods";
-
     private final AtomicLong totalStartedThreadCount = new AtomicLong(0);
     private final AtomicInteger peakThreadCount = new AtomicInteger(0);
     private final AtomicInteger threadCount = new AtomicInteger(0);
@@ -148,27 +144,32 @@ public final class SubstrateThreadMXBean implements com.sun.management.ThreadMXB
 
     @Override
     public long[] getAllThreadIds() {
-        throw VMError.unsupportedFeature(MSG);
+        // TODO: implement later
+        return null;
     }
 
     @Override
     public ThreadInfo getThreadInfo(long id) {
-        throw VMError.unsupportedFeature(MSG);
+        // TODO: implement later
+        return null;
     }
 
     @Override
     public ThreadInfo[] getThreadInfo(long[] ids) {
-        throw VMError.unsupportedFeature(MSG);
+        // TODO: implement later
+        return null;
     }
 
     @Override
     public ThreadInfo getThreadInfo(long id, int maxDepth) {
-        throw VMError.unsupportedFeature(MSG);
+        // TODO: implement later
+        return null;
     }
 
     @Override
     public ThreadInfo[] getThreadInfo(long[] ids, int maxDepth) {
-        throw VMError.unsupportedFeature(MSG);
+        // TODO: implement later
+        return null;
     }
 
     @Override
@@ -250,32 +251,38 @@ public final class SubstrateThreadMXBean implements com.sun.management.ThreadMXB
 
     @Override
     public long[] findMonitorDeadlockedThreads() {
-        throw VMError.unsupportedFeature(MSG);
+        // TODO: implement later
+        throw null;
     }
 
     @Override
     public long[] findDeadlockedThreads() {
-        throw VMError.unsupportedFeature(MSG);
+        // TODO: implement later
+        throw null;
     }
 
     @Override
     public boolean isObjectMonitorUsageSupported() {
-        throw VMError.unsupportedFeature(MSG);
+        // TODO: implement later
+        return false;
     }
 
     @Override
     public boolean isSynchronizerUsageSupported() {
-        throw VMError.unsupportedFeature(MSG);
+        // TODO: implement later
+        return false;
     }
 
     @Override
     public ThreadInfo[] getThreadInfo(long[] ids, boolean lockedMonitors, boolean lockedSynchronizers) {
-        throw VMError.unsupportedFeature(MSG);
+        // TODO: implement later
+        return null;
     }
 
     @Override
     public ThreadInfo[] dumpAllThreads(boolean lockedMonitors, boolean lockedSynchronizers) {
-        throw VMError.unsupportedFeature(MSG);
+        // TODO: implement later
+        return null;
     }
 
     @Override

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/jdk/JmxCommonFeature.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/jdk/JmxCommonFeature.java
@@ -86,6 +86,7 @@ public class JmxCommonFeature implements InternalFeature {
                         "java.io.IOException", "java.lang.Boolean", "java.lang.ClassCastException", "java.lang.Error",
                         "java.lang.Exception", "java.lang.IllegalArgumentException", "java.lang.IllegalStateException",
                         "java.lang.Integer", "[Ljava.lang.Integer;", "java.lang.Long", "java.lang.NoSuchMethodException",
+                        "java.lang.NullPointerException",
                         "java.lang.Number", "[Ljava.lang.Object;", "java.lang.ReflectiveOperationException",
                         "java.lang.RuntimeException", "java.lang.SecurityException", "java.lang.StackTraceElement",
                         "[Ljava.lang.StackTraceElement;", "java.lang.String", "java.lang.Throwable",


### PR DESCRIPTION
Some PlatformMXBeans don't have all their methods implemented in SVM so when they are invoked from VisualVM they throw an `com.oracle.svm.core.jdk.UnsupportedFeatureError`. This causes VisualVM to simply not show any MBeans. This PR returns default values for those methods instead of throwing errors. 