### PR TITLE
[GR-40463] RJMX Configuration Optimization.

### DIFF
--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/jdk/JmxCommonFeature.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/jdk/JmxCommonFeature.java
@@ -126,24 +126,22 @@ public class JmxCommonFeature implements InternalFeature {
 
     private static void configureProxy(BeforeAnalysisAccess access) {
         DynamicProxyRegistry dynamicProxySupport = ImageSingletons.lookup(DynamicProxyRegistry.class);
-
-        dynamicProxySupport.addProxyClass(access.findClassByName("jdk.management.jfr.FlightRecorderMXBean"),
-                        access.findClassByName("javax.management.NotificationEmitter"));
-
-        dynamicProxySupport.addProxyClass(access.findClassByName("java.lang.management.RuntimeMXBean"));
-        dynamicProxySupport.addProxyClass(access.findClassByName("java.lang.management.ClassLoadingMXBean"));
-        dynamicProxySupport.addProxyClass(access.findClassByName("com.sun.management.ThreadMXBean"));
-        dynamicProxySupport.addProxyClass(access.findClassByName("java.lang.management.ThreadMXBean"));
-        dynamicProxySupport.addProxyClass(access.findClassByName("java.lang.management.GarbageCollectorMXBean"), access.findClassByName("javax.management.NotificationEmitter"));
         dynamicProxySupport.addProxyClass(access.findClassByName("com.sun.management.GarbageCollectorMXBean"), access.findClassByName("javax.management.NotificationEmitter"));
         dynamicProxySupport.addProxyClass(access.findClassByName("com.sun.management.OperatingSystemMXBean"));
-        dynamicProxySupport.addProxyClass(access.findClassByName("java.lang.management.OperatingSystemMXBean"));
-        dynamicProxySupport.addProxyClass(access.findClassByName("java.lang.management.MemoryManagerMXBean"), access.findClassByName("javax.management.NotificationEmitter"));
+        dynamicProxySupport.addProxyClass(access.findClassByName("com.sun.management.ThreadMXBean"));
+        dynamicProxySupport.addProxyClass(access.findClassByName("com.sun.management.UnixOperatingSystemMXBean"));
         dynamicProxySupport.addProxyClass(access.findClassByName("java.lang.management.BufferPoolMXBean"));
+        dynamicProxySupport.addProxyClass(access.findClassByName("java.lang.management.ClassLoadingMXBean"));
+        dynamicProxySupport.addProxyClass(access.findClassByName("java.lang.management.CompilationMXBean"));
+        dynamicProxySupport.addProxyClass(access.findClassByName("java.lang.management.GarbageCollectorMXBean"), access.findClassByName("javax.management.NotificationEmitter"));
+        dynamicProxySupport.addProxyClass(access.findClassByName("java.lang.management.MemoryManagerMXBean"), access.findClassByName("javax.management.NotificationEmitter"));
         dynamicProxySupport.addProxyClass(access.findClassByName("java.lang.management.MemoryPoolMXBean"), access.findClassByName("javax.management.NotificationEmitter"));
         dynamicProxySupport.addProxyClass(access.findClassByName("java.lang.management.MemoryMXBean"), access.findClassByName("javax.management.NotificationEmitter"));
-        dynamicProxySupport.addProxyClass(access.findClassByName("com.sun.management.UnixOperatingSystemMXBean"));
-        dynamicProxySupport.addProxyClass(access.findClassByName("com.sun.management.java.lang.management.CompilationMXBean"));
+        dynamicProxySupport.addProxyClass(access.findClassByName("java.lang.management.OperatingSystemMXBean"));
+        dynamicProxySupport.addProxyClass(access.findClassByName("java.lang.management.RuntimeMXBean"));
+        dynamicProxySupport.addProxyClass(access.findClassByName("java.lang.management.ThreadMXBean"));
+        dynamicProxySupport.addProxyClass(access.findClassByName("jdk.management.jfr.FlightRecorderMXBean"),
+                access.findClassByName("javax.management.NotificationEmitter"));
     }
 
     private static void configureJNI() {

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/jdk/JmxCommonFeature.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/jdk/JmxCommonFeature.java
@@ -39,6 +39,8 @@ import com.oracle.svm.core.jdk.proxy.DynamicProxyRegistry;
 import com.oracle.svm.core.jni.JNIRuntimeAccess;
 import com.oracle.svm.util.ReflectionUtil;
 
+import javax.management.openmbean.CompositeData;
+
 @AutomaticallyRegisteredFeature
 public class JmxCommonFeature implements InternalFeature {
     @Override
@@ -205,7 +207,6 @@ public class JmxCommonFeature implements InternalFeature {
     }
 
     private static void configureReflection(BeforeAnalysisAccess access) {
-        // Only JmxServerFeature, not JmxClientFeature, has registrations for platform MBeans
         String[] classes = {
                         "com.sun.crypto.provider.AESCipher$General", "com.sun.crypto.provider.ARCFOURCipher",
                         "com.sun.crypto.provider.ChaCha20Cipher$ChaCha20Poly1305", "com.sun.crypto.provider.DESCipher",
@@ -233,17 +234,12 @@ public class JmxCommonFeature implements InternalFeature {
         };
 
         String[] methods = {
-                        "com.sun.management.GcInfo",
-                        "com.sun.management.VMOption",
-                        "java.lang.management.MemoryUsage", "java.rmi.registry.Registry",
-                        "javax.management.remote.rmi.RMIConnection", "javax.management.remote.rmi.RMIConnectionImpl_Stub",
-                        "javax.management.remote.rmi.RMIServer", "javax.management.remote.rmi.RMIServerImpl_Stub",
-                        "java.lang.management.MonitorInfo",
+                        "com.sun.management.GcInfo", "java.lang.management.MemoryUsage", "java.lang.management.MonitorInfo",
+                        "javax.management.remote.rmi.RMIConnection",
+                        "javax.management.remote.rmi.RMIServer",
                         "java.lang.management.ThreadInfo", "jdk.management.jfr.ConfigurationInfo",
                         "jdk.management.jfr.EventTypeInfo", "jdk.management.jfr.RecordingInfo",
-                        "jdk.management.jfr.SettingDescriptorInfo", "sun.rmi.registry.RegistryImpl_Stub",
-                        "sun.rmi.server.UnicastRef2", "sun.rmi.transport.DGCImpl", "sun.rmi.transport.DGCImpl_Skel",
-                        "sun.rmi.transport.DGCImpl_Stub"
+                        "jdk.management.jfr.SettingDescriptorInfo"
         };
 
         String[] constructors = {

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/jdk/JmxCommonFeature.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/jdk/JmxCommonFeature.java
@@ -39,8 +39,6 @@ import com.oracle.svm.core.jdk.proxy.DynamicProxyRegistry;
 import com.oracle.svm.core.jni.JNIRuntimeAccess;
 import com.oracle.svm.util.ReflectionUtil;
 
-import javax.management.openmbean.CompositeData;
-
 @AutomaticallyRegisteredFeature
 public class JmxCommonFeature implements InternalFeature {
     @Override
@@ -141,7 +139,7 @@ public class JmxCommonFeature implements InternalFeature {
         dynamicProxySupport.addProxyClass(access.findClassByName("java.lang.management.RuntimeMXBean"));
         dynamicProxySupport.addProxyClass(access.findClassByName("java.lang.management.ThreadMXBean"));
         dynamicProxySupport.addProxyClass(access.findClassByName("jdk.management.jfr.FlightRecorderMXBean"),
-                access.findClassByName("javax.management.NotificationEmitter"));
+                        access.findClassByName("javax.management.NotificationEmitter"));
     }
 
     private static void configureJNI() {
@@ -206,26 +204,10 @@ public class JmxCommonFeature implements InternalFeature {
 
     private static void configureReflection(BeforeAnalysisAccess access) {
         String[] classes = {
-                        "com.sun.crypto.provider.AESCipher$General", "com.sun.crypto.provider.ARCFOURCipher",
-                        "com.sun.crypto.provider.ChaCha20Cipher$ChaCha20Poly1305", "com.sun.crypto.provider.DESCipher",
-                        "com.sun.crypto.provider.DESedeCipher", "com.sun.crypto.provider.DHParameters",
-                        "com.sun.crypto.provider.HmacCore$HmacSHA256",
-                        "com.sun.management.GcInfo",
                         "com.sun.management.internal.OperatingSystemImpl",
-                        "javax.management.remote.rmi.RMIConnection", "com.sun.management.VMOption",
-                        "javax.management.remote.rmi.RMIConnectionImpl_Stub", "javax.management.remote.rmi.RMIServer",
+                        "javax.management.remote.rmi.RMIConnectionImpl_Stub",
                         "javax.management.remote.rmi.RMIServerImpl_Stub", "sun.rmi.registry.RegistryImpl_Stub",
-                        "java.rmi.MarshalledObject", "java.rmi.Remote", "java.rmi.dgc.Lease", "java.rmi.dgc.VMID",
-                        "java.rmi.registry.Registry", "java.rmi.server.ObjID", "java.rmi.server.RemoteObject",
-                        "java.rmi.server.RemoteStub", "java.rmi.server.UID", "javax.management.openmbean.OpenType",
-                        "java.lang.management.LockInfo", "java.lang.management.ManagementPermission",
-                        "java.lang.management.MemoryUsage", "java.lang.management.MonitorInfo",
-                        "java.lang.management.ThreadInfo", "java.security.SecureRandomParameters",
-                        "javax.management.MBeanServerBuilder", "javax.management.NotificationBroadcaster",
-                        "javax.management.NotificationEmitter", "javax.management.NotificationFilterSupport",
-                        "javax.management.ObjectName", "jdk.management.jfr.ConfigurationInfo",
-                        "jdk.management.jfr.EventTypeInfo",
-                        "jdk.management.jfr.RecordingInfo", "jdk.management.jfr.SettingDescriptorInfo",
+                        "java.rmi.server.RemoteStub",
                         "sun.rmi.registry.RegistryImpl_Skel", "sun.rmi.transport.DGCImpl_Skel",
                         "sun.rmi.server.UnicastRef2", "sun.rmi.transport.DGCImpl", "sun.rmi.transport.DGCImpl_Skel",
                         "sun.rmi.transport.DGCImpl_Stub"
@@ -241,10 +223,10 @@ public class JmxCommonFeature implements InternalFeature {
         };
 
         String[] constructors = {
-                 "javax.management.remote.rmi.RMIConnectionImpl_Stub",
-                "javax.management.remote.rmi.RMIServerImpl_Stub", "sun.rmi.transport.DGCImpl_Stub",
-                "sun.rmi.registry.RegistryImpl_Skel", "sun.rmi.registry.RegistryImpl_Stub",
-                 "sun.rmi.transport.DGCImpl_Skel"
+                        "javax.management.remote.rmi.RMIConnectionImpl_Stub",
+                        "javax.management.remote.rmi.RMIServerImpl_Stub", "sun.rmi.transport.DGCImpl_Stub",
+                        "sun.rmi.registry.RegistryImpl_Skel", "sun.rmi.registry.RegistryImpl_Stub",
+                        "sun.rmi.transport.DGCImpl_Skel"
         };
 
         for (String clazz : classes) {

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/jdk/JmxCommonFeature.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/jdk/JmxCommonFeature.java
@@ -47,7 +47,7 @@ public class JmxCommonFeature implements InternalFeature {
     }
 
     /**
-     * This methods adds JMX-specific initialization policies when JMX support is enabled.
+     * This method adds JMX-specific initialization policies when JMX support is enabled.
      * <p>
      * Note that
      * {@link com.oracle.svm.core.jdk.management.ManagementFeature#duringSetup(org.graalvm.nativeimage.hosted.Feature.DuringSetupAccess)
@@ -246,15 +246,11 @@ public class JmxCommonFeature implements InternalFeature {
                         "sun.rmi.transport.DGCImpl_Stub"
         };
 
-        String[] fields = {"com.sun.management.GcInfo"};
-
         String[] constructors = {
-                        "com.sun.management.internal.GarbageCollectorExtImpl",
-                        "com.sun.management.internal.OperatingSystemImpl", "java.lang.management.ManagementPermission",
-                        "javax.management.MBeanServerBuilder", "javax.management.remote.rmi.RMIConnectionImpl_Stub",
-                        "javax.management.remote.rmi.RMIServerImpl_Stub", "sun.rmi.transport.DGCImpl_Stub",
-                        "sun.rmi.registry.RegistryImpl_Skel", "sun.rmi.registry.RegistryImpl_Stub",
-                        "sun.rmi.server.UnicastRef2", "sun.rmi.transport.DGCImpl_Skel"
+                 "javax.management.remote.rmi.RMIConnectionImpl_Stub",
+                "javax.management.remote.rmi.RMIServerImpl_Stub", "sun.rmi.transport.DGCImpl_Stub",
+                "sun.rmi.registry.RegistryImpl_Skel", "sun.rmi.registry.RegistryImpl_Stub",
+                 "sun.rmi.transport.DGCImpl_Skel"
         };
 
         for (String clazz : classes) {
@@ -265,9 +261,6 @@ public class JmxCommonFeature implements InternalFeature {
         }
         for (String clazz : constructors) {
             RuntimeReflection.register(access.findClassByName(clazz).getConstructors());
-        }
-        for (String clazz : fields) {
-            RuntimeReflection.register(access.findClassByName(clazz).getFields());
         }
     }
 }

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/jdk/JmxServerFeature.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/jdk/JmxServerFeature.java
@@ -68,7 +68,7 @@ public class JmxServerFeature implements InternalFeature {
     public void beforeAnalysis(BeforeAnalysisAccess access) {
         handleNativeLibraries(access);
         registerJMXAgentResources();
-        configureReflection(access);
+        configureReflection();
         configureProxy(access);
         RuntimeSupport.getRuntimeSupport().addStartupHook(new ManagementAgentStartupHook());
     }
@@ -92,7 +92,7 @@ public class JmxServerFeature implements InternalFeature {
         dynamicProxySupport.addProxyClass(access.findClassByName("javax.management.remote.rmi.RMIServer"));
     }
 
-    private static void configureReflection(BeforeAnalysisAccess access) {
+    private static void configureReflection() {
         /*
          * Register all the custom substrate MXBeans. They won't be accounted for by the native
          * image tracing agent so a user may not know they need to register them.

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/jdk/JmxServerFeature.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/jdk/JmxServerFeature.java
@@ -107,40 +107,6 @@ public class JmxServerFeature implements InternalFeature {
             }
             Class<?> clazz = p.getClass();
             RuntimeReflection.register(clazz);
-            RuntimeReflection.register(clazz.getDeclaredConstructors());
-            RuntimeReflection.register(clazz.getDeclaredMethods());
-            RuntimeReflection.register(clazz.getDeclaredFields());
-            RuntimeReflection.register(clazz.getInterfaces());
-        }
-
-        // Only JmxServerFeature, not JmxClientFeature, has registrations for platform MBeans
-        String[] classes = {
-                        "com.sun.management.GarbageCollectorMXBean",
-                        "com.sun.management.OperatingSystemMXBean",
-                        "com.sun.management.ThreadMXBean",
-                        "com.sun.management.UnixOperatingSystemMXBean", "java.lang.management.CompilationMXBean",
-                        "java.lang.management.GarbageCollectorMXBean", "java.lang.management.MemoryMXBean",
-                        "java.lang.management.MemoryManagerMXBean", "java.lang.management.MemoryPoolMXBean",
-                        "java.lang.management.RuntimeMXBean", "java.lang.management.BufferPoolMXBean",
-                        "java.lang.management.ClassLoadingMXBean", "java.lang.management.PlatformLoggingMXBean"
-        };
-
-        String[] methods = {
-                        "com.sun.management.OperatingSystemMXBean",
-                        "com.sun.management.ThreadMXBean", "com.sun.management.UnixOperatingSystemMXBean",
-                        "java.lang.management.BufferPoolMXBean",
-                        "java.lang.management.ClassLoadingMXBean", "java.lang.management.CompilationMXBean",
-                        "java.lang.management.GarbageCollectorMXBean", "java.lang.management.MemoryMXBean",
-                        "java.lang.management.MemoryManagerMXBean", "java.lang.management.MemoryPoolMXBean",
-                        "java.lang.management.RuntimeMXBean",
-                        "java.lang.management.PlatformLoggingMXBean"
-        };
-
-        for (String clazz : classes) {
-            RuntimeReflection.register(access.findClassByName(clazz));
-        }
-        for (String clazz : methods) {
-            RuntimeReflection.register(access.findClassByName(clazz).getMethods());
         }
     }
 }

--- a/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/jmx/JmxTest.java
+++ b/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/jmx/JmxTest.java
@@ -37,7 +37,6 @@ import java.lang.management.MemoryMXBean;
 import java.lang.management.MemoryManagerMXBean;
 import java.lang.management.OperatingSystemMXBean;
 import java.lang.management.GarbageCollectorMXBean;
-import java.lang.management.BufferPoolMXBean;
 import java.lang.management.MemoryPoolMXBean;
 import java.lang.management.MemoryUsage;
 import java.util.HashMap;
@@ -199,7 +198,7 @@ public class JmxTest {
         ObjectName objectName = new ObjectName("java.lang:type=Threading");
         try {
             mbsc.invoke(objectName, "resetPeakThreadCount", null, null);
-            assertTrue("Peak thread count should be positive ",(int) mbsc.getAttribute(objectName, "PeakThreadCount") > 0);
+            assertTrue("Peak thread count should be positive ", (int) mbsc.getAttribute(objectName, "PeakThreadCount") > 0);
         } catch (Exception e) {
             Assert.fail("Remote invocations failed : " + e.getMessage());
         }
@@ -227,7 +226,7 @@ public class JmxTest {
         MBeanServerConnection mbsc = getLocalMBeanServerConnectionStatic();
         ObjectName objectName = new ObjectName("java.lang:type=Memory");
         try {
-            mbsc.invoke(objectName, "gc", null,null);
+            mbsc.invoke(objectName, "gc", null, null);
         } catch (Exception e) {
             Assert.fail("Remote invocations failed : " + e.getMessage());
         }

--- a/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/jmx/JmxTest.java
+++ b/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/jmx/JmxTest.java
@@ -126,7 +126,7 @@ public class JmxTest {
     }
 
     @Test
-    public void testRuntimeMXBean() {
+    public void testRuntimeMXBeanProxy() {
         // This test checks to make sure we are able to get the MXBean and do simple things with it.
         MBeanServerConnection mbsc = getLocalMBeanServerConnectionStatic();
         RuntimeMXBean runtimeMXBean = null;
@@ -135,14 +135,28 @@ public class JmxTest {
         } catch (IOException e) {
             Assert.fail("Failed to get RuntimeMXBean. : " + e.getMessage());
         }
-        assertTrue("Uptime should be positive. ", runtimeMXBean.getUptime() > 0);
+
         assertTrue("PID should be positive.", runtimeMXBean.getPid() > 0);
         assertTrue("Class Path should not be null: ", runtimeMXBean.getClassPath() != null);
         assertTrue("Start time should be positive", runtimeMXBean.getStartTime() > 0);
     }
 
     @Test
-    public void testClassLoadingMXBean() {
+    public void testRuntimeMXBeanDirect() throws MalformedObjectNameException {
+        // Basic test to make sure reflective accesses are set up correctly.
+        MBeanServerConnection mbsc = getLocalMBeanServerConnectionStatic();
+        ObjectName objectName = new ObjectName("java.lang:type=Runtime");
+        try {
+            assertTrue("Uptime should be positive. ", (long) mbsc.getAttribute(objectName, "Pid") > 0);
+            assertTrue("Class Path should not be null: ", mbsc.getAttribute(objectName, "ClassPath") != null);
+            assertTrue("Start time should be positive", (long) mbsc.getAttribute(objectName, "StartTime") > 0);
+        } catch (Exception e) {
+            Assert.fail("Remote invocations failed : " + e.getMessage());
+        }
+    }
+
+    @Test
+    public void testClassLoadingMXBeanProxy() {
         // This test checks to make sure we are able to get the MXBean and do simple things with it.
         MBeanServerConnection mbsc = getLocalMBeanServerConnectionStatic();
 
@@ -160,7 +174,7 @@ public class JmxTest {
     }
 
     @Test
-    public void testThreadMXBean() {
+    public void testThreadMXBeanProxy() {
         // This test checks to make sure we are able to get the MXBean and do simple things with it.
         MBeanServerConnection mbsc = getLocalMBeanServerConnectionStatic();
         ThreadMXBean threadMXBean = null;
@@ -176,11 +190,23 @@ public class JmxTest {
         if (!ImageInfo.inImageRuntimeCode()) {
             assertTrue("Current thread user time should be positive in java mode", threadMXBean.getCurrentThreadUserTime() >= 0);
         }
-
     }
 
     @Test
-    public void testMemoryMXBean() {
+    public void testThreadMXBeanDirect() throws MalformedObjectNameException {
+        // Basic test to make sure reflective accesses are set up correctly.
+        MBeanServerConnection mbsc = getLocalMBeanServerConnectionStatic();
+        ObjectName objectName = new ObjectName("java.lang:type=Threading");
+        try {
+            mbsc.invoke(objectName, "resetPeakThreadCount", null, null);
+            assertTrue("Peak thread count should be positive ",(int) mbsc.getAttribute(objectName, "PeakThreadCount") > 0);
+        } catch (Exception e) {
+            Assert.fail("Remote invocations failed : " + e.getMessage());
+        }
+    }
+
+    @Test
+    public void testMemoryMXBeanProxy() {
         // This test checks to make sure we are able to get the MXBean and do simple things with it.
         MBeanServerConnection mbsc = getLocalMBeanServerConnectionStatic();
         MemoryMXBean memoryMXBean = null;
@@ -196,9 +222,20 @@ public class JmxTest {
     }
 
     @Test
-    public void testGarbageCollectorMXBean() {
-        // This test checks to make sure we are able to get the MXBean and do simple things with it.
+    public void testMemoryMXBeanDirect() throws MalformedObjectNameException {
+        // Basic test to make sure reflective accesses are set up correctly.
+        MBeanServerConnection mbsc = getLocalMBeanServerConnectionStatic();
+        ObjectName objectName = new ObjectName("java.lang:type=Memory");
+        try {
+            mbsc.invoke(objectName, "gc", null,null);
+        } catch (Exception e) {
+            Assert.fail("Remote invocations failed : " + e.getMessage());
+        }
+    }
 
+    @Test
+    public void testGarbageCollectorMXBeanProxy() {
+        // This test checks to make sure we are able to get the MXBean and do simple things with it.
         MBeanServerConnection mbsc = getLocalMBeanServerConnectionStatic();
         List<GarbageCollectorMXBean> garbageCollectorMXBeans = null;
         try {
@@ -214,7 +251,7 @@ public class JmxTest {
     }
 
     @Test
-    public void testOperatingSystemMXBean() {
+    public void testOperatingSystemMXBeanProxy() {
         // This test checks to make sure we are able to get the MXBean and do simple things with it.
         MBeanServerConnection mbsc = getLocalMBeanServerConnectionStatic();
 
@@ -229,7 +266,19 @@ public class JmxTest {
     }
 
     @Test
-    public void testMemoryManagerMXBean() {
+    public void testOperatingSystemMXBeanDirect() throws MalformedObjectNameException {
+        // Basic test to make sure reflective accesses are set up correctly.
+        MBeanServerConnection mbsc = getLocalMBeanServerConnectionStatic();
+        ObjectName objectName = new ObjectName("java.lang:type=OperatingSystem");
+        try {
+            assertTrue("OS version can't be null. ", mbsc.getAttribute(objectName, "Version") != null);
+        } catch (Exception e) {
+            Assert.fail("Remote invokations failed : " + e.getMessage());
+        }
+    }
+
+    @Test
+    public void testMemoryManagerMXBeanProxy() {
         // This test checks to make sure we are able to get the MXBean and do simple things with it.
         MBeanServerConnection mbsc = getLocalMBeanServerConnectionStatic();
         List<MemoryManagerMXBean> memoryManagerMXBeans = null;
@@ -245,23 +294,7 @@ public class JmxTest {
     }
 
     @Test
-    public void testBufferPoolMXBean() {
-        // This test checks to make sure we are able to get the MXBean and do simple things with it.
-        MBeanServerConnection mbsc = getLocalMBeanServerConnectionStatic();
-        List<BufferPoolMXBean> bufferPoolMXBeans = null;
-        try {
-            bufferPoolMXBeans = ManagementFactory.getPlatformMXBeans(mbsc, BufferPoolMXBean.class);
-
-        } catch (Exception e) {
-            Assert.fail("Failed to get BufferPoolMXBean. : " + e.getMessage());
-        }
-        for (BufferPoolMXBean bufferPoolMXBean : bufferPoolMXBeans) {
-            assertTrue("Total buffer pool capacity should be positive. ", bufferPoolMXBean.getName() != null);
-        }
-    }
-
-    @Test
-    public void testMemoryPoolMXBean() {
+    public void testMemoryPoolMXBeanProxy() {
         // This test checks to make sure we are able to get the MXBean and do simple things with it.
         MBeanServerConnection mbsc = getLocalMBeanServerConnectionStatic();
 
@@ -278,7 +311,7 @@ public class JmxTest {
     }
 
     @Test
-    public void testFlightRecorderMXBean() {
+    public void testFlightRecorderMXBeanProxy() {
         // This test checks to make sure we are able to get the MXBean and do simple things with it.
         MBeanServerConnection mbsc = getLocalMBeanServerConnectionStatic();
 
@@ -294,7 +327,7 @@ public class JmxTest {
     }
 
     @Test
-    public void testRemoteInvocation() throws MalformedObjectNameException {
+    public void testFlightRecorderMXBeanDirect() throws MalformedObjectNameException {
         MBeanServerConnection mbsc = getLocalMBeanServerConnectionStatic();
         ObjectName objectName = new ObjectName("jdk.management.jfr:type=FlightRecorder");
         try {


### PR DESCRIPTION
This PR tries to optimize some of the configuration needed for remote JMX support. Another round of optimizations will be done at some point in the future.

Unfortunately, even after these changes, the native image doesn't get much smaller. But this might help increase maintainability at least. 

### Summary of Changes
Added some more tests in substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/jmx/JmxTest.java
Removed BufferPoolMXBean test because it's not actually implemented (so the test always passes anyway).

Slimmed down reflection configuration for platform MXBeans in substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/jdk/JmxServerFeature.java 
(this doesn't actually make the image much smaller unfortunately). Only the dynamic proxy configuration and reflection configuration for the classes is kept.

Removed some reflection registrations from JmxCommon. The "stub" and "skel" class reflection registrations could not be removed because they are needed for creating the remote stubs. Additionally all the methods for "Info" type classes that have a `from(CompositeData)` method require that all their methods be registered for reflections. The same is true for RMIConnection and RMIServer who's every method is accessed via RMIServerImpl  and RMIConnectionImpl_Stub.

None of the dynamic proxy registrations could be removed. The PlatformMXBeans can be accessed remotely via dynamic proxies that abstract away the connection handling with the remote MBean server (The other way is direct interaction through the MBeanServer). So any platform MBean that we want to be available needs to have a dynamic proxy registrations. VisualVM/JMC also need this in order to display PlatformMXBean info.  
