### PR TITLE
List<Value> parameter may get List<anything>

### DIFF
--- a/truffle/src/com.oracle.truffle.api.test/src/com/oracle/truffle/api/test/polyglot/HostAccessTest.java
+++ b/truffle/src/com.oracle.truffle.api.test/src/com/oracle/truffle/api/test/polyglot/HostAccessTest.java
@@ -2396,6 +2396,45 @@ public class HostAccessTest extends AbstractHostAccessTest {
         }
     }
 
+    public final class WorkWithArray {
+        WorkWithArray() {
+        }
+
+        public List<String> stringsAsList() {
+            return Arrays.asList("Hello", "World");
+        }
+
+        public String[] stringsAsArray() {
+            return Arrays.asList("Hello", "World").toArray(String[]::new);
+        }
+
+        public String concatenate(List<Value> values) {
+            StringBuilder sb = new StringBuilder();
+            for (Value val : values) {
+                sb.append(val.toString());
+            }
+            return sb.toString();
+        }
+    }
+
+    private void checkListOfValue(String factoryName) throws Exception {
+        setupEnv(HostAccess.newBuilder(HostAccess.ALL).build());
+        Value workWithArray = context.asValue(new WorkWithArray());
+        Value strings = workWithArray.invokeMember(factoryName);
+        Value text = workWithArray.invokeMember("concatenate", strings);
+        assertEquals("Converted to string", "HelloWorld", text.asString());
+    }
+
+    @Test
+    public void testListOfValueAndRawList() throws Exception {
+        checkListOfValue("stringsAsList");
+    }
+
+    @Test
+    public void testListOfValueAndRawArray() throws Exception {
+        checkListOfValue("stringsAsArray");
+    }
+
     public void testMutableObjectMappingDisabled(MutableTargetMapping mapping) {
         MutableTargetMapping[] allowed = new MutableTargetMapping[MutableTargetMapping.values().length - 1];
         int i = 0;

--- a/truffle/src/com.oracle.truffle.host/src/com/oracle/truffle/host/HostToTypeNode.java
+++ b/truffle/src/com.oracle.truffle.host/src/com/oracle/truffle/host/HostToTypeNode.java
@@ -177,7 +177,7 @@ abstract class HostToTypeNode extends Node {
             }
         }
         HostLanguage language = HostLanguage.get(interop);
-        if (HostObject.isJavaInstance(language, targetType, value)) {
+        if (targetType != List.class && HostObject.isJavaInstance(language, targetType, value)) {
             return HostObject.valueOf(language, value);
         }
 
@@ -392,7 +392,7 @@ abstract class HostToTypeNode extends Node {
         InteropLibrary interop = InteropLibrary.getFactory().getUncached(value);
         assert !interop.isNull(value); // already handled
         Object obj;
-        if (HostObject.isJavaInstance(hostContext.language, targetType, value)) {
+        if (targetType != List.class && HostObject.isJavaInstance(hostContext.language, targetType, value)) {
             obj = HostObject.valueOf(hostContext.language, value);
         } else if (targetType == Object.class) {
             obj = convertToObject(node, hostContext, value, interop);


### PR DESCRIPTION
While working on https://github.com/enso-org/enso/issues/5590 I realized there is a limitation in _host interop conversions_. If you have a `String[]` host interop value and you try to pass it into `List<org.graalvm.polyglot.Value>` parameter, everything works properly. However, if you have `List<String>` host interop value, one gets `ClassCastException` as the conversion to `Value` doesn't happen.

b2afd2f2aa7298a3c237580aeeda95d51ed64627 contains a test showing the good (with `[]`) and bad (with `List`) behavior.

d60e7822cf9767c7dda6b8cf71d139844397814b proposes a fix. I am not saying it is the correct fix, but it seems to work. The idea is to treat `java.util.List` target type in a special way and never pass it directly as _host value_. Rather always wrap it with a delegate to `InteropLibrary.readArrayElement`.

CCing @woess, @chumer 