### PR TITLE
Avoid NPE when build JDK has no source zip.

### DIFF
--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/image/sources/SourceCache.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/image/sources/SourceCache.java
@@ -91,7 +91,7 @@ public class SourceCache {
             Path javaHomePath = Paths.get("", javaHome);
             Path srcZipPath = javaHomePath.resolve("lib").resolve("src.zip");
             if (!srcZipPath.toFile().exists()) {
-                System.out.printf("Warning: Unable to locate JDK sources file '%s'. Source line debug will not be available for JDK classes\n", srcZipPath);
+                System.out.printf("Warning: Unable to locate JDK sources file '%s'. Source line debug will not be available for JDK classes%n", srcZipPath);
                 return;
             }
             try {

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/image/sources/SourceCache.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/image/sources/SourceCache.java
@@ -91,6 +91,7 @@ public class SourceCache {
             Path javaHomePath = Paths.get("", javaHome);
             Path srcZipPath = javaHomePath.resolve("lib").resolve("src.zip");
             if (!srcZipPath.toFile().exists()) {
+                System.out.printf("Warning: Unable to locate JDK sources file '%s'. Source line debug will not be available for JDK classes\n", srcZipPath);
                 return;
             }
             try {
@@ -298,7 +299,7 @@ public class SourceCache {
             for (String specialRootModule : SourceRoots.specialRootModules) {
                 if (moduleName.equals(specialRootModule)) {
                     // handle this module specially as it has intermediate dirs
-                    List<Path>  specialModulePathList =  SourceRoots.specialSrcRoots.get(specialRootModule);
+                    List<Path> specialModulePathList = SourceRoots.specialSrcRoots.get(specialRootModule);
                     // if we have no src.zip then there will be no entry in the hash table
                     if (specialModulePathList == null) {
                         break;
@@ -368,7 +369,7 @@ public class SourceCache {
             for (String specialRootModule : SourceRoots.specialRootModules) {
                 if (moduleName.equals(specialRootModule)) {
                     // handle this module specially as it has intermediate dirs
-                    List<Path>  specialModulePathList =  SourceRoots.specialSrcRoots.get(specialRootModule);
+                    List<Path> specialModulePathList = SourceRoots.specialSrcRoots.get(specialRootModule);
                     // if we have no src.zip then there will be no entry in the hash table
                     if (specialModulePathList == null) {
                         break;

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/image/sources/SourceCache.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/image/sources/SourceCache.java
@@ -297,7 +297,13 @@ public class SourceCache {
         if (moduleName != null) {
             for (String specialRootModule : SourceRoots.specialRootModules) {
                 if (moduleName.equals(specialRootModule)) {
-                    for (Path srcRoot : SourceRoots.specialSrcRoots.get(specialRootModule)) {
+                    // handle this module specially as it has intermediate dirs
+                    List<Path>  specialModulePathList =  SourceRoots.specialSrcRoots.get(specialRootModule);
+                    // if we have no src.zip then there will be no entry in the hash table
+                    if (specialModulePathList == null) {
+                        break;
+                    }
+                    for (Path srcRoot : specialModulePathList) {
                         String srcRootGroup = srcRoot.subpath(1, 2).toString().replace(".", filePath.getFileSystem().getSeparator());
                         if (filePath.toString().startsWith(srcRootGroup)) {
                             Path sourcePath = extendPath(srcRoot, filePath);
@@ -362,7 +368,12 @@ public class SourceCache {
             for (String specialRootModule : SourceRoots.specialRootModules) {
                 if (moduleName.equals(specialRootModule)) {
                     // handle this module specially as it has intermediate dirs
-                    for (Path srcRoot : SourceRoots.specialSrcRoots.get(specialRootModule)) {
+                    List<Path>  specialModulePathList =  SourceRoots.specialSrcRoots.get(specialRootModule);
+                    // if we have no src.zip then there will be no entry in the hash table
+                    if (specialModulePathList == null) {
+                        break;
+                    }
+                    for (Path srcRoot : specialModulePathList) {
                         String srcRootGroup = srcRoot.subpath(1, 2).toString().replace(".", filePath.getFileSystem().getSeparator());
                         if (filePath.toString().startsWith(srcRootGroup)) {
                             Path sourcePath = extendPath(srcRoot, filePath);


### PR DESCRIPTION
This patch avoids a potential NPE when the buildJDK does not include sources file `lib/src.zip`.