### PR TITLE
Add StandardGraphBuilderPlugins for standalone analysis

### DIFF
--- a/substratevm/src/com.oracle.graal.pointsto.standalone.test/src/com/oracle/graal/pointsto/standalone/test/ArrayNewInstancePluginCase.java
+++ b/substratevm/src/com.oracle.graal.pointsto.standalone.test/src/com/oracle/graal/pointsto/standalone/test/ArrayNewInstancePluginCase.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2023, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2023, Alibaba Group Holding Limited. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package com.oracle.graal.pointsto.standalone.test;
+
+import java.lang.reflect.Array;
+
+/**
+ * This case is for
+ * {@code org.graalvm.compiler.replacements.StandardGraphBuilderPlugins#registerArrayPlugins(InvocationPlugins, Replacements)}.
+ */
+public class ArrayNewInstancePluginCase {
+    public static void main(String[] args) {
+        int size = 3;
+        C[] newArray = (C[]) Array.newInstance(C.class, size);
+        for (int i = 0; i < size; i++) {
+            newArray[i] = new C();
+        }
+        newArray[0].foo();
+    }
+
+    static class C {
+        public void foo() {
+        }
+    }
+}

--- a/substratevm/src/com.oracle.graal.pointsto.standalone.test/src/com/oracle/graal/pointsto/standalone/test/PointstoAnalyzerTester.java
+++ b/substratevm/src/com.oracle.graal.pointsto.standalone.test/src/com/oracle/graal/pointsto/standalone/test/PointstoAnalyzerTester.java
@@ -302,7 +302,7 @@ public class PointstoAnalyzerTester {
             // Find all the elements that should be reachable but not
             List<T> shouldReachableButNot = expectedReachables.stream().filter(t -> {
                 R element = getAnalysisElement.apply(t);
-                return !element.isReachable();
+                return element != null && !element.isReachable();
             }).collect(Collectors.toList());
 
             if (!shouldReachableButNot.isEmpty()) {

--- a/substratevm/src/com.oracle.graal.pointsto.standalone.test/src/com/oracle/graal/pointsto/standalone/test/StandardGraphPluginTest.java
+++ b/substratevm/src/com.oracle.graal.pointsto.standalone.test/src/com/oracle/graal/pointsto/standalone/test/StandardGraphPluginTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2022, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2022, Alibaba Group Holding Limited. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package com.oracle.graal.pointsto.standalone.test;
+
+import org.graalvm.compiler.nodes.graphbuilderconf.InvocationPlugin;
+import org.graalvm.compiler.replacements.StandardGraphBuilderPlugins;
+import org.junit.Test;
+
+import java.lang.reflect.Array;
+
+/**
+ * Method {@link StandardGraphBuilderPlugins#registerInvocationPlugins} has registered many
+ * {@link InvocationPlugin}s. This class tests a typical one of them to check if the
+ * {@code registerInvocationPlugins} method has been invoked for standalone analysis.
+ */
+public class StandardGraphPluginTest {
+
+    /**
+     * Check the invocation of method
+     * {@code StandardGraphBuilderPlugins#registerArrayPlugins(InvocationPlugins, Replacements)}
+     * which is invoked by {@link StandardGraphBuilderPlugins#registerInvocationPlugins}.
+     * 
+     * @throws NoSuchMethodException
+     */
+    @Test
+    public void testArrayNewInstanceReachability() throws NoSuchMethodException {
+        PointstoAnalyzerTester tester = new PointstoAnalyzerTester(ArrayNewInstancePluginCase.class);
+        tester.setAnalysisArguments(tester.getTestClassName(),
+                        "-H:AnalysisTargetAppCP=" + tester.getTestClassJar());
+        tester.setExpectedReachableMethods(ArrayNewInstancePluginCase.C.class.getDeclaredMethod("foo"));
+        tester.setExpectedUnreachableMethods(Array.class.getDeclaredMethod("newArray", Class.class, int.class));
+        tester.runAnalysisAndAssert();
+    }
+}

--- a/substratevm/src/com.oracle.graal.pointsto.standalone/src/com/oracle/graal/pointsto/standalone/PointsToAnalyzer.java
+++ b/substratevm/src/com.oracle.graal.pointsto.standalone/src/com/oracle/graal/pointsto/standalone/PointsToAnalyzer.java
@@ -83,6 +83,8 @@ import jdk.vm.ci.hotspot.HotSpotJVMCIRuntime;
 import jdk.vm.ci.meta.JavaKind;
 import jdk.vm.ci.meta.MetaAccessProvider;
 
+import static org.graalvm.compiler.replacements.StandardGraphBuilderPlugins.registerInvocationPlugins;
+
 public final class PointsToAnalyzer {
 
     static {
@@ -109,7 +111,7 @@ public final class PointsToAnalyzer {
     private boolean entrypointsAreSet;
     private boolean mainEntryIsSet;
 
-    @SuppressWarnings("try")
+    @SuppressWarnings({"try", "unchecked"})
     private PointsToAnalyzer(String mainEntryClass, OptionValues options) {
         standaloneAnalysisFeatureManager = new StandaloneAnalysisFeatureManager(options);
         String appCP = StandaloneOptions.AnalysisTargetAppCP.getValue(options);
@@ -197,6 +199,8 @@ public final class PointsToAnalyzer {
             NoClassInitializationPlugin classInitializationPlugin = new NoClassInitializationPlugin();
             plugins.setClassInitializationPlugin(classInitializationPlugin);
             aProviders.setGraphBuilderPlugins(plugins);
+            registerInvocationPlugins(originalProviders.getSnippetReflection(), plugins.getInvocationPlugins(), originalProviders.getReplacements(),
+                            false, true, false, originalProviders.getLowerer());
         }
     }
 


### PR DESCRIPTION
Register invocation plugins for standalone analysis.

This PR should be merged after PR https://github.com/oracle/graal/pull/5894, otherwise the tests will fail. 
This PR is part of https://github.com/oracle/graal/pull/4375.