### PR TITLE
Fixes and features for LLVM backend

### DIFF
--- a/compiler/src/org.graalvm.compiler.lir/src/org/graalvm/compiler/lir/gen/LIRGenerator.java
+++ b/compiler/src/org.graalvm.compiler.lir/src/org/graalvm/compiler/lir/gen/LIRGenerator.java
@@ -221,7 +221,16 @@ public abstract class LIRGenerator implements LIRGeneratorTool {
     @Override
     public Variable emitMove(Value input) {
         assert !isVariable(input) : "Creating a copy of a variable via this method is not supported (and potentially a bug): " + input;
-        Variable result = newVariable(input.getValueKind());
+        return emitMoveHelper(input.getValueKind(), input);
+    }
+
+    @Override
+    public Variable emitMove(ValueKind<?> dst, Value src) {
+        return emitMoveHelper(dst, src);
+    }
+
+    private Variable emitMoveHelper(ValueKind<?> dst, Value input) {
+        Variable result = newVariable(dst);
         emitMove(result, input);
         return result;
     }

--- a/compiler/src/org.graalvm.compiler.lir/src/org/graalvm/compiler/lir/gen/LIRGeneratorTool.java
+++ b/compiler/src/org.graalvm.compiler.lir/src/org/graalvm/compiler/lir/gen/LIRGeneratorTool.java
@@ -161,6 +161,8 @@ public interface LIRGeneratorTool extends DiagnosticLIRGeneratorTool, ValueKindF
 
     Variable emitMove(Value input);
 
+    Variable emitMove(ValueKind<?> dst, Value src);
+
     void emitMove(AllocatableValue dst, Value src);
 
     Variable emitReadRegister(Register register, ValueKind<?> kind);

--- a/compiler/src/org.graalvm.compiler.word/src/org/graalvm/compiler/word/WordCastNode.java
+++ b/compiler/src/org.graalvm.compiler.word/src/org/graalvm/compiler/word/WordCastNode.java
@@ -202,7 +202,7 @@ public final class WordCastNode extends FixedWithNextNode implements LIRLowerabl
             } else if (!trackedPointer && !((AbstractPointerStamp) input.stamp(NodeView.DEFAULT)).nonNull()) {
                 generator.getLIRGeneratorTool().emitConvertNullToZero(result, (AllocatableValue) value);
             } else {
-                generator.getLIRGeneratorTool().emitMove(result, value);
+                result = generator.getLIRGeneratorTool().emitMove(kind, value);
             }
             generator.setResult(this, result);
         }

--- a/substratevm/src/com.oracle.svm.core.graal.llvm/src/com/oracle/svm/core/graal/llvm/LLVMGenerator.java
+++ b/substratevm/src/com.oracle.svm.core.graal.llvm/src/com/oracle/svm/core/graal/llvm/LLVMGenerator.java
@@ -109,6 +109,7 @@ import com.oracle.svm.core.graal.llvm.util.LLVMTargetSpecific;
 import com.oracle.svm.core.graal.llvm.util.LLVMUtils;
 import com.oracle.svm.core.graal.llvm.util.LLVMUtils.LLVMConstant;
 import com.oracle.svm.core.graal.llvm.util.LLVMUtils.LLVMKind;
+import com.oracle.svm.core.graal.llvm.util.LLVMUtils.LLVMPendingPtrToInt;
 import com.oracle.svm.core.graal.llvm.util.LLVMUtils.LLVMPendingSpecialRegisterRead;
 import com.oracle.svm.core.graal.llvm.util.LLVMUtils.LLVMStackSlot;
 import com.oracle.svm.core.graal.llvm.util.LLVMUtils.LLVMValueWrapper;
@@ -602,6 +603,23 @@ public class LLVMGenerator implements LIRGeneratorTool, SubstrateLIRGenerator {
             return new LLVMVariable(getVal(input));
         }
         throw shouldNotReachHere("Unknown move input");
+    }
+
+    @Override
+    public Variable emitMove(ValueKind<?> dst, Value src) {
+        LLVMValueRef source = getVal(src);
+        LLVMTypeRef sourceType = typeOf(source);
+        LLVMTypeRef destType = ((LLVMKind) dst.getPlatformKind()).get();
+
+        /* Floating word cast */
+        if (LLVMIRBuilder.isObjectType(destType) && LLVMIRBuilder.isWordType(sourceType)) {
+            source = builder.buildIntToPtr(source, destType);
+        } else if (((LIRKind) dst).isValue() && LLVMIRBuilder.isWordType(destType) && LLVMIRBuilder.isObjectType(sourceType)) {
+            source = builder.buildPtrToInt(source);
+        } else if (!((LIRKind) dst).isValue() && LLVMIRBuilder.isWordType(destType) && LLVMIRBuilder.isObjectType(sourceType)) {
+            return new LLVMPendingPtrToInt(this, source);
+        }
+        return new LLVMVariable(source);
     }
 
     @Override

--- a/substratevm/src/com.oracle.svm.core.graal.llvm/src/com/oracle/svm/core/graal/llvm/LLVMGenerator.java
+++ b/substratevm/src/com.oracle.svm.core.graal.llvm/src/com/oracle/svm/core/graal/llvm/LLVMGenerator.java
@@ -36,6 +36,7 @@ import static com.oracle.svm.core.graal.llvm.util.LLVMUtils.getVal;
 import static org.graalvm.compiler.debug.GraalError.shouldNotReachHere;
 import static org.graalvm.compiler.debug.GraalError.unimplemented;
 
+import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -45,6 +46,7 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.BiFunction;
 
 import org.graalvm.compiler.code.CompilationResult;
+import org.graalvm.compiler.code.DataSection;
 import org.graalvm.compiler.core.common.CompressEncoding;
 import org.graalvm.compiler.core.common.LIRKind;
 import org.graalvm.compiler.core.common.NumUtil;
@@ -85,10 +87,13 @@ import org.graalvm.nativeimage.AnnotationAccess;
 import org.graalvm.nativeimage.c.constant.CEnum;
 import org.graalvm.nativeimage.c.function.CEntryPoint;
 
+import com.oracle.graal.pointsto.heap.ImageHeapArray;
+import com.oracle.graal.pointsto.heap.ImageHeapInstance;
 import com.oracle.svm.core.FrameAccess;
 import com.oracle.svm.core.ReservedRegisters;
 import com.oracle.svm.core.SubstrateOptions;
 import com.oracle.svm.core.SubstrateUtil;
+import com.oracle.svm.core.config.ConfigurationValues;
 import com.oracle.svm.core.graal.code.SubstrateCallingConvention;
 import com.oracle.svm.core.graal.code.SubstrateCallingConventionType;
 import com.oracle.svm.core.graal.code.SubstrateDataBuilder;
@@ -148,6 +153,7 @@ import jdk.vm.ci.meta.MetaAccessProvider;
 import jdk.vm.ci.meta.PlatformKind;
 import jdk.vm.ci.meta.ResolvedJavaMethod;
 import jdk.vm.ci.meta.ResolvedJavaType;
+import jdk.vm.ci.meta.VMConstant;
 import jdk.vm.ci.meta.Value;
 import jdk.vm.ci.meta.ValueKind;
 
@@ -546,7 +552,19 @@ public class LLVMGenerator implements LIRGeneratorTool, SubstrateLIRGenerator {
             constants.put(constant, symbolName);
 
             Constant storedConstant = uncompressedObject ? ((CompressibleConstant) constant).compress() : constant;
-            DataSectionReference reference = compilationResult.getDataSection().insertData(dataBuilder.createDataItem(storedConstant));
+            DataSection.Data data;
+            if (constant instanceof ImageHeapArray || constant instanceof ImageHeapInstance) {
+                int referenceSize = ConfigurationValues.getObjectLayout().getReferenceSize();
+                data = new DataSection.Data(referenceSize, referenceSize) {
+                    @Override
+                    protected void emit(ByteBuffer buffer, DataSection.Patches patches) {
+                        SubstrateDataBuilder.ObjectData.emit(buffer, patches, getSize(), (VMConstant) constant);
+                    }
+                };
+            } else {
+                data = dataBuilder.createDataItem(storedConstant);
+            }
+            DataSectionReference reference = compilationResult.getDataSection().insertData(data);
             compilationResult.recordDataPatchWithNote(0, reference, symbolName);
         }
         return builder.getExternalObject(symbolName, isUncompressedObjectConstant(constant));

--- a/substratevm/src/com.oracle.svm.core.graal.llvm/src/com/oracle/svm/core/graal/llvm/LLVMGenerator.java
+++ b/substratevm/src/com.oracle.svm.core.graal.llvm/src/com/oracle/svm/core/graal/llvm/LLVMGenerator.java
@@ -1310,7 +1310,12 @@ public class LLVMGenerator implements LIRGeneratorTool, SubstrateLIRGenerator {
             // https://docs.oracle.com/javase/specs/jls/se7/html/jls-15.html#jls-15.19
 
             LLVMTypeRef typeA = typeOf(a);
-            final int bitWidthA = LLVMIRBuilder.integerTypeWidth(typeA);
+            int bitWidthA = LLVMIRBuilder.integerTypeWidth(typeA);
+
+            if (bitWidthA == 8 || bitWidthA == 16) {
+                bitWidthA = 32;
+            }
+
             assert bitWidthA == 32 || bitWidthA == 64;
 
             LLVMValueRef shiftDistanceBitMask = builder.constantInteger(bitWidthA - 1, bitWidthA);

--- a/substratevm/src/com.oracle.svm.core.graal.llvm/src/com/oracle/svm/core/graal/llvm/LLVMGenerator.java
+++ b/substratevm/src/com.oracle.svm.core.graal.llvm/src/com/oracle/svm/core/graal/llvm/LLVMGenerator.java
@@ -1118,6 +1118,16 @@ public class LLVMGenerator implements LIRGeneratorTool, SubstrateLIRGenerator {
         builder.setCallSiteAttribute(call, Attribute.GCLeafFunction);
     }
 
+    public void clobberRegister(String register) {
+        LLVMTypeRef inlineAsmType = builder.functionType(builder.voidType());
+        String asmSnippet = LLVMTargetSpecific.get().getNopInlineAssembly();
+        InlineAssemblyConstraint clobberConstraint = new InlineAssemblyConstraint(Type.Clobber, Location.namedRegister(register));
+
+        LLVMValueRef clobber = builder.buildInlineAsm(inlineAsmType, asmSnippet, true, false, clobberConstraint);
+        LLVMValueRef call = builder.buildCall(clobber);
+        builder.setCallSiteAttribute(call, Attribute.GCLeafFunction);
+    }
+
     /* Unimplemented */
 
     @Override

--- a/substratevm/src/com.oracle.svm.core.graal.llvm/src/com/oracle/svm/core/graal/llvm/NodeLLVMBuilder.java
+++ b/substratevm/src/com.oracle.svm.core.graal.llvm/src/com/oracle/svm/core/graal/llvm/NodeLLVMBuilder.java
@@ -190,6 +190,10 @@ public class NodeLLVMBuilder implements NodeLIRBuilderTool, SubstrateNodeLIRBuil
             builder.buildStackmap(builder.constantLong(startPatchpointID));
             gen.getCompilationResult().recordInfopoint(NumUtil.safeToInt(startPatchpointID), null, InfopointReason.METHOD_START);
 
+            if (gen.isEntryPoint() && SubstrateOptions.SpawnIsolates.getValue()) {
+                gen.clobberRegister(ReservedRegisters.singleton().getHeapBaseRegister().name);
+            }
+
             for (ParameterNode param : graph.getNodes(ParameterNode.TYPE)) {
                 LLVMValueRef paramValue = builder.getFunctionParam(param.index());
                 setResult(param, paramValue);

--- a/substratevm/src/com.oracle.svm.core.graal.llvm/src/com/oracle/svm/core/graal/llvm/NodeLLVMBuilder.java
+++ b/substratevm/src/com.oracle.svm.core.graal.llvm/src/com/oracle/svm/core/graal/llvm/NodeLLVMBuilder.java
@@ -35,7 +35,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import org.graalvm.collections.Pair;
 import org.graalvm.compiler.code.CompilationResult;
+import org.graalvm.compiler.core.common.CompressEncoding;
 import org.graalvm.compiler.core.common.NumUtil;
 import org.graalvm.compiler.core.common.calc.Condition;
 import org.graalvm.compiler.core.common.cfg.BasicBlock;
@@ -105,11 +107,16 @@ import com.oracle.svm.core.graal.llvm.util.LLVMUtils.LLVMValueWrapper;
 import com.oracle.svm.core.graal.llvm.util.LLVMUtils.LLVMVariable;
 import com.oracle.svm.core.graal.meta.KnownOffsets;
 import com.oracle.svm.core.graal.nodes.CGlobalDataLoadAddressNode;
+import com.oracle.svm.core.graal.nodes.ComputedIndirectCallTargetNode;
 import com.oracle.svm.core.graal.nodes.ForeignCallWithExceptionNode;
+import com.oracle.svm.core.heap.ReferenceAccess;
+import com.oracle.svm.core.meta.SharedField;
+import com.oracle.svm.core.meta.SubstrateObjectConstant;
 import com.oracle.svm.core.nodes.SafepointCheckNode;
 import com.oracle.svm.core.thread.Safepoint;
 import com.oracle.svm.core.thread.ThreadingSupportImpl;
 import com.oracle.svm.core.thread.VMThreads;
+import com.oracle.svm.core.util.VMError;
 import com.oracle.svm.shadowed.org.bytedeco.llvm.LLVM.LLVMBasicBlockRef;
 import com.oracle.svm.shadowed.org.bytedeco.llvm.LLVM.LLVMTypeRef;
 import com.oracle.svm.shadowed.org.bytedeco.llvm.LLVM.LLVMValueRef;
@@ -120,6 +127,7 @@ import jdk.vm.ci.code.RegisterValue;
 import jdk.vm.ci.code.site.InfopointReason;
 import jdk.vm.ci.meta.Assumptions;
 import jdk.vm.ci.meta.JavaConstant;
+import jdk.vm.ci.meta.JavaKind;
 import jdk.vm.ci.meta.PlatformKind;
 import jdk.vm.ci.meta.ResolvedJavaMethod;
 import jdk.vm.ci.meta.Value;
@@ -471,26 +479,51 @@ public class NodeLLVMBuilder implements NodeLIRBuilderTool, SubstrateNodeLIRBuil
             gen.getCompilationResult().recordCall(NumUtil.safeToInt(patchpointId), 0, targetMethod, debugInfo, true);
         } else if (callTarget instanceof IndirectCallTargetNode) {
             LLVMValueRef computedAddress = llvmOperand(((IndirectCallTargetNode) callTarget).computedAddress());
-            LLVMTypeRef functionType;
-            if (targetMethod != null) {
-                functionType = gen.getLLVMFunctionPointerType(targetMethod);
-                isVoid = gen.isVoidReturnType(gen.getLLVMFunctionReturnType(targetMethod, false));
-            } else {
-                LLVMTypeRef returnType = getUnknownCallReturnType(callTarget);
-                isVoid = gen.isVoidReturnType(returnType);
-                LLVMTypeRef[] argTypes = getUnknownCallArgumentTypes(callTarget);
-                assert args.length == argTypes.length;
-                functionType = builder.functionPointerType(returnType, argTypes);
+            Pair<LLVMValueRef, Boolean> calleeAndReturnType = getCalleeAndReturnType(targetMethod, callTarget, args, computedAddress, patchpointId, debugInfo);
+            callee = calleeAndReturnType.getLeft();
+            isVoid = calleeAndReturnType.getRight();
+        } else if (callTarget instanceof ComputedIndirectCallTargetNode) {
+            VMError.guarantee(SubstrateOptions.SpawnIsolates.getValue(), "Memory access without isolates is not implemented");
+
+            ComputedIndirectCallTargetNode computedIndirectCallTargetNode = (ComputedIndirectCallTargetNode) callTarget;
+            LLVMValueRef computedAddress = llvmOperand(computedIndirectCallTargetNode.getAddressBase());
+            CompressEncoding compressEncoding = ReferenceAccess.singleton().getCompressEncoding();
+            boolean nextMemoryAccessNeedsDecompress = false;
+
+            for (var computation : computedIndirectCallTargetNode.getAddressComputation()) {
+                SharedField field;
+                if (computation instanceof ComputedIndirectCallTargetNode.FieldLoad) {
+                    field = (SharedField) ((ComputedIndirectCallTargetNode.FieldLoad) computation).getField();
+
+                    if (nextMemoryAccessNeedsDecompress) {
+                        computedAddress = builder.buildAddrSpaceCast(computedAddress, builder.objectType(true));
+                        LLVMValueRef heapBase = ((LLVMVariable) gen.emitReadRegister(ReservedRegisters.singleton().getHeapBaseRegister(), null)).get();
+                        computedAddress = builder.buildUncompress(computedAddress, heapBase, true, compressEncoding.getShift());
+                    }
+
+                    computedAddress = builder.buildGEP(computedAddress, builder.constantInt(field.getOffset()));
+                    computedAddress = builder.buildLoad(computedAddress, builder.objectType(false));
+                } else if (computation instanceof ComputedIndirectCallTargetNode.FieldLoadIfZero) {
+                    SubstrateObjectConstant object = (SubstrateObjectConstant) ((ComputedIndirectCallTargetNode.FieldLoadIfZero) computation).getObject();
+                    field = (SharedField) ((ComputedIndirectCallTargetNode.FieldLoadIfZero) computation).getField();
+
+                    LLVMValueRef heapBase = ((LLVMVariable) gen.emitReadRegister(ReservedRegisters.singleton().getHeapBaseRegister(), null)).get();
+                    heapBase = builder.buildIntToPtr(heapBase, builder.objectType(false));
+                    LLVMValueRef objectAddress = builder.buildPtrToInt(gen.emitLLVMConstant(builder.objectType(false), object));
+                    LLVMValueRef computedAddressIfNull = builder.buildGEP(heapBase, builder.buildAdd(builder.constantLong(field.getOffset()), objectAddress));
+                    computedAddressIfNull = builder.buildLoad(computedAddressIfNull, builder.objectType(false));
+
+                    LLVMValueRef cond = builder.buildCompare(Condition.NE, builder.constantLong(0), builder.buildPtrToInt(computedAddress), true);
+                    computedAddress = builder.buildSelect(cond, computedAddress, computedAddressIfNull);
+                } else {
+                    throw VMError.shouldNotReachHere("Computation is not supported yet: " + computation.getClass().getTypeName());
+                }
+                nextMemoryAccessNeedsDecompress = field.getStorageKind() == JavaKind.Object;
             }
 
-            if (LLVMIRBuilder.isObjectType(LLVMIRBuilder.typeOf(computedAddress))) {
-                callee = builder.buildBitcast(builder.buildAddrSpaceCast(computedAddress, builder.rawPointerType()), functionType);
-            } else {
-                callee = builder.buildIntToPtr(computedAddress, functionType);
-            }
-            gen.getCompilationResult().recordCall(NumUtil.safeToInt(patchpointId), 0, targetMethod, debugInfo, false);
-
-            gen.getDebugInfoPrinter().printIndirectCall(targetMethod, callee);
+            Pair<LLVMValueRef, Boolean> calleeAndReturnType = getCalleeAndReturnType(targetMethod, callTarget, args, computedAddress, patchpointId, debugInfo);
+            callee = calleeAndReturnType.getLeft();
+            isVoid = calleeAndReturnType.getRight();
         } else {
             throw shouldNotReachHere();
         }
@@ -500,6 +533,33 @@ public class NodeLLVMBuilder implements NodeLIRBuilderTool, SubstrateNodeLIRBuil
         if (!isVoid) {
             setResult(i.asNode(), call);
         }
+    }
+
+    private Pair<LLVMValueRef, Boolean> getCalleeAndReturnType(ResolvedJavaMethod targetMethod, LoweredCallTargetNode callTarget, LLVMValueRef[] args, LLVMValueRef computedAddress, long patchpointId,
+                    DebugInfo debugInfo) {
+        LLVMValueRef callee;
+        boolean isVoid;
+        LLVMTypeRef functionType;
+        if (targetMethod != null) {
+            functionType = gen.getLLVMFunctionPointerType(targetMethod);
+            isVoid = gen.isVoidReturnType(gen.getLLVMFunctionReturnType(targetMethod, false));
+        } else {
+            LLVMTypeRef returnType = getUnknownCallReturnType(callTarget);
+            isVoid = gen.isVoidReturnType(returnType);
+            LLVMTypeRef[] argTypes = getUnknownCallArgumentTypes(callTarget);
+            assert args.length == argTypes.length;
+            functionType = builder.functionPointerType(returnType, argTypes);
+        }
+
+        if (LLVMIRBuilder.isObjectType(LLVMIRBuilder.typeOf(computedAddress))) {
+            callee = builder.buildBitcast(builder.buildAddrSpaceCast(computedAddress, builder.rawPointerType()), functionType);
+        } else {
+            callee = builder.buildIntToPtr(computedAddress, functionType);
+        }
+        gen.getCompilationResult().recordCall(NumUtil.safeToInt(patchpointId), 0, targetMethod, debugInfo, false);
+
+        gen.getDebugInfoPrinter().printIndirectCall(targetMethod, callee);
+        return Pair.create(callee, isVoid);
     }
 
     @Override

--- a/substratevm/src/com.oracle.svm.core.graal.llvm/src/com/oracle/svm/core/graal/llvm/runtime/LLVMExceptionUnwind.java
+++ b/substratevm/src/com.oracle.svm.core.graal.llvm/src/com/oracle/svm/core/graal/llvm/runtime/LLVMExceptionUnwind.java
@@ -82,6 +82,7 @@ public class LLVMExceptionUnwind {
      * NodeLLVMBuilder.emitReadExceptionObject).
      */
     @CEntryPoint(include = IncludeForLLVMOnly.class, publishAs = CEntryPoint.Publish.NotPublished)
+    @Uninterruptible(reason = "Must not execute a recurring callback before returning", calleeMustBe = false)
     @SuppressWarnings("unused")
     public static int personality(int version, int action, IsolateThread thread, _Unwind_Exception unwindException, _Unwind_Context context) {
         Pointer ip = getIP(context);

--- a/substratevm/src/com.oracle.svm.core.graal.llvm/src/com/oracle/svm/core/graal/llvm/util/LLVMIRBuilder.java
+++ b/substratevm/src/com.oracle.svm.core.graal.llvm/src/com/oracle/svm/core/graal/llvm/util/LLVMIRBuilder.java
@@ -729,7 +729,8 @@ public class LLVMIRBuilder implements AutoCloseable {
 
         public enum Type {
             Output("="),
-            Input("");
+            Input(""),
+            Clobber("~");
 
             private String repr;
 

--- a/substratevm/src/com.oracle.svm.core.graal.llvm/src/com/oracle/svm/core/graal/llvm/util/LLVMTargetSpecific.java
+++ b/substratevm/src/com.oracle.svm.core.graal.llvm/src/com/oracle/svm/core/graal/llvm/util/LLVMTargetSpecific.java
@@ -38,8 +38,8 @@ import org.graalvm.nativeimage.Platforms;
 
 import com.oracle.svm.core.FrameAccess;
 import com.oracle.svm.core.SubstrateOptions;
-import com.oracle.svm.core.feature.InternalFeature;
 import com.oracle.svm.core.feature.AutomaticallyRegisteredFeature;
+import com.oracle.svm.core.feature.InternalFeature;
 import com.oracle.svm.shadowed.org.bytedeco.llvm.LLVM.LLVMRelocationIteratorRef;
 import com.oracle.svm.shadowed.org.bytedeco.llvm.LLVM.LLVMSectionIteratorRef;
 import com.oracle.svm.shadowed.org.bytedeco.llvm.LLVM.LLVMSymbolIteratorRef;
@@ -77,6 +77,11 @@ public interface LLVMTargetSpecific {
      * Snippet that adds two registers and save the result in one of them.
      */
     String getAddInlineAssembly(String outputRegisterName, String inputRegisterName);
+
+    /**
+     * Snippet representing a nop instruction.
+     */
+    String getNopInlineAssembly();
 
     /**
      * Name of the architecture to be passed to the LLVM compiler.
@@ -186,6 +191,11 @@ class LLVMAMD64TargetSpecificFeature implements InternalFeature {
             }
 
             @Override
+            public String getNopInlineAssembly() {
+                return "nop";
+            }
+
+            @Override
             public String getLLVMArchName() {
                 return "x86-64";
             }
@@ -279,6 +289,11 @@ class LLVMAArch64TargetSpecificFeature implements InternalFeature {
             @Override
             public String getAddInlineAssembly(String outputRegister, String inputRegister) {
                 return "ADD " + getLLVMRegisterName(outputRegister) + ", " + getLLVMRegisterName(outputRegister) + ", " + getLLVMRegisterName(inputRegister);
+            }
+
+            @Override
+            public String getNopInlineAssembly() {
+                return "NOP";
             }
 
             @Override
@@ -379,6 +394,11 @@ class LLVMRISCV64TargetSpecificFeature implements InternalFeature {
             @Override
             public String getAddInlineAssembly(String outputRegister, String inputRegister) {
                 return "add " + getLLVMRegisterName(outputRegister) + ", " + getLLVMRegisterName(outputRegister) + ", " + getLLVMRegisterName(inputRegister);
+            }
+
+            @Override
+            public String getNopInlineAssembly() {
+                return "nop";
             }
 
             @Override

--- a/substratevm/src/com.oracle.svm.core.graal.llvm/src/com/oracle/svm/core/graal/llvm/util/LLVMUtils.java
+++ b/substratevm/src/com.oracle.svm.core.graal.llvm/src/com/oracle/svm/core/graal/llvm/util/LLVMUtils.java
@@ -177,6 +177,23 @@ public class LLVMUtils {
         }
     }
 
+    public static class LLVMPendingPtrToInt extends LLVMVariable implements LLVMValueWrapper {
+        private final LLVMGenerator gen;
+        private final LLVMValueRef val;
+
+        public LLVMPendingPtrToInt(LLVMGenerator gen, LLVMValueRef val) {
+            super(LLVMKind.toLIRKind(gen.getBuilder().wordType()));
+            this.gen = gen;
+            this.val = val;
+        }
+
+        @Override
+        public LLVMValueRef get() {
+            LLVMIRBuilder builder = gen.getBuilder();
+            return builder.buildPtrToInt(val);
+        }
+    }
+
     public static class LLVMKindTool implements LIRKindTool {
         private LLVMIRBuilder builder;
 

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/graal/code/SubstrateDataBuilder.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/graal/code/SubstrateDataBuilder.java
@@ -81,13 +81,17 @@ public class SubstrateDataBuilder extends DataBuilder {
 
         @Override
         protected void emit(ByteBuffer buffer, Patches patches) {
+            emit(buffer, patches, getSize(), constant);
+        }
+
+        public static void emit(ByteBuffer buffer, Patches patches, int size, VMConstant constant) {
             int position = buffer.position();
-            if (getSize() == Integer.BYTES) {
+            if (size == Integer.BYTES) {
                 buffer.putInt(0);
-            } else if (getSize() == Long.BYTES) {
+            } else if (size == Long.BYTES) {
                 buffer.putLong(0L);
             } else {
-                shouldNotReachHere("Unsupported object constant reference size: " + getSize());
+                shouldNotReachHere("Unsupported object constant reference size: " + size);
             }
             patches.registerPatch(position, constant);
         }


### PR DESCRIPTION
This PR regroups fixes and new features for the LLVM backend.

- When emitting a shift, according to the documentation, we have to allow a number with a bit width of 8 or 16 and treat it as a 32 bit number.
- On a `Word.objectToTrackedPointer` call, we need to emit the `ptrToInt` LLVM call at the latest moment, to ensure the value used is correctly put in the statepoint.
- Handle `ComputeIndirectCallTargetNode` in the LLVM backend.
- Handle `ImageHeapConstant` in the LLVM backend.
- Make the `personality` function uninterruptible to avoid recurring callbacks when handling LLVM exceptions.
- Clobber the heap base register in functions that are entry points when isolates are enabled to ensure we return the correct isolate even when we create a new one in a JNI call for example.