### PR TITLE
Throw no exceptions when actual extraction should be skipped

### DIFF
--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/annotation/AnnotationMemberValue.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/annotation/AnnotationMemberValue.java
@@ -25,6 +25,7 @@
 package com.oracle.svm.hosted.annotation;
 
 import java.lang.annotation.Annotation;
+import java.nio.BufferUnderflowException;
 import java.nio.ByteBuffer;
 import java.util.Collections;
 import java.util.List;
@@ -34,7 +35,17 @@ import jdk.vm.ci.meta.JavaConstant;
 
 public abstract class AnnotationMemberValue {
     static AnnotationMemberValue extract(ByteBuffer buf, ConstantPool cp, Class<?> container, boolean skip) {
-        char tag = (char) buf.get();
+        final char tag;
+        try {
+            tag = (char) buf.get();
+        } catch (BufferUnderflowException e) {
+            if (skip) {
+                return null;
+            } else {
+                throw e;
+            }
+        }
+
         switch (tag) {
             case 'e':
                 return AnnotationEnumValue.extract(buf, cp, container, skip);

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/annotation/AnnotationMetadata.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/annotation/AnnotationMetadata.java
@@ -28,6 +28,7 @@ import java.lang.annotation.Annotation;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.nio.BufferUnderflowException;
 import java.nio.ByteBuffer;
 
 import org.graalvm.compiler.debug.GraalError;
@@ -84,8 +85,16 @@ public class AnnotationMetadata {
     }
 
     static String extractString(ByteBuffer buf, ConstantPool cp, boolean skip) {
-        int index = buf.getShort() & 0xFFFF;
-        return skip ? null : cp.getUTF8At(index);
+        int index = 0;
+        try {
+            index = buf.getShort();
+        } catch (BufferUnderflowException e) {
+            if (!skip) {
+                throw e;
+            }
+        }
+
+        return skip ? null : cp.getUTF8At(index & 0xFFFF);
     }
 
     static Object checkResult(Object value, Class<?> expectedType) {

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/annotation/AnnotationPrimitiveValue.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/annotation/AnnotationPrimitiveValue.java
@@ -24,6 +24,7 @@
  */
 package com.oracle.svm.hosted.annotation;
 
+import java.nio.BufferUnderflowException;
 import java.nio.ByteBuffer;
 import java.util.Objects;
 
@@ -35,10 +36,19 @@ public final class AnnotationPrimitiveValue extends AnnotationMemberValue {
     private final Object value;
 
     static AnnotationPrimitiveValue extract(ByteBuffer buf, ConstantPool cp, char tag, boolean skip) {
-        int constIndex = buf.getShort() & 0xFFFF;
+        int constIndex = 0;
+        try {
+            constIndex = buf.getShort() & 0xFFFF;
+        } catch (BufferUnderflowException e) {
+            if (!skip) {
+                throw e;
+            }
+        }
+
         if (skip) {
             return null;
         }
+
         Object value;
         switch (tag) {
             case 'B':


### PR DESCRIPTION
When the `skip` flag is true, any `BufferUnderflowException`s should be reported
to the caller by returning `null`.