### PR TITLE
[GR-44409] Reinitialize `java.util.PropertyResourceBundle`.

### DIFF
--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/jdk/JDKInitializationFeature.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/jdk/JDKInitializationFeature.java
@@ -94,6 +94,8 @@ public class JDKInitializationFeature implements InternalFeature {
          */
         rci.rerunInitialization("java.io.ObjectInputFilter$Config", "Field filter have to be initialized at runtime");
 
+        rci.rerunInitialization("java.util.PropertyResourceBundle", "Changes behavior according to 'java.util.PropertyResourceBundle.encoding' system property");
+
         rci.rerunInitialization("sun.nio.ch.DevPollArrayWrapper", "Calls IOUtil.fdLimit()");
         rci.rerunInitialization("sun.nio.ch.EPoll", "Calls EPoll.eventSize(), EPoll.eventsOffset() and EPoll.dataOffset()");
         rci.rerunInitialization("sun.nio.ch.EPollSelectorImpl", "Calls IOUtil.fdLimit()");


### PR DESCRIPTION
Reinitialize `java.util.PropertyResourceBundle` at run time, because it changes behavior according to the `java.util.PropertyResourceBundle.encoding` Java system property.
