### PR TITLE
Ensure raw struct field getter identifies same field setter.

### DIFF
--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/SubstrateDiagnostics.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/SubstrateDiagnostics.java
@@ -534,7 +534,7 @@ public class SubstrateDiagnostics {
                 log.string("General purpose register values:").indent(true);
                 RegisterDumper.singleton().dumpRegisters(log, context.getRegisterContext(), printLocationInfo, allowJavaHeapAccess, allowUnsafeOperations);
                 log.indent(false);
-            } else if (CalleeSavedRegisters.supportedByPlatform() && context.frameHasCalleeSavedRegisters()) {
+            } else if (CalleeSavedRegisters.supportedByPlatform() && context.getFrameHasCalleeSavedRegisters()) {
                 CalleeSavedRegisters.singleton().dumpRegisters(log, context.getStackPointer(), printLocationInfo, allowJavaHeapAccess, allowUnsafeOperations);
             }
         }
@@ -1037,7 +1037,7 @@ public class SubstrateDiagnostics {
         void setRegisterContext(RegisterDumper.Context value);
 
         @RawField
-        boolean frameHasCalleeSavedRegisters();
+        boolean getFrameHasCalleeSavedRegisters();
 
         @RawField
         void setFrameHasCalleeSavedRegisters(boolean value);

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/c/info/InfoTreeBuilder.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/c/info/InfoTreeBuilder.java
@@ -345,10 +345,28 @@ public class InfoTreeBuilder {
             StructFieldInfo fieldInfo = new StructFieldInfo(entry.getKey(), elementKind(entry.getValue()));
             fieldInfo.adoptChildren(entry.getValue());
             structInfo.adoptChild(fieldInfo);
+            assert verifyRawStructFieldAccessors(fieldInfo) : "fields must have both a getter and a setter";
         }
 
         nativeCodeInfo.adoptChild(structInfo);
         nativeLibs.registerElementInfo(type, structInfo);
+    }
+
+    private boolean verifyRawStructFieldAccessors(StructFieldInfo fieldInfo) {
+        boolean hasGetter = false;
+        boolean hasSetter = false;
+        for (ElementInfo child : fieldInfo.getChildren()) {
+            if (child instanceof AccessorInfo) {
+                AccessorKind kind = ((AccessorInfo) child).getAccessorKind();
+                if (kind == AccessorKind.GETTER) {
+                    hasGetter = true;
+                }
+                if (kind == AccessorKind.SETTER) {
+                    hasSetter = true;
+                }
+            }
+        }
+        return hasSetter && hasGetter;
     }
 
     private boolean hasLocationIdentityParameter(ResolvedJavaMethod method) {


### PR DESCRIPTION
This fixes a problem in class `SubstrateDiagnostics$ErrorContext` where it declares a raw structure field getter with name `frameHasCalleeSavedRegisters` and a corresponding setter with name `setFrameHasCalleeSavedRegisters`. The result is to treat them as independent accessors for distinct, foreign, single bit fields, one with name `frameHasCalleeSavedRegisters` and the other with name `FrameHasCalleeSavedRegisters`, with the result that accesses do not reflect prior updates.

The fix provided by this PR simply employs the expected name `getFrameHasCalleeSavedRegisters`. However, the PR also inserts a sanity check assertion to ensure that raw structure fields are always provided with both a getter and a setter.