### PR TITLE
Cast unsigned values explicitly to avoid signed extension

### DIFF
--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/heap/InstanceReferenceMapEncoder.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/heap/InstanceReferenceMapEncoder.java
@@ -112,6 +112,6 @@ public class InstanceReferenceMapEncoder extends ReferenceMapEncoder {
     private void encodeRun(int offset, int refsCount) {
         assert offset >= 0 && refsCount >= 0;
         writeBuffer.putS4(offset);
-        writeBuffer.putU4(refsCount);
+        writeBuffer.putU4(Integer.toUnsignedLong(refsCount));
     }
 }

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/heap/HeapDumpFieldsMapFeature.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/heap/HeapDumpFieldsMapFeature.java
@@ -135,7 +135,7 @@ class HeapDumpHostedUtils {
         try {
             byte[] buf = name.getBytes("UTF-8");
             for (byte b : buf) {
-                writeBuffer.putU1(b);
+                writeBuffer.putS1(b);
             }
             writeBuffer.putU1(0);
         } catch (UnsupportedEncodingException ex) {


### PR DESCRIPTION
Cast unsigned values, stored in smaller types, to `long` using zero-extension instead of Java's default sign extension.