### PR TITLE
[Backport][22.3] Fix JDK-17 builds with jdk-17.0.7+1 and later

### DIFF
--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/Target_jdk_jfr_internal_JVM.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/Target_jdk_jfr_internal_JVM.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@
 package com.oracle.svm.core.jfr;
 
 import java.util.List;
+import java.util.function.BooleanSupplier;
 
 import org.graalvm.nativeimage.ProcessProperties;
 
@@ -40,6 +41,7 @@ import com.oracle.svm.core.jdk.JDK17OrLater;
 import com.oracle.svm.core.jdk.JDK19OrLater;
 import com.oracle.svm.core.jfr.traceid.JfrTraceId;
 import com.oracle.svm.core.util.VMError;
+import com.oracle.svm.util.ReflectionUtil;
 
 import jdk.jfr.Event;
 import jdk.jfr.internal.JVM;
@@ -49,8 +51,38 @@ import jdk.jfr.internal.LogTag;
 @TargetClass(value = jdk.jfr.internal.JVM.class, onlyWith = HasJfrSupport.class)
 public final class Target_jdk_jfr_internal_JVM {
     // Checkstyle: stop
-    @Alias static Object FILE_DELTA_CHANGE;
+    @Alias @TargetElement(onlyWith = JvmChunkRotationMonitorAvailable.class) //
+    static Object CHUNK_ROTATION_MONITOR;
+
+    @Alias @TargetElement(onlyWith = JvmFileDeltaChangeAvailable.class) //
+    static Object FILE_DELTA_CHANGE;
     // Checkstyle: resume
+
+    static class JvmChunkRotationMonitorAvailable extends JvmFieldAvailable {
+        protected JvmChunkRotationMonitorAvailable() {
+            super("CHUNK_ROTATION_MONITOR");
+        }
+    }
+
+    private static class JvmFileDeltaChangeAvailable extends JvmFieldAvailable {
+        protected JvmFileDeltaChangeAvailable() {
+            super("FILE_DELTA_CHANGE");
+        }
+    }
+
+    private abstract static class JvmFieldAvailable implements BooleanSupplier {
+
+        private final String fieldName;
+
+        protected JvmFieldAvailable(String fieldName) {
+            this.fieldName = fieldName;
+        }
+
+        @Override
+        public boolean getAsBoolean() {
+            return ReflectionUtil.lookupField(true, JVM.class, fieldName) != null;
+        }
+    }
 
     @Alias @RecomputeFieldValue(kind = RecomputeFieldValue.Kind.Reset) //
     private volatile boolean nativeOK;


### PR DESCRIPTION
`FILE_DELTA_CHANGE` got removed and `CHUNK_ROTATION_MONITOR` got introduced by https://bugs.openjdk.org/browse/JDK-8286707 starting with jdk-17.0.7+1

Backport of https://github.com/oracle/graal/pull/6041

Cherry-picked from `master`: 2f9018e77a9f4c6c36127d0abdf4378269fb572d  and fa6728502d820f465db3e63cc33454bf90abca34

The cherry-pick had some conflicts due to https://github.com/oracle/graal/commit/4b1a2f4cc95bef363a575da78b8bb98563af0e8f not being backported to 22.3. I decided to resolve the conflicts (nothing non-trivial) instead of backporting https://github.com/oracle/graal/commit/4b1a2f4cc95bef363a575da78b8bb98563af0e8f as well since JDK 20 support is not a goal for 22.3 AFAIK.