### PR TITLE
Use java.vendor.version only if IS_AOT

### DIFF
--- a/substratevm/src/com.oracle.svm.driver/src/com/oracle/svm/driver/CmdLineOptionHandler.java
+++ b/substratevm/src/com.oracle.svm.driver/src/com/oracle/svm/driver/CmdLineOptionHandler.java
@@ -36,6 +36,7 @@ import com.oracle.svm.core.option.OptionOrigin;
 import com.oracle.svm.core.option.OptionUtils;
 import com.oracle.svm.core.util.ExitStatus;
 import com.oracle.svm.driver.NativeImage.ArgumentQueue;
+import static com.oracle.svm.driver.NativeImage.IS_AOT;
 
 class CmdLineOptionHandler extends NativeImage.OptionHandler<NativeImage> {
 
@@ -208,7 +209,7 @@ class CmdLineOptionHandler extends NativeImage.OptionHandler<NativeImage> {
         }
 
         String javaRuntimeName = System.getProperty("java.runtime.name");
-        String vendorVersion = System.getProperty("java.vendor.version");
+        String vendorVersion = (IS_AOT ? System.getProperty("java.vendor.version") : System.getProperty("org.graalvm.vendorversion"));
         nativeImage.showMessage("%s %s (%sbuild %s)", javaRuntimeName, vendorVersion, jdkDebugLevel, javaRuntimeVersion);
 
         /* Third line: VM information. */

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/ProgressReporter.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/ProgressReporter.java
@@ -250,7 +250,9 @@ public class ProgressReporter {
         recordJsonMetric(GeneralInfo.JAVA_VERSION, vm.version);
         recordJsonMetric(GeneralInfo.VENDOR, vm.vendor);
         recordJsonMetric(GeneralInfo.GRAALVM_VERSION, vm.vendorVersion + " " + vm.version); // deprecated
-        l().a(" ").doclink("Java version", "#glossary-java-info").a(": ").a(vm.version).a(", ").doclink("vendor", "#glossary-java-info").a(": ").a(vm.vendor).println();
+        l().a(" ").doclink("Java version", "#glossary-java-info")
+                        .a(": ").a(vm.version).a(", ").doclink("vendor", "#glossary-java-info").a(": ").a(vm.vendor)
+                        .a(" - ").a(vm.vendorVersion).println();
         String optimizationLevel = SubstrateOptions.Optimize.getValue();
         recordJsonMetric(GeneralInfo.GRAAL_COMPILER_OPTIMIZATION_LEVEL, optimizationLevel);
         String march = CPUType.getSelectedOrDefaultMArch();


### PR DESCRIPTION
This allows for the bash launcher to print a sensible `native-image --version` output. Otherwise it would only contain OpenJDK properties, which gives no info on the actual code level in use.

Also add the vendor version to the build output as otherwise, the same issue applies. Only Java version information is present.

Closes: #6319