### PR TITLE
Remote JMX SSL bug fix and updated tests

### DIFF
--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/c/util/FileUtils.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/c/util/FileUtils.java
@@ -35,16 +35,16 @@ import java.io.OutputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-import jdk.graal.compiler.debug.DebugContext;
 import org.graalvm.nativeimage.ImageSingletons;
 
 import com.oracle.svm.core.SubstrateOptions;
 import com.oracle.svm.core.SubstrateUtil;
 import com.oracle.svm.core.c.libc.TemporaryBuildDirectoryProvider;
+
+import jdk.graal.compiler.debug.DebugContext;
 
 public class FileUtils {
 
@@ -64,20 +64,7 @@ public class FileUtils {
     }
 
     public static List<String> readAllLines(InputStream source) {
-        try {
-            BufferedReader reader = new BufferedReader(new InputStreamReader(source));
-            List<String> result = new ArrayList<>();
-            while (true) {
-                String line = reader.readLine();
-                if (line == null) {
-                    break;
-                }
-                result.add(line);
-            }
-            return result;
-        } catch (IOException ex) {
-            throw shouldNotReachHere(ex);
-        }
+        return new BufferedReader(new InputStreamReader(source)).lines().toList();
     }
 
     public static int executeCommand(String... args) throws IOException, InterruptedException {

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/jdk/JmxServerFeature.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/jdk/JmxServerFeature.java
@@ -83,7 +83,7 @@ public class JmxServerFeature implements InternalFeature {
                         "jdk.internal.agent.resources.agent");
 
         resourcesRegistry.addResourceBundles(ConfigurationCondition.alwaysTrue(),
-                        "sun.security.util.Resources"); // required for password auth
+                        "sun.security.util.resources.security"); // required for password auth
     }
 
     private static void configureProxy(BeforeAnalysisAccess access) {


### PR DESCRIPTION
This is a follow up to this pull request here: https://github.com/oracle/graal/pull/6250
 
It adds a reflection configuration that was missing, but needed for a JMX client to connect using SSL. The tests have been updated to connect with SSL and password authentication.

I've included dummy password, access, and SSL files required to configure the JMX properties needed for authentication and SSL.