### PR TITLE
Proper input validation in replaced implementation of `Array.newInstance()`

### DIFF
--- a/compiler/src/org.graalvm.compiler.replacements/src/org/graalvm/compiler/replacements/StandardGraphBuilderPlugins.java
+++ b/compiler/src/org.graalvm.compiler.replacements/src/org/graalvm/compiler/replacements/StandardGraphBuilderPlugins.java
@@ -468,12 +468,10 @@ public class StandardGraphBuilderPlugins {
 
     private static void registerArrayPlugins(InvocationPlugins plugins, Replacements replacements) {
         Registration r = new Registration(plugins, Array.class, replacements);
-        r.register(new InvocationPlugin("newInstance", Class.class, int.class) {
+        r.register(new InvocationPlugin("newArray", Class.class, int.class) {
             @Override
             public boolean apply(GraphBuilderContext b, ResolvedJavaMethod targetMethod, Receiver unused, ValueNode componentType, ValueNode length) {
-                ValueNode componentTypeNonNull = b.nullCheckedValue(componentType);
-                ValueNode lengthPositive = b.maybeEmitExplicitNegativeArraySizeCheck(length);
-                b.addPush(JavaKind.Object, new DynamicNewArrayNode(componentTypeNonNull, lengthPositive, true));
+                b.addPush(JavaKind.Object, new DynamicNewArrayNode(componentType, length, true));
                 return true;
             }
         });

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/JavaLangReflectSubstitutions.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/JavaLangReflectSubstitutions.java
@@ -32,6 +32,7 @@ import org.graalvm.compiler.word.BarrieredAccess;
 import org.graalvm.word.UnsignedWord;
 
 import com.oracle.svm.core.SubstrateUtil;
+import com.oracle.svm.core.annotate.Alias;
 import com.oracle.svm.core.annotate.Substitute;
 import com.oracle.svm.core.annotate.TargetClass;
 import com.oracle.svm.core.config.ConfigurationValues;
@@ -360,6 +361,25 @@ final class Target_java_lang_reflect_Array {
             }
         }
         throw new IllegalArgumentException();
+    }
+
+    @Alias
+    private static native Object newArray(Class<?> componentType, int length);
+
+    @Substitute
+    public static Object newInstance(Class<?> componentType, int length) {
+        if (componentType == null) {
+            throw new NullPointerException();
+        }
+        if (componentType.equals(void.class) ||
+                        (componentType.isArray() && SubstrateUtil.arrayTypeDimension(componentType) >= 255)) {
+            throw new IllegalArgumentException();
+        }
+        if (length < 0) {
+            throw new NegativeArraySizeException();
+        }
+
+        return newArray(componentType, length);
     }
 
     @Substitute


### PR DESCRIPTION
The JDK implementation of `Array.newInstance()` simply calls the private `Array.newArray()`.

The previous implementation replacement only checked for `null` `componentType` and strictly negative `length`, but did not check that the dimension of `componentType` (when it is an array class) is less than 255.

The previous incomplete checks were removed, and moved into the replacement implementation of `Array.newInstance()` in `Target_java_lang_reflect_Array`.
That implementation performs the complete set of checks before calling `Array.newArray()`.
