### PR TITLE
Pass org.graalvm.version property if set

### DIFF
--- a/substratevm/src/com.oracle.svm.driver/src/com/oracle/svm/driver/NativeImage.java
+++ b/substratevm/src/com.oracle.svm.driver/src/com/oracle/svm/driver/NativeImage.java
@@ -115,6 +115,7 @@ public class NativeImage {
     static final String graalvmVendor = System.getProperty("org.graalvm.vendor", "GraalVM Community");
     static final String graalvmVendorUrl = System.getProperty("org.graalvm.vendorurl", "https://www.graalvm.org/");
     static final String graalvmVendorVersion = System.getProperty("org.graalvm.vendorversion", "GraalVM CE");
+    static final String graalvmVersion = System.getProperty("org.graalvm.version");
 
     private static Map<String, String[]> getCompilerFlags() {
         Map<String, String[]> result = new HashMap<>();
@@ -819,6 +820,9 @@ public class NativeImage {
         addImageBuilderJavaArgs("-Djava.awt.headless=true");
         addImageBuilderJavaArgs("-Dorg.graalvm.vendor=" + graalvmVendor);
         addImageBuilderJavaArgs("-Dorg.graalvm.vendorurl=" + graalvmVendorUrl);
+        if (graalvmVersion != null) {
+            addImageBuilderJavaArgs("-Dorg.graalvm.version=" + graalvmVersion);
+        }
         addImageBuilderJavaArgs("-Dorg.graalvm.vendorversion=" + graalvmVendorVersion);
         addImageBuilderJavaArgs("-Dcom.oracle.graalvm.isaot=true");
         addImageBuilderJavaArgs("-Djava.system.class.loader=" + CUSTOM_SYSTEM_CLASS_LOADER);
@@ -1519,7 +1523,7 @@ public class NativeImage {
 
     /**
      * Adds a shutdown hook to kill the image builder process if it's still alive.
-     * 
+     *
      * @param p image builder process
      */
     private static void installImageBuilderCleanupHook(Process p) {


### PR DESCRIPTION
This fixes Version.getCurrent() invocations for builds, not modifying the base JDK.

Closes: #6379