### PR TITLE
Print reports after standalone pointsto analysis

### DIFF
--- a/substratevm/src/com.oracle.graal.pointsto.standalone.test/src/com/oracle/graal/pointsto/standalone/test/PointstoAnalyzerTester.java
+++ b/substratevm/src/com.oracle.graal.pointsto.standalone.test/src/com/oracle/graal/pointsto/standalone/test/PointstoAnalyzerTester.java
@@ -157,7 +157,11 @@ public class PointstoAnalyzerTester {
         try {
             try {
                 int ret = pointstoAnalyzer.run();
-                assertEquals("Analysis return code is expected to 0", 0, ret);
+                if (expectPass) {
+                    assertEquals("Analysis return code is expected to 0", 0, ret);
+                } else {
+                    assertNotEquals("The analysis is expected to fail, but succeeded", 0, ret);
+                }
             } catch (UnsupportedFeatureException e) {
                 unsupportedFeatureException = e;
             }

--- a/substratevm/src/com.oracle.graal.pointsto.standalone.test/src/com/oracle/graal/pointsto/standalone/test/StandaloneAnalysisReportTest.java
+++ b/substratevm/src/com.oracle.graal.pointsto.standalone.test/src/com/oracle/graal/pointsto/standalone/test/StandaloneAnalysisReportTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2022, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2022, Alibaba Group Holding Limited. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package com.oracle.graal.pointsto.standalone.test;
+
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+
+import static org.junit.Assert.assertTrue;
+
+public class StandaloneAnalysisReportTest {
+    // Take an arbitrary case for this test
+    private static final Class<?> TEST_CLASS = ClassEqualityCase.class;
+
+    @Test
+    public void testPrintAnalysisCallTree() throws IOException {
+        PointstoAnalyzerTester tester = new PointstoAnalyzerTester(TEST_CLASS);
+        Path testTmpDir = tester.createTestTmpDir();
+        tester.setAnalysisArguments(tester.getTestClassName(),
+                        "-H:AnalysisTargetAppCP=" + tester.getTestClassJar(),
+                        "-H:ReportsPath=" + testTmpDir.toString(),
+                        "-H:+PrintAnalysisCallTree");
+        try {
+            tester.runAnalysisAndAssert();
+            File reportDir = testTmpDir.resolve("reports").toFile();
+            assertTrue(reportDir.isDirectory());
+            File[] reportFiles = reportDir.listFiles();
+            assertTrue(reportFiles.length > 0);
+        } finally {
+            tester.deleteTestTmpDir();
+        }
+    }
+
+    @Test
+    public void testPrintAnalysisObjectTree() throws IOException {
+        PointstoAnalyzerTester tester = new PointstoAnalyzerTester(TEST_CLASS);
+        Path testTmpDir = tester.createTestTmpDir();
+        tester.setAnalysisArguments(tester.getTestClassName(),
+                        "-H:AnalysisTargetAppCP=" + tester.getTestClassJar(),
+                        "-H:ReportsPath=" + testTmpDir.toString(),
+                        "-H:+PrintImageObjectTree");
+        try {
+            tester.runAnalysisAndAssert();
+            File reportDir = testTmpDir.resolve("reports").toFile();
+            assertTrue(reportDir.isDirectory());
+            File[] reportFiles = reportDir.listFiles();
+            assertTrue(reportFiles.length > 0);
+        } finally {
+            tester.deleteTestTmpDir();
+        }
+    }
+}

--- a/substratevm/src/com.oracle.graal.pointsto.standalone/src/com/oracle/graal/pointsto/standalone/PointsToAnalyzer.java
+++ b/substratevm/src/com.oracle.graal.pointsto.standalone/src/com/oracle/graal/pointsto/standalone/PointsToAnalyzer.java
@@ -65,6 +65,7 @@ import com.oracle.graal.pointsto.meta.PointsToAnalysisFactory;
 import com.oracle.graal.pointsto.phases.NoClassInitializationPlugin;
 import com.oracle.graal.pointsto.standalone.features.StandaloneAnalysisFeatureImpl;
 import com.oracle.graal.pointsto.standalone.features.StandaloneAnalysisFeatureManager;
+import com.oracle.graal.pointsto.reports.AnalysisReporter;
 import com.oracle.graal.pointsto.standalone.heap.StandaloneImageHeapScanner;
 import com.oracle.graal.pointsto.standalone.meta.StandaloneConstantFieldProvider;
 import com.oracle.graal.pointsto.standalone.meta.StandaloneConstantReflectionProvider;
@@ -99,6 +100,7 @@ public final class PointsToAnalyzer {
         ModuleSupport.accessPackagesToClass(ModuleSupport.Access.OPEN, null, false, "jdk.jdeps", "com.sun.tools.classfile");
     }
 
+    private final OptionValues options;
     private final StandalonePointsToAnalysis bigbang;
     private final StandaloneAnalysisFeatureManager standaloneAnalysisFeatureManager;
     private final ClassLoader analysisClassLoader;
@@ -110,6 +112,7 @@ public final class PointsToAnalyzer {
 
     @SuppressWarnings({"try", "unchecked"})
     private PointsToAnalyzer(String mainEntryClass, OptionValues options) {
+        this.options = options;
         standaloneAnalysisFeatureManager = new StandaloneAnalysisFeatureManager(options);
         String appCP = StandaloneOptions.AnalysisTargetAppCP.getValue(options);
         if (appCP == null) {
@@ -149,7 +152,7 @@ public final class PointsToAnalyzer {
                         originalProviders.getStampProvider(), snippetReflection, new WordTypes(aMetaAccess, wordKind),
                         originalProviders.getPlatformConfigurationProvider(), aMetaAccessExtensionProvider, originalProviders.getLoopsDataProvider());
         standaloneHost.initializeProviders(aProviders);
-        analysisName = getAnalysisName(mainEntryClass, options);
+        analysisName = getAnalysisName(mainEntryClass);
         bigbang = new StandalonePointsToAnalysis(options, aUniverse, standaloneHost, aMetaAccess, snippetReflection, aConstantReflection, aProviders.getWordTypes(), executor, () -> {
             /* do nothing */
         }, new TimerCollection());
@@ -202,7 +205,7 @@ public final class PointsToAnalyzer {
         }
     }
 
-    private String getAnalysisName(String entryClass, OptionValues options) {
+    private String getAnalysisName(String entryClass) {
         String entryPointsFile = StandaloneOptions.AnalysisEntryPointsFile.getValue(options);
         String entryPointsFileOptionName = StandaloneOptions.AnalysisEntryPointsFile.getName();
         mainEntryIsSet = entryClass != null && !entryClass.isBlank();
@@ -283,6 +286,7 @@ public final class PointsToAnalyzer {
         }
         onAnalysisExitAccess = new StandaloneAnalysisFeatureImpl.OnAnalysisExitAccessImpl(standaloneAnalysisFeatureManager, analysisClassLoader, bigbang, debugContext);
         standaloneAnalysisFeatureManager.forEachFeature(feature -> feature.onAnalysisExit(onAnalysisExitAccess));
+        AnalysisReporter.printAnalysisReports("pointsto_" + analysisName, options, StandaloneOptions.reportsPath(options, "reports").toString(), bigbang);
         bigbang.getUnsupportedFeatures().report(bigbang);
         return exitCode;
     }
@@ -311,7 +315,6 @@ public final class PointsToAnalyzer {
      * Register analysis entry points.
      */
     public void registerEntryMethods() {
-        OptionValues options = bigbang.getOptions();
         if (mainEntryIsSet) {
             String entryClass = analysisName;
             try {

--- a/substratevm/src/com.oracle.graal.pointsto.standalone/src/com/oracle/graal/pointsto/standalone/StandaloneOptions.java
+++ b/substratevm/src/com.oracle.graal.pointsto.standalone/src/com/oracle/graal/pointsto/standalone/StandaloneOptions.java
@@ -28,6 +28,11 @@ package com.oracle.graal.pointsto.standalone;
 
 import org.graalvm.compiler.options.Option;
 import org.graalvm.compiler.options.OptionKey;
+import org.graalvm.compiler.options.OptionType;
+import org.graalvm.compiler.options.OptionValues;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
 
 public class StandaloneOptions {
 
@@ -36,4 +41,11 @@ public class StandaloneOptions {
 
     @Option(help = "file:doc-files/AnalysisEntryPointsFileHelp.txt")//
     public static final OptionKey<String> AnalysisEntryPointsFile = new OptionKey<>(null);
+
+    @Option(help = "Directory of analysis reports to be generated", type = OptionType.User)//
+    public static final OptionKey<String> ReportsPath = new OptionKey<>("./");
+
+    public static Path reportsPath(OptionValues options, String relativePath) {
+        return Paths.get(Paths.get(ReportsPath.getValue(options)).toString(), relativePath).normalize().toAbsolutePath();
+    }
 }


### PR DESCRIPTION
Refactor the SubstrateOptions.Path option to a common place for both pointsto and SVM, so that the analysis report can be printed to the location specified by Path in standalone pointsto.

This PR is part of https://github.com/oracle/graal/pull/4375