### PR TITLE
Interrupting a thread that is not alive need not have any effect

### DIFF
--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/thread/Target_java_lang_Thread.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/thread/Target_java_lang_Thread.java
@@ -458,6 +458,13 @@ public final class Target_java_lang_Thread {
      */
     @Substitute
     void interrupt0() {
+        Thread thread = JavaThreads.fromTarget(this);
+
+        // Interrupting a thread that is not alive need not have any effect.
+        if (!PlatformThreads.isAlive(thread)) {
+            return;
+        }
+
         if (JavaVersionUtil.JAVA_SPEC <= 11) {
             interruptedJDK11OrEarlier = true;
         } else {
@@ -472,7 +479,6 @@ public final class Target_java_lang_Thread {
             return;
         }
 
-        Thread thread = JavaThreads.fromTarget(this);
         PlatformThreads.interrupt(thread);
         /*
          * This may unpark the thread unnecessarily (e.g., the interrupt above could have already


### PR DESCRIPTION
Interrupting a thread that is not alive need not have any effect. See [Thread.interrupt()](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/lang/Thread.html#interrupt()).
