### PR TITLE
Check UTF-8 encoding in JNI functions

### DIFF
--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jni/functions/JNIFunctions.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jni/functions/JNIFunctions.java
@@ -341,6 +341,10 @@ public final class JNIFunctions {
     @CEntryPointOptions(prologue = JNIEnvEnterPrologue.class, prologueBailout = ReturnNullHandle.class)
     static JNIObjectHandle FindClass(JNIEnvironment env, CCharPointer cname) {
         CharSequence name = Utf8.wrapUtf8CString(cname);
+        if (name == null) {
+            throw new NoClassDefFoundError("Class name is either null or invalid UTF-8 string");
+        }
+
         Class<?> clazz = JNIReflectionDictionary.singleton().getClassObjectByName(name);
         if (clazz == null) {
             throw new NoClassDefFoundError(name.toString());
@@ -363,7 +367,15 @@ public final class JNIFunctions {
         for (int i = 0; i < nmethods; i++) {
             JNINativeMethod entry = (JNINativeMethod) p;
             CharSequence name = Utf8.wrapUtf8CString(entry.name());
+            if (name == null) {
+                throw new NoSuchMethodError("Method name at index " + i + " is either null or invalid UTF-8 string");
+            }
+
             CharSequence signature = Utf8.wrapUtf8CString(entry.signature());
+            if (signature == null) {
+                throw new NoSuchMethodError("Method signature at index " + i + " is either null or invalid UTF-8 string");
+            }
+
             CFunctionPointer fnPtr = entry.fnPtr();
 
             String declaringClass = MetaUtil.toInternalName(clazz.getName());
@@ -1243,7 +1255,15 @@ public final class JNIFunctions {
             DynamicHub.fromClass(clazz).ensureInitialized();
 
             CharSequence name = Utf8.wrapUtf8CString(cname);
+            if (name == null) {
+                throw new NoSuchMethodError("Method name is either null or invalid UTF-8 string");
+            }
+
             CharSequence signature = Utf8.wrapUtf8CString(csig);
+            if (signature == null) {
+                throw new NoSuchMethodError("Method signature is either null or invalid UTF-8 string");
+            }
+
             return getMethodID(clazz, name, signature, isStatic);
         }
 
@@ -1269,6 +1289,10 @@ public final class JNIFunctions {
             DynamicHub.fromClass(clazz).ensureInitialized();
 
             CharSequence name = Utf8.wrapUtf8CString(cname);
+            if (name == null) {
+                throw new NoSuchFieldError("Field name is either null or invalid UTF-8 string");
+            }
+
             JNIFieldId fieldID = JNIReflectionDictionary.singleton().getFieldID(clazz, name, isStatic);
             if (fieldID.isNull()) {
                 throw new NoSuchFieldError(clazz.getName() + '.' + name);


### PR DESCRIPTION
The following JNI functions accept some UTF-8 strings as arguments:
- `FindClass`
- `GetFieldID`
- `GetMethodID`
- `GetStaticFieldID`
- `GetStaticMethodID`
- `RegisterNatives`

This patch checks that the UTF-8 strings provided to these methods are correctly encoded. If they are not, then the proper [JNI error reporting behavior](https://docs.oracle.com/en/java/javase/11/docs/specs/jni/functions.html) is performed, mainly:
- `FindClass` throws `NoClassDefFoundError`.
- `GetFieldID` and `GetStaticFieldID` throw `NoSuchFieldError`.
- `GetMethodID`, `GetStaticMethodID` and `RegisterNatives` throw `NoSuchMethodError`.
