### PR TITLE
Thread user cpu time implementation for LinuxThreadCpuTimeSupport.getThreadCpuTime() method

### DIFF
--- a/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/headers/Unistd.java
+++ b/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/headers/Unistd.java
@@ -142,8 +142,5 @@ public class Unistd {
 
         @CFunction(transition = Transition.NO_TRANSITION)
         public static native int geteuid();
-
-        @CFunction(transition = Transition.NO_TRANSITION)
-        public static native int gettid();
     }
 }

--- a/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/headers/Unistd.java
+++ b/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/headers/Unistd.java
@@ -142,5 +142,8 @@ public class Unistd {
 
         @CFunction(transition = Transition.NO_TRANSITION)
         public static native int geteuid();
+
+        @CFunction(transition = Transition.NO_TRANSITION)
+        public static native int gettid();
     }
 }

--- a/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/headers/linux/LinuxPthread.java
+++ b/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/headers/linux/LinuxPthread.java
@@ -34,12 +34,16 @@ import org.graalvm.nativeimage.c.type.CIntPointer;
 import com.oracle.svm.core.posix.headers.PosixDirectives;
 import com.oracle.svm.core.posix.headers.Pthread;
 import com.oracle.svm.core.posix.headers.Pthread.pthread_t;
+import com.oracle.svm.core.thread.VMThreads.OSThreadId;
 
 // Checkstyle: stop
 
 @CContext(PosixDirectives.class)
 @CLibrary("pthread")
 public class LinuxPthread {
+
+    public interface pid_t extends OSThreadId {
+    }
 
     @CFunction
     public static native int pthread_setname_np(pthread_t target_thread, CCharPointer name);
@@ -49,4 +53,7 @@ public class LinuxPthread {
 
     @CFunction(transition = Transition.NO_TRANSITION)
     public static native int pthread_condattr_setclock(Pthread.pthread_condattr_t attr, int clock_id);
+
+    @CFunction(transition = Transition.NO_TRANSITION)
+    public static native pid_t gettid();
 }

--- a/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/linux/LinuxThreadCpuTimeSupport.java
+++ b/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/linux/LinuxThreadCpuTimeSupport.java
@@ -75,7 +75,7 @@ final class LinuxThreadCpuTimeSupport implements ThreadCpuTimeSupport {
             return getThreadUserTime(kernelThreadId.get(isolateThread));
         }
 
-        return getThreadCpuTime(VMThreads.findOSThreadHandleForIsolateThread(isolateThread), includeSystemTime);
+        return getThreadCpuTime(VMThreads.findOSThreadHandleForIsolateThread(isolateThread));
     }
 
     /**
@@ -86,12 +86,8 @@ final class LinuxThreadCpuTimeSupport implements ThreadCpuTimeSupport {
      * @param includeSystemTime if {@code true} includes both system and user time, if {@code false}
      *            returns user time.
      */
-    @Override
     @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
-    public long getThreadCpuTime(OSThreadHandle osThreadHandle, boolean includeSystemTime) {
-        if (!includeSystemTime) {
-            return -1;
-        }
+    private long getThreadCpuTime(OSThreadHandle osThreadHandle) {
         CIntPointer threadsClockId = StackValue.get(Integer.BYTES);
         if (LinuxPthread.pthread_getcpuclockid((pthread_t) osThreadHandle, threadsClockId) != 0) {
             return -1;

--- a/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/linux/LinuxThreadCpuTimeSupport.java
+++ b/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/linux/LinuxThreadCpuTimeSupport.java
@@ -35,18 +35,12 @@ import com.oracle.svm.core.posix.headers.Pthread.pthread_t;
 import com.oracle.svm.core.posix.headers.Time.timespec;
 import com.oracle.svm.core.posix.headers.linux.LinuxPthread;
 import com.oracle.svm.core.posix.headers.linux.LinuxTime;
-import com.oracle.svm.core.posix.headers.Unistd;
 import com.oracle.svm.core.thread.ThreadCpuTimeSupport;
 import com.oracle.svm.core.thread.VMThreads;
 import com.oracle.svm.core.thread.VMThreads.OSThreadId;
 import com.oracle.svm.core.thread.VMThreads.OSThreadHandle;
 import com.oracle.svm.core.util.TimeUtils;
-
-import java.io.FileReader;
-import java.io.IOException;
-import java.io.BufferedReader;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
+import com.oracle.svm.core.LibCHelper;
 
 @AutomaticallyRegisteredImageSingleton(ThreadCpuTimeSupport.class)
 final class LinuxThreadCpuTimeSupport implements ThreadCpuTimeSupport {
@@ -55,7 +49,7 @@ final class LinuxThreadCpuTimeSupport implements ThreadCpuTimeSupport {
     @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
     public long getCurrentThreadCpuTime(boolean includeSystemTime) {
         if (!includeSystemTime) {
-            return getThreadUserTime(LinuxPthread.gettid());
+            return LibCHelper.getThreadUserTime(LinuxPthread.gettid().rawValue());
         }
         return getThreadCpuTimeImpl(LinuxTime.CLOCK_THREAD_CPUTIME_ID());
     }
@@ -64,7 +58,8 @@ final class LinuxThreadCpuTimeSupport implements ThreadCpuTimeSupport {
     @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
     public long getThreadCpuTime(IsolateThread isolateThread, boolean includeSystemTime) {
         if (!includeSystemTime) {
-            return getThreadUserTime(VMThreads.findOSThreadIdForIsolateThread(isolateThread));
+            OSThreadId tid = VMThreads.findOSThreadIdForIsolateThread(isolateThread);
+            return LibCHelper.getThreadUserTime(tid.rawValue());
         }
 
         return getThreadCpuTime(VMThreads.findOSThreadHandleForIsolateThread(isolateThread));
@@ -92,46 +87,5 @@ final class LinuxThreadCpuTimeSupport implements ThreadCpuTimeSupport {
             return -1;
         }
         return time.tv_sec() * TimeUtils.nanosPerSecond + time.tv_nsec();
-    }
-
-    @Uninterruptible(reason = "Used as a transition between uninterruptible and interruptible code", calleeMustBe = false)
-    private static long getThreadUserTime(OSThreadId tid) {
-        return getSlowThreadUserTimeImpl(tid);
-    }
-
-    /*
-     * Returns the thread user time. Based on <link href=
-     * "https://github.com/openjdk/jdk/blob/612d8c6cb1d0861957d3f6af96556e2739283800/src/hotspot/os/linux/os_linux.cpp#L5012">slow_thread_cpu_time</link>.
-     */
-    private static long getSlowThreadUserTimeImpl(OSThreadId tid) {
-        String fileName = "/proc/self/task/" + tid.rawValue() + "/stat";
-        try (BufferedReader buff = new BufferedReader(new FileReader(fileName))) {
-            String line = buff.readLine();
-            Matcher matcher = PatternSingleton.USER_CPU_TIME_PATTERN.matcher(line);
-            if (matcher.find()) {
-                String userTime = matcher.group(1);
-                try {
-                    long clockTicksPerSeconds = Unistd.sysconf(Unistd._SC_CLK_TCK());
-                    return Long.parseLong(userTime) * TimeUtils.nanosPerSecond / clockTicksPerSeconds;
-                } catch (NumberFormatException e) {
-                }
-            }
-        } catch (IOException e) {
-        }
-        return -1;
-    }
-
-    private static class PatternSingleton {
-        // File /proc/self/task/tid/stat
-        // Field 2 is a filename in parentheses
-        // Field 3 is a character
-        // Fields 1,4-8 are integers
-        // Fields 9-15 are unsigned integers
-        // Field 14 is the CPU time spent in user code
-        private static final String USER_CPU_TIME_REGEX = """
-                -?\\d+ \\(.+\\) . -?\\d+ -?\\d+ -?\\d+ -?\\d+ -?\\d+ \
-                \\d+ \\d+ \\d+ \\d+ \\d+ \
-                (\\d+) \\d+""";
-        private static final Pattern USER_CPU_TIME_PATTERN = Pattern.compile(USER_CPU_TIME_REGEX);
     }
 }

--- a/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/thread/PosixVMThreads.java
+++ b/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/thread/PosixVMThreads.java
@@ -45,6 +45,9 @@ import com.oracle.svm.core.posix.pthread.PthreadVMLockSupport;
 import com.oracle.svm.core.thread.VMThreads;
 import com.oracle.svm.core.util.TimeUtils;
 
+import com.oracle.svm.core.os.IsDefined;
+import com.oracle.svm.core.posix.headers.linux.LinuxPthread;
+
 @AutomaticallyRegisteredImageSingleton(VMThreads.class)
 public final class PosixVMThreads extends VMThreads {
 
@@ -57,6 +60,9 @@ public final class PosixVMThreads extends VMThreads {
     @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
     @Override
     protected OSThreadId getCurrentOSThreadId() {
+        if (IsDefined.isLinux()) {
+            return LinuxPthread.gettid();
+        }
         return Pthread.pthread_self();
     }
 

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/LibCHelper.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/LibCHelper.java
@@ -39,4 +39,7 @@ public class LibCHelper {
     // Checkstyle: stop
     public static native CCharPointer SVM_FindJavaTZmd(CCharPointer tzMappings, int length);
     // Checkstyle: start
+
+    @CFunction(transition = Transition.NO_TRANSITION)
+    public static native long getThreadUserTime(long tid);
 }

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/thread/PlatformThreads.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/thread/PlatformThreads.java
@@ -830,8 +830,6 @@ public abstract class PlatformThreads {
                 currentThread.get().interrupt();
             }
 
-            ThreadCpuTimeSupport.getInstance().init(toTarget(thread).isolateThread);
-
             ThreadListenerSupport.get().beforeThreadRun();
             thread.run();
         } catch (Throwable ex) {

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/thread/PlatformThreads.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/thread/PlatformThreads.java
@@ -245,7 +245,7 @@ public abstract class PlatformThreads {
             while (isolateThread.isNonNull()) {
                 Thread javaThread = PlatformThreads.currentThread.get(isolateThread);
                 if (javaThread != null && JavaThreads.getThreadId(javaThread) == javaThreadId) {
-                    return ThreadCpuTimeSupport.getInstance().getThreadCpuTime(VMThreads.findOSThreadHandleForIsolateThread(isolateThread), includeSystemTime);
+                    return ThreadCpuTimeSupport.getInstance().getThreadCpuTime(isolateThread, includeSystemTime);
                 }
                 isolateThread = VMThreads.nextThread(isolateThread);
             }
@@ -829,6 +829,8 @@ public abstract class PlatformThreads {
                  */
                 currentThread.get().interrupt();
             }
+
+            ThreadCpuTimeSupport.getInstance().init(toTarget(thread).isolateThread);
 
             ThreadListenerSupport.get().beforeThreadRun();
             thread.run();

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/thread/ThreadCpuTimeSupport.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/thread/ThreadCpuTimeSupport.java
@@ -28,6 +28,7 @@ import com.oracle.svm.core.Uninterruptible;
 import com.oracle.svm.core.thread.VMThreads.OSThreadHandle;
 import org.graalvm.compiler.api.replacements.Fold;
 import org.graalvm.nativeimage.ImageSingletons;
+import org.graalvm.nativeimage.IsolateThread;
 
 /**
  * Support for getting thread execution time.
@@ -54,6 +55,21 @@ public interface ThreadCpuTimeSupport {
      */
     @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
     long getThreadCpuTime(OSThreadHandle osThreadHandle, boolean includeSystemTime);
+
+    /**
+     * Returns the {@code isolateThread} thread CPU time.
+     *
+     * @param isolateThread existing context for the current thread.
+     * @param includeSystemTime if {@code true} includes both system and user time, if {@code false}
+     *            returns user time.
+     */
+    @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
+    default long getThreadCpuTime(IsolateThread isolateThread, boolean includeSystemTime) {
+        return getThreadCpuTime(VMThreads.findOSThreadHandleForIsolateThread(isolateThread), includeSystemTime);
+    }
+
+    default void init(IsolateThread isolateThread) {
+    }
 
     @Fold
     static ThreadCpuTimeSupport getInstance() {

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/thread/ThreadCpuTimeSupport.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/thread/ThreadCpuTimeSupport.java
@@ -68,7 +68,7 @@ public interface ThreadCpuTimeSupport {
         return getThreadCpuTime(VMThreads.findOSThreadHandleForIsolateThread(isolateThread), includeSystemTime);
     }
 
-    default void init(IsolateThread isolateThread) {
+    default void init(@SuppressWarnings("unused") IsolateThread isolateThread) {
     }
 
     @Fold

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/thread/ThreadCpuTimeSupport.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/thread/ThreadCpuTimeSupport.java
@@ -47,16 +47,6 @@ public interface ThreadCpuTimeSupport {
     long getCurrentThreadCpuTime(boolean includeSystemTime);
 
     /**
-     * Returns the {@code osThreadHandle} thread CPU time.
-     *
-     * @param osThreadHandle the OS thread handle
-     * @param includeSystemTime if {@code true} includes both system and user time, if {@code false}
-     *            returns user time.
-     */
-    @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
-    long getThreadCpuTime(OSThreadHandle osThreadHandle, boolean includeSystemTime);
-
-    /**
      * Returns the {@code isolateThread} thread CPU time.
      *
      * @param isolateThread existing context for the current thread.
@@ -64,9 +54,7 @@ public interface ThreadCpuTimeSupport {
      *            returns user time.
      */
     @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
-    default long getThreadCpuTime(IsolateThread isolateThread, boolean includeSystemTime) {
-        return getThreadCpuTime(VMThreads.findOSThreadHandleForIsolateThread(isolateThread), includeSystemTime);
-    }
+    long getThreadCpuTime(IsolateThread isolateThread, boolean includeSystemTime);
 
     default void init(@SuppressWarnings("unused") IsolateThread isolateThread) {
     }

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/thread/ThreadCpuTimeSupport.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/thread/ThreadCpuTimeSupport.java
@@ -25,7 +25,6 @@
 package com.oracle.svm.core.thread;
 
 import com.oracle.svm.core.Uninterruptible;
-import com.oracle.svm.core.thread.VMThreads.OSThreadHandle;
 import org.graalvm.compiler.api.replacements.Fold;
 import org.graalvm.nativeimage.ImageSingletons;
 import org.graalvm.nativeimage.IsolateThread;

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/thread/ThreadCpuTimeSupport.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/thread/ThreadCpuTimeSupport.java
@@ -56,9 +56,6 @@ public interface ThreadCpuTimeSupport {
     @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
     long getThreadCpuTime(IsolateThread isolateThread, boolean includeSystemTime);
 
-    default void init(@SuppressWarnings("unused") IsolateThread isolateThread) {
-    }
-
     @Fold
     static ThreadCpuTimeSupport getInstance() {
         return ImageSingletons.lookup(ThreadCpuTimeSupport.class);

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/thread/VMThreads.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/thread/VMThreads.java
@@ -608,6 +608,11 @@ public abstract class VMThreads {
     }
 
     @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
+    public static OSThreadId findOSThreadIdForIsolateThread(IsolateThread isolateThread) {
+        return OSThreadIdTL.get(isolateThread);
+    }
+
+    @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
     public static void guaranteeOwnsThreadMutex(String message) {
         THREAD_MUTEX.guaranteeIsOwner(message);
     }

--- a/substratevm/src/com.oracle.svm.native.libchelper/src/getThreadUserTime.c
+++ b/substratevm/src/com.oracle.svm.native.libchelper/src/getThreadUserTime.c
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2023, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2023, BELLSOFT. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation. Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#ifdef __linux__
+
+#include <stdio.h>
+#include <unistd.h>
+
+#define NANOS_PER_SECOND 1000000000
+#define STAT_FILE_NAME_SIZE 64
+#define STAT_SIZE 2048
+
+/*
+ * Returns the thread user time. Based on slow_thread_cpu_time(...) method from
+ * https://github.com/openjdk/jdk/blob/612d8c6cb1d0861957d3f6af96556e2739283800/src/hotspot/os/linux/os_linux.cpp#L5012
+ */
+long getThreadUserTime(long tid) {
+    char statFileName[STAT_FILE_NAME_SIZE];
+    char stat[STAT_SIZE];
+    int statSize;
+    char *s;
+    int matchedCount;
+    long userTime;
+    FILE *fp;
+
+    static long clockTicksPerSeconds = -1;
+
+    if (clockTicksPerSeconds == -1) {
+        clockTicksPerSeconds = sysconf(_SC_CLK_TCK);
+    }
+
+    snprintf(statFileName, STAT_FILE_NAME_SIZE, "/proc/self/task/%ld/stat", tid);
+    fp = fopen(statFileName, "r");
+
+    if (fp == NULL) {
+        return -1;
+    }
+
+    statSize = fread(stat, 1, STAT_SIZE - 1, fp);
+    stat[statSize] = '\0';
+    fclose(fp);
+
+    // File /proc/self/task/tid/stat
+    // Field 1 is the process id
+    // Field 2 is a command in parentheses
+    // Field 3 is a character
+    // Fields 1,4-8 are integers
+    // Fields 9-14 are unsigned integers
+    // Field 14 is the CPU time spent in user code
+    //
+    // Skip pid and the command string. Note that we could be dealing with
+    // weird command names, e.g. user could decide to rename java launcher
+    // to "java 1.4.2 :)", then the stat file would look like
+    //                1234 (java 1.4.2 :)) R ... ...
+    // We don't really need to know the command string, just find the last
+    // occurrence of ")" and then start parsing from there. See bug 4726580.
+    s = strrchr(stat, ')');
+
+    if (s == NULL)  {
+        return -1;
+    }
+
+    // Skip blank chars
+    do {
+        s++;
+    } while (s && isspace(*s));
+
+    matchedCount = sscanf(s, "%*c %*d %*d %*d %*d %*d %*lu %*lu %*lu %*lu %*lu %lu", &userTime);
+
+    if (matchedCount != 1) {
+        return -1;
+    }
+
+    return userTime * NANOS_PER_SECOND / clockTicksPerSeconds;
+}
+
+#else
+
+long getThreadUserTime(long tid) {
+    return -1;
+}
+
+#endif

--- a/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/jmx/ThreadCpuTimeTest.java
+++ b/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/jmx/ThreadCpuTimeTest.java
@@ -97,6 +97,7 @@ public class ThreadCpuTimeTest {
 
     private static class ThreadCpuTimeRunnable implements Runnable {
 
+        @Override
         public void run() {
             try {
                 long time = System.currentTimeMillis() + MILLIS;

--- a/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/jmx/ThreadCpuTimeTest.java
+++ b/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/jmx/ThreadCpuTimeTest.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright (c) 2023, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2023, BELLSOFT. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package com.oracle.svm.test.jmx;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.RandomAccessFile;
+import java.lang.management.ManagementFactory;
+import java.lang.management.ThreadMXBean;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertTrue;
+
+public class ThreadCpuTimeTest {
+
+    private static final int MILLIS = 20;
+    private static final AtomicReference<Throwable> exceptionReference = new AtomicReference<>();
+    private static final CountDownLatch testLatch = new CountDownLatch(1);
+    private static final CountDownLatch threadLatch = new CountDownLatch(1);
+
+    @Before
+    public void init() {
+        Thread.setDefaultUncaughtExceptionHandler((Thread t, Throwable e) -> {
+            if (exceptionReference.get() == null) {
+                exceptionReference.set(e);
+            } else {
+                e.printStackTrace();
+            }
+        });
+    }
+
+    @After
+    public void checkExceptions() throws Throwable {
+        if (exceptionReference.get() != null) {
+            throw exceptionReference.get();
+        }
+    }
+
+    @Test
+    public void testThreadCpuTime() throws Exception {
+        try {
+            Thread thread = new Thread(new ThreadCpuTimeRunnable());
+            thread.start();
+            testLatch.await();
+            checkThreadCpuTime(thread.threadId(), false);
+        } finally {
+            threadLatch.countDown();
+        }
+    }
+
+    private static void checkThreadCpuTime(long tid, boolean checkCurrentThread) {
+
+        ThreadMXBean threadMXBean = ManagementFactory.getThreadMXBean();
+        assertTrue("Thread CPU time is not supported",
+                threadMXBean.isThreadCpuTimeSupported());
+
+        if (checkCurrentThread) {
+            assertTrue("Current thread CPU time is less or equal to zero",
+                    threadMXBean.getCurrentThreadCpuTime() > 0);
+            assertTrue("Current Thread User time is is less or equal to zero",
+                    threadMXBean.getCurrentThreadUserTime() > 0);
+        }
+
+        assertTrue("Thread CPU time is is less or equal to zero",
+                threadMXBean.getThreadCpuTime(tid) > 0);
+        assertTrue("Thread User time is is less or equal to zero",
+                threadMXBean.getThreadUserTime(tid) > 0);
+    }
+
+    private static class ThreadCpuTimeRunnable implements Runnable {
+
+        public void run() {
+            try {
+                long time = System.currentTimeMillis() + MILLIS;
+                long count = 0;
+                do {
+                    count++;
+                } while (time > System.currentTimeMillis());
+
+                assertTrue(count > 0);
+
+                time = System.currentTimeMillis() + MILLIS;
+                do {
+                    writeToFile();
+                } while (time > System.currentTimeMillis());
+
+                checkThreadCpuTime(Thread.currentThread().threadId(), true);
+            } finally {
+                testLatch.countDown();
+            }
+
+            try {
+                threadLatch.await();
+            } catch (InterruptedException e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+
+        private static void writeToFile() {
+            int fileSize = 1000;
+            try {
+                File temp = File.createTempFile("ThreadCpuTimeTestData_", ".tmp");
+                temp.deleteOnExit();
+                try (RandomAccessFile file = new RandomAccessFile(temp, "rw")) {
+                    for (int i = 0; i < fileSize; i++) {
+                        file.writeByte(i);
+                    }
+                }
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        }
+    }
+}

--- a/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/jmx/ThreadCpuTimeTest.java
+++ b/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/jmx/ThreadCpuTimeTest.java
@@ -85,13 +85,13 @@ public class ThreadCpuTimeTest {
         if (checkCurrentThread) {
             assertTrue("Current thread CPU time is less or equal to zero",
                     threadMXBean.getCurrentThreadCpuTime() > 0);
-            assertTrue("Current Thread User time is is less or equal to zero",
+            assertTrue("Current thread user time is less or equal to zero",
                     threadMXBean.getCurrentThreadUserTime() > 0);
         }
 
-        assertTrue("Thread CPU time is is less or equal to zero",
+        assertTrue("Thread CPU time is less or equal to zero",
                 threadMXBean.getThreadCpuTime(tid) > 0);
-        assertTrue("Thread User time is is less or equal to zero",
+        assertTrue("Thread user time is less or equal to zero",
                 threadMXBean.getThreadUserTime(tid) > 0);
     }
 


### PR DESCRIPTION
This is a proposal for a thread user cpu time implementaion in `LinuxThreadCpuTimeSupport.getThreadCpuTime()` method:  https://github.com/oracle/graal/blob/be7610ba0c935325098746b7431f1577661c89b3/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/linux/LinuxThreadCpuTimeSupport.java#L63

The logic which retrieves thread user time is based on jdk [static jlong slow_thread_cpu_time(Thread *thread, bool user_sys_cpu_time)](https://github.com/openjdk/jdk/blob/9df20600592427550998c6685f103737e3115a51/src/hotspot/os/linux/os_linux.cpp#L5035) method.

- `PosixVMThreads.getCurrentOSThreadId()` is updated to return `gettid()` on Linux platform.
-  `ThreadCpuTimeSupport.getThreadCpuTime(OSThreadHandle, boolean)` method is changed to  `getThreadCpuTime(IsolateThread, boolean)`. This allows to use `IsolateThread` to get `OSThreadId` for thread user time and `OSThreadHandle` for thread system time.
- `/proc/self/task/tid/stat` file is used to get a user cpu time by kernel thread id using regular expressions.
- `ThreadCpuTimeTest` junit test is added,