### PR TITLE
`System.arraycopy()` should not copy `Object[]` into `Object`

### DIFF
--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/graal/jdk/SubstrateArraycopySnippets.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/graal/jdk/SubstrateArraycopySnippets.java
@@ -100,13 +100,13 @@ public final class SubstrateArraycopySnippets extends SubstrateTemplates impleme
                 boundsCheck(fromArray, fromIndex, toArray, toIndex, length);
                 JavaMemoryUtil.copyObjectArrayBackward(fromArray, fromIndex, fromArray, toIndex, length, fromLayoutEncoding);
                 return;
-            } else if (fromHub == toHub || DynamicHub.toClass(toHub).isAssignableFrom(DynamicHub.toClass(fromHub))) {
-                boundsCheck(fromArray, fromIndex, toArray, toIndex, length);
-                JavaMemoryUtil.copyObjectArrayForward(fromArray, fromIndex, toArray, toIndex, length, fromLayoutEncoding);
-                return;
             } else if (LayoutEncoding.isObjectArray(toHub.getLayoutEncoding())) {
                 boundsCheck(fromArray, fromIndex, toArray, toIndex, length);
-                JavaMemoryUtil.copyObjectArrayForwardWithStoreCheck(fromArray, fromIndex, toArray, toIndex, length);
+                if (fromHub == toHub || DynamicHub.toClass(toHub).isAssignableFrom(DynamicHub.toClass(fromHub))) {
+                    JavaMemoryUtil.copyObjectArrayForward(fromArray, fromIndex, toArray, toIndex, length, fromLayoutEncoding);
+                } else {
+                    JavaMemoryUtil.copyObjectArrayForwardWithStoreCheck(fromArray, fromIndex, toArray, toIndex, length);
+                }
                 return;
             }
         }


### PR DESCRIPTION
`System.arraycopy​(Object src, int, Object dest, int, int)` should throw an `ArrayStoreException` when:
- `src` is an instance of `Object[]`, and
- `dest` is an instance of `Object`, and
- `src.getClass()` != `dest.getClass()`.

In the previous implementation, the following condition is satisfied:
```java
DynamicHub.toClass(toHub).isAssignableFrom(DynamicHub.toClass(fromHub))
```
where:
- `DynamicHub.toClass(toHub)` is `Object`, and
- `DynamicHub.toClass(fromHub)` is `Object[]`

because an `Object` variable can be assigned an `Object[]` value.

In this situation, `JavaMemoryUtil.copyObjectArrayForward()` is called, and the behavior is undefined.

The correct behavior should be throwing an `ArrayStoreException`.
