### PR TITLE
Avoid NPE when build JDK has no source zip.

### DIFF
--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/image/sources/SourceCache.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/image/sources/SourceCache.java
@@ -315,7 +315,13 @@ public class SourceCache {
         if (moduleName != null) {
             for (String specialRootModule : specialRootModules) {
                 if (moduleName.equals(specialRootModule)) {
-                    for (Path srcRoot : specialSrcRoots.get(specialRootModule)) {
+                    // handle this module specially as it has intermediate dirs
+                    List<Path>  specialModulePathList =  specialSrcRoots.get(specialRootModule);
+                    // if we have no src.zip then there will be no entry in the hash table
+                    if (specialModulePathList == null) {
+                        break;
+                    }
+                    for (Path srcRoot : specialModulePathList) {
                         String srcRootGroup = srcRoot.subpath(1, 2).toString().replace(".", filePath.getFileSystem().getSeparator());
                         if (filePath.toString().startsWith(srcRootGroup)) {
                             Path sourcePath = extendPath(srcRoot, filePath);
@@ -380,7 +386,12 @@ public class SourceCache {
             for (String specialRootModule : specialRootModules) {
                 if (moduleName.equals(specialRootModule)) {
                     // handle this module specially as it has intermediate dirs
-                    for (Path srcRoot : specialSrcRoots.get(specialRootModule)) {
+                    List<Path>  specialModulePathList =  specialSrcRoots.get(specialRootModule);
+                    // if we have no src.zip then there will be no entry in the hash table
+                    if (specialModulePathList == null) {
+                        break;
+                    }
+                    for (Path srcRoot : specialModulePathList) {
                         String srcRootGroup = srcRoot.subpath(1, 2).toString().replace(".", filePath.getFileSystem().getSeparator());
                         if (filePath.toString().startsWith(srcRootGroup)) {
                             Path sourcePath = extendPath(srcRoot, filePath);


### PR DESCRIPTION
This patch fixes a potential NPE looking up JDK sources when the build JDK does not include a src.zip file.
