### PR TITLE
Better handling of `ObjectStamp.type()` return value semantics

### DIFF
--- a/substratevm/src/com.oracle.graal.pointsto/src/com/oracle/graal/pointsto/meta/AnalysisType.java
+++ b/substratevm/src/com.oracle.graal.pointsto/src/com/oracle/graal/pointsto/meta/AnalysisType.java
@@ -941,6 +941,7 @@ public abstract class AnalysisType extends AnalysisElement implements WrappedJav
 
     @Override
     public boolean isAssignableFrom(ResolvedJavaType other) {
+        assert other != null : "other is null";
         return wrapped.isAssignableFrom(((AnalysisType) other).getWrappedWithResolve());
     }
 


### PR DESCRIPTION
`ObjectStamp.type()` can return `null`, and that sometimes means the `java.lang.Object` class.

Instead of using `null` to indicate that, actually resolve the `java.lang.Object` class and use a proper `ResolvedJavaType`.
