### PR TITLE
Persist the `java.awt.headless` Java system property.

### DIFF
--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/SystemPropertiesSupport.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/SystemPropertiesSupport.java
@@ -129,6 +129,11 @@ public abstract class SystemPropertiesSupport implements RuntimeSystemProperties
             initializeProperty("awt.toolkit", System.getProperty("awt.toolkit"));
             initializeProperty("java.awt.graphicsenv", System.getProperty("java.awt.graphicsenv"));
             initializeProperty("java.awt.printerjob", System.getProperty("java.awt.printerjob"));
+
+            final String javaAWTHeadless = System.getProperty("java.awt.headless");
+            if (javaAWTHeadless != null) {
+                initializeProperty("java.awt.headless", javaAWTHeadless);
+            }
         }
 
         lazyRuntimeValues = new HashMap<>();


### PR DESCRIPTION
If the `java.awt.headless` Java system property is defined during the native image build, then it is defined to the same value at runtime too. A lot of behavior in AWT is based on this value, so it should be the same at build and run time, so that classes initialized at build time have the expected state at run time.