### PR TITLE
`java.util.concurrent.SubmissionPublisher.ASYNC_POOL` needs to be resolved at run time.

### DIFF
--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/Target_java_util_concurrent_CompletableFuture.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/Target_java_util_concurrent_CompletableFuture.java
@@ -80,3 +80,25 @@ class CompletableFutureFeature implements InternalFeature {
         RuntimeClassInitialization.initializeAtRunTime(CompletableFutureFieldHolder.class);
     }
 }
+
+@TargetClass(value = java.util.concurrent.SubmissionPublisher.class, innerClass = "ThreadPerTaskExecutor")
+final class Target_java_util_concurrent_SubmissionPublisher_ThreadPerTaskExecutor {
+}
+
+@TargetClass(java.util.concurrent.SubmissionPublisher.class)
+final class Target_java_util_concurrent_SubmissionPublisher {
+
+    @Alias
+    @InjectAccessors(SubmissionPublisherAsyncPoolAccessor.class) //
+    private static Executor ASYNC_POOL;
+}
+
+class SubmissionPublisherAsyncPoolAccessor {
+    static Executor get() {
+        if (ForkJoinPool.getCommonPoolParallelism() > 1) {
+            return ForkJoinPoolCommonAccessor.get();
+        } else {
+            return SubstrateUtil.cast(new Target_java_util_concurrent_SubmissionPublisher_ThreadPerTaskExecutor(), Executor.class);
+        }
+    }
+}


### PR DESCRIPTION
`java.util.concurrent.SubmissionPublisher.ASYNC_POOL` needs to be resolved at run time.