### PR TITLE
Fix bug in JFR constant pool clearing

### DIFF
--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/JfrChunkWriter.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/JfrChunkWriter.java
@@ -301,6 +301,10 @@ public final class JfrChunkWriter implements JfrUnlockedChunkWriter {
         /* The code below is only atomic enough because the epoch can't change while flushing. */
         if (SubstrateJVM.getThreadRepo().hasUnflushedData()) {
             writeCheckpointEvent(JfrCheckpointType.Threads, threadCheckpointRepos, false, flushpoint);
+        } else if (!flushpoint) {
+            // At an epoch change, the previous epoch data must be completely clear.
+            // It's safe to do this without holding the mutex, because we are at a safepoint.
+            SubstrateJVM.getThreadRepo().clearPreviousEpoch();
         }
     }
 

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/JfrChunkWriter.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/JfrChunkWriter.java
@@ -302,8 +302,11 @@ public final class JfrChunkWriter implements JfrUnlockedChunkWriter {
         if (SubstrateJVM.getThreadRepo().hasUnflushedData()) {
             writeCheckpointEvent(JfrCheckpointType.Threads, threadCheckpointRepos, false, flushpoint);
         } else if (!flushpoint) {
-            // At an epoch change, the previous epoch data must be completely clear.
-            // It's safe to do this without holding the mutex, because we are at a safepoint.
+            /*
+             * After an epoch change, the previous epoch data must be completely clear. It's safe to
+             * clear the previous epoch data without holding the JfrThreadRepository mutex, because
+             * this is at a chunk rotation and the JfrChunkWriter lock is held.
+             */
             SubstrateJVM.getThreadRepo().clearPreviousEpoch();
         }
     }

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/JfrMethodRepository.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/JfrMethodRepository.java
@@ -109,8 +109,9 @@ public class JfrMethodRepository implements JfrRepository {
     @Uninterruptible(reason = "Locking without transition requires that the whole critical section is uninterruptible.")
     public int write(JfrChunkWriter writer, boolean flushpoint) {
         mutex.lockNoTransition();
+        JfrMethodEpochData epochData = null;
         try {
-            JfrMethodEpochData epochData = getEpochData(!flushpoint);
+            epochData = getEpochData(!flushpoint);
             int count = epochData.unflushedEntries;
             if (count == 0) {
                 return EMPTY;
@@ -120,9 +121,9 @@ public class JfrMethodRepository implements JfrRepository {
             writer.writeCompressedInt(count);
             writer.write(epochData.buffer);
 
-            epochData.clear(flushpoint);
             return NON_EMPTY;
         } finally {
+            epochData.clear(flushpoint);
             mutex.unlock();
         }
     }

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/JfrStackTraceRepository.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/JfrStackTraceRepository.java
@@ -239,8 +239,9 @@ public class JfrStackTraceRepository implements JfrRepository {
         }
 
         mutex.lockNoTransition();
+        JfrStackTraceEpochData epochData = null;
         try {
-            JfrStackTraceEpochData epochData = getEpochData(!flushpoint);
+            epochData = getEpochData(!flushpoint);
             int count = epochData.unflushedEntries;
             if (count == 0) {
                 return EMPTY;
@@ -250,9 +251,9 @@ public class JfrStackTraceRepository implements JfrRepository {
             writer.writeCompressedInt(count);
             writer.write(epochData.buffer);
 
-            epochData.clear(flushpoint);
             return NON_EMPTY;
         } finally {
+            epochData.clear(flushpoint);
             mutex.unlock();
         }
     }

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/JfrSymbolRepository.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/JfrSymbolRepository.java
@@ -132,8 +132,9 @@ public class JfrSymbolRepository implements JfrRepository {
     @Uninterruptible(reason = "Locking without transition requires that the whole critical section is uninterruptible.")
     public int write(JfrChunkWriter writer, boolean flushpoint) {
         mutex.lockNoTransition();
+        JfrSymbolEpochData epochData = null;
         try {
-            JfrSymbolEpochData epochData = getEpochData(!flushpoint);
+            epochData = getEpochData(!flushpoint);
             int count = epochData.unflushedEntries;
             if (count == 0) {
                 return EMPTY;
@@ -143,9 +144,9 @@ public class JfrSymbolRepository implements JfrRepository {
             writer.writeCompressedLong(count);
             writer.write(epochData.buffer);
 
-            epochData.clear(flushpoint);
             return NON_EMPTY;
         } finally {
+            epochData.clear(flushpoint);
             mutex.unlock();
         }
     }

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/JfrThreadRepository.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/JfrThreadRepository.java
@@ -69,6 +69,12 @@ public final class JfrThreadRepository implements JfrRepository {
         epochData1.teardown();
     }
 
+    @Uninterruptible(reason = "Required to get epoch data.")
+    public void clearPreviousEpoch() {
+        assert VMOperation.isInProgressAtSafepoint();
+        getEpochData(true).clear(false);
+    }
+
     @Uninterruptible(reason = "Prevent any JFR events from triggering.")
     public void registerRunningThreads() {
         assert VMOperation.isInProgressAtSafepoint();

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/JfrThreadRepository.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/JfrThreadRepository.java
@@ -71,7 +71,6 @@ public final class JfrThreadRepository implements JfrRepository {
 
     @Uninterruptible(reason = "Required to get epoch data.")
     public void clearPreviousEpoch() {
-        assert VMOperation.isInProgressAtSafepoint();
         getEpochData(true).clear(false);
     }
 

--- a/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/jfr/TestConstantPoolClearing.java
+++ b/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/jfr/TestConstantPoolClearing.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2022, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2022, Red Hat Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package com.oracle.svm.test.jfr;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Random;
+import java.util.List;
+
+import jdk.jfr.Configuration;
+import jdk.jfr.Recording;
+import org.junit.Test;
+
+import com.oracle.svm.test.jfr.events.ClassEvent;
+import com.oracle.svm.test.jfr.utils.JfrFileParser;
+import com.oracle.svm.core.jfr.SubstrateJVM;
+
+import jdk.jfr.consumer.RecordedEvent;
+
+/**
+ * This test ensures that constant pool epochData is properly cleared before beginning a new chunk
+ * or recording. Upon a new chunk, a constant pool epochData starts with residual entries, while the
+ * serialized data buffer does not, it will fail constant pool verification in {@link JfrFileParser}
+ */
+public class TestConstantPoolClearing extends AbstractJfrTest {
+    private Recording recording;
+    Path preTestFile;
+
+    @Override
+    public void startRecording(Configuration config) throws Throwable {
+        long id = new Random().nextLong(0, Long.MAX_VALUE);
+        preTestFile = File.createTempFile(getClass().getName() + "-" + id, ".jfr").toPath();
+        startRecording(config, preTestFile);
+    }
+
+    private void startRecording(Configuration config, Path destination) throws IOException {
+        recording = new Recording(config);
+        recording.setDestination(destination);
+        // Turn off flushing so we can control it precisely.
+        Map<String, String> settings = new HashMap<>();
+        settings.put("flush-interval", String.valueOf(Long.MAX_VALUE));
+        recording.setSettings(settings);
+        recording.enable("com.jfr.Class");
+        recording.start();
+    }
+
+    @Override
+    public void stopRecording() {
+        recording.stop();
+        recording.close();
+    }
+
+    @Override
+    public String[] getTestedEvents() {
+        return new String[]{"com.jfr.Class"};
+    }
+
+    @Override
+    protected void validateEvents(List<RecordedEvent> events) throws Throwable {
+        assertEquals(1, events.size());
+    }
+
+    @Test
+    public void test() throws Exception {
+        // Epoch 1 ---------------
+        ClassEvent event = new ClassEvent();
+        event.clazz = TestConstantPoolClearing.class;
+        event.commit();
+        // Force a flush. This clears the constant pool serialized data buffers but not the
+        // deduplication maps.
+        SubstrateJVM.get().flush();
+        // No events should be committed between the previous flush and the below chunk rotation.
+        recording.dump(preTestFile);
+
+        // Epoch 2 ---------------
+        // Force another chunk rotation and end recording.
+        recording.stop();
+        recording.close();
+        // A new recording is started, now we can test if it has completely fresh constant pool
+        // epochData.
+        startRecording(Configuration.getConfiguration("default"), jfrFile);
+
+        // Epoch 1 ---------------
+        // Test for the case where the constant pool epochData starts with residual entries,
+        // but the serialized data buffer does not.
+        ClassEvent eventWithDanglingReference = new ClassEvent();
+        eventWithDanglingReference.clazz = TestConstantPoolClearing.class;
+        eventWithDanglingReference.commit();
+    }
+
+}


### PR DESCRIPTION
**Summary of Changes**
Always clear symbol, method, and stacktrace constant pools after a write. 

**Description of Bug**
Previously, the constant pool epochData was only cleared after a write if there were unflushed entries. This is incorrect because a flushpoint may clear the serialized entry buffer and reset unflushedEntries, then if there are no entries added before the next chunk rotation, [the constant pool will not be cleared at the chunk rotation](https://github.com/oracle/graal/pull/6293/files#diff-e7b044a7ea6e171ab0088db387f18f9e25275f64a3ce2b3d98a968a2670c4742R116). This is a problem because the next time that epochData is active its data buffer will be empty, but the hash table used for deduplication will still contain entries from the a prior epoch. This results in references to constants that never actually get serialized and written to the chunk during the epoch. 

This bug is only visible when a constant pool is written at flushpoints, and when there's a chance no entries are written for the length of time between flushpoint and chunk rotation.