### PR TITLE
[GR-45654] Single compile unit for Java DWARF debug info

### DIFF
--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/ClassEntry.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/ClassEntry.java
@@ -80,50 +80,16 @@ public class ClassEntry extends StructureTypeEntry {
      * A list recording details of all normal compiled methods included in this class sorted by
      * ascending address range. Note that the associated address ranges are disjoint and contiguous.
      */
-    private final List<CompiledMethodEntry> normalCompiledEntries = new ArrayList<>();
+    private final List<CompiledMethodEntry> compiledEntries = new ArrayList<>();
     /**
-     * A list recording details of all deopt fallback compiled methods included in this class sorted
-     * by ascending address range. Note that the associated address ranges are disjoint, contiguous
-     * and above all ranges for normal compiled methods.
-     */
-    private List<CompiledMethodEntry> deoptCompiledEntries;
-    /**
-     * An index identifying ranges for compiled method which have already been encountered, whether
-     * normal or deopt fallback methods.
+     * An index identifying ranges for compiled method which have already been encountered.
      */
     private final EconomicMap<Range, CompiledMethodEntry> compiledMethodIndex = EconomicMap.create();
-    /**
-     * An index of all primary and secondary files referenced from this class's compilation unit.
-     */
-    private final EconomicMap<FileEntry, Integer> localFilesIndex = EconomicMap.create();
-    /**
-     * A list of the same files.
-     */
-    private final List<FileEntry> localFiles = new ArrayList<>();
-    /**
-     * An index of all primary and secondary dirs referenced from this class's compilation unit.
-     */
-    private final EconomicMap<DirEntry, Integer> localDirsIndex = EconomicMap.create();
-    /**
-     * A list of the same dirs.
-     */
-    private final List<DirEntry> localDirs = new ArrayList<>();
 
     public ClassEntry(String className, FileEntry fileEntry, int size) {
         super(className, size);
         this.fileEntry = fileEntry;
         this.loader = null;
-        // deopt methods list is created on demand
-        this.deoptCompiledEntries = null;
-        if (fileEntry != null) {
-            localFiles.add(fileEntry);
-            localFilesIndex.put(fileEntry, localFiles.size());
-            DirEntry dirEntry = fileEntry.getDirEntry();
-            if (dirEntry != null) {
-                localDirs.add(dirEntry);
-                localDirsIndex.put(dirEntry, localDirs.size());
-            }
-        }
     }
 
     @Override
@@ -159,25 +125,12 @@ public class ClassEntry extends StructureTypeEntry {
         debugInstanceTypeInfo.methodInfoProvider().forEach(debugMethodInfo -> this.processMethod(debugMethodInfo, debugInfoBase, debugContext));
     }
 
-    public void indexPrimary(PrimaryRange primary, List<DebugFrameSizeChange> frameSizeInfos, int frameSize) {
-        if (compiledMethodIndex.get(primary) == null) {
-            CompiledMethodEntry compiledEntry = new CompiledMethodEntry(primary, frameSizeInfos, frameSize, this);
-            compiledMethodIndex.put(primary, compiledEntry);
-            if (primary.isDeoptTarget()) {
-                if (deoptCompiledEntries == null) {
-                    deoptCompiledEntries = new ArrayList<>();
-                }
-                deoptCompiledEntries.add(compiledEntry);
-            } else {
-                normalCompiledEntries.add(compiledEntry);
-                /* deopt targets should all come after normal methods */
-                assert deoptCompiledEntries == null;
-            }
-            FileEntry primaryFileEntry = primary.getFileEntry();
-            if (primaryFileEntry != null) {
-                indexLocalFileEntry(primaryFileEntry);
-            }
-        }
+    public CompiledMethodEntry indexPrimary(PrimaryRange primary, List<DebugFrameSizeChange> frameSizeInfos, int frameSize) {
+        assert compiledMethodIndex.get(primary) == null : "repeat of primary range [0x%x, 0x%x]!".formatted(primary.getLo(), primary.getHi());
+        CompiledMethodEntry compiledEntry = new CompiledMethodEntry(primary, frameSizeInfos, frameSize, this);
+        compiledMethodIndex.put(primary, compiledEntry);
+        compiledEntries.add(compiledEntry);
+        return compiledEntry;
     }
 
     public void indexSubRange(SubRange subrange) {
@@ -188,44 +141,12 @@ public class ClassEntry extends StructureTypeEntry {
         /* We should already have seen the primary range. */
         assert compiledEntry != null;
         assert compiledEntry.getClassEntry() == this;
-        FileEntry subFileEntry = subrange.getFileEntry();
-        if (subFileEntry != null) {
-            indexLocalFileEntry(subFileEntry);
-        }
     }
 
     private void indexMethodEntry(MethodEntry methodEntry, ResolvedJavaMethod idMethod) {
         assert methodsIndex.get(idMethod) == null : methodEntry.getSymbolName();
         methods.add(methodEntry);
         methodsIndex.put(idMethod, methodEntry);
-    }
-
-    private void indexLocalFileEntry(FileEntry localFileEntry) {
-        if (localFilesIndex.get(localFileEntry) == null) {
-            localFiles.add(localFileEntry);
-            localFilesIndex.put(localFileEntry, localFiles.size());
-            DirEntry dirEntry = localFileEntry.getDirEntry();
-            if (dirEntry != null && localDirsIndex.get(dirEntry) == null) {
-                localDirs.add(dirEntry);
-                localDirsIndex.put(dirEntry, localDirs.size());
-            }
-        }
-    }
-
-    public int localDirsIdx(DirEntry dirEntry) {
-        if (dirEntry != null) {
-            return localDirsIndex.get(dirEntry);
-        } else {
-            return 0;
-        }
-    }
-
-    public int localFilesIdx() {
-        return localFilesIndex.get(fileEntry);
-    }
-
-    public int localFilesIdx(@SuppressWarnings("hiding") FileEntry fileEntry) {
-        return localFilesIndex.get(fileEntry);
     }
 
     public String getFileName() {
@@ -236,7 +157,6 @@ public class ClassEntry extends StructureTypeEntry {
         }
     }
 
-    @SuppressWarnings("unused")
     public String getFullFileName() {
         if (fileEntry != null) {
             return fileEntry.getFullName();
@@ -258,6 +178,10 @@ public class ClassEntry extends StructureTypeEntry {
         return fileEntry;
     }
 
+    public int getFileIdx() {
+        return fileEntry.getIdx();
+    }
+
     public String getLoaderId() {
         return (loader != null ? loader.getLoaderId() : "");
     }
@@ -269,11 +193,7 @@ public class ClassEntry extends StructureTypeEntry {
      * @return a stream of all compiled method entries for this class.
      */
     public Stream<CompiledMethodEntry> compiledEntries() {
-        Stream<CompiledMethodEntry> stream = normalCompiledEntries.stream();
-        if (deoptCompiledEntries != null) {
-            stream = Stream.concat(stream, deoptCompiledEntries.stream());
-        }
-        return stream;
+        return compiledEntries.stream();
     }
 
     /**
@@ -283,32 +203,7 @@ public class ClassEntry extends StructureTypeEntry {
      * @return a stream of all normal compiled method entries for this class.
      */
     public Stream<CompiledMethodEntry> normalCompiledEntries() {
-        return normalCompiledEntries.stream();
-    }
-
-    /**
-     * Retrieve a stream of all deopt fallback compiled method entries for this class.
-     *
-     * @return a stream of all deopt fallback compiled method entries for this class.
-     */
-    public Stream<CompiledMethodEntry> deoptCompiledEntries() {
-        if (hasDeoptCompiledEntries()) {
-            return deoptCompiledEntries.stream();
-        } else {
-            return Stream.empty();
-        }
-    }
-
-    public List<DirEntry> getLocalDirs() {
-        return localDirs;
-    }
-
-    public List<FileEntry> getLocalFiles() {
-        return localFiles;
-    }
-
-    public boolean hasDeoptCompiledEntries() {
-        return deoptCompiledEntries != null;
+        return compiledEntries();
     }
 
     private void processInterface(ResolvedJavaType interfaceType, DebugInfoBase debugInfoBase, DebugContext debugContext) {
@@ -352,10 +247,6 @@ public class ClassEntry extends StructureTypeEntry {
     @Override
     protected FieldEntry addField(DebugFieldInfo debugFieldInfo, DebugInfoBase debugInfoBase, DebugContext debugContext) {
         FieldEntry fieldEntry = super.addField(debugFieldInfo, debugInfoBase, debugContext);
-        FileEntry fieldFileEntry = fieldEntry.getFileEntry();
-        if (fieldFileEntry != null) {
-            indexLocalFileEntry(fieldFileEntry);
-        }
         return fieldEntry;
     }
 
@@ -377,7 +268,7 @@ public class ClassEntry extends StructureTypeEntry {
     }
 
     public boolean hasCompiledEntries() {
-        return normalCompiledEntries.size() != 0;
+        return compiledEntries.size() != 0;
     }
 
     public ClassEntry getSuperClass() {
@@ -391,11 +282,6 @@ public class ClassEntry extends StructureTypeEntry {
             methodEntry = processMethod(debugRangeInfo, debugInfoBase, debugContext);
         } else {
             methodEntry.updateRangeInfo(debugInfoBase, debugRangeInfo);
-            /* Ensure that the methodEntry's fileEntry is present in the localsFileIndex */
-            FileEntry methodFileEntry = methodEntry.fileEntry;
-            if (methodFileEntry != null) {
-                indexLocalFileEntry(methodFileEntry);
-            }
         }
         return methodEntry;
     }
@@ -417,47 +303,18 @@ public class ClassEntry extends StructureTypeEntry {
      */
     public int lowpc() {
         assert hasCompiledEntries();
-        return normalCompiledEntries.get(0).getPrimary().getLo();
+        return compiledEntries.get(0).getPrimary().getLo();
     }
 
     /**
-     * Retrieve the lowest code section offset for compiled method code belonging to this class that
-     * belongs to a deoptimization fallback compiled method. It is an error to call this for a class
-     * entry which has no deoptimization fallback compiled methods.
-     *
-     * @return the lowest code section offset for a deoptimization fallback compiled method
-     *         belonging to this class.
-     */
-    public int lowpcDeopt() {
-        assert hasCompiledEntries();
-        assert hasDeoptCompiledEntries();
-        return deoptCompiledEntries.get(0).getPrimary().getLo();
-    }
-
-    /**
-     * Retrieve the highest code section offset for compiled method code belonging to this class
-     * that does not belong to a deoptimization fallback compiled method. The returned value is the
-     * offset of the first byte that succeeds the code for that method. It is an error to call this
-     * for a class entry which has no compiled methods.
+     * Retrieve the highest code section offset for compiled method code belonging to this class.
+     * The returned value is the offset of the first byte that succeeds the code for that method.
+     * It is an error to call this for a class entry which has no compiled methods.
      *
      * @return the highest code section offset for compiled method code belonging to this class
      */
     public int hipc() {
         assert hasCompiledEntries();
-        return normalCompiledEntries.get(normalCompiledEntries.size() - 1).getPrimary().getHi();
-    }
-
-    /**
-     * Retrieve the highest code section offset for compiled method code belonging to this class
-     * that belongs to a deoptimization fallback compiled method. It is an error to call this for a
-     * class entry which has no deoptimization fallback compiled methods.
-     *
-     * @return the highest code section offset for a deoptimization fallback compiled method
-     *         belonging to this class.
-     */
-    public int hipcDeopt() {
-        assert hasCompiledEntries();
-        assert hasDeoptCompiledEntries();
-        return deoptCompiledEntries.get(deoptCompiledEntries.size() - 1).getPrimary().getHi();
+        return compiledEntries.get(compiledEntries.size() - 1).getPrimary().getHi();
     }
 }

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/ClassEntry.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/ClassEntry.java
@@ -62,7 +62,7 @@ public class ClassEntry extends StructureTypeEntry {
     /**
      * Details of the associated file.
      */
-    private FileEntry fileEntry;
+    private final FileEntry fileEntry;
     /**
      * Details of the associated loader.
      */

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/ClassEntry.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/ClassEntry.java
@@ -308,8 +308,8 @@ public class ClassEntry extends StructureTypeEntry {
 
     /**
      * Retrieve the highest code section offset for compiled method code belonging to this class.
-     * The returned value is the offset of the first byte that succeeds the code for that method.
-     * It is an error to call this for a class entry which has no compiled methods.
+     * The returned value is the offset of the first byte that succeeds the code for that method. It
+     * is an error to call this for a class entry which has no compiled methods.
      *
      * @return the highest code section offset for compiled method code belonging to this class
      */

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/CompiledMethodEntry.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/CompiledMethodEntry.java
@@ -41,19 +41,19 @@ public class CompiledMethodEntry {
     /**
      * The primary range detailed by this object.
      */
-    private PrimaryRange primary;
+    private final PrimaryRange primary;
     /**
      * Details of the class owning this range.
      */
-    private ClassEntry classEntry;
+    private final ClassEntry classEntry;
     /**
      * Details of of compiled method frame size changes.
      */
-    private List<DebugFrameSizeChange> frameSizeInfos;
+    private final List<DebugFrameSizeChange> frameSizeInfos;
     /**
      * Size of compiled method frame.
      */
-    private int frameSize;
+    private final int frameSize;
 
     public CompiledMethodEntry(PrimaryRange primary, List<DebugFrameSizeChange> frameSizeInfos, int frameSize, ClassEntry classEntry) {
         this.primary = primary;

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/DebugInfoBase.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/DebugInfoBase.java
@@ -716,17 +716,6 @@ public abstract class DebugInfoBase {
         return classEntry.getTypeName().equals(DwarfDebugInfo.HUB_TYPE_NAME);
     }
 
-    public int classLayoutAbbrevCode(ClassEntry classEntry) {
-        if (!useHeapBase & isHubClassEntry(classEntry)) {
-            /*
-             * This layout adds special logic to remove tag bits from indirect pointers to this
-             * type.
-             */
-            return DwarfDebugInfo.DW_ABBREV_CODE_class_layout2;
-        }
-        return DwarfDebugInfo.DW_ABBREV_CODE_class_layout1;
-    }
-
     public ClassEntry getHubClassEntry() {
         return hubClassEntry;
     }

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/DebugInfoBase.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/DebugInfoBase.java
@@ -545,16 +545,17 @@ public abstract class DebugInfoBase {
 
     private FileEntry addFileEntry(String fileName, Path filePath) {
         assert fileName != null;
+        Path dirPath = filePath;
         Path fileAsPath;
         if (filePath != null) {
-            fileAsPath = filePath.resolve(fileName);
+            fileAsPath = dirPath.resolve(fileName);
         } else {
             fileAsPath = Paths.get(fileName);
-            filePath = EMPTY_PATH;
+            dirPath = EMPTY_PATH;
         }
         FileEntry fileEntry = filesIndex.get(fileAsPath);
         if (fileEntry == null) {
-            DirEntry dirEntry = ensureDirEntry(filePath);
+            DirEntry dirEntry = ensureDirEntry(dirPath);
             /* Ensure file and cachepath are added to the debug_str section. */
             uniqueDebugString(fileName);
             uniqueDebugString(cachePath);
@@ -563,7 +564,7 @@ public abstract class DebugInfoBase {
             /* Index the file entry by file path. */
             filesIndex.put(fileAsPath, fileEntry);
         } else {
-            assert fileEntry.getDirEntry().getPath().equals(filePath);
+            assert fileEntry.getDirEntry().getPath().equals(dirPath);
         }
         return fileEntry;
     }

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/DebugInfoBase.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/DebugInfoBase.java
@@ -43,6 +43,7 @@ import org.graalvm.collections.EconomicMap;
 import org.graalvm.compiler.debug.DebugContext;
 
 import com.oracle.objectfile.debuginfo.DebugInfoProvider;
+import com.oracle.objectfile.debuginfo.DebugInfoProvider.DebugCodeInfo;
 import com.oracle.objectfile.debuginfo.DebugInfoProvider.DebugLocationInfo;
 import com.oracle.objectfile.debuginfo.DebugInfoProvider.DebugLocalValueInfo;
 import com.oracle.objectfile.debuginfo.DebugInfoProvider.DebugTypeInfo.DebugTypeKind;
@@ -109,6 +110,10 @@ public abstract class DebugInfoBase {
      */
     private final StringTable stringTable = new StringTable();
     /**
+      * List of dirs in which files are found to reside.
+      */
+   private final List<DirEntry> dirs = new ArrayList<>();
+    /**
      * Index of all dirs in which files are found to reside either as part of substrate/compiler or
      * user code.
      */
@@ -141,6 +146,11 @@ public abstract class DebugInfoBase {
      * Handle on class entry for java.lang.Object.
      */
     private ClassEntry objectClass;
+    /**
+     * List of all top level compiled methods found in debug info. These ought to arrive
+     * via the debug info API in ascending address range order.
+     */
+    private final List<CompiledMethodEntry> compiledMethods = new ArrayList<>();
     /**
      * List of of files which contain primary or secondary ranges.
      */
@@ -190,10 +200,14 @@ public abstract class DebugInfoBase {
      */
     private int oopAlignShift;
     /**
-     *
      * The compilation directory in which to look for source files as a {@link String}.
      */
     private String cachePath;
+
+    /**
+     * The offset of the first byte beyond the end of the Java compiled code address range.
+     */
+    private int compiledCodeMax;
 
     /**
      * The type entry for java.lang.Class.
@@ -210,6 +224,13 @@ public abstract class DebugInfoBase {
         this.oopAlignment = 0;
         this.oopAlignShift = 0;
         this.hubClassEntry = null;
+        this.compiledCodeMax = 0;
+        // create and index an empty dir with index 0.
+        ensureDirEntry(EMPTY_PATH);
+    }
+
+    public int compiledCodeMax() {
+        return compiledCodeMax;
     }
 
     /**
@@ -264,6 +285,9 @@ public abstract class DebugInfoBase {
         /* Reference alignment must be 8 bytes. */
         assert oopAlignment == 8;
 
+        /* retrieve limit for Java code address range */
+        compiledCodeMax = debugInfoProvider.compiledCodeMax();
+
         /* Ensure we have a null string and cachePath in the string section. */
         String uniqueNullString = stringTable.uniqueDebugString("");
         if (debugInfoProvider.getCachePath() != null) {
@@ -314,7 +338,7 @@ public abstract class DebugInfoBase {
             MethodEntry methodEntry = classEntry.ensureMethodEntryForDebugRangeInfo(debugCodeInfo, this, debugContext);
             PrimaryRange primaryRange = Range.createPrimary(methodEntry, lo, hi, primaryLine);
             debugContext.log(DebugContext.INFO_LEVEL, "PrimaryRange %s.%s %s %s:%d [0x%x, 0x%x]", ownerType.toJavaName(), methodName, filePath, fileName, primaryLine, lo, hi);
-            classEntry.indexPrimary(primaryRange, debugCodeInfo.getFrameSizeChanges(), debugCodeInfo.getFrameSize());
+            addPrimaryRange(primaryRange, debugCodeInfo, classEntry);
             /*
              * Record all subranges even if they have no line or file so we at least get a symbol
              * for them and don't see a break in the address range.
@@ -433,6 +457,10 @@ public abstract class DebugInfoBase {
         return objectClass;
     }
 
+    private void addPrimaryRange(PrimaryRange primaryRange, DebugCodeInfo debugCodeInfo, ClassEntry classEntry) {
+        CompiledMethodEntry compiledMethod = classEntry.indexPrimary(primaryRange, debugCodeInfo.getFrameSizeChanges(), debugCodeInfo.getFrameSize());
+        indexCompiledMethod(compiledMethod);
+    }
     /**
      * Recursively creates subranges based on DebugLocationInfo including, and appropriately
      * linking, nested inline subranges.
@@ -492,6 +520,26 @@ public abstract class DebugInfoBase {
         instanceClassesIndex.put(idType, classEntry);
     }
 
+    private void indexCompiledMethod(CompiledMethodEntry compiledMethod) {
+        assert verifyMethodOrder(compiledMethod);
+        compiledMethods.add(compiledMethod);
+    }
+
+    private boolean verifyMethodOrder(CompiledMethodEntry next) {
+        int size = compiledMethods.size();
+        if (size > 0) {
+            CompiledMethodEntry last = compiledMethods.get(size - 1);
+            PrimaryRange lastRange = last.getPrimary();
+            PrimaryRange nextRange = next.getPrimary();
+            if (lastRange.getHi() > nextRange.getLo()) {
+                assert false : "methods %s [0x%x, 0x%x] and %s [0x%x, 0x%x] presented out of order".formatted(lastRange.getFullMethodName(), lastRange.getLo(), lastRange.getHi(), nextRange.getFullMethodName(), nextRange.getLo(), nextRange.getHi());
+                return false;
+            }
+        }
+        return true;
+    }
+
+    final static Path EMPTY_PATH = Paths.get("");
     private FileEntry addFileEntry(String fileName, Path filePath) {
         assert fileName != null;
         Path fileAsPath;
@@ -499,6 +547,7 @@ public abstract class DebugInfoBase {
             fileAsPath = filePath.resolve(fileName);
         } else {
             fileAsPath = Paths.get(fileName);
+            filePath = EMPTY_PATH;
         }
         FileEntry fileEntry = filesIndex.get(fileAsPath);
         if (fileEntry == null) {
@@ -506,13 +555,12 @@ public abstract class DebugInfoBase {
             /* Ensure file and cachepath are added to the debug_str section. */
             uniqueDebugString(fileName);
             uniqueDebugString(cachePath);
-            fileEntry = new FileEntry(fileName, dirEntry);
+            fileEntry = new FileEntry(fileName, dirEntry, files.size() + 1);
             files.add(fileEntry);
             /* Index the file entry by file path. */
             filesIndex.put(fileAsPath, fileEntry);
         } else {
-            assert (filePath == null ||
-                            fileEntry.getDirEntry().getPath().equals(filePath));
+            assert fileEntry.getDirEntry().getPath().equals(filePath);
         }
         return fileEntry;
     }
@@ -545,8 +593,9 @@ public abstract class DebugInfoBase {
         if (dirEntry == null) {
             /* Ensure dir path is entered into the debug_str section. */
             uniqueDebugString(filePath.toString());
-            dirEntry = new DirEntry(filePath);
+            dirEntry = new DirEntry(filePath, dirs.size());
             dirsIndex.put(filePath, dirEntry);
+            dirs.add(dirEntry);
         }
         return dirEntry;
     }
@@ -573,9 +622,16 @@ public abstract class DebugInfoBase {
         return instanceClasses;
     }
 
-    @SuppressWarnings("unused")
+    public List<CompiledMethodEntry> getCompiledMethods() {
+        return compiledMethods;
+    }
+
     public List<FileEntry> getFiles() {
         return files;
+    }
+
+    public List<DirEntry> getDirs() {
+        return dirs;
     }
 
     @SuppressWarnings("unused")
@@ -657,7 +713,7 @@ public abstract class DebugInfoBase {
     }
 
     public int classLayoutAbbrevCode(ClassEntry classEntry) {
-        if (useHeapBase & isHubClassEntry(classEntry)) {
+        if (!useHeapBase & isHubClassEntry(classEntry)) {
             /*
              * This layout adds special logic to remove tag bits from indirect pointers to this
              * type.

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/DebugInfoBase.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/DebugInfoBase.java
@@ -110,9 +110,9 @@ public abstract class DebugInfoBase {
      */
     private final StringTable stringTable = new StringTable();
     /**
-      * List of dirs in which files are found to reside.
-      */
-   private final List<DirEntry> dirs = new ArrayList<>();
+     * List of dirs in which files are found to reside.
+     */
+    private final List<DirEntry> dirs = new ArrayList<>();
     /**
      * Index of all dirs in which files are found to reside either as part of substrate/compiler or
      * user code.
@@ -147,8 +147,8 @@ public abstract class DebugInfoBase {
      */
     private ClassEntry objectClass;
     /**
-     * List of all top level compiled methods found in debug info. These ought to arrive
-     * via the debug info API in ascending address range order.
+     * List of all top level compiled methods found in debug info. These ought to arrive via the
+     * debug info API in ascending address range order.
      */
     private final List<CompiledMethodEntry> compiledMethods = new ArrayList<>();
     /**
@@ -461,6 +461,7 @@ public abstract class DebugInfoBase {
         CompiledMethodEntry compiledMethod = classEntry.indexPrimary(primaryRange, debugCodeInfo.getFrameSizeChanges(), debugCodeInfo.getFrameSize());
         indexCompiledMethod(compiledMethod);
     }
+
     /**
      * Recursively creates subranges based on DebugLocationInfo including, and appropriately
      * linking, nested inline subranges.
@@ -532,14 +533,16 @@ public abstract class DebugInfoBase {
             PrimaryRange lastRange = last.getPrimary();
             PrimaryRange nextRange = next.getPrimary();
             if (lastRange.getHi() > nextRange.getLo()) {
-                assert false : "methods %s [0x%x, 0x%x] and %s [0x%x, 0x%x] presented out of order".formatted(lastRange.getFullMethodName(), lastRange.getLo(), lastRange.getHi(), nextRange.getFullMethodName(), nextRange.getLo(), nextRange.getHi());
+                assert false : "methods %s [0x%x, 0x%x] and %s [0x%x, 0x%x] presented out of order".formatted(lastRange.getFullMethodName(), lastRange.getLo(), lastRange.getHi(),
+                                nextRange.getFullMethodName(), nextRange.getLo(), nextRange.getHi());
                 return false;
             }
         }
         return true;
     }
 
-    final static Path EMPTY_PATH = Paths.get("");
+    static final Path EMPTY_PATH = Paths.get("");
+
     private FileEntry addFileEntry(String fileName, Path filePath) {
         assert fileName != null;
         Path fileAsPath;

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/DirEntry.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/DirEntry.java
@@ -37,9 +37,11 @@ import java.nio.file.Path;
  */
 public class DirEntry {
     private Path path;
+    private int idx;
 
-    public DirEntry(Path path) {
+    public DirEntry(Path path, int idx) {
         this.path = path;
+        this.idx = idx;
     }
 
     public Path getPath() {
@@ -49,4 +51,14 @@ public class DirEntry {
     public String getPathString() {
         return path.toString();
     }
+
+    /**
+     * Retrieve the index of the dir entry in the list of all known dirs
+     *
+     * @return the index of the file entry.
+     */
+    public int getIdx() {
+        return idx;
+    }
+
 }

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/DirEntry.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/DirEntry.java
@@ -36,8 +36,8 @@ import java.nio.file.Path;
  * into directory tables once only rather than once per file.
  */
 public class DirEntry {
-    private Path path;
-    private int idx;
+    private final Path path;
+    private final int idx;
 
     public DirEntry(Path path, int idx) {
         this.path = path;

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/DirEntry.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/DirEntry.java
@@ -53,7 +53,7 @@ public class DirEntry {
     }
 
     /**
-     * Retrieve the index of the dir entry in the list of all known dirs
+     * Retrieve the index of the dir entry in the list of all known dirs.
      *
      * @return the index of the file entry.
      */

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/FileEntry.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/FileEntry.java
@@ -32,10 +32,12 @@ package com.oracle.objectfile.debugentry;
 public class FileEntry {
     private String fileName;
     private DirEntry dirEntry;
+    private int idx;
 
-    public FileEntry(String fileName, DirEntry dirEntry) {
+    public FileEntry(String fileName, DirEntry dirEntry, int idx) {
         this.fileName = fileName;
         this.dirEntry = dirEntry;
+        this.idx = idx;
     }
 
     /**
@@ -43,6 +45,15 @@ public class FileEntry {
      */
     public String getFileName() {
         return fileName;
+    }
+
+    /**
+     * Retrieve the index of the file entry in the list of all known files.
+     *
+     * @return the index of the file entry.
+     */
+    public int getIdx() {
+        return idx;
     }
 
     public String getPathName() {

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/FileEntry.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/FileEntry.java
@@ -30,9 +30,9 @@ package com.oracle.objectfile.debugentry;
  * Tracks debug info associated with a Java source file.
  */
 public class FileEntry {
-    private String fileName;
-    private DirEntry dirEntry;
-    private int idx;
+    private final String fileName;
+    private final DirEntry dirEntry;
+    private final int idx;
 
     public FileEntry(String fileName, DirEntry dirEntry, int idx) {
         this.fileName = fileName;

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/InterfaceClassEntry.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/InterfaceClassEntry.java
@@ -36,7 +36,7 @@ import java.util.List;
 import java.util.stream.Stream;
 
 public class InterfaceClassEntry extends ClassEntry {
-    private List<ClassEntry> implementors;
+    private final List<ClassEntry> implementors;
 
     public InterfaceClassEntry(String className, FileEntry fileEntry, int size) {
         super(className, fileEntry, size);

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/LoaderEntry.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/LoaderEntry.java
@@ -32,7 +32,7 @@ package com.oracle.objectfile.debugentry;
  * need to be embedded in debug info that identifies class and method names.
  */
 public class LoaderEntry {
-    String loaderId;
+    private final String loaderId;
 
     public LoaderEntry(String id) {
         loaderId = id;

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/MemberEntry.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/MemberEntry.java
@@ -81,6 +81,10 @@ public abstract class MemberEntry {
         return fileEntry;
     }
 
+    public int getFileIdx() {
+        return fileEntry.getIdx();
+    }
+
     public int getLine() {
         return line;
     }

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/MemberEntry.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/MemberEntry.java
@@ -32,7 +32,7 @@ package com.oracle.objectfile.debugentry;
  */
 public abstract class MemberEntry {
     protected FileEntry fileEntry;
-    protected int line;
+    protected final int line;
     protected final String memberName;
     protected final StructureTypeEntry ownerType;
     protected final TypeEntry valueType;

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/MethodEntry.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/MethodEntry.java
@@ -51,9 +51,9 @@ public class MethodEntry extends MemberEntry {
     static final int INLINED = 1 << 2;
     static final int IS_OVERRIDE = 1 << 3;
     static final int IS_CONSTRUCTOR = 1 << 4;
-    int flags;
-    int vtableOffset = -1;
-    final String symbolName;
+    private int flags;
+    private final int vtableOffset;
+    private final String symbolName;
 
     public MethodEntry(DebugInfoBase debugInfoBase, DebugMethodInfo debugMethodInfo,
                     FileEntry fileEntry, int line, String methodName, ClassEntry ownerType,

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/PrimitiveTypeEntry.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/PrimitiveTypeEntry.java
@@ -36,9 +36,9 @@ import static com.oracle.objectfile.debuginfo.DebugInfoProvider.DebugPrimitiveTy
 import static com.oracle.objectfile.debuginfo.DebugInfoProvider.DebugPrimitiveTypeInfo.FLAG_SIGNED;
 
 public class PrimitiveTypeEntry extends TypeEntry {
-    char typeChar;
-    int flags;
-    int bitCount;
+    private char typeChar;
+    private int flags;
+    private int bitCount;
 
     public PrimitiveTypeEntry(String typeName, int size) {
         super(typeName, size);

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/StringEntry.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/StringEntry.java
@@ -31,7 +31,7 @@ package com.oracle.objectfile.debugentry;
  * be located in the debug_string section and, if so, tracks the offset at which it gets written.
  */
 public class StringEntry {
-    private String string;
+    private final String string;
     private int offset;
     private boolean addToStrSection;
 

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/StructureTypeEntry.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/StructureTypeEntry.java
@@ -43,7 +43,7 @@ public abstract class StructureTypeEntry extends TypeEntry {
     /**
      * Details of fields located in this instance.
      */
-    protected List<FieldEntry> fields;
+    protected final List<FieldEntry> fields;
 
     public StructureTypeEntry(String typeName, int size) {
         super(typeName, size);

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/TypeEntry.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/TypeEntry.java
@@ -41,7 +41,7 @@ public abstract class TypeEntry {
     /**
      * The name of this type.
      */
-    protected String typeName;
+    protected final String typeName;
 
     /**
      * The offset of the java.lang.Class instance for this class in the image heap or -1 if no such
@@ -52,7 +52,7 @@ public abstract class TypeEntry {
     /**
      * The size of an occurrence of this type in bytes.
      */
-    protected int size;
+    protected final int size;
 
     protected TypeEntry(String typeName, int size) {
         this.typeName = typeName;

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/range/PrimaryRange.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/range/PrimaryRange.java
@@ -26,7 +26,6 @@
 
 package com.oracle.objectfile.debugentry.range;
 
-import com.oracle.objectfile.debugentry.ClassEntry;
 import com.oracle.objectfile.debugentry.MethodEntry;
 
 public class PrimaryRange extends Range {

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/range/PrimaryRange.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/range/PrimaryRange.java
@@ -47,12 +47,6 @@ public class PrimaryRange extends Range {
     }
 
     @Override
-    public int getFileIndex() {
-        ClassEntry owner = methodEntry.ownerType();
-        return owner.localFilesIdx(getFileEntry());
-    }
-
-    @Override
     public boolean isPrimary() {
         return true;
     }

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/range/Range.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/range/Range.java
@@ -211,7 +211,9 @@ public abstract class Range {
         return methodEntry.getFileEntry();
     }
 
-    public abstract int getFileIndex();
+    public int getFileIndex() {
+        return getFileEntry().getIdx();
+    };
 
     public int getModifiers() {
         return methodEntry.getModifiers();

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/range/Range.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/range/Range.java
@@ -213,7 +213,7 @@ public abstract class Range {
 
     public int getFileIndex() {
         return getFileEntry().getIdx();
-    };
+    }
 
     public int getModifiers() {
         return methodEntry.getModifiers();

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/range/SubRange.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/range/SubRange.java
@@ -26,7 +26,6 @@
 
 package com.oracle.objectfile.debugentry.range;
 
-import com.oracle.objectfile.debugentry.ClassEntry;
 import com.oracle.objectfile.debugentry.MethodEntry;
 import com.oracle.objectfile.debuginfo.DebugInfoProvider;
 

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/range/SubRange.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debugentry/range/SubRange.java
@@ -75,13 +75,6 @@ public abstract class SubRange extends Range {
     }
 
     @Override
-    public int getFileIndex() {
-        // the primary range's class entry indexes all files defined by the compilation unit
-        ClassEntry owner = primary.methodEntry.ownerType();
-        return owner.localFilesIdx(getFileEntry());
-    }
-
-    @Override
     public boolean isPrimary() {
         return false;
     }

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debuginfo/DebugInfoProvider.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/debuginfo/DebugInfoProvider.java
@@ -69,6 +69,8 @@ public interface DebugInfoProvider {
      */
     int oopAlignment();
 
+    int compiledCodeMax();
+
     /**
      * An interface implemented by items that can be located in a file.
      */

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfARangesSectionImpl.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfARangesSectionImpl.java
@@ -60,7 +60,7 @@ public class DwarfARangesSectionImpl extends DwarfSectionImpl {
     @Override
     public void createContent() {
         /*
-         * We need an entry for each compilation unit.
+         * We need a single entry for the Java compilation unit
          *
          * <ul>
          *
@@ -68,7 +68,7 @@ public class DwarfARangesSectionImpl extends DwarfSectionImpl {
          *
          * <li><code>uint16 dwarf_version ..... always 2</code>
          *
-         * <li><code>uint32 info_offset ....... offset of compilation unit on debug_info</code>
+         * <li><code>uint32 info_offset ....... offset of compilation unit in debug_info -- always 0</code>
          *
          * <li><code>uint8 address_size ....... always 8</code>
          *
@@ -92,44 +92,25 @@ public class DwarfARangesSectionImpl extends DwarfSectionImpl {
          *
          * </ul>
          *
-         * Where N is the number of ranges belonging to the compilation unit and the last range
-         * contains two zeroes.
+         * Where N is the number of compiled methods.
          */
         assert !contentByteArrayCreated();
-        Cursor cursor = new Cursor();
-        // size arange entries for normal compiled methods
-        instanceClassStream().filter(ClassEntry::hasCompiledEntries).forEach(classEntry -> {
-            cursor.add(normalEntrySize(classEntry));
-        });
-        // size arange entries for deopt compiled methods
-        instanceClassStream().filter(ClassEntry::hasDeoptCompiledEntries).forEach(classEntry -> {
-            cursor.add(deoptEntrySize(classEntry));
-        });
-        byte[] buffer = new byte[cursor.get()];
+        int methodCount = compiledMethodsCount();
+        byte[] buffer = new byte[entrySize(methodCount)];
         super.setContent(buffer);
     }
 
-    private static int normalEntrySize(ClassEntry classEntry) {
-        assert classEntry.hasCompiledEntries();
-        return entrySize(classEntry.normalCompiledEntries());
-    }
-
-    private static int deoptEntrySize(ClassEntry classEntry) {
-        assert classEntry.hasDeoptCompiledEntries();
-        return entrySize(classEntry.deoptCompiledEntries());
-    }
-
-    private static int entrySize(Stream<CompiledMethodEntry> compiledEntries) {
-        long size = 0;
+    private static int entrySize(int methodCount) {
+        int size = 0;
         // allow for header data
         size += DW_AR_HEADER_SIZE;
         // align to 2 * address size.
         size += DW_AR_HEADER_PAD_SIZE;
         // count 16 bytes for each deopt compiled method
-        size += compiledEntries.count() * (2 * 8);
+        size += methodCount * (2 * 8);
         // allow for two trailing zeroes to terminate
         size += 2 * 8;
-        return Math.toIntExact(size);
+        return size;
     }
 
     @Override
@@ -154,44 +135,21 @@ public class DwarfARangesSectionImpl extends DwarfSectionImpl {
         assert contentByteArrayCreated();
         byte[] buffer = getContent();
         int size = buffer.length;
-        int pos = 0;
+        Cursor cursor = new Cursor();
 
-        enableLog(context, pos);
+        enableLog(context, cursor.get());
 
-        // write normal entry aranges
-        List<ClassEntry> classEntries = instanceClassStream().filter(ClassEntry::hasCompiledEntries).collect(Collectors.toList());
-        classEntries.sort(this::sortByLowPC);
-
-        log(context, "  [0x%08x] DEBUG_ARANGES", pos);
-        for (ClassEntry classEntry : classEntries) {
-            int lengthPos = pos;
-            int cuIndex = getCUIndex(classEntry);
-            log(context, "  [0x%08x] %s CU %d ", pos, classEntry.getFileName(), cuIndex);
-            pos = writeHeader(cuIndex, buffer, pos);
-            pos = writeARanges(context, classEntry.normalCompiledEntries(), buffer, pos);
-            // write two terminating zeroes
-            pos = writeLong(0, buffer, pos);
-            pos = writeLong(0, buffer, pos);
-            // backpatch the length field
-            patchLength(lengthPos, buffer, pos);
-        }
-        // now write the deopt entry aranges
-        classEntries = instanceClassStream().filter(ClassEntry::hasDeoptCompiledEntries).collect(Collectors.toList());
-        classEntries.sort(this::sortByLowPCDeopt);
-
-        for (ClassEntry classEntry : classEntries) {
-            int lengthPos = pos;
-            int cuIndex = getDeoptCUIndex(classEntry);
-            log(context, "  [0x%08x] %s CU (deopt) %d ", pos, classEntry.getFileName(), cuIndex);
-            pos = writeHeader(cuIndex, buffer, pos);
-            pos = writeARanges(context, classEntry.deoptCompiledEntries(), buffer, pos);
-            // write two terminating zeroes
-            pos = writeLong(0, buffer, pos);
-            pos = writeLong(0, buffer, pos);
-            // backpatch the length field
-            patchLength(lengthPos, buffer, pos);
-        }
-        assert pos == size;
+        log(context, "  [0x%08x] DEBUG_ARANGES", cursor.get());
+        int lengthPos = cursor.get();
+        cursor.set(writeHeader(0, buffer, cursor.get()));
+        compiledMethodsStream().forEach( compiledMethodEntry -> {
+            cursor.set(writeARange(context, compiledMethodEntry, buffer, cursor.get()));
+        });
+        // write two terminating zeroes
+        cursor.set(writeLong(0, buffer, cursor.get()));
+        cursor.set(writeLong(0, buffer, cursor.get()));
+        patchLength(lengthPos, buffer, cursor.get());
+        assert cursor.get() == buffer.length;
     }
 
     private int writeHeader(int cuIndex, byte[] buffer, int p) {
@@ -215,25 +173,13 @@ public class DwarfARangesSectionImpl extends DwarfSectionImpl {
         return pos;
     }
 
-    int writeARanges(DebugContext context, Stream<CompiledMethodEntry> compiledEntries, byte[] buffer, int p) {
-        return compiledEntries.reduce(p,
-                        (p1, compiledEntry) -> {
-                            int pos = p1;
-                            Range primary = compiledEntry.getPrimary();
-                            log(context, "  [0x%08x] %016x %016x %s", pos, debugTextBase + primary.getLo(), primary.getHi() - primary.getLo(), primary.getFullMethodNameWithParams());
-                            pos = writeRelocatableCodeOffset(primary.getLo(), buffer, pos);
-                            pos = writeLong(primary.getHi() - primary.getLo(), buffer, pos);
-                            return pos;
-                        },
-                        (oldpos, newpos) -> newpos);
-    }
-
-    private int sortByLowPC(ClassEntry classEntry1, ClassEntry classEntry2) {
-        return classEntry1.lowpc() - classEntry2.lowpc();
-    }
-
-    private int sortByLowPCDeopt(ClassEntry classEntry1, ClassEntry classEntry2) {
-        return classEntry1.lowpcDeopt() - classEntry2.lowpcDeopt();
+    int writeARange(DebugContext context, CompiledMethodEntry compiledMethod, byte[] buffer, int p) {
+        int pos = p;
+        Range primary = compiledMethod.getPrimary();
+        log(context, "  [0x%08x] %016x %016x %s", pos, debugTextBase + primary.getLo(), primary.getHi() - primary.getLo(), primary.getFullMethodNameWithParams());
+        pos = writeRelocatableCodeOffset(primary.getLo(), buffer, pos);
+        pos = writeLong(primary.getHi() - primary.getLo(), buffer, pos);
+        return pos;
     }
 
     /*

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfARangesSectionImpl.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfARangesSectionImpl.java
@@ -146,7 +146,7 @@ public class DwarfARangesSectionImpl extends DwarfSectionImpl {
         cursor.set(writeLong(0, buffer, cursor.get()));
         cursor.set(writeLong(0, buffer, cursor.get()));
         patchLength(lengthPos, buffer, cursor.get());
-        assert cursor.get() == buffer.length;
+        assert cursor.get() == size;
     }
 
     private int writeHeader(int cuIndex, byte[] buffer, int p) {

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfARangesSectionImpl.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfARangesSectionImpl.java
@@ -26,17 +26,13 @@
 
 package com.oracle.objectfile.elf.dwarf;
 
-import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import org.graalvm.compiler.debug.DebugContext;
 
 import com.oracle.objectfile.LayoutDecision;
 import com.oracle.objectfile.LayoutDecisionMap;
 import com.oracle.objectfile.ObjectFile;
-import com.oracle.objectfile.debugentry.ClassEntry;
 import com.oracle.objectfile.debugentry.CompiledMethodEntry;
 import com.oracle.objectfile.debugentry.range.Range;
 
@@ -68,7 +64,8 @@ public class DwarfARangesSectionImpl extends DwarfSectionImpl {
          *
          * <li><code>uint16 dwarf_version ..... always 2</code>
          *
-         * <li><code>uint32 info_offset ....... offset of compilation unit in debug_info -- always 0</code>
+         * <li><code>uint32 info_offset ....... offset of compilation unit in debug_info -- always
+         * 0</code>
          *
          * <li><code>uint8 address_size ....... always 8</code>
          *
@@ -142,7 +139,7 @@ public class DwarfARangesSectionImpl extends DwarfSectionImpl {
         log(context, "  [0x%08x] DEBUG_ARANGES", cursor.get());
         int lengthPos = cursor.get();
         cursor.set(writeHeader(0, buffer, cursor.get()));
-        compiledMethodsStream().forEach( compiledMethodEntry -> {
+        compiledMethodsStream().forEach(compiledMethodEntry -> {
             cursor.set(writeARange(context, compiledMethodEntry, buffer, cursor.get()));
         });
         // write two terminating zeroes

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfAbbrevSectionImpl.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfAbbrevSectionImpl.java
@@ -30,11 +30,11 @@ import com.oracle.objectfile.LayoutDecision;
 import org.graalvm.compiler.debug.DebugContext;
 
 /**
- * Section generator for <code>debug_abbrev</code> section. That section defines the
- * layout of the DWARF Information Entries (DIEs) used to model Java debug info. Top
- * level DIEs define Java Compile Units (CUs). Embedded DIEs describe the content of
- * the CU: types, code, variable, etc. These definitions are used to interpret the DIE
- * content inserted into the <code>debug_info</code> section.
+ * Section generator for <code>debug_abbrev</code> section. That section defines the layout of the
+ * DWARF Information Entries (DIEs) used to model Java debug info. Top level DIEs define Java
+ * Compile Units (CUs). Embedded DIEs describe the content of the CU: types, code, variable, etc.
+ * These definitions are used to interpret the DIE content inserted into the <code>debug_info</code>
+ * section.
  * <p>
  *
  * An abbrev table contains abbrev entries for one or more DIEs, the last one being a null entry.
@@ -95,59 +95,60 @@ import org.graalvm.compiler.debug.DebugContext;
  *
  * <ul>
  *
- * <li><code>code = primitive_type, tag == base_type, parent = class_unit</code> - Java primitive type (non-void)
+ * <li><code>code = primitive_type, tag == base_type, parent = class_unit</code> - Java primitive
+ * type (non-void)
  *
  * <li><code>code = void_type, tag == unspecified_type, parent = class_unit</code> - Java void type
  *
- * <li><code>code = object_header, tag == structure_type, parent = class_unit</code> - Java object header
+ * <li><code>code = object_header, tag == structure_type, parent = class_unit</code> - Java object
+ * header
  *
- * <li><code>code = class_layout, tag == class_type, parent = class_unit</code> - Java
- * instance type structure definition
+ * <li><code>code = class_layout, tag == class_type, parent = class_unit</code> - Java instance type
+ * structure definition
  *
- * <li><code>code = class_pointer, tag == pointer_type, parent = class_unit</code> - Java
- * instance ref type
+ * <li><code>code = class_pointer, tag == pointer_type, parent = class_unit</code> - Java instance
+ * ref type
  *
- * <li><code>code = method_location, tag == subprogram , parent = class_unit</code> - Java
- * method code definition (i.e. location of code)
+ * <li><code>code = method_location, tag == subprogram , parent = class_unit</code> - Java method
+ * code definition (i.e. location of code)
  *
- * <li><code>code = abstract_inline_method, tag == subprogram , parent = class_unit</code> -
- * Java abstract inline method (i.e. proxy for method definition referenced by concrete
- * inline instance)
+ * <li><code>code = abstract_inline_method, tag == subprogram , parent = class_unit</code> - Java
+ * abstract inline method (i.e. proxy for method definition referenced by concrete inline instance)
  *
- * <li><code>code = static_field_location, tag == variable, parent = class_unit</code> - Java
- * static field definition (i.e. location of data)
+ * <li><code>code = static_field_location, tag == variable, parent = class_unit</code> - Java static
+ * field definition (i.e. location of data)
  *
- * <li><code>code = array_layout, tag == structure_type, parent = array_unit</code> - Java
- * array type structure definition
+ * <li><code>code = array_layout, tag == structure_type, parent = array_unit</code> - Java array
+ * type structure definition
  *
- * <li><code>code = array_pointer, tag == pointer_type, parent = array_unit</code> - Java
- * array ref type
+ * <li><code>code = array_pointer, tag == pointer_type, parent = array_unit</code> - Java array ref
+ * type
  *
- * <li><code>code = interface_layout, tag == union_type, parent = class_unit</code> - Java
- * array type structure definition
+ * <li><code>code = interface_layout, tag == union_type, parent = class_unit</code> - Java array
+ * type structure definition
  *
  * <li><code>code = interface_pointer, tag == pointer_type, parent = class_unit</code> - Java
  * interface ref type
  *
  * <li><code>code = indirect_layout, tag == class_type, parent = class_unit, array_unit,
- * interface_unit</code> - wrapper layout attaches address rewriting logic to the layout
- * types that it wraps using a data_location attribute
+ * interface_unit</code> - wrapper layout attaches address rewriting logic to the layout types that
+ * it wraps using a data_location attribute
  *
  * <li><code>code = indirect_pointer, tag == pointer_type, parent = class_unit, array_unit,
- * interface_unit</code> - indirect ref type used to type indirect oops that encode the
- * address of an object, whether by adding tag bits or representing the address as an offset
- * from some base address. these are used to type object references stored in static and
- * instance fields. They are not needed when typing local vars and parameters held in
- * registers or on the stack as they appear as raw addresses.
+ * interface_unit</code> - indirect ref type used to type indirect oops that encode the address of
+ * an object, whether by adding tag bits or representing the address as an offset from some base
+ * address. these are used to type object references stored in static and instance fields. They are
+ * not needed when typing local vars and parameters held in registers or on the stack as they appear
+ * as raw addresses.
  *
  * <li><code>code = namespace, tag == namespace, parent = class_unit, array_unit,
- * interface_unit</code> - a wrap-around DIE that is used to embed all the normal level 1
- * DIEs of a <code>class_unit</code> or <code>array_unit</code> in a namespace. This is
- * needed when the corresponding class/interface or array base element type have been loaded
- * by a loader with a non-empty loader in order to ensure that mangled names for the class
- * and its members can legitimately employ the loader id as a namespace prefix. Note that
- * use of a namespace wrapper DIE causes all the embedded level 1+ DIEs documented above and
- * all their children to be generated at a level one greater than documented here.
+ * interface_unit</code> - a wrap-around DIE that is used to embed all the normal level 1 DIEs of a
+ * <code>class_unit</code> or <code>array_unit</code> in a namespace. This is needed when the
+ * corresponding class/interface or array base element type have been loaded by a loader with a
+ * non-empty loader in order to ensure that mangled names for the class and its members can
+ * legitimately employ the loader id as a namespace prefix. Note that use of a namespace wrapper DIE
+ * causes all the embedded level 1+ DIEs documented above and all their children to be generated at
+ * a level one greater than documented here.
  *
  * </ul>
  *
@@ -155,8 +156,8 @@ import org.graalvm.compiler.debug.DebugContext;
  *
  * <ul>
  *
- * <li><code>code = header_field, tag == member, parent = object_header</code> - object/array
- * header field
+ * <li><code>code = header_field, tag == member, parent = object_header</code> - object/array header
+ * field
  *
  * <li><code>code == method_declaration1/2, tag == subprogram, parent = class_layout</code>
  *
@@ -364,8 +365,8 @@ import org.graalvm.compiler.debug.DebugContext;
  *
  * <li><code>DW_AT_declaration : ....... DW_FORM_flag</code>
  *
- * <li><code>Dw_AT_object_pointer : .... DW_FORM_ref_addr</code> n.b. only for
- * method_declaration1, points to param 0 DIE
+ * <li><code>Dw_AT_object_pointer : .... DW_FORM_ref_addr</code> n.b. only for method_declaration1,
+ * points to param 0 DIE
  *
  * <li><code>DW_AT_virtuality : ........ DW_FORM_data1<code> (for override methods)
  *

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfAbbrevSectionImpl.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfAbbrevSectionImpl.java
@@ -30,7 +30,779 @@ import com.oracle.objectfile.LayoutDecision;
 import org.graalvm.compiler.debug.DebugContext;
 
 /**
- * Section generator for debug_abbrev section.
+ * Section generator for <code>debug_abbrev<code> section. That section defines the
+ * layout of the DWARF Information Entries (DIEs) used to model Java debug info. Top
+ * level DIEs define Java Compile Units (CUs). Embedded DIEs describe the content of
+ * the CU: types, code, variable, etc. These definitions are used to interpret the DIE
+ * content inserted into the <code>debug_info</code> section.<p>
+ *
+ * An abbrev table contains abbrev entries for one or more DIEs, the last one being
+ * a null entry.<p>
+ *
+ * A null entry consists of just a 0 abbrev code.
+ *
+ * <ul>
+ *
+ * <li><code>LEB128 abbrev_code; ...... == 0</code>
+ *
+ * </ul>
+ *
+ * Non-null entries have the following format:
+ *
+ * <ul>
+ *
+ * <li><code>LEB128 abbrev_code; ......unique code for this layout != 0</code>
+ *
+ * <li><code>LEB128 tag; .............. defines the type of the DIE (class, subprogram, var
+ * etc)</code>
+ *
+ * <li><code>uint8 has_chldren; ....... is the DIE followed by child DIEs or a sibling
+ * DIE</code>
+ *
+ * <li><code>attribute_spec* .......... zero or more attributes</code>
+ *
+ * <li><code>null_attribute_spec ...... terminator</code>
+ *
+ * </ul>
+ *
+ * An attribute_spec consists of an attribute name and form:
+ *
+ * <ul>
+ *
+ * <li><code>LEB128 attr_name; ........ 0 for the null attribute name</code>
+ *
+ * <li><code>LEB128 attr_form; ........ 0 for the null attribute form</code>
+ *
+ * </ul>
+ *
+ * For the moment we only use one abbrev table and one CU. It employs the following top
+ * level and nested DIES<p>
+ *
+ * Level 0 DIEs
+ *
+ * <ul>
+ *
+ * <li><code>code = null, tag == null<code> - empty terminator
+ *
+ * <li><code>code = class_unit, tag == compile_unit<code> - CU that defines the Java object header
+ * struct, all Java primitive and object types and all Java compiled code.
+ *
+ * </ul>
+ *
+ * Level 1 DIES
+ *
+ * <ul>
+ *
+ * <li><code>code = primitive_type, tag == base_type, parent = class_unit<code> - Java primitive type (non-void)
+ *
+ * <li><code>code = void_type, tag == unspecified_type, parent = class_unit<code> - Java void type
+ *
+ * <li><code>code = object_header, tag == structure_type, parent = class_unit<code> - Java object header
+ *
+ * <li><code>code = class_layout, tag == class_type, parent = class_unit<code> - Java
+ * instance type structure definition
+ *
+ * <li><code>code = class_pointer, tag == pointer_type, parent = class_unit<code> - Java
+ * instance ref type
+ *
+ * <li><code>code = method_location, tag == subprogram , parent = class_unit<code> - Java
+ * method code definition (i.e. location of code)
+ *
+ * <li><code>code = abstract_inline_method, tag == subprogram , parent = class_unit<code> -
+ * Java abstract inline method (i.e. proxy for method definition referenced by concrete
+ * inline instance)
+ *
+ * <li><code>code = static_field_location, tag == variable, parent = class_unit<code> - Java
+ * static field definition (i.e. location of data)
+ *
+ * <li><code>code = array_layout, tag == structure_type, parent = array_unit<code> - Java
+ * array type structure definition
+ *
+ * <li><code>code = array_pointer, tag == pointer_type, parent = array_unit<code> - Java
+ * array ref type
+ *
+ * <li><code>code = interface_layout, tag == union_type, parent = class_unit<code> - Java
+ * array type structure definition
+ *
+ * <li><code>code = interface_pointer, tag == pointer_type, parent = class_unit<code> - Java
+ * interface ref type
+ *
+ * <li><code>code = indirect_layout, tag == class_type, parent = class_unit, array_unit,
+ * interface_unit<code> - wrapper layout attaches address rewriting logic to the layout
+ * types that it wraps using a data_location attribute
+ *
+ * <li><code>code = indirect_pointer, tag == pointer_type, parent = class_unit, array_unit,
+ * interface_unit<code> - indirect ref type used to type indirect oops that encode the
+ * address of an object, whether by adding tag bits or representing the address as an offset
+ * from some base address. these are used to type object references stored in static and
+ * instance fields. They are not needed when typing local vars and parameters held in
+ * registers or on the stack as they appear as raw addresses.
+ *
+ * <li><code>code = namespace, tag == namespace, parent = class_unit, array_unit,
+ * interface_unit<code> - a wrap-around DIE that is used to embed all the normal level 1
+ * DIEs of a <code>class_unit</code> or <code>array_unit</code_unit> in a namespace. This is
+ * needed when the corresponding class/interface or array base element type have been loaded
+ * by a loader with a non-empty loader in order to ensure that mangled names for the class
+ * and its members can legitimately employ the loader id as a namespace prefix. Note that
+ * use of a namespace wrapper DIE causes all the embedded level 1+ DIEs documented above and
+ * all their children to be generated at a level one greater than documented here.
+ *
+ * </ul>
+ *
+ * Level 2 DIEs
+ *
+ * <ul>
+ *
+ * <li><code>code = header_field, tag == member, parent = object_header<code> - object/array
+ * header field
+ *
+ * <li><code>code == method_declaration1/2, tag == subprogram, parent = class_layout</code>
+ *
+ * <li><code>code = field_declaration1/2/3/4, tag == member, parent = class_layout<code> - instance
+ * field declaration (i.e. specification of properties)
+ *
+ * <li><code>code == super_reference, tag == inheritance, parent = class_layout,
+ * array_layout</code> - reference to super class layout or to appropriate header struct for
+ * {code java.lang.Object} or arrays.
+ *
+ * <li><code>code == interface_implementor, tag == member, parent = interface_layout</code>
+ * - union member typed using class layout of a given implementing class
+ *
+ * <li><code>code = inlined_subroutine/inlined_subroutine_with_children, tag == subprogram,
+ * parent = method_location/inlined_subroutine_with_children<code> - provides range and
+ * abstract origin for a concrete inline method
+ *
+ * <li><code>code == method_parameter_declaration1/2/3, tag == formal_parameter, parent =
+ * method_declaration1/2, abstract_inline_method</code> - details of method parameters
+ *
+ * <li><code>code == method_local_declaration1/2, tag == variable, parent =
+ * method_declaration1/2, abstract_inline_method</code> - details of method local vars
+ *
+ * </ul>
+ *
+ * Level 3 DIEs
+ *
+ * <ul>
+ *
+ * <li><code>code == method_local_location, tag == formal_parameter, parent =
+ * method_location, concrete_inline_method</code> - details of method parameter or local
+ * locations
+ *
+ * </ul>
+ *
+ * Detailed layouts of the DIEs listed above are as follows:<p>
+ *
+ * A single instance of the level 0 <code>class_unit</code> compile unit provides details
+ * of the object header struct, all Java primitive and object types and all Java compiled
+ * code.
+ *
+ * <ul>
+ *
+ * <li><code>abbrev_code == class_unit, tag == DW_TAG_compilation_unit,
+ * has_children</code>
+ *
+ * <li><code>DW_AT_language : ... DW_FORM_data1</code>
+ *
+ * <li><code>DW_AT_name : ....... DW_FORM_strp</code>
+ *
+ * <li><code>DW_AT_comp_dir : ... DW_FORM_strp</code>
+ *
+ * <li><code>DW_AT_low_pc : ..... DW_FORM_address</code>
+ *
+ * <li><code>DW_AT_hi_pc : ...... DW_FORM_address</code>
+ *
+ * <li><code>DW_AT_use_UTF8 : ... DW_FORM_flag</code>
+ *
+ * <li><code>DW_AT_stmt_list : .. DW_FORM_sec_offset</code>
+ *
+ * </ul>
+ *
+ * All other Java derived DIEs are embedded within this top level CU.<p>
+ *
+ * Primitive Types: For each non-void Java primitive type there is a level 1 DIE defining a
+ * base type
+ *
+ * <ul>
+ *
+ * <li><code>abbrev_code == primitive_type, tag == DW_TAG_base_type, no_children</code>
+ *
+ * <li><code>DW_AT_byte_size : ... DW_FORM_data1</code> (or data2 ???)
+ *
+ * <li><code>DW_AT_bit_size : ... DW_FORM_data1</code> (or data2 ???)
+ *
+ * <li><code>DW_AT_encoding : .... DW_FORM_data1</code>
+ *
+ * <li><code>DW_AT_name : ........ DW_FORM_strp</code>
+ *
+ * </ul>
+ *
+ * <ul>
+ *
+ * The void type is defined as an unspecified type
+ *
+ * <li><code>abbrev_code == void_type, tag == DW_TAG_unspecified_type, no_children</code>
+ *
+ * <li><code>DW_AT_name : ........ DW_FORM_strp</code>
+ *
+ * </ul>
+ *
+ * Header Struct: There is a level 1 DIE defining a structure type which models the
+ * header information embedded at the start of every instance or array (all instances embed
+ * the same object header). Child DIEs are employed to define the name, type and layout of
+ * fields in the header.
+ *
+ * <ul>
+ *
+ * <li><code>abbrev_code == object_header, tag == DW_TAG_structure_type, has_children</code>
+ *
+ * <li><code>DW_AT_name : ......... DW_FORM_strp</code> "oop"
+ *
+ * <li><code>DW_AT_byte_size : ... DW_FORM_data1</code> "oop"
+ *
+ * </ul>
+ *
+ * Header Data: A level 2 DIE of type member is used to describe the fields of both object
+ * and array headers. This includes the type tag and other tag bits in all objects and the
+ * length field in all arrays.
+ *
+ * <ul>
+ *
+ * <li><code>abbrev_code = header_field, tag == DW_TAG_member, no_children</code>
+ *
+ * <li><code>Dw_AT_name : ................... DW_FORM_strp</code>
+ *
+ * <li><code>Dw_AT_type : ................... DW_FORM_ref_addr</code>
+ *
+ * <li><code>Dw_AT_data_member_location : ... DW_FORM_data1</code>
+ *
+ * <li><code>Dw_AT_accessibility : .......... DW_FORM_data1</code>
+ *
+ * </ul>
+ *
+ * Namespace embedding for Java class DIEs:<p>
+ *
+ * When the class loader associated with a class defined in the Java class
+ * compile unit has a non-empty loader id string then a namespace DIE is used to wrap
+ * the level 1 DIEs that define the class layout, methods etc. Otherwise, these children
+ * are embedded directly in the Java class compile unit. The namespace DIE has a
+ * single attribute defining the namespace's name as the loader id string.
+ *
+ * <li><code>abbrev_code == namespace, tag == DW_TAG_namespace, parent = class_unit, has_children</code>
+ *
+ * <li><code>DW_AT_name : ....... DW_FORM_strp</code>
+ *
+ * </ul>
+ *
+ * Instance Classes: For each instance class type there is a sequence of up to four level 1 DIEs
+ * defining the class.<p>
+ *
+ * Instance Class Structure: Each java class is described by a series of level 1 DIEs. The first
+ * one describes the class layout. The normal layout does not include a <code>data_location</code>
+ * attribute. However, an alternative layout, including that extra attribute, is provided to deal
+ * with a single special case, <code>java.lang.Class</code>. Oop references to instances of this
+ * class are encoded using tag bits. The <code>data_location</code> attribute defines masking logic
+ * which a debugger can use to decode the oop pointer to a raw address. n.b. this only applies in
+ * the case where normal oop references are raw addresses (no compressed oops, no isolates). If a
+ * heapbase register is being used then decoding logic is encoded for both normal classes and for
+ * code>java.lang.Class</code> using an indirect layout (see below).
+ *
+ * <ul>
+ *
+ * <li><code>abbrev_code == class_layout1/class_layout2, tag == DW_TAG_class_type,
+ * has_children</code>
+ *
+ * <li><code>Dw_AT_name : ........ DW_FORM_strp</code>
+ *
+ * <li><code>Dw_AT_byte_size : ... DW_FORM_data1/2</code>
+ *
+ * <li><code>Dw_AT_decl_file : ... DW_FORM_data1/2</code>
+ *
+ * <li><code>Dw_AT_decl_line : ... DW_FORM_data1/2</code>
+ *
+ * <li><code>Dw_AT_data_location : ... DW_FORM_expr_loc</code> n.b. only for class_layout2
+ *
+ * </ul>
+ *
+ * Instance Class members: A level 1 <code>class_layout</code> DIE includes a level 2 child for each of
+ * the class's methods and fields. The first type <em>declares</em> a method but omits details of the
+ * location of the code that implements the method. The second type <em>declares</em> an instance or
+ * static field. A class_layout DIE also contains a level 2 DIE specifying the type from
+ * which it inherits superclass structure. In the case of class <code>Object</code> structure is
+ * inherited from the object header structure type.
+ *
+ * n.b. Code implementation details for each method (i.e. the method <em>definition</em>) are
+ * provided in an auxiliary level 1 <code>method_location</code> DIE that follows the
+ * <code>class_layout</code> DIE. Instance field declarations need no auxiliary level 1 DIE as all
+ * relevant details, including size and offset in the instance, are specified in the field declaration
+ * DIE. Static field locations (i.e. the field <em>definition</em>) are provided in an auxiliary level 1
+ * <code>static_field_location</code>DIE that follows the <code>class_layout</code> DIE.
+ *
+ * <ul>
+ *
+ * <li><code>abbrev_code == method_declaration1/2, tag == DW_TAG_subprogram,
+ * has_children</code>
+ *
+ * <li><code>DW_AT_external : .......... DW_FORM_flag</code>
+ *
+ * <li><code>Dw_AT_name : .............. DW_FORM_strp</code>
+ *
+ * <li><code>DW_AT_decl_file : ......... DW_FORM_data1/2</code>
+ *
+ * <li><code>DW_AT_decl_line : ......... DW_FORM_data1/2<code>
+ *
+ * <li><code>Dw_AT_linkage_name : ...... DW_FORM_strp</code>
+ *
+ * <li><code>Dw_AT_type : .............. DW_FORM_ref_addr</code> (optional!!)
+ *
+ * <li><code>DW_AT_artificial : ........ DW_FORM_flag</code>
+ *
+ * <li><code>DW_AT_accessibility : ..... DW_FORM_data1</code>
+ *
+ * <li><code>DW_AT_declaration : ....... DW_FORM_flag</code>
+ *
+ * <li><code>Dw_AT_object_pointer : .... DW_FORM_ref_addr<code> n.b. only for
+ * method_declaration1, points to param 0 DIE
+ *
+ * <li><code>DW_AT_virtuality : ........ DW_FORM_data1<code> (for override methods)
+ *
+ * <li><code>DW_AT_containing_type : ... DW_FORM_ref_addr</code> (for override methods)
+ *
+ * </ul>
+ *
+ * <ul>
+ *
+ * <li><code>abbrev_code == field_declaration1/2/3/4, tag == DW_TAG_member, no_children</code>
+ *
+ * <li><code>Dw_AT_name : ................... DW_FORM_strp</code>
+ *
+ * <li><code>DW_AT_decl_file : .............. DW_FORM_data1/2</code> n.b. only for
+ * field_declaration2/4
+ *
+ * <li><code>DW_AT_decl_line : .............. DW_FORM_data1/2</code> n.b. only for
+ * field_declaration2/4
+ *
+ * <li><code>Dw_AT_type : ................... DW_FORM_ref_addr</code>
+ *
+ * <li><code>Dw_AT_data_member_location : ... DW_FORM_data1/2</code> (n.b. nly for
+ * field_declaration1/2 instance
+ *
+ * <li><code>Dw_AT_artificial : ............. DW_FORM_flag</code>
+ *
+ * <li><code>Dw_AT_accessibility : .......... DW_FORM_data1</code>
+ *
+ * <li><code>Dw_AT_external : ............... DW_FORM_flag</code> (n.b. only for
+ * field_declaration3/4 static
+ *
+ * <li><code>Dw_AT_declaration : ............ DW_FORM_flag</code> n.b. only for
+ * field_declaration3/4 static
+ *
+ * </ul>
+ *
+ * <ul>
+ *
+ * <li><code>abbrev_code == super_reference, tag == DW_TAG_inheritance, no_children</code>
+ *
+ * <li><code>Dw_AT_type : ................... DW_FORM_ref_addr</code>
+ *
+ * <li><code>Dw_AT_data_member_location : ... DW_FORM_data1/2</code>
+ *
+ * <li><code>Dw_AT_accessibility :........... DW_FORM_data1</code>
+ *
+ * </ul>
+ *
+ * Method Parameters: Level 2 method_declaration DIEs may include level 3 DIEs that describe
+ * their parameters and/or their local variables. n.b. these two DIEs only differ in the value
+ * of their tag.
+ *
+ * <ul>
+ *
+ * <li><code>abbrev_code == method_parameter_declaration1/2/3, tag ==
+ * DW_TAG_formal_parameter, no_children</code>
+ *
+ * <li><code>Dw_AT_name : ... DW_FORM_strp</code> (may be empty string)
+ *
+ * <li><code>Dw_AT_file : ... DW_FORM_data1/2</code> n.b. only for
+ * method_parameter_declaration2
+ *
+ * <li><code>Dw_AT_line : ... DW_FORM_data1/2</code> n.b. only for
+ * method_parameter_declaration2
+ *
+ * <li><code>Dw_AT_type : ... DW_FORM_ref_addr</code>
+ *
+ * <li><code>Dw_AT_artificial : ... DW_FORM_flag</code> n.b. only for
+ * method_parameter_declaration1 used for this and access vars
+ *
+ * <li><code>Dw_AT_declaration : ... DW_FORM_flag</code>
+ *
+ * </ul>
+ *
+ * <li><code>abbrev_code == method_local_declaration1/2, tag == DW_TAG_variable,
+ * no_children</code>
+ *
+ * <li><code>Dw_AT_name : ... DW_FORM_strp</code> (may be empty string)
+ *
+ * <li><code>Dw_AT_file : ... DW_FORM_data1/2</code> n.b. only for
+ * method_parameter_declaration1
+ *
+ * <li><code>Dw_AT_line : ... DW_FORM_data1/2</code> n.b. only for
+ * method_parameter_declaration1
+ *
+ * <li><code>Dw_AT_type : ... DW_FORM_ref_addr</code>
+ *
+ * <li><code>Dw_AT_declaration : ... DW_FORM_flag</code>
+ *
+ * </ul>
+ *
+ * Indirect Instance Class Structure: The level 1 class layout DIE may be followed by a
+ * level 1 <code>indirect_layout</code> DIE. The indirect layout is only needed when a
+ * heapbase register is in use (isolates or compressed oops are enabled). This means that
+ * oop fields will hold encoded oops. The indirect layout defines an empty wrapper class
+ * which declares the previous layout as its super class. This wrapper type also supplies a
+ * <code>data_location</code> attribute, ensuring that indirect pointers to the class (see next
+ * item) are translated to raw addresses. The name of the indirect type is constructed by
+ * prefixing the class name with <code>DwarfDebugInfo.INDIRECT_PREFIX</code>. This DIE has only
+ * one child DIE with type super_reference (see above). This effectively embeds the standard
+ * layout type in the indirect layout as a type compatible referent for the Java oop. The size
+ * of the indirect layout is the same as the size of the class layout.
+ *
+ * <ul>
+ *
+ * <li><code>abbrev_code == indirect_layout, tag == DW_TAG_class_type, has_children</code>
+ *
+ * <li><code>Dw_AT_name : ........ DW_FORM_strp</code>
+ *
+ * <li><code>Dw_AT_byte_size : ... DW_FORM_data1/2</code>
+ *
+ * <li><code>Dw_AT_data_location : ... DW_FORM_expr_loc</code>
+ *
+ * </ul>
+ *
+ * Instance Class Reference Types: The level 1 <code>class_layout</code> and
+ * <code>indirect_layout</code> DIEs are followed by level 1 DIEs defining pointers to the
+ * respective class layouts. A <code>class_pointer</code> DIE defines a pointer type for the
+ * <code>class_layout</code> type and is used to type pointers which directly address an instance.
+ * It is used to type local and parameter var references whether located in a register or on the
+ * stack. It may be followed by an <code>indirect_pointer</code> DIE which defines a pointer type
+ * for the class's <code>indirect_layout</code> type. This is used to type references to instances
+ * of the class located in a static or instance field. These latter references require address
+ * translation by masking off tag bits and/or rebasing from an offset to a raw address. The logic
+ * for this translation is encoded in the <code>data_location</code> attribute of the corresponding
+ * <code>indirect_layout</code> DIE.
+ *
+ * <ul>
+ *
+ * <li><code>abbrev_code == class_pointer, tag == DW_TAG_pointer_type, no_children</code>
+ *
+ * <li><code>Dw_AT_byte_size : ... DW_FORM_data1</code>
+ *
+ * <li><code>Dw_AT_type : ........ DW_FORM_ref_addr</code>
+ *
+ * </ul>
+ *
+ * <ul>
+ *
+ * <li><code>abbrev_code == indirect_pointer, tag == DW_TAG_pointer_type, no_children</code>
+ *
+ * <li><code>Dw_AT_byte_size : ... DW_FORM_data1</code>
+ *
+ * <li><code>Dw_AT_type : ........ DW_FORM_ref_addr</code>
+ *
+ * </ul>
+ *
+ * n.b. the name used in the <code>class_layout</code> DIE is the Java class name. This is
+ * <em>deliberately</em> inconsistent with the Java naming where the name refers to the pointer
+ * type. In consequence when gdb displays Java types and signatures oop references appear as
+ * pointer types. So, for example the Java String class looks like<p>
+ *
+ * <pre>
+ *   class java.lang.String : public java.lang.Object {
+ *    private:
+ *     byte[] value;
+ *     ...
+ *    public:
+ *     ...
+ *     java.lang.String *concat(java.lang.String *)
+ *     ...
+ * </pre>
+ *
+ * Method Code Locations: For each level 2 method <em>declaration</em> which has been compiled
+ * as a top-level method (i.e. not just occurring inline) there will be a corresponding level
+ * 1 method <em>definition</em> DIE providing details of the location of the compiled code. The
+ * two DIEs are cross-referenced using a <code>specification</code> attribute.
+ * This cross-reference should imply that the location DIE inherits attributes from the
+ * <code>method_definition</code> DIE, including attributes specified int the latter's child DIEs,
+ * such as parameter and local variable declarations.
+ *
+ * TODO - check we no longer need to replicate the DIES
+ *
+ * However, it is actually necessary to replicate the parameter and local variable declarations
+ * as children of the method definition DIE in order to ensure that gdb is aware of the parameters
+ * and locals.
+ *
+ * <ul>
+ *
+ * <li><code>abbrev_code == DW_ABBREV_CODE_method_location, tag == DW_TAG_subprogram,
+ * has_children</code>
+ *
+ * <li><code>DW_AT_low_pc : .......... DW_FORM_addr</code>
+ *
+ * <li><code>DW_AT_hi_pc : ........... DW_FORM_addr</code>
+ *
+ * <li><code>DW_AT_external : ........ DW_FORM_flag</code>
+ *
+ * <li><code>DW_AT_specification : ... DW_FORM_ref_addr</code>
+ *
+ * </ul>
+ *
+ * Method local locations: A method location may be followed by zero or more
+ * <code>method_local_location</code> DIEs which identify the in-memory location of
+ * parameter and/or local values during execution of the compiled code. A
+ * <code>method_local_location</code> DIE references the corresponding
+ * <code>method_parameter_declaration</code> or <code>method_local_declaration</code>.
+ * It also specifies a location list which defines address ranges where the parameter or
+ * local is valid and provides details of where to find the value of the parameter or local
+ * in memory. Likewise, an inline concrete method DIE is followed by zero or more
+ * <code>method_local_location</code> DIEs, providing details of where to find the specification
+ * of inlined parameters or locals and their value in memory.
+ *
+ * <ul>
+ *
+ * <li><code>abbrev_code == DW_ABBREV_CODE_method_local_location1/2, tag ==
+ * DW_TAG_formal_parameter, no_children</code>
+ *
+ * <li><code>DW_AT_specification : .......... DW_FORM_ref_addr</code>
+ *
+ * <li><code>DW_AT_location: ................ DW_FORM_sec_offset</code> n.b. only for
+ * method_local_location2
+ *
+ * </ul>
+ *
+ * Abstract Inline Methods: For any method <code>m'</code> which has been inlined into a
+ * top level compiled method <code>m</code> there will be an <code>abstract_inline_method</code>
+ * DIE for <code>m'</code> at level 1 in the Java CU. The declaration serves as the
+ * <code>abstract_origin</code> for any corresponding inlined method DIEs appearing as children
+ * of <code>m</code>.
+ *
+ * TODO - ensure we only generate per inlined method rather than per class per method inlined by that class
+ *
+ * The <code>abstract_inline_method</code> DIE should inherit attributes from
+ * the method_definition DIE referenced as its <code>abstract_origin</code> attribute without the
+ * need to repeat them. However, it is actually necessary to replicate the method parameter and
+ * local declaration DIEs of the specification as children of the <code>abstract_inline_method</code>
+ * DIE.
+ *
+ * <ul>
+ *
+ * <li><code>abbrev_code == DW_ABBREV_CODE_abstract_inline_method, tag == DW_TAG_subprogram,
+ * has_children</code>
+ *
+ * <li><code>DW_AT_inline : .......... DW_FORM_data1</code>
+ *
+ * <li><code>DW_AT_external : ........ DW_FORM_flag</code>
+ *
+ * <li><code>DW_AT_specification : ... DW_FORM_ref_addr</code>
+ *
+ * </ul>
+ *
+ * Concrete Inlined Methods: Concrete inlined method DIEs are nested as a tree of children
+ * under the method_location DIE for the method into which they have been inlined. Each
+ * inlined method DIE defines an address range that is a subrange of its parent DIE. A
+ * method_location DIE occurs at depth 1 in a compile unit (class_unit). So, this means that
+ * for any method which has been inlined into a compiled method at depth K in the inline
+ * frame stack there will be a corresponding level 2+K DIE that identifies the method that
+ * was inlined (by referencing the corresponding abstract inline method DIE) and locates the
+ * call point by citing the file index and line number of its caller. So, if compiled method
+ * M inlines a call to m1 at source position f0:l0, m1 inlines a call to method m2 at source
+ * position f1:l1 and m2 inlines a call to m3 at source position f2:l2 then there will be a
+ * level 2 DIE for the inline code range derived from m1 referencing the abstract entry for
+ * m1 with f0 and l0 as file and line, a level 3 DIE for the inline code range derived from
+ * m2 referencing the abstract entry for m2 with f1 and l1 as file and line and a level 3
+ * DIE for the inline code range derived from m3 referencing the abstract entry for m3 with
+ * f2 and l2 as file and line.
+ *
+ * <ul>
+ *
+ * <li><code>abbrev_code == DW_ABBREV_CODE_inlined_subroutine, tag == DW_TAG_subprogram,
+ * no_children</code>
+ *
+ * <li><code>abbrev_code == DW_ABBREV_CODE_inlined_subroutine_with_children, tag ==
+ * DW_TAG_subprogram, has_children</code>
+ *
+ * <li><code>DW_AT_abstract_origin : ... DW_FORM_ref_addr</code>
+ *
+ * <li><code>DW_AT_low_pc : ............ DW_FORM_addr</code>
+ *
+ * <li><code>DW_AT_hi_pc : ............. DW_FORM_addr</code>
+ *
+ * <li><code>DW_AT_call_file : ......... DW_FORM_data4</code>
+ *
+ * <li><code>DW_AT_call_line : ......... DW_FORM_data4</code>
+ *
+ * </ul>
+ *
+ * Static Field Locations: For each static field within the class there is a level 1
+ * field <em>definition</em>DIE providing details of the static field location
+ *
+ * <ul>
+ *
+ * <li><code>abbrev_code == static_field_location, tag == DW_TAG_variable,
+ * no_children</code>
+ *
+ * <li><code>DW_AT_specification : ... DW_FORM_ref_addr</code>
+ *
+ * <li><code>DW_AT_linkage_name : .... DW_FORM_strp</code>
+ *
+ * <li><code>DW_AT_location : ........ DW_FORM_expr_loc</code>
+ *
+ * </ul>
+ *
+ * Arrays: For each array type there is a sequence of up to five level 1 DIEs defining the array.<p>
+ *
+ * Array Layout: The first array DIE describes the array layout. It has three children. The
+ * first is a <code>super_reference</code> DIE (see above) to class <code>java.lang.Object</code>.
+ * The other two children are field declarations, a length field that overlays the Java array
+ * length field and an array data field which aligns with the element 0 of the Java
+ * array's data area. The data field type is typed (via a later level 1 DIE) as a DWARF
+ * array, i.e. it is a data block embedded directly in the layout, with a nominal element count
+ * of 0. The elements of this DWARF array are typed using the DWARF type corresponding to the
+ * Java array's element type. It is either a Java primitive type or a Java reference type (i.e.
+ * the pointer type ot the underlying layout type). A nominal array length of zero means that
+ * this second data field does not actually add any extra size to the array layout. So, all array
+ * types have the same length.<p>
+ *
+ * Note that when the base element type of the array is a class whose loader has an
+ * associated loader id the array type and associated types are embedded in a namespace DIE. This
+ * is needed because the encoded type name for the array will include a namespace prefix in order to
+ * guarantee that it remains unique.
+ *
+ * <ul>
+ *
+ * <li><code>abbrev_code == array_layout, tag == DW_TAG_class_type, has_children</code>
+ *
+ * <li><code>Dw_AT_name : ........ DW_FORM_strp</code>
+ *
+ * <li><code>Dw_AT_byte_size : ... DW_FORM_data1/2</code>
+ *
+ * </ul>
+ *
+ * The immediately following DIE is an indirect_layout (see above) that wraps the array
+ * layout as its super type (just as with class layouts). The wrapper type supplies a
+ * data_location attribute, allowing indirect pointers to the array to be translated to raw
+ * addresses. The name of the indirect array type is constructed by prefixing the array name
+ * with <code>DwarfDebugInfo.INDIRECT_PREFIX</code>. This DIE has only one child DIE with type
+ * <code>super_reference</code> (see above). The latter references the array layout DIE,
+ * effectively embedding the standard array layout type in the indirect layout. The size of
+ * the indirect layout is the same as the size of the array layout.<p>
+ *
+ * The third and fourth DIEs define array reference types as a pointers to the underlying
+ * structure layout types. As with classes, there is an array_pointer type for raw address
+ * references used to type local and param vars and an indirect_pointer type (see above) for
+ * array references stored in static and instance fields.
+ *
+ * <ul>
+ *
+ * <li><code>abbrev_code == array_pointer, tag == DW_TAG_pointer_type, no_children</code>
+ *
+ * <li><code>Dw_AT_byte_size : ... DW_FORM_data1</code>
+ *
+ * <li><code>Dw_AT_type : ........ DW_FORM_ref_addr</code>
+ *
+ * </ul>
+ *
+ * n.b. the name used in the array_layout DIE is the Java array name. This is deliberately
+ * inconsistent with the Java naming where the name refers to the pointer type. As with
+ * normal objects an array reference in a Java signature appears as a pointer to an array
+ * layout when printed by gdb.
+ *
+ * Array members: The level 1 array_layout DIE includes a member field DIE that defines
+ * the layout of the array data. The type of this embedded field is declared by a fifth
+ * level 1 DIE, a <code>array_data_type</code> DIE (with DWARF tag <code>array_type</code>).
+ *
+ * <ul>
+ *
+ * <li><code>abbrev_code == array_data_type, tag == DW_TAG_array_type, no_children</code>
+ *
+ * <li><code>Dw_AT_byte_size : ... DW_FORM_data1</code>
+ *
+ * <li><code>Dw_AT_type : ........ DW_FORM_ref_addr</code>
+ *
+ * </ul>
+ *
+ * Interfaces: For each interface there is a sequence of DIEs defining the interface.<p>
+ *
+ * Interface Layout and Reference Types: An interface is primarily modeled by a level 1
+ * DIE defining its layout as a union of all the layouts for the classes which implement
+ * the interface. The size of the interface layout is the maximum of the sizes for the
+ * implementing classes. A DWARF union type is used to ensure that the resulting layout is
+ * overlay type compatible with all its implementors. This also means that a reference
+ * to an instance of the interface can be cast to a reference to any of the implementors.
+ *
+ * <ul>
+ *
+ * <li><code>abbrev_code == interface_layout, tag == union_type, has_children</code>
+ *
+ * <li><code>Dw_AT_name : ....... DW_FORM_strp</code>
+ *
+ * </ul>
+ *
+ * A second level 1 DIE provides an indirect layout that wraps the interface layout as its
+ * super type (just as with class layouts). The wrapper type supplies a <code>data_location</code>
+ * attribute, allowing indirect pointers to the interface to be translated to raw addresses.
+ * The name of the indirect interface type is constructed by prefixing the interface name
+ * with <code>DwarfDebugInfo.INDIRECT_PREFIX</code>. This DIE has only one child DIE with type
+ * <code>sup[er_reference</code> (see above). The latter references the interface layout DIE,
+ * effectively embedding the standard interface layout type in the indirect layout. The size
+ * of the indirect layout is the same as the size of the interface layout.
+ *
+ * The third and fourth DIEs define interface reference types as a pointers to the
+ * underlying structure layout types. As with classes, there is an interface_pointer type
+ * for raw address references used to type local and param vars and an indirect_pointer type
+ * (see above) for interface references stored in static and instance fields.
+ *
+ * A second level 1 defines a pointer to this layout type.
+ *
+ * n.b. the name used in the <code>interface_layout</code> DIE is the Java array name. This is
+ * deliberately inconsistent with the Java naming where the name refers to the pointer type.
+ * As with normal objects an interface reference in a Java signature appears as a pointer to
+ * an interface layout when printed by gdb.
+ *
+ * <ul>
+ *
+ * <li><code>abbrev_code == interface_pointer, tag == pointer_type, has_children</code>
+ *
+ * <li><code>Dw_AT_byte_size : ... DW_FORM_data1</code>
+ *
+ * <li><code>DW_AT_TYPE : ....... DW_FORM_ref_addr</code>
+ *
+ * </ul>
+ *
+ * The union type embeds level 2 DIEs with tag member. There is a member for each
+ * implementing class, typed using the layout.
+ *
+ * <ul>
+ *
+ * <li><code>abbrev_code == interface_implementor, tag == member, no_children</code>
+ *
+ * <li><code>Dw_AT_name : ................... DW_FORM_strp</code>
+ *
+ * <li><code>Dw_AT_type : ................... DW_FORM_ref_addr</code>
+ *
+ * <li><code>Dw_AT_accessibility : .......... DW_FORM_data1</code>
+ *
+ * </ul>
+ *
+ * The union member name is constructed by appending an '_' to the Java* name of the implementing
+ * class. So, this means that, for example, the Java interface java.lang.CharSequence will
+ * include members for String, StringBuffer etc as follows
+ *
+ * <pre>
+ *   union java.lang.CharSequence {
+ *     java.lang.String _java.lang.String;
+ *     java.lang.StringBuffer _java.lang.StringBuffer;
+ *     ...
+ *   };
+ * </pre>
+ *
  */
 public class DwarfAbbrevSectionImpl extends DwarfSectionImpl {
 
@@ -47,789 +819,6 @@ public class DwarfAbbrevSectionImpl extends DwarfSectionImpl {
     public void createContent() {
         assert !contentByteArrayCreated();
         /*
-         * An abbrev table contains abbrev entries for one or more CUs. the table includes a
-         * sequence of abbrev entries each of which defines a specific DIE layout employed to
-         * describe some DIE in a CU. a table is terminated by a null entry.
-         *
-         * A null entry consists of just a 0 abbrev code.
-         *
-         * <ul>
-         *
-         * <li><code>LEB128 abbrev_code; ...... == 0</code>
-         *
-         * </ul>
-         *
-         * Non-null entries have the following format.
-         *
-         * <ul>
-         *
-         * <li><code>LEB128 abbrev_code; ......unique noncode for this layout != 0</code>
-         *
-         * <li><code>LEB128 tag; .............. defines the type of the DIE (class, subprogram, var
-         * etc)</code>
-         *
-         * <li><code>uint8 has_chldren; ....... is the DIE followed by child DIEs or a sibling
-         * DIE</code>
-         *
-         * <li><code>attribute_spec* .......... zero or more attributes</code>
-         *
-         * <li><code>null_attribute_spec ...... terminator</code>
-         *
-         * </ul>
-         *
-         * An attribute_spec consists of an attribute name and form
-         *
-         * <ul>
-         *
-         * <li><code>LEB128 attr_name; ........ 0 for the null attribute name</code>
-         *
-         * <li><code>LEB128 attr_form; ........ 0 for the null attribute form</code>
-         *
-         * </ul>
-         *
-         * For the moment we only use one abbrev table for all CUs. It contains the following DIES:
-         *
-         * <ul>
-         *
-         * <li>Level 0 DIEs
-         *
-         * <li><code>code = null, TAG = null<code> - empty terminator
-         *
-         * <li><code>code = builtin_unit, TAG = compile_unit<code> - Java primitive and header type
-         * compile unit
-         *
-         * <li><code>code = class_unit1/2, tag = compile_unit<code> - Java instance type compile
-         * unit
-         *
-         * <li><code>code = array_unit, tag = compile_unit<code> - Java array type compile unit
-         *
-         * </ul>
-         *
-         * <ul>
-         *
-         * <li>Level 1 DIES
-         *
-         * <li><code>code = primitive_type, tag = base_type<code> - Java primitive type (non-void)
-         *
-         * <li><code>code = void_type, tag = unspecified_type<code> - Java void type
-         *
-         * <li><code>code = object_header, tag = structure_type<code> - Java object header
-         *
-         * <li><code>code = class_layout, tag = class_type, parent = class_unit<code> - Java
-         * instance type structure definition
-         *
-         * <li><code>code = class_pointer, tag = pointer_type, parent = class_unit<code> - Java
-         * instance ref type
-         *
-         * <li><code>code = method_location, tag = subprogram , parent = class_unit<code> - Java
-         * method code definition (i.e. location of code)
-         *
-         * <li><code>code = abstract_inline_method, tag = subprogram , parent = class_unit<code> -
-         * Java abstract inline method (i.e. proxy for method definition referenced by concrete
-         * inline instance)
-         *
-         * <li><code>code = static_field_location, tag = variable, parent = class_unit<code> - Java
-         * static field definition (i.e. location of data)
-         *
-         * <li><code>code = array_layout, tag = structure_type, parent = array_unit<code> - Java
-         * array type structure definition
-         *
-         * <li><code>code = array_pointer, tag = pointer_type, parent = array_unit<code> - Java
-         * array ref type
-         *
-         * <li><code>code = interface_layout, tag = union_type, parent = class_unit<code> - Java
-         * array type structure definition
-         *
-         * <li><code>code = interface_pointer, tag = pointer_type, parent = class_unit<code> - Java
-         * interface ref type
-         *
-         * <li><code>code = indirect_layout, tag = class_type, parent = class_unit, array_unit,
-         * interface_unit<code> - wrapper layout attaches address rewriting logic to the layout
-         * types that it wraps using a data_location attribute
-         *
-         * <li><code>code = indirect_pointer, tag = pointer_type, parent = class_unit, array_unit,
-         * interface_unit<code> - indirect ref type used to type indirect oops that encode the
-         * address of an object, whether by adding tag bits or representing the address as an offset
-         * from some base address. these are used to type object references stored in static and
-         * instance fields. They are not needed when typing local vars and parameters held in
-         * registers or on the stack as they appear as raw addresses.
-         *
-         * <li><code>code = namespace, tag = namespace, parent = class_unit, array_unit,
-         * interface_unit<code> - a wrap-around DIE that is used to embed all the normal level 1
-         * DIEs of a <code>class_unit</code> or <code>array_unit</code_unit> in a namespace. This is
-         * needed when the corresponding class/interface or array base element type have been loaded
-         * by a loader with a non-empty loader in order to ensure that mangled names for the class
-         * and its members can legitimately employ the loader id as a namespace prefix. Note that
-         * use of a namespace wrapper DIE causes all the embedded level 1+ DIEs documented above and
-         * all their children to be generated at a level one greater than documented here.
-         *
-         * </ul>
-         *
-         * <ul>
-         *
-         * <li> Level 2 DIEs
-         *
-         * <li><code>code = header_field, tag = member, parent = object_header<code> - object/array
-         * header field
-         *
-         * <li><code>code == method_declaration1/2, tag == subprogram, parent = class_layout</code>
-         *
-         * <li><code>code = field_declaration1/2/3/4, tag = member, parent =
-         * object_header/class_layout<code> - object header or instance field declaration (i.e.
-         * specification of properties)
-         *
-         * <li><code>code == super_reference, tag == inheritance, parent = class_layout,
-         * array_layout</code> - reference to super class layout or to appropriate header struct for
-         * {code java.lang.Object} or arrays.
-         *
-         * <li><code>code == interface_implementor, tag == member, parent = interface_layout</code>
-         * - union member typed using class layout of a given implementing class
-         *
-         * <li><code>code = inlined_subroutine/inlined_subroutine_with_children, tag = subprogram,
-         * parent = method_location/inlined_subroutine_with_children<code> - provides range and
-         * abstract origin for a concrete inline method
-         *
-         * </ul>
-         *
-         * <li> Level 2/3 DIEs
-         *
-         * <li><code>code == method_parameter_declaration1/2/3, tag == formal_parameter, parent =
-         * method_declaration1/2, abstract_inline_method</code> - details of method parameters
-         *
-         * <li><code>code == method_local_declaration1/2, tag == variable, parent =
-         * method_declaration1/2, abstract_inline_method</code> - details of method parameters
-         *
-         * <li> Level 3 DIEs
-         *
-         * <li><code>code == method_local_location, tag == formal_parameter, parent =
-         * method_location, concrete_inline_method</code> - details of method parameter or local
-         * locations
-         *
-         * Details of each specific DIE contents are as follows:
-         *
-         * A single instance of the level 0 <code>builtin_unit</code> compile unit provides details
-         * of all Java primitive types and of the struct type which describes the layout of object
-         * headers, including array headers.
-         *
-         * <li><code>abbrev_code == builtin_unit, tag == DW_TAG_compilation_unit,
-         * has_children</code>
-         *
-         * <li><code>DW_AT_language : ... DW_FORM_data1</code>
-         *
-         * </ul>
-         *
-         * Primitive Types: For each non-void Java primitive type there is a level 1 DIE defining a
-         * base type
-         *
-         * <ul>
-         *
-         * <li><code>abbrev_code == primitive_type, tag == DW_TAG_base_type, no_children</code>
-         *
-         * <li><code>DW_AT_byte_size : ... DW_FORM_data1</code> (or data2 ???)
-         *
-         * <li><code>DW_AT_bit_size : ... DW_FORM_data1</code> (or data2 ???)
-         *
-         * <li><code>DW_AT_encoding : .... DW_FORM_data1</code>
-         *
-         * <li><code>DW_AT_name : ........ DW_FORM_strp</code>
-         *
-         * </ul>
-         *
-         * <ul>
-         *
-         * The void type is defined as an unspecified type
-         *
-         * <li><code>abbrev_code == void_type, tag == DW_TAG_unspecified_type, no_children</code>
-         *
-         * <li><code>DW_AT_name : ........ DW_FORM_strp</code>
-         *
-         * </ul>
-         *
-         * Header: There is a level 1 DIE defining structure types used to define the various types
-         * of header structure embedded at the start of every instance or array. All instances embed
-         * the same object header. Array headers embed the object header as a parent type, allowing
-         * an array to be viewed as a type of object. Multiple array headers structures are defined
-         * to allow for the possibility of different amounts of padding required between the array
-         * header fields and the array elements that are allocate at the end of the header. Child
-         * DIEs are employed to define the name, type and layout of fields in each header.
-         *
-         * <ul>
-         *
-         * <li><code>abbrev_code == object_header, tag == DW_TAG_structure_type, has_children</code>
-         *
-         * <li><code>DW_AT_name : ......... DW_FORM_strp</code> "oop"
-         *
-         * <li><code>DW_AT_byte_size : ... DW_FORM_data1</code> "oop"
-         *
-         * </ul>
-         *
-         * Header Data: A level 2 DIE of type member is used to describe the fields of both object
-         * and array headers. This includes the type tag and other tag bits in all objects, the
-         * length field in all arrays and any padding bytes needed to complete the layout.
-         *
-         * <ul>
-         *
-         * <li><code>abbrev_code = header_field, tag == DW_TAG_member, no_children</code>
-         *
-         * <li><code>Dw_AT_name : ................... DW_FORM_strp</code>
-         *
-         * <li><code>Dw_AT_type : ................... DW_FORM_ref_addr</code>
-         *
-         * <li><code>Dw_AT_data_member_location : ... DW_FORM_data1</code>
-         *
-         * <li><code>Dw_AT_accessibility : .......... DW_FORM_data1</code>
-         *
-         * </ul>
-         *
-         * Instance Classes: For each class there is a level 0 DIE defining the class compilation
-         * unit. low_pc and hi_pc are only included if the class has compiled methods i.e. for
-         * variants 1 and 2. stmt_list is included for all classes, even when they have no compiled
-         * methods, to ensure that a basic line entry record exists for the class. This is needed to
-         * ensure some tools report a file name for methods that may only exist inlined.
-         *
-         * <ul>
-         *
-         * <li><code>abbrev_code == class_unit1/2, tag == DW_TAG_compilation_unit,
-         * has_children</code>
-         *
-         * <li><code>DW_AT_language : ... DW_FORM_data1</code>
-         *
-         * <li><code>DW_AT_name : ....... DW_FORM_strp</code>
-         *
-         * <li><code>DW_AT_comp_dir : ... DW_FORM_strp</code>
-         *
-         * <li><code>DW_AT_low_pc : ..... DW_FORM_address</code> n.b only for <code>abbrev-code ==
-         * class_unit1</code>
-         *
-         * <li><code>DW_AT_hi_pc : ...... DW_FORM_address</code> n.b only for <code>abbrev-code ==
-         * class_unit1</code>
-         *
-         * <li><code>DW_AT_use_UTF8 : ... DW_FORM_flag</code>
-         *
-         * <li><code>DW_AT_stmt_list : .. DW_FORM_sec_offset</code>
-         *
-         * </ul>
-         *
-         * Namespace embedding:
-         *
-         * When the class loader associated with a class defined in a <code>class_unit</code>
-         * compile unit has a non-empty loader id string then a namespace DIE is used to wrap all
-         * its child DIEs. Otherwise the children are embedded directly. The namespace DIE has a
-         * single attribute defining the namespace's name as the loader id string.
-         *
-         * <li><code>abbrev_code == namespace, tag == DW_TAG_namespace, has_children</code>
-         *
-         * <li><code>DW_AT_name : ....... DW_FORM_strp</code>
-         *
-         * </ul>
-         *
-         *
-         * Instance Class Structure: Each class_unit DIE contains a series of level 1 DIEs. The
-         * first one describes the class layout. The normal layout does not include a data_location
-         * attribute. However, an alternative layout, including that extra attribute, is provided to
-         * ensure that tag bits can be removed from pointers to instances of java.lang.Class. This
-         * alternative layout is only needed when a heapbase register is not in use and fields hold
-         * raw oops. If a heapbase register is in use and fields hold indirect oops then the masking
-         * logic for* class pointer tags is included in the data_location attribute attached to the
-         * indirect layout record (see below)
-         *
-         * <ul>
-         *
-         * <li><code>abbrev_code == class_layout1/class_layout2, tag == DW_TAG_class_type,
-         * has_children</code>
-         *
-         * <li><code>Dw_AT_name : ........ DW_FORM_strp</code>
-         *
-         * <li><code>Dw_AT_byte_size : ... DW_FORM_data1/2</code>
-         *
-         * <li><code>Dw_AT_decl_file : ... DW_FORM_data1/2</code>
-         *
-         * <li><code>Dw_AT_decl_line : ... DW_FORM_data1/2</code>
-         *
-         * <li><code>Dw_AT_data_location : ... DW_FORM_expr_loc</code> n.b. only for class_layout2
-         *
-         * </ul>
-         *
-         * Instance Class members: A level 1 class_layout DIE includes a level 2 child for each of
-         * the class's methods and fields. The first type declares a method but omits details of the
-         * location of the code that implements the method. The second type declares an instance or
-         * static field. A class_layout DIE also contains an level 2 DIE specifying the type from
-         * which it inherits superclass structure. In the case of class Object structure is
-         * inherited from the object header structure type.
-         *
-         * n.b. Code implementation details for each method are provided in an auxiliary level 1
-         * method_location DIE that follows the class_unit DIE. Instance field declarations need no
-         * auxiliary level 1 DIE as all relevant details, including size and offset in the instance,
-         * are specified in the level 2 field declaration DIE. Static field locations are provided
-         * in an auxiliary level 1 DIE (with tag variable) that follows the class_unit DIE.
-         *
-         * <ul>
-         *
-         * <li><code>abbrev_code == method_declaration1/2, tag == DW_TAG_subprogram,
-         * has_children</code>
-         *
-         * <li><code>DW_AT_external : .......... DW_FORM_flag</code>
-         *
-         * <li><code>Dw_AT_name : .............. DW_FORM_strp</code>
-         *
-         * <li><code>DW_AT_decl_file : ......... DW_FORM_data1/2</code>
-         *
-         * <li><code>DW_AT_decl_line : ......... DW_FORM_data1/2<code>
-         *
-         * <li><code>Dw_AT_linkage_name : ...... DW_FORM_strp</code>
-         *
-         * <li><code>Dw_AT_type : .............. DW_FORM_ref_addr</code> (optional!!)
-         *
-         * <li><code>DW_AT_artificial : ........ DW_FORM_flag</code>
-         *
-         * <li><code>DW_AT_accessibility : ..... DW_FORM_data1</code>
-         *
-         * <li><code>DW_AT_declaration : ....... DW_FORM_flag</code>
-         *
-         * <li><code>Dw_AT_object_pointer : .... DW_FORM_ref_addr<code> n.b. only for
-         * method_declaration1, points to param 0 DIE
-         *
-         * <li><code>DW_AT_virtuality : ........ DW_FORM_data1<code> (for override methods)
-         *
-         * <li><code>DW_AT_containing_type : ... DW_FORM_ref_addr</code> (for override methods)
-         *
-         * </ul>
-         *
-         * <ul>
-         *
-         * <li><code>abbrev_code == field_declaration1/2/3/4, tag == DW_TAG_member,
-         * no_children</code>
-         *
-         * <li><code>Dw_AT_name : ................... DW_FORM_strp</code>
-         *
-         * <li><code>DW_AT_decl_file : .............. DW_FORM_data1/2</code> n.b. only for
-         * field_declaration2/4
-         *
-         * <li><code>DW_AT_decl_line : .............. DW_FORM_data1/2</code> n.b. only for
-         * field_declaration2/4
-         *
-         * <li><code>Dw_AT_type : ................... DW_FORM_ref_addr</code>
-         *
-         * <li><code>Dw_AT_data_member_location : ... DW_FORM_data1/2</code> (n.b. nly for
-         * field_declaration1/2 instance
-         *
-         * <li><code>Dw_AT_artificial : ............. DW_FORM_flag</code>
-         *
-         * <li><code>Dw_AT_accessibility : .......... DW_FORM_data1</code>
-         *
-         * <li><code>Dw_AT_external : ............... DW_FORM_flag</code> (n.b. only for
-         * field_declaration3/4 static
-         *
-         * <li><code>Dw_AT_declaration : ............ DW_FORM_flag</code> n.b. only for
-         * field_declaration3/4 static
-         *
-         * </ul>
-         *
-         * <ul>
-         *
-         * <li><code>abbrev_code == super_reference, tag == DW_TAG_inheritance, no_children</code>
-         *
-         * <li><code>Dw_AT_type : ................... DW_FORM_ref_addr</code>
-         *
-         * <li><code>Dw_AT_data_member_location : ... DW_FORM_data1/2</code>
-         *
-         * <li><code>Dw_AT_accessibility :........... DW_FORM_data1</code>
-         *
-         * </ul>
-         *
-         * Method Parameters: Level 2 method_declaration DIEs may include level 3 DIEs that describe
-         * their parameters
-         *
-         * <ul>
-         *
-         * <li><code>abbrev_code == method_parameter_declaration1/2/3, tag ==
-         * DW_TAG_formal_parameter, no_children</code>
-         *
-         * <li><code>Dw_AT_name : ... DW_FORM_strp</code> (may be empty string)
-         *
-         * <li><code>Dw_AT_file : ... DW_FORM_data1/2</code> n.b. only for
-         * method_parameter_declaration2
-         *
-         * <li><code>Dw_AT_line : ... DW_FORM_data1/2</code> n.b. only for
-         * method_parameter_declaration2
-         *
-         * <li><code>Dw_AT_type : ... DW_FORM_ref_addr</code>
-         *
-         * <li><code>Dw_AT_artificial : ... DW_FORM_flag</code> n.b. only for
-         * method_parameter_declaration1 used for this and access vars
-         *
-         * <li><code>Dw_AT_declaration : ... DW_FORM_flag</code>
-         *
-         * </ul>
-         *
-         * <li><code>abbrev_code == method_local_declaration1/2, tag == DW_TAG_variable,
-         * no_children</code>
-         *
-         * <li><code>Dw_AT_name : ... DW_FORM_strp</code> (may be empty string)
-         *
-         * <li><code>Dw_AT_file : ... DW_FORM_data1/2</code> n.b. only for
-         * method_parameter_declaration1
-         *
-         * <li><code>Dw_AT_line : ... DW_FORM_data1/2</code> n.b. only for
-         * method_parameter_declaration1
-         *
-         * <li><code>Dw_AT_type : ... DW_FORM_ref_addr</code>
-         *
-         * <li><code>Dw_AT_declaration : ... DW_FORM_flag</code>
-         *
-         * </ul>
-         *
-         * Indirect Instance Class Structure: The level 1 class layout DIE may be followed by a
-         * level 1 indirect_layout DIE that wraps the class layout as a super class. The wrapper
-         * type supplies a data_location attribute, allowing indirect pointers to the class (see
-         * next item) to be translated to raw addresses. The name of the indirect type is
-         * constructed by prefixing the class name with DwarfDebufInfo.INDIRECT_PREFIX. This DIE has
-         * only one child DIE with type super_reference (see above). The latter references the class
-         * layout DIE as a super, effectively embedding the standard layout type in the indirect
-         * layout. The size of the indirect layout is the same as the size of the class layout.
-         *
-         * <ul>
-         *
-         * <li><code>abbrev_code == indirect_layout, tag == DW_TAG_class_type, has_children</code>
-         *
-         * <li><code>Dw_AT_name : ........ DW_FORM_strp</code>
-         *
-         * <li><code>Dw_AT_byte_size : ... DW_FORM_data1/2</code>
-         *
-         * <li><code>Dw_AT_data_location : ... DW_FORM_expr_loc</code>
-         *
-         * </ul>
-         *
-         * Instance Class Reference Types: The level 1 class_layout and indirect_layout DIEs are
-         * followed by DIEs defining pointers to the respective class layouts. A class_pointer DIE
-         * defines a pointer type for the class_layout type and is used to type pointers which
-         * directly address an instance. It is used to type local and parameter var references
-         * whether located in a register or on the stack. It is followed by an indirect_pointer DIE
-         * which defines a pointer type for the class's indirect_layout type. This is used to type
-         * references to instances of the class located in a static or instance field. These
-         * references require address translation by masking off tag bits and rebasing from an
-         * offset to a raw address. The logic for this translation is encoded in a data_location
-         * attribute of the indirect_layout DIE.
-         *
-         * <ul>
-         *
-         * <li><code>abbrev_code == class_pointer, tag == DW_TAG_pointer_type, no_children</code>
-         *
-         * <li><code>Dw_AT_byte_size : ... DW_FORM_data1</code>
-         *
-         * <li><code>Dw_AT_type : ........ DW_FORM_ref_addr</code>
-         *
-         * </ul>
-         *
-         * <ul>
-         *
-         * <li><code>abbrev_code == indirect_pointer, tag == DW_TAG_pointer_type, no_children</code>
-         *
-         * <li><code>Dw_AT_byte_size : ... DW_FORM_data1</code>
-         *
-         * <li><code>Dw_AT_type : ........ DW_FORM_ref_addr</code>
-         *
-         * </ul>
-         *
-         * n.b. the name used in the class_layout DIE is the Java class name. This is deliberately
-         * inconsistent with the Java naming where the name refers to the pointer type. In
-         * consequence when gdb displays Java types and signatures oop reference appear as pointer
-         * types. So, for example the Java String class looks like
-         *
-         * <ul>
-         *
-         * <li><code>class java.lang.String : public java.lang.Object {<code>
-         *
-         * <li><code> private:</code>
-         *
-         * <li><code> byte[] value;</code>
-         *
-         * <li><code>...</code>
-         *
-         * <li><code>public:</code>
-         *
-         * <li><code>...</code>
-         *
-         * <li><code> java.lang.String *concat(java.lang.String *);</code>
-         *
-         * <li><code>...</code>
-         *
-         * </ul>
-         *
-         * Method Code Locations: For each method within a class there will normally be a
-         * corresponding level 1 DIE providing details of the location of the compiled code for the
-         * method. This DIE should inherit attributes from the method_definition DIE referenced from
-         * its specification attribute without the need to repeat them, including attributes
-         * specified in child DIEs of the method_definition. It is actually necessary to provide the
-         * method_location DIE with method_parameter child DIES in order to ensure that gdb carries
-         * across parameter attributes across from the specification DIE. The local method_parameter
-         * DIEs refer to their originals using a specification attribute.
-         *
-         * Note that for methods which only occur as inlined code rather than as a top-level
-         * compiles method the method location DIE will be omitted
-         *
-         * <ul>
-         *
-         * <li><code>abbrev_code == DW_ABBREV_CODE_method_location, tag == DW_TAG_subprogram,
-         * has_children</code>
-         *
-         * <li><code>DW_AT_low_pc : .......... DW_FORM_addr</code>
-         *
-         * <li><code>DW_AT_hi_pc : ........... DW_FORM_addr</code>
-         *
-         * <li><code>DW_AT_external : ........ DW_FORM_flag</code>
-         *
-         * <li><code>DW_AT_specification : ... DW_FORM_ref_addr</code>
-         *
-         * </ul>
-         *
-         * Method local locations: A method location is followed by zero or more
-         * method_local_location DIEs that refer back to the corresponding
-         * method_parameter_declaration or method_local_declaration that follows the method
-         * declaration. These DIEs also specify a location list which defines address ranges where
-         * the parameter or local is valid and provide details of where to find the value of the
-         * parameter or local in memory. Likewise, an inline concrete method DIE is followed by zero
-         * or more method_local_location DIEs providing details of where to find the specification
-         * of inlined parameters or locals and their value in memory.
-         *
-         * <ul>
-         *
-         * <li><code>abbrev_code == DW_ABBREV_CODE_method_local_location1/2, tag ==
-         * DW_TAG_formal_parameter, no_children</code>
-         *
-         * <li><code>DW_AT_specification : .......... DW_FORM_ref_addr</code>
-         *
-         * <li><code>DW_AT_location: ................ DW_FORM_sec_offset</code> n.b. only for
-         * method_local_location2
-         *
-         * </ul>
-         *
-         * Abstract Inline Methods: For any method m' which has been inlined into a top level
-         * compiled method m there will be an abstract_inline_method DIE for m' at level 1 DIE in
-         * the CU to which m belongs. The declaration serves as an abstract_origin for any
-         * corresponding inlined method DIEs appearing as children of m. The abstract_inline_method
-         * DIE should inherit attributes from the method_definition DIE referenced as its
-         * specification attribute without the need to repeat them, including attributes specified
-         * in child DIEs of the method_definition. However, it is actually necessary to replicate
-         * the method_parameter/local_declaration DIEs of the specification as children of the
-         * abstract_inline_method DIE. This provides a CU-local target for references from the
-         * corresponding method_parameter/local_location DIEs that sit below the inlined_subroutine
-         * DIEs in the concrete inlined subroutine tree. This is needed because some tools require
-         * the location DIEs abstract_origin attribute that links the location to specification to
-         * be a CU-relative offset (FORM_Ref4) rather than an info section offset.
-         *
-         * <ul>
-         *
-         * <li><code>abbrev_code == DW_ABBREV_CODE_abstract_inline_method, tag == DW_TAG_subprogram,
-         * has_children</code>
-         *
-         * <li><code>DW_AT_inline : .......... DW_FORM_data1</code>
-         *
-         * <li><code>DW_AT_external : ........ DW_FORM_flag</code>
-         *
-         * <li><code>DW_AT_specification : ... DW_FORM_ref_addr</code>
-         *
-         * </ul>
-         *
-         * Concrete Inlined Methods: Concrete inlined method DIEs are nested as a tree of children
-         * under the method_location DIE for the method into which they have been inlined. Each
-         * inlined method DIE defines an address range that is a subrange of its parent DIE. A
-         * method_location DIE occurs at depth 1 in a compile unit (class_unit). So, this means that
-         * for any method which has been inlined into a compiled method at depth K in the inline
-         * frame stack there will be a corresponding level 2+K DIE that identifies the method that
-         * was inlined (by referencing the corresponding abstract inline method DIE) and locates the
-         * call point by citing the file index and line number of its caller. So, if compiled method
-         * M inlines a call to m1 at source position f0:l0, m1 inlines a call to method m2 at source
-         * position f1:l1 and m2 inlines a call to m3 at source position f2:l2 then there will be a
-         * level 2 DIE for the inline code range derived from m1 referencing the abstract entry for
-         * m1 with f0 and l0 as file and line, a level 3 DIE for the inline code range derived from
-         * m2 referencing the abstract entry for m2 with f1 and l1 as file and line and a level 3
-         * DIE for the inline code range derived from m3 referencing the abstract entry for m3 with
-         * f2 and l2 as file and line.
-         *
-         * <ul>
-         *
-         * <li><code>abbrev_code == DW_ABBREV_CODE_inlined_subroutine, tag == DW_TAG_subprogram,
-         * no_children</code>
-         *
-         * <li><code>abbrev_code == DW_ABBREV_CODE_inlined_subroutine_with_children, tag ==
-         * DW_TAG_subprogram, has_children</code>
-         *
-         * <li><code>DW_AT_abstract_origin : ... DW_FORM_ref_addr</code>
-         *
-         * <li><code>DW_AT_low_pc : ............ DW_FORM_addr</code>
-         *
-         * <li><code>DW_AT_hi_pc : ............. DW_FORM_addr</code>
-         *
-         * <li><code>DW_AT_call_file : ......... DW_FORM_data4</code>
-         *
-         * <li><code>DW_AT_call_line : ......... DW_FORM_data4</code>
-         *
-         * </ul>
-         *
-         * Static Field Locations: For each static field within the class there is a level 1 DIE
-         * providing details of the static field location
-         *
-         * <ul>
-         *
-         * <li><code>abbrev_code == static_field_location, tag == DW_TAG_variable,
-         * no_children</code>
-         *
-         * <li><code>DW_AT_specification : ... DW_FORM_ref_addr</code>
-         *
-         * <li><code>DW_AT_linkage_name : .... DW_FORM_strp</code>
-         *
-         * <li><code>DW_AT_location : ........ DW_FORM_expr_loc</code>
-         *
-         * </ul>
-         *
-         * Arrays: For each array type there is a level 0 DIE defining the array compilation unit
-         *
-         * <ul>
-         *
-         * <li><code>abbrev_code == array_unit, tag == DW_TAG_compilation_unit, has_children</code>
-         *
-         * <li><code>DW_AT_language : ... DW_FORM_data1</code>
-         *
-         * <li><code>DW_AT_name : ....... DW_FORM_strp</code>
-         *
-         * </ul>
-         *
-         * Array Structure: Each array_unit DIE contains four level 1 DIEs. The first one describes
-         * the array layout. It has only one child, a super_reference DIE (see above) that
-         * references the appropriate array header type for an object array or primitive array of
-         * the relevant primitive type). The size of the array layout is the same as the size of the
-         * array header.
-         *
-         * Note that when the base element type of the array is a class whose loader has an
-         * associated loader id the array's children are embedded in a namespace DIE. This is needed
-         * because the encoded type name for the array will include a namespace prefix in order to
-         * guarantee that it remains unique.
-         *
-         * <ul>
-         *
-         * <li><code>abbrev_code == array_layout, tag == DW_TAG_class_type, has_children</code>
-         *
-         * <li><code>Dw_AT_name : ........ DW_FORM_strp</code>
-         *
-         * <li><code>Dw_AT_byte_size : ... DW_FORM_data1/2</code>
-         *
-         * </ul>
-         *
-         * The immediately following DIE is an indirect_layout (see above) that wraps the array
-         * layout as its super type (just as with class layouts). The wrapper type supplies a
-         * data_location attribute, allowing indirect pointers to the array to be translated to raw
-         * addresses. The name of the indirect array type is constructed by prefixing the array name
-         * with INDIRECT_PREFIX. This DIE has only one child DIE with type super_reference (see
-         * above). The latter references the array layout DIE, effectively embedding the standard
-         * array layout type in the indirect layout. The size of the indirect layout is the same as
-         * the size of the array layout.
-         *
-         * The third and fourth DIEs define array reference types as a pointers to the underlying
-         * structure layout types. As with classes, there is an array_pointer type for raw address
-         * references used to type local and param vars and an indirect_pointer type (see above) for
-         * array references stored in static and instance fields.
-         *
-         * <ul>
-         *
-         * <li><code>abbrev_code == array_pointer, tag == DW_TAG_pointer_type, no_children</code>
-         *
-         * <li><code>Dw_AT_byte_size : ... DW_FORM_data1</code>
-         *
-         * <li><code>Dw_AT_type : ........ DW_FORM_ref_addr</code>
-         *
-         * </ul>
-         *
-         * n.b. the name used in the array_layout DIE is the Java array name. This is deliberately
-         * inconsistent with the Java naming where the name refers to the pointer type. As with
-         * normal objects an array reference in a Java signature appears as a pointer to an array
-         * layout when printed by gdb.
-         *
-         * Array members: The level 1 array_layout DIE includes level 2 child DIEs with tag member
-         * that describe the layout of the array. header_field DIEs are used to declare members of
-         * the array header, including the zero length array data member that follows other header
-         * fields. An auxiliary array_data_type DIE with tag array_type also occurs as a child DIE
-         * defining the type for the array data member.
-         *
-         * <ul>
-         *
-         * <li><code>abbrev_code == array_data_type, tag == DW_TAG_array_type, no_children</code>
-         *
-         * <li><code>Dw_AT_byte_size : ... DW_FORM_data1</code>
-         *
-         * <li><code>Dw_AT_type : ........ DW_FORM_ref_addr</code>
-         *
-         * </ul>
-         *
-         * Interfaces: For each interface there is a level 0 class_unit DIE defining the interface
-         * compilation unit.
-         *
-         * Interface Layout and Reference Types: The level 0 class_unit DIE for an interface is
-         * followed by a level 1 DIE defining the interface layout as a union of all the layouts for
-         * the classes which implement the interface. The size of the interface layout is the
-         * maximum of the sizes for the implementing classes.
-         *
-         * <ul>
-         *
-         * <li><code>abbrev_code == interface_layout, tag == union_type, has_children</code>
-         *
-         * <li><code>Dw_AT_name : ....... DW_FORM_strp</code>
-         *
-         * </ul>
-         *
-         * A second level 1 DIE provides an indirect_layout that wraps the interface layout as its
-         * super type (just as with class layouts). The wrapper type supplies a data_location
-         * attribute, allowing indirect pointers to the interface to be translated to raw addresses.
-         * The name of the indirect interface type is constructed by prefixing the interface name
-         * with INDIRECT_PREFIX. This DIE has only one child DIE with type super_reference (see
-         * above). The latter references the interface layout DIE, effectively embedding the
-         * standard interface layout type in the indirect layout. The size of the indirect layout is
-         * the same as the size of the interface layout.
-         *
-         * The third and fourth DIEs define interface reference types as a pointers to the
-         * underlying structure layout types. As with classes, there is an interface_pointer type
-         * for raw address references used to type local and param vars and an indirect_pointer type
-         * (see above) for interface references stored in static and instance fields.
-         *
-         * A second level 1 defines a pointer to this layout type.
-         *
-         * n.b. the name used in the interface_layout DIE is the Java array name. This is
-         * deliberately inconsistent with the Java naming where the name refers to the pointer type.
-         * As with normal objects an interface reference in a Java signature appears as a pointer to
-         * an interface layout when printed by gdb.
-         *
-         * <ul>
-         *
-         * <li><code>abbrev_code == interface_pointer, tag == pointer_type, has_children</code>
-         *
-         * <li><code>Dw_AT_byte_size : ... DW_FORM_data1</code>
-         *
-         * <li><code>DW_AT_TYPE : ....... DW_FORM_ref_addr</code>
-         *
-         * </ul>
-         *
-         * The union type embeds level 2 DIEs with tag member. There is a member for each
-         * implementing class, typed using the layout.
-         *
-         * <ul>
-         *
-         * <li><code>abbrev_code == interface_implementor, tag == member, no_children</code>
-         *
-         * <li><code>Dw_AT_name : ................... DW_FORM_strp</code>
-         *
-         * <li><code>Dw_AT_type : ................... DW_FORM_ref_addr</code>
-         *
-         * <li><code>Dw_AT_accessibility : .......... DW_FORM_data1</code>
-         *
-         * </ul>
-         *
-         * The member name is constructed by appending an '_' to the Java* name of the implementing
-         * class. So, this means that, for example, the Java interface java.lang.CharSequence will
-         * include members for String, StringBuffer etc as follows
-         *
-         * <code>union java.lang.CharSequence { java.lang.String _java.lang.String;
-         * java.lang.StringBuffer _java.lang.StringBuffer; ... };</code>
-         *
          */
 
         int pos = 0;
@@ -856,9 +845,7 @@ public class DwarfAbbrevSectionImpl extends DwarfSectionImpl {
 
     public int writeAbbrevs(DebugContext context, byte[] buffer, int p) {
         int pos = p;
-        pos = writeBuiltInUnitAbbrev(context, buffer, pos);
-        pos = writeClassUnitAbbrevs(context, buffer, pos);
-        pos = writeArrayUnitAbbrev(context, buffer, pos);
+        pos = writeClassUnitAbbrev(context, buffer, pos);
 
         pos = writePrimitiveTypeAbbrev(context, buffer, pos);
         pos = writeVoidTypeAbbrev(context, buffer, pos);
@@ -871,8 +858,10 @@ public class DwarfAbbrevSectionImpl extends DwarfSectionImpl {
         pos = writeMethodDeclarationAbbrevs(context, buffer, pos);
         pos = writeFieldDeclarationAbbrevs(context, buffer, pos);
         pos = writeClassConstantAbbrev(context, buffer, pos);
+
         pos = writeArrayLayoutAbbrev(context, buffer, pos);
         pos = writeArrayReferenceAbbrev(context, buffer, pos);
+
         pos = writeInterfaceLayoutAbbrev(context, buffer, pos);
         pos = writeInterfaceReferenceAbbrev(context, buffer, pos);
 
@@ -920,37 +909,9 @@ public class DwarfAbbrevSectionImpl extends DwarfSectionImpl {
         return writeSLEB(code, buffer, pos);
     }
 
-    private int writeBuiltInUnitAbbrev(@SuppressWarnings("unused") DebugContext context, byte[] buffer, int p) {
+    private int writeClassUnitAbbrev(@SuppressWarnings("unused") DebugContext context, byte[] buffer, int p) {
         int pos = p;
-        pos = writeAbbrevCode(DwarfDebugInfo.DW_ABBREV_CODE_builtin_unit, buffer, pos);
-        pos = writeTag(DwarfDebugInfo.DW_TAG_compile_unit, buffer, pos);
-        pos = writeFlag(DwarfDebugInfo.DW_CHILDREN_yes, buffer, pos);
-        pos = writeAttrType(DwarfDebugInfo.DW_AT_language, buffer, pos);
-        pos = writeAttrForm(DwarfDebugInfo.DW_FORM_data1, buffer, pos);
-        pos = writeAttrType(DwarfDebugInfo.DW_AT_comp_dir, buffer, pos);
-        pos = writeAttrForm(DwarfDebugInfo.DW_FORM_strp, buffer, pos);
-        pos = writeAttrType(DwarfDebugInfo.DW_AT_stmt_list, buffer, pos);
-        pos = writeAttrForm(DwarfDebugInfo.DW_FORM_sec_offset, buffer, pos);
-        /*
-         * Now terminate.
-         */
-        pos = writeAttrType(DwarfDebugInfo.DW_AT_null, buffer, pos);
-        pos = writeAttrForm(DwarfDebugInfo.DW_FORM_null, buffer, pos);
-        return pos;
-    }
-
-    private int writeClassUnitAbbrevs(DebugContext context, byte[] buffer, int p) {
-        int pos = p;
-        /* class compile unit with compiled methods and line info */
-        pos = writeClassUnitAbbrev(context, DwarfDebugInfo.DW_ABBREV_CODE_class_unit1, buffer, pos);
-        /* class compile unit without compiled methods */
-        pos = writeClassUnitAbbrev(context, DwarfDebugInfo.DW_ABBREV_CODE_class_unit2, buffer, pos);
-        return pos;
-    }
-
-    private int writeClassUnitAbbrev(@SuppressWarnings("unused") DebugContext context, int abbrevCode, byte[] buffer, int p) {
-        int pos = p;
-        pos = writeAbbrevCode(abbrevCode, buffer, pos);
+        pos = writeAbbrevCode(DwarfDebugInfo.DW_ABBREV_CODE_class_unit, buffer, pos);
         pos = writeTag(DwarfDebugInfo.DW_TAG_compile_unit, buffer, pos);
         pos = writeFlag(DwarfDebugInfo.DW_CHILDREN_yes, buffer, pos);
         pos = writeAttrType(DwarfDebugInfo.DW_AT_language, buffer, pos);
@@ -961,34 +922,10 @@ public class DwarfAbbrevSectionImpl extends DwarfSectionImpl {
         pos = writeAttrForm(DwarfDebugInfo.DW_FORM_strp, buffer, pos);
         pos = writeAttrType(DwarfDebugInfo.DW_AT_comp_dir, buffer, pos);
         pos = writeAttrForm(DwarfDebugInfo.DW_FORM_strp, buffer, pos);
-        if (abbrevCode == DwarfDebugInfo.DW_ABBREV_CODE_class_unit1) {
-            pos = writeAttrType(DwarfDebugInfo.DW_AT_low_pc, buffer, pos);
-            pos = writeAttrForm(DwarfDebugInfo.DW_FORM_addr, buffer, pos);
-            pos = writeAttrType(DwarfDebugInfo.DW_AT_hi_pc, buffer, pos);
-            pos = writeAttrForm(DwarfDebugInfo.DW_FORM_addr, buffer, pos);
-        }
-        pos = writeAttrType(DwarfDebugInfo.DW_AT_stmt_list, buffer, pos);
-        pos = writeAttrForm(DwarfDebugInfo.DW_FORM_sec_offset, buffer, pos);
-        /*
-         * Now terminate.
-         */
-        pos = writeAttrType(DwarfDebugInfo.DW_AT_null, buffer, pos);
-        pos = writeAttrForm(DwarfDebugInfo.DW_FORM_null, buffer, pos);
-        return pos;
-    }
-
-    private int writeArrayUnitAbbrev(@SuppressWarnings("unused") DebugContext context, byte[] buffer, int p) {
-        int pos = p;
-
-        pos = writeAbbrevCode(DwarfDebugInfo.DW_ABBREV_CODE_array_unit, buffer, pos);
-        pos = writeTag(DwarfDebugInfo.DW_TAG_compile_unit, buffer, pos);
-        pos = writeFlag(DwarfDebugInfo.DW_CHILDREN_yes, buffer, pos);
-        pos = writeAttrType(DwarfDebugInfo.DW_AT_language, buffer, pos);
-        pos = writeAttrForm(DwarfDebugInfo.DW_FORM_data1, buffer, pos);
-        pos = writeAttrType(DwarfDebugInfo.DW_AT_name, buffer, pos);
-        pos = writeAttrForm(DwarfDebugInfo.DW_FORM_strp, buffer, pos);
-        pos = writeAttrType(DwarfDebugInfo.DW_AT_comp_dir, buffer, pos);
-        pos = writeAttrForm(DwarfDebugInfo.DW_FORM_strp, buffer, pos);
+        pos = writeAttrType(DwarfDebugInfo.DW_AT_low_pc, buffer, pos);
+        pos = writeAttrForm(DwarfDebugInfo.DW_FORM_addr, buffer, pos);
+        pos = writeAttrType(DwarfDebugInfo.DW_AT_hi_pc, buffer, pos);
+        pos = writeAttrForm(DwarfDebugInfo.DW_FORM_addr, buffer, pos);
         pos = writeAttrType(DwarfDebugInfo.DW_AT_stmt_list, buffer, pos);
         pos = writeAttrForm(DwarfDebugInfo.DW_FORM_sec_offset, buffer, pos);
         /*
@@ -1089,7 +1026,7 @@ public class DwarfAbbrevSectionImpl extends DwarfSectionImpl {
         pos = writeAttrType(DwarfDebugInfo.DW_AT_decl_file, buffer, pos);
         pos = writeAttrForm(DwarfDebugInfo.DW_FORM_data2, buffer, pos);
         /*-
-         * At present we definitely don't have line numbers.
+         * At present we definitely don't have a line number for the class itself.
            pos = writeAttrType(DwarfDebugInfo.DW_AT_decl_line, buffer, pos);
            pos = writeAttrForm(DwarfDebugInfo.DW_FORM_data2, buffer, pos);
          */
@@ -1109,7 +1046,7 @@ public class DwarfAbbrevSectionImpl extends DwarfSectionImpl {
     private int writeClassReferenceAbbrev(@SuppressWarnings("unused") DebugContext context, byte[] buffer, int p) {
         int pos = p;
 
-        /* First the basic pointer type for a pointer to the class struct type. */
+        /* A pointer to the class struct type. */
         pos = writeAbbrevCode(DwarfDebugInfo.DW_ABBREV_CODE_class_pointer, buffer, pos);
         pos = writeTag(DwarfDebugInfo.DW_TAG_pointer_type, buffer, pos);
         pos = writeFlag(DwarfDebugInfo.DW_CHILDREN_no, buffer, pos);

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfAbbrevSectionImpl.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfAbbrevSectionImpl.java
@@ -30,14 +30,15 @@ import com.oracle.objectfile.LayoutDecision;
 import org.graalvm.compiler.debug.DebugContext;
 
 /**
- * Section generator for <code>debug_abbrev<code> section. That section defines the
+ * Section generator for <code>debug_abbrev</code> section. That section defines the
  * layout of the DWARF Information Entries (DIEs) used to model Java debug info. Top
  * level DIEs define Java Compile Units (CUs). Embedded DIEs describe the content of
  * the CU: types, code, variable, etc. These definitions are used to interpret the DIE
- * content inserted into the <code>debug_info</code> section.<p>
+ * content inserted into the <code>debug_info</code> section.
+ * <p>
  *
- * An abbrev table contains abbrev entries for one or more DIEs, the last one being
- * a null entry.<p>
+ * An abbrev table contains abbrev entries for one or more DIEs, the last one being a null entry.
+ * <p>
  *
  * A null entry consists of just a 0 abbrev code.
  *
@@ -75,16 +76,17 @@ import org.graalvm.compiler.debug.DebugContext;
  *
  * </ul>
  *
- * For the moment we only use one abbrev table and one CU. It employs the following top
- * level and nested DIES<p>
+ * For the moment we only use one abbrev table and one CU. It employs the following top level and
+ * nested DIES
+ * <p>
  *
  * Level 0 DIEs
  *
  * <ul>
  *
- * <li><code>code = null, tag == null<code> - empty terminator
+ * <li><code>code = null, tag == null</code> - empty terminator
  *
- * <li><code>code = class_unit, tag == compile_unit<code> - CU that defines the Java object header
+ * <li><code>code = class_unit, tag == compile_unit</code> - CU that defines the Java object header
  * struct, all Java primitive and object types and all Java compiled code.
  *
  * </ul>
@@ -93,54 +95,54 @@ import org.graalvm.compiler.debug.DebugContext;
  *
  * <ul>
  *
- * <li><code>code = primitive_type, tag == base_type, parent = class_unit<code> - Java primitive type (non-void)
+ * <li><code>code = primitive_type, tag == base_type, parent = class_unit</code> - Java primitive type (non-void)
  *
- * <li><code>code = void_type, tag == unspecified_type, parent = class_unit<code> - Java void type
+ * <li><code>code = void_type, tag == unspecified_type, parent = class_unit</code> - Java void type
  *
- * <li><code>code = object_header, tag == structure_type, parent = class_unit<code> - Java object header
+ * <li><code>code = object_header, tag == structure_type, parent = class_unit</code> - Java object header
  *
- * <li><code>code = class_layout, tag == class_type, parent = class_unit<code> - Java
+ * <li><code>code = class_layout, tag == class_type, parent = class_unit</code> - Java
  * instance type structure definition
  *
- * <li><code>code = class_pointer, tag == pointer_type, parent = class_unit<code> - Java
+ * <li><code>code = class_pointer, tag == pointer_type, parent = class_unit</code> - Java
  * instance ref type
  *
- * <li><code>code = method_location, tag == subprogram , parent = class_unit<code> - Java
+ * <li><code>code = method_location, tag == subprogram , parent = class_unit</code> - Java
  * method code definition (i.e. location of code)
  *
- * <li><code>code = abstract_inline_method, tag == subprogram , parent = class_unit<code> -
+ * <li><code>code = abstract_inline_method, tag == subprogram , parent = class_unit</code> -
  * Java abstract inline method (i.e. proxy for method definition referenced by concrete
  * inline instance)
  *
- * <li><code>code = static_field_location, tag == variable, parent = class_unit<code> - Java
+ * <li><code>code = static_field_location, tag == variable, parent = class_unit</code> - Java
  * static field definition (i.e. location of data)
  *
- * <li><code>code = array_layout, tag == structure_type, parent = array_unit<code> - Java
+ * <li><code>code = array_layout, tag == structure_type, parent = array_unit</code> - Java
  * array type structure definition
  *
- * <li><code>code = array_pointer, tag == pointer_type, parent = array_unit<code> - Java
+ * <li><code>code = array_pointer, tag == pointer_type, parent = array_unit</code> - Java
  * array ref type
  *
- * <li><code>code = interface_layout, tag == union_type, parent = class_unit<code> - Java
+ * <li><code>code = interface_layout, tag == union_type, parent = class_unit</code> - Java
  * array type structure definition
  *
- * <li><code>code = interface_pointer, tag == pointer_type, parent = class_unit<code> - Java
+ * <li><code>code = interface_pointer, tag == pointer_type, parent = class_unit</code> - Java
  * interface ref type
  *
  * <li><code>code = indirect_layout, tag == class_type, parent = class_unit, array_unit,
- * interface_unit<code> - wrapper layout attaches address rewriting logic to the layout
+ * interface_unit</code> - wrapper layout attaches address rewriting logic to the layout
  * types that it wraps using a data_location attribute
  *
  * <li><code>code = indirect_pointer, tag == pointer_type, parent = class_unit, array_unit,
- * interface_unit<code> - indirect ref type used to type indirect oops that encode the
+ * interface_unit</code> - indirect ref type used to type indirect oops that encode the
  * address of an object, whether by adding tag bits or representing the address as an offset
  * from some base address. these are used to type object references stored in static and
  * instance fields. They are not needed when typing local vars and parameters held in
  * registers or on the stack as they appear as raw addresses.
  *
  * <li><code>code = namespace, tag == namespace, parent = class_unit, array_unit,
- * interface_unit<code> - a wrap-around DIE that is used to embed all the normal level 1
- * DIEs of a <code>class_unit</code> or <code>array_unit</code_unit> in a namespace. This is
+ * interface_unit</code> - a wrap-around DIE that is used to embed all the normal level 1
+ * DIEs of a <code>class_unit</code> or <code>array_unit</code> in a namespace. This is
  * needed when the corresponding class/interface or array base element type have been loaded
  * by a loader with a non-empty loader in order to ensure that mangled names for the class
  * and its members can legitimately employ the loader id as a namespace prefix. Note that
@@ -153,30 +155,30 @@ import org.graalvm.compiler.debug.DebugContext;
  *
  * <ul>
  *
- * <li><code>code = header_field, tag == member, parent = object_header<code> - object/array
+ * <li><code>code = header_field, tag == member, parent = object_header</code> - object/array
  * header field
  *
  * <li><code>code == method_declaration1/2, tag == subprogram, parent = class_layout</code>
  *
- * <li><code>code = field_declaration1/2/3/4, tag == member, parent = class_layout<code> - instance
+ * <li><code>code = field_declaration1/2/3/4, tag == member, parent = class_layout</code> - instance
  * field declaration (i.e. specification of properties)
  *
  * <li><code>code == super_reference, tag == inheritance, parent = class_layout,
- * array_layout</code> - reference to super class layout or to appropriate header struct for
- * {code java.lang.Object} or arrays.
+ * array_layout</code> - reference to super class layout or to appropriate header struct for {code
+ * java.lang.Object} or arrays.
  *
- * <li><code>code == interface_implementor, tag == member, parent = interface_layout</code>
- * - union member typed using class layout of a given implementing class
+ * <li><code>code == interface_implementor, tag == member, parent = interface_layout</code> - union
+ * member typed using class layout of a given implementing class
  *
  * <li><code>code = inlined_subroutine/inlined_subroutine_with_children, tag == subprogram,
  * parent = method_location/inlined_subroutine_with_children<code> - provides range and
  * abstract origin for a concrete inline method
  *
  * <li><code>code == method_parameter_declaration1/2/3, tag == formal_parameter, parent =
- * method_declaration1/2, abstract_inline_method</code> - details of method parameters
+ * method_declaration1/2</code> - details of method parameters
  *
  * <li><code>code == method_local_declaration1/2, tag == variable, parent =
- * method_declaration1/2, abstract_inline_method</code> - details of method local vars
+ * method_declaration1/2</code> - details of method local vars
  *
  * </ul>
  *
@@ -185,16 +187,15 @@ import org.graalvm.compiler.debug.DebugContext;
  * <ul>
  *
  * <li><code>code == method_local_location, tag == formal_parameter, parent =
- * method_location, concrete_inline_method</code> - details of method parameter or local
- * locations
+ * method_location, concrete_inline_method</code> - details of method parameter or local locations
  *
  * </ul>
  *
- * Detailed layouts of the DIEs listed above are as follows:<p>
+ * Detailed layouts of the DIEs listed above are as follows:
+ * <p>
  *
- * A single instance of the level 0 <code>class_unit</code> compile unit provides details
- * of the object header struct, all Java primitive and object types and all Java compiled
- * code.
+ * A single instance of the level 0 <code>class_unit</code> compile unit provides details of the
+ * object header struct, all Java primitive and object types and all Java compiled code.
  *
  * <ul>
  *
@@ -217,10 +218,11 @@ import org.graalvm.compiler.debug.DebugContext;
  *
  * </ul>
  *
- * All other Java derived DIEs are embedded within this top level CU.<p>
+ * All other Java derived DIEs are embedded within this top level CU.
+ * <p>
  *
- * Primitive Types: For each non-void Java primitive type there is a level 1 DIE defining a
- * base type
+ * Primitive Types: For each non-void Java primitive type there is a level 1 DIE defining a base
+ * type
  *
  * <ul>
  *
@@ -246,10 +248,9 @@ import org.graalvm.compiler.debug.DebugContext;
  *
  * </ul>
  *
- * Header Struct: There is a level 1 DIE defining a structure type which models the
- * header information embedded at the start of every instance or array (all instances embed
- * the same object header). Child DIEs are employed to define the name, type and layout of
- * fields in the header.
+ * Header Struct: There is a level 1 DIE defining a structure type which models the header
+ * information embedded at the start of every instance or array (all instances embed the same object
+ * header). Child DIEs are employed to define the name, type and layout of fields in the header.
  *
  * <ul>
  *
@@ -261,9 +262,9 @@ import org.graalvm.compiler.debug.DebugContext;
  *
  * </ul>
  *
- * Header Data: A level 2 DIE of type member is used to describe the fields of both object
- * and array headers. This includes the type tag and other tag bits in all objects and the
- * length field in all arrays.
+ * Header Data: A level 2 DIE of type member is used to describe the fields of both object and array
+ * headers. This includes the type tag and other tag bits in all objects and the length field in all
+ * arrays.
  *
  * <ul>
  *
@@ -279,13 +280,14 @@ import org.graalvm.compiler.debug.DebugContext;
  *
  * </ul>
  *
- * Namespace embedding for Java class DIEs:<p>
+ * Namespace embedding for Java class DIEs:
+ * <p>
  *
- * When the class loader associated with a class defined in the Java class
- * compile unit has a non-empty loader id string then a namespace DIE is used to wrap
- * the level 1 DIEs that define the class layout, methods etc. Otherwise, these children
- * are embedded directly in the Java class compile unit. The namespace DIE has a
- * single attribute defining the namespace's name as the loader id string.
+ * When the class loader associated with a class defined in the Java class compile unit has a
+ * non-empty loader id string then a namespace DIE is used to wrap the level 1 DIEs that define the
+ * class layout, methods etc. Otherwise, these children are embedded directly in the Java class
+ * compile unit. The namespace DIE has a single attribute defining the namespace's name as the
+ * loader id string.
  *
  * <li><code>abbrev_code == namespace, tag == DW_TAG_namespace, parent = class_unit, has_children</code>
  *
@@ -294,17 +296,18 @@ import org.graalvm.compiler.debug.DebugContext;
  * </ul>
  *
  * Instance Classes: For each instance class type there is a sequence of up to four level 1 DIEs
- * defining the class.<p>
+ * defining the class.
+ * <p>
  *
- * Instance Class Structure: Each java class is described by a series of level 1 DIEs. The first
- * one describes the class layout. The normal layout does not include a <code>data_location</code>
+ * Instance Class Structure: Each java class is described by a series of level 1 DIEs. The first one
+ * describes the class layout. The normal layout does not include a <code>data_location</code>
  * attribute. However, an alternative layout, including that extra attribute, is provided to deal
  * with a single special case, <code>java.lang.Class</code>. Oop references to instances of this
  * class are encoded using tag bits. The <code>data_location</code> attribute defines masking logic
  * which a debugger can use to decode the oop pointer to a raw address. n.b. this only applies in
  * the case where normal oop references are raw addresses (no compressed oops, no isolates). If a
  * heapbase register is being used then decoding logic is encoded for both normal classes and for
- * code>java.lang.Class</code> using an indirect layout (see below).
+ * <code>java.lang.Class</code> using an indirect layout (see below).
  *
  * <ul>
  *
@@ -323,19 +326,20 @@ import org.graalvm.compiler.debug.DebugContext;
  *
  * </ul>
  *
- * Instance Class members: A level 1 <code>class_layout</code> DIE includes a level 2 child for each of
- * the class's methods and fields. The first type <em>declares</em> a method but omits details of the
- * location of the code that implements the method. The second type <em>declares</em> an instance or
- * static field. A class_layout DIE also contains a level 2 DIE specifying the type from
+ * Instance Class members: A level 1 <code>class_layout</code> DIE includes a level 2 child for each
+ * of the class's methods and fields. The first type <em>declares</em> a method but omits details of
+ * the location of the code that implements the method. The second type <em>declares</em> an
+ * instance or static field. A class_layout DIE also contains a level 2 DIE specifying the type from
  * which it inherits superclass structure. In the case of class <code>Object</code> structure is
  * inherited from the object header structure type.
  *
  * n.b. Code implementation details for each method (i.e. the method <em>definition</em>) are
  * provided in an auxiliary level 1 <code>method_location</code> DIE that follows the
  * <code>class_layout</code> DIE. Instance field declarations need no auxiliary level 1 DIE as all
- * relevant details, including size and offset in the instance, are specified in the field declaration
- * DIE. Static field locations (i.e. the field <em>definition</em>) are provided in an auxiliary level 1
- * <code>static_field_location</code>DIE that follows the <code>class_layout</code> DIE.
+ * relevant details, including size and offset in the instance, are specified in the field
+ * declaration DIE. Static field locations (i.e. the field <em>definition</em>) are provided in an
+ * auxiliary level 1 <code>static_field_location</code> DIE that follows the
+ * <code>class_layout</code> DIE.
  *
  * <ul>
  *
@@ -360,7 +364,7 @@ import org.graalvm.compiler.debug.DebugContext;
  *
  * <li><code>DW_AT_declaration : ....... DW_FORM_flag</code>
  *
- * <li><code>Dw_AT_object_pointer : .... DW_FORM_ref_addr<code> n.b. only for
+ * <li><code>Dw_AT_object_pointer : .... DW_FORM_ref_addr</code> n.b. only for
  * method_declaration1, points to param 0 DIE
  *
  * <li><code>DW_AT_virtuality : ........ DW_FORM_data1<code> (for override methods)
@@ -393,8 +397,8 @@ import org.graalvm.compiler.debug.DebugContext;
  * <li><code>Dw_AT_external : ............... DW_FORM_flag</code> (n.b. only for
  * field_declaration3/4 static
  *
- * <li><code>Dw_AT_declaration : ............ DW_FORM_flag</code> n.b. only for
- * field_declaration3/4 static
+ * <li><code>Dw_AT_declaration : ............ DW_FORM_flag</code> n.b. only for field_declaration3/4
+ * static
  *
  * </ul>
  *
@@ -410,9 +414,9 @@ import org.graalvm.compiler.debug.DebugContext;
  *
  * </ul>
  *
- * Method Parameters: Level 2 method_declaration DIEs may include level 3 DIEs that describe
- * their parameters and/or their local variables. n.b. these two DIEs only differ in the value
- * of their tag.
+ * Method Parameters: Level 2 method_declaration DIEs may include level 3 DIEs that describe their
+ * parameters and/or their local variables. n.b. these two DIEs only differ in the value of their
+ * tag.
  *
  * <ul>
  *
@@ -421,16 +425,14 @@ import org.graalvm.compiler.debug.DebugContext;
  *
  * <li><code>Dw_AT_name : ... DW_FORM_strp</code> (may be empty string)
  *
- * <li><code>Dw_AT_file : ... DW_FORM_data1/2</code> n.b. only for
- * method_parameter_declaration2
+ * <li><code>Dw_AT_file : ... DW_FORM_data1/2</code> n.b. only for method_parameter_declaration2
  *
- * <li><code>Dw_AT_line : ... DW_FORM_data1/2</code> n.b. only for
- * method_parameter_declaration2
+ * <li><code>Dw_AT_line : ... DW_FORM_data1/2</code> n.b. only for method_parameter_declaration2
  *
  * <li><code>Dw_AT_type : ... DW_FORM_ref_addr</code>
  *
- * <li><code>Dw_AT_artificial : ... DW_FORM_flag</code> n.b. only for
- * method_parameter_declaration1 used for this and access vars
+ * <li><code>Dw_AT_artificial : ... DW_FORM_flag</code> n.b. only for method_parameter_declaration1
+ * used for this and access vars
  *
  * <li><code>Dw_AT_declaration : ... DW_FORM_flag</code>
  *
@@ -441,11 +443,9 @@ import org.graalvm.compiler.debug.DebugContext;
  *
  * <li><code>Dw_AT_name : ... DW_FORM_strp</code> (may be empty string)
  *
- * <li><code>Dw_AT_file : ... DW_FORM_data1/2</code> n.b. only for
- * method_parameter_declaration1
+ * <li><code>Dw_AT_file : ... DW_FORM_data1/2</code> n.b. only for method_parameter_declaration1
  *
- * <li><code>Dw_AT_line : ... DW_FORM_data1/2</code> n.b. only for
- * method_parameter_declaration1
+ * <li><code>Dw_AT_line : ... DW_FORM_data1/2</code> n.b. only for method_parameter_declaration1
  *
  * <li><code>Dw_AT_type : ... DW_FORM_ref_addr</code>
  *
@@ -453,17 +453,17 @@ import org.graalvm.compiler.debug.DebugContext;
  *
  * </ul>
  *
- * Indirect Instance Class Structure: The level 1 class layout DIE may be followed by a
- * level 1 <code>indirect_layout</code> DIE. The indirect layout is only needed when a
- * heapbase register is in use (isolates or compressed oops are enabled). This means that
- * oop fields will hold encoded oops. The indirect layout defines an empty wrapper class
- * which declares the previous layout as its super class. This wrapper type also supplies a
- * <code>data_location</code> attribute, ensuring that indirect pointers to the class (see next
- * item) are translated to raw addresses. The name of the indirect type is constructed by
- * prefixing the class name with <code>DwarfDebugInfo.INDIRECT_PREFIX</code>. This DIE has only
- * one child DIE with type super_reference (see above). This effectively embeds the standard
- * layout type in the indirect layout as a type compatible referent for the Java oop. The size
- * of the indirect layout is the same as the size of the class layout.
+ * Indirect Instance Class Structure: The level 1 class layout DIE may be followed by a level 1
+ * <code>indirect_layout</code> DIE. The indirect layout is only needed when a heapbase register is
+ * in use (isolates or compressed oops are enabled). This means that oop fields will hold encoded
+ * oops. The indirect layout defines an empty wrapper class which declares the previous layout as
+ * its super class. This wrapper type also supplies a <code>data_location</code> attribute, ensuring
+ * that indirect pointers to the class (see next item) are translated to raw addresses. The name of
+ * the indirect type is constructed by prefixing the class name with
+ * <code>DwarfDebugInfo.INDIRECT_PREFIX</code>. This DIE has only one child DIE with type
+ * super_reference (see above). This effectively embeds the standard layout type in the indirect
+ * layout as a type compatible referent for the Java oop. The size of the indirect layout is the
+ * same as the size of the class layout.
  *
  * <ul>
  *
@@ -511,8 +511,9 @@ import org.graalvm.compiler.debug.DebugContext;
  *
  * n.b. the name used in the <code>class_layout</code> DIE is the Java class name. This is
  * <em>deliberately</em> inconsistent with the Java naming where the name refers to the pointer
- * type. In consequence when gdb displays Java types and signatures oop references appear as
- * pointer types. So, for example the Java String class looks like<p>
+ * type. In consequence when gdb displays Java types and signatures oop references appear as pointer
+ * types. So, for example the Java String class looks like
+ * <p>
  *
  * <pre>
  *   class java.lang.String : public java.lang.Object {
@@ -525,17 +526,13 @@ import org.graalvm.compiler.debug.DebugContext;
  *     ...
  * </pre>
  *
- * Method Code Locations: For each level 2 method <em>declaration</em> which has been compiled
- * as a top-level method (i.e. not just occurring inline) there will be a corresponding level
- * 1 method <em>definition</em> DIE providing details of the location of the compiled code. The
- * two DIEs are cross-referenced using a <code>specification</code> attribute.
- * This cross-reference should imply that the location DIE inherits attributes from the
- * <code>method_definition</code> DIE, including attributes specified int the latter's child DIEs,
- * such as parameter and local variable declarations.
- *
- * However, it is actually necessary to replicate the parameter and local variable declarations
- * as children of the inline method definition DIE in order to ensure that gdb is aware of the
- * parameters and locals.
+ * Method Code Locations: For each level 2 method <em>declaration</em> which has been compiled as a
+ * top-level method (i.e. not just occurring inline) there will be a corresponding level 1 method
+ * <em>definition</em> DIE providing details of the location of the compiled code. The two DIEs are
+ * cross-referenced using a <code>specification</code> attribute. This cross-reference means that
+ * the location DIE inherits attributes from the <code>method_definition</code> DIE, including
+ * attributes specified int the latter's child DIEs, such as parameter and local variable
+ * declarations.
  *
  * <ul>
  *
@@ -553,15 +550,14 @@ import org.graalvm.compiler.debug.DebugContext;
  * </ul>
  *
  * Method local locations: A method location may be followed by zero or more
- * <code>method_local_location</code> DIEs which identify the in-memory location of
- * parameter and/or local values during execution of the compiled code. A
- * <code>method_local_location</code> DIE references the corresponding
- * <code>method_parameter_declaration</code> or <code>method_local_declaration</code>.
- * It also specifies a location list which defines address ranges where the parameter or
- * local is valid and provides details of where to find the value of the parameter or local
- * in memory. Likewise, an inline concrete method DIE is followed by zero or more
- * <code>method_local_location</code> DIEs, providing details of where to find the specification
- * of inlined parameters or locals and their value in memory.
+ * <code>method_local_location</code> DIEs which identify the in-memory location of parameter and/or
+ * local values during execution of the compiled code. A <code>method_local_location</code> DIE
+ * references the corresponding <code>method_parameter_declaration</code> or
+ * <code>method_local_declaration</code>. It also specifies a location list which defines address
+ * ranges where the parameter or local is valid and provides details of where to find the value of
+ * the parameter or local in memory. Likewise, an inline concrete method DIE is followed by zero or
+ * more <code>method_local_location</code> DIEs, providing details of where to find the
+ * specification of inlined parameters or locals and their value in memory.
  *
  * <ul>
  *
@@ -575,22 +571,22 @@ import org.graalvm.compiler.debug.DebugContext;
  *
  * </ul>
  *
- * Abstract Inline Methods: For any method <code>m'</code> which has been inlined into a
- * top level compiled method <code>m</code> there will be an <code>abstract_inline_method</code>
- * DIE for <code>m'</code> at level 1 in the Java CU. The declaration serves as the
- * <code>abstract_origin</code> for any corresponding inlined method DIEs appearing as children
- * of <code>m</code>.
- *
- * The <code>abstract_inline_method</code> DIE should inherit attributes from
- * the method_definition DIE referenced as its <code>abstract_origin</code> attribute without the
- * need to repeat them. However, it is actually necessary to replicate the method parameter and
- * local declaration DIEs of the specification as children of the <code>abstract_inline_method</code>
- * DIE.
+ * Abstract Inline Methods: For any method <code>m'</code> which has been inlined into a top level
+ * compiled method <code>m</code> there will be an <code>abstract_inline_method</code> DIE for
+ * <code>m'</code> at level 1 in the Java CU. The declaration serves as the
+ * <code>abstract_origin</code> for any corresponding inlined method DIEs appearing as children of
+ * <code>m</code>. This declaration references the original method declaration via its
+ * <code>specification</code> and inherits attributes from that original declaration including
+ * parameter and local declarations. The GNU compiler sometimes replicates the parameter and local
+ * declarations so they can be referenced from location info in concrete inline methods, ensuring
+ * that any such reference is local to the compile unit of the method into which the call is
+ * inlined. There is no need for that with Java as all the declarations are lcoated in one compile
+ * unit.
  *
  * <ul>
  *
  * <li><code>abbrev_code == DW_ABBREV_CODE_abstract_inline_method, tag == DW_TAG_subprogram,
- * has_children</code>
+ * no_children</code>
  *
  * <li><code>DW_AT_inline : .......... DW_FORM_data1</code>
  *
@@ -600,21 +596,20 @@ import org.graalvm.compiler.debug.DebugContext;
  *
  * </ul>
  *
- * Concrete Inlined Methods: Concrete inlined method DIEs are nested as a tree of children
- * under the method_location DIE for the method into which they have been inlined. Each
- * inlined method DIE defines an address range that is a subrange of its parent DIE. A
- * method_location DIE occurs at depth 1 in a compile unit (class_unit). So, this means that
- * for any method which has been inlined into a compiled method at depth K in the inline
- * frame stack there will be a corresponding level 2+K DIE that identifies the method that
- * was inlined (by referencing the corresponding abstract inline method DIE) and locates the
- * call point by citing the file index and line number of its caller. So, if compiled method
- * M inlines a call to m1 at source position f0:l0, m1 inlines a call to method m2 at source
- * position f1:l1 and m2 inlines a call to m3 at source position f2:l2 then there will be a
- * level 2 DIE for the inline code range derived from m1 referencing the abstract entry for
- * m1 with f0 and l0 as file and line, a level 3 DIE for the inline code range derived from
- * m2 referencing the abstract entry for m2 with f1 and l1 as file and line and a level 3
- * DIE for the inline code range derived from m3 referencing the abstract entry for m3 with
- * f2 and l2 as file and line.
+ * Concrete Inlined Methods: Concrete inlined method DIEs are nested as a tree of children under the
+ * method_location DIE for the method into which they have been inlined. Each inlined method DIE
+ * defines an address range that is a subrange of its parent DIE. A method_location DIE occurs at
+ * depth 1 in a compile unit (class_unit). So, this means that for any method which has been inlined
+ * into a compiled method at depth K in the inline frame stack there will be a corresponding level
+ * 2+K DIE that identifies the method that was inlined (by referencing the corresponding abstract
+ * inline method DIE) and locates the call point by citing the file index and line number of its
+ * caller. So, if compiled method M inlines a call to m1 at source position f0:l0, m1 inlines a call
+ * to method m2 at source position f1:l1 and m2 inlines a call to m3 at source position f2:l2 then
+ * there will be a level 2 DIE for the inline code range derived from m1 referencing the abstract
+ * entry for m1 with f0 and l0 as file and line, a level 3 DIE for the inline code range derived
+ * from m2 referencing the abstract entry for m2 with f1 and l1 as file and line and a level 3 DIE
+ * for the inline code range derived from m3 referencing the abstract entry for m3 with f2 and l2 as
+ * file and line.
  *
  * <ul>
  *
@@ -636,8 +631,8 @@ import org.graalvm.compiler.debug.DebugContext;
  *
  * </ul>
  *
- * Static Field Locations: For each static field within the class there is a level 1
- * field <em>definition</em>DIE providing details of the static field location
+ * Static Field Locations: For each static field within the class there is a level 1 field
+ * <em>definition</em> DIE providing details of the static field location
  *
  * <ul>
  *
@@ -652,24 +647,25 @@ import org.graalvm.compiler.debug.DebugContext;
  *
  * </ul>
  *
- * Arrays: For each array type there is a sequence of up to five level 1 DIEs defining the array.<p>
+ * Arrays: For each array type there is a sequence of up to five level 1 DIEs defining the array.
+ * <p>
  *
- * Array Layout: The first array DIE describes the array layout. It has three children. The
- * first is a <code>super_reference</code> DIE (see above) to class <code>java.lang.Object</code>.
- * The other two children are field declarations, a length field that overlays the Java array
- * length field and an array data field which aligns with the element 0 of the Java
- * array's data area. The data field type is typed (via a later level 1 DIE) as a DWARF
- * array, i.e. it is a data block embedded directly in the layout, with a nominal element count
- * of 0. The elements of this DWARF array are typed using the DWARF type corresponding to the
- * Java array's element type. It is either a Java primitive type or a Java reference type (i.e.
- * the pointer type ot the underlying layout type). A nominal array length of zero means that
- * this second data field does not actually add any extra size to the array layout. So, all array
- * types have the same length.<p>
+ * Array Layout: The first array DIE describes the array layout. It has three children. The first is
+ * a <code>super_reference</code> DIE (see above) to class <code>java.lang.Object</code>. The other
+ * two children are field declarations, a length field that overlays the Java array length field and
+ * an array data field which aligns with the element 0 of the Java array's data area. The data field
+ * type is typed (via a later level 1 DIE) as a DWARF array, i.e. it is a data block embedded
+ * directly in the layout, with a nominal element count of 0. The elements of this DWARF array are
+ * typed using the DWARF type corresponding to the Java array's element type. It is either a Java
+ * primitive type or a Java reference type (i.e. the pointer type ot the underlying layout type). A
+ * nominal array length of zero means that this second data field does not actually add any extra
+ * size to the array layout. So, all array types have the same length.
+ * <p>
  *
- * Note that when the base element type of the array is a class whose loader has an
- * associated loader id the array type and associated types are embedded in a namespace DIE. This
- * is needed because the encoded type name for the array will include a namespace prefix in order to
- * guarantee that it remains unique.
+ * Note that when the base element type of the array is a class whose loader has an associated
+ * loader id the array type and associated types are embedded in a namespace DIE. This is needed
+ * because the encoded type name for the array will include a namespace prefix in order to guarantee
+ * that it remains unique.
  *
  * <ul>
  *
@@ -681,19 +677,20 @@ import org.graalvm.compiler.debug.DebugContext;
  *
  * </ul>
  *
- * The immediately following DIE is an indirect_layout (see above) that wraps the array
- * layout as its super type (just as with class layouts). The wrapper type supplies a
- * data_location attribute, allowing indirect pointers to the array to be translated to raw
- * addresses. The name of the indirect array type is constructed by prefixing the array name
- * with <code>DwarfDebugInfo.INDIRECT_PREFIX</code>. This DIE has only one child DIE with type
- * <code>super_reference</code> (see above). The latter references the array layout DIE,
- * effectively embedding the standard array layout type in the indirect layout. The size of
- * the indirect layout is the same as the size of the array layout.<p>
+ * The immediately following DIE is an indirect_layout (see above) that wraps the array layout as
+ * its super type (just as with class layouts). The wrapper type supplies a data_location attribute,
+ * allowing indirect pointers to the array to be translated to raw addresses. The name of the
+ * indirect array type is constructed by prefixing the array name with
+ * <code>DwarfDebugInfo.INDIRECT_PREFIX</code>. This DIE has only one child DIE with type
+ * <code>super_reference</code> (see above). The latter references the array layout DIE, effectively
+ * embedding the standard array layout type in the indirect layout. The size of the indirect layout
+ * is the same as the size of the array layout.
+ * <p>
  *
- * The third and fourth DIEs define array reference types as a pointers to the underlying
- * structure layout types. As with classes, there is an array_pointer type for raw address
- * references used to type local and param vars and an indirect_pointer type (see above) for
- * array references stored in static and instance fields.
+ * The third and fourth DIEs define array reference types as a pointers to the underlying structure
+ * layout types. As with classes, there is an array_pointer type for raw address references used to
+ * type local and param vars and an indirect_pointer type (see above) for array references stored in
+ * static and instance fields.
  *
  * <ul>
  *
@@ -706,13 +703,13 @@ import org.graalvm.compiler.debug.DebugContext;
  * </ul>
  *
  * n.b. the name used in the array_layout DIE is the Java array name. This is deliberately
- * inconsistent with the Java naming where the name refers to the pointer type. As with
- * normal objects an array reference in a Java signature appears as a pointer to an array
- * layout when printed by gdb.
+ * inconsistent with the Java naming where the name refers to the pointer type. As with normal
+ * objects an array reference in a Java signature appears as a pointer to an array layout when
+ * printed by gdb.
  *
- * Array members: The level 1 array_layout DIE includes a member field DIE that defines
- * the layout of the array data. The type of this embedded field is declared by a fifth
- * level 1 DIE, a <code>array_data_type</code> DIE (with DWARF tag <code>array_type</code>).
+ * Array members: The level 1 array_layout DIE includes a member field DIE that defines the layout
+ * of the array data. The type of this embedded field is declared by a fifth level 1 DIE, a
+ * <code>array_data_type</code> DIE (with DWARF tag <code>array_type</code>).
  *
  * <ul>
  *
@@ -724,14 +721,15 @@ import org.graalvm.compiler.debug.DebugContext;
  *
  * </ul>
  *
- * Interfaces: For each interface there is a sequence of DIEs defining the interface.<p>
+ * Interfaces: For each interface there is a sequence of DIEs defining the interface.
+ * <p>
  *
- * Interface Layout and Reference Types: An interface is primarily modeled by a level 1
- * DIE defining its layout as a union of all the layouts for the classes which implement
- * the interface. The size of the interface layout is the maximum of the sizes for the
- * implementing classes. A DWARF union type is used to ensure that the resulting layout is
- * overlay type compatible with all its implementors. This also means that a reference
- * to an instance of the interface can be cast to a reference to any of the implementors.
+ * Interface Layout and Reference Types: An interface is primarily modeled by a level 1 DIE defining
+ * its layout as a union of all the layouts for the classes which implement the interface. The size
+ * of the interface layout is the maximum of the sizes for the implementing classes. A DWARF union
+ * type is used to ensure that the resulting layout is overlay type compatible with all its
+ * implementors. This also means that a reference to an instance of the interface can be cast to a
+ * reference to any of the implementors.
  *
  * <ul>
  *
@@ -741,26 +739,26 @@ import org.graalvm.compiler.debug.DebugContext;
  *
  * </ul>
  *
- * A second level 1 DIE provides an indirect layout that wraps the interface layout as its
- * super type (just as with class layouts). The wrapper type supplies a <code>data_location</code>
- * attribute, allowing indirect pointers to the interface to be translated to raw addresses.
- * The name of the indirect interface type is constructed by prefixing the interface name
- * with <code>DwarfDebugInfo.INDIRECT_PREFIX</code>. This DIE has only one child DIE with type
+ * A second level 1 DIE provides an indirect layout that wraps the interface layout as its super
+ * type (just as with class layouts). The wrapper type supplies a <code>data_location</code>
+ * attribute, allowing indirect pointers to the interface to be translated to raw addresses. The
+ * name of the indirect interface type is constructed by prefixing the interface name with
+ * <code>DwarfDebugInfo.INDIRECT_PREFIX</code>. This DIE has only one child DIE with type
  * <code>sup[er_reference</code> (see above). The latter references the interface layout DIE,
- * effectively embedding the standard interface layout type in the indirect layout. The size
- * of the indirect layout is the same as the size of the interface layout.
+ * effectively embedding the standard interface layout type in the indirect layout. The size of the
+ * indirect layout is the same as the size of the interface layout.
  *
- * The third and fourth DIEs define interface reference types as a pointers to the
- * underlying structure layout types. As with classes, there is an interface_pointer type
- * for raw address references used to type local and param vars and an indirect_pointer type
- * (see above) for interface references stored in static and instance fields.
+ * The third and fourth DIEs define interface reference types as a pointers to the underlying
+ * structure layout types. As with classes, there is an interface_pointer type for raw address
+ * references used to type local and param vars and an indirect_pointer type (see above) for
+ * interface references stored in static and instance fields.
  *
  * A second level 1 defines a pointer to this layout type.
  *
  * n.b. the name used in the <code>interface_layout</code> DIE is the Java array name. This is
- * deliberately inconsistent with the Java naming where the name refers to the pointer type.
- * As with normal objects an interface reference in a Java signature appears as a pointer to
- * an interface layout when printed by gdb.
+ * deliberately inconsistent with the Java naming where the name refers to the pointer type. As with
+ * normal objects an interface reference in a Java signature appears as a pointer to an interface
+ * layout when printed by gdb.
  *
  * <ul>
  *
@@ -772,8 +770,8 @@ import org.graalvm.compiler.debug.DebugContext;
  *
  * </ul>
  *
- * The union type embeds level 2 DIEs with tag member. There is a member for each
- * implementing class, typed using the layout.
+ * The union type embeds level 2 DIEs with tag member. There is a member for each implementing
+ * class, typed using the layout.
  *
  * <ul>
  *
@@ -788,8 +786,8 @@ import org.graalvm.compiler.debug.DebugContext;
  * </ul>
  *
  * The union member name is constructed by appending an '_' to the Java* name of the implementing
- * class. So, this means that, for example, the Java interface java.lang.CharSequence will
- * include members for String, StringBuffer etc as follows
+ * class. So, this means that, for example, the Java interface java.lang.CharSequence will include
+ * members for String, StringBuffer etc as follows
  *
  * <pre>
  *   union java.lang.CharSequence {
@@ -1338,7 +1336,7 @@ public class DwarfAbbrevSectionImpl extends DwarfSectionImpl {
         int pos = p;
         pos = writeAbbrevCode(DwarfDebugInfo.DW_ABBREV_CODE_abstract_inline_method, buffer, pos);
         pos = writeTag(DwarfDebugInfo.DW_TAG_subprogram, buffer, pos);
-        pos = writeFlag(DwarfDebugInfo.DW_CHILDREN_yes, buffer, pos);
+        pos = writeFlag(DwarfDebugInfo.DW_CHILDREN_no, buffer, pos);
         pos = writeAttrType(DwarfDebugInfo.DW_AT_inline, buffer, pos);
         pos = writeAttrForm(DwarfDebugInfo.DW_FORM_data1, buffer, pos);
         pos = writeAttrType(DwarfDebugInfo.DW_AT_external, buffer, pos);

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfAbbrevSectionImpl.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfAbbrevSectionImpl.java
@@ -533,11 +533,9 @@ import org.graalvm.compiler.debug.DebugContext;
  * <code>method_definition</code> DIE, including attributes specified int the latter's child DIEs,
  * such as parameter and local variable declarations.
  *
- * TODO - check we no longer need to replicate the DIES
- *
  * However, it is actually necessary to replicate the parameter and local variable declarations
- * as children of the method definition DIE in order to ensure that gdb is aware of the parameters
- * and locals.
+ * as children of the inline method definition DIE in order to ensure that gdb is aware of the
+ * parameters and locals.
  *
  * <ul>
  *
@@ -582,8 +580,6 @@ import org.graalvm.compiler.debug.DebugContext;
  * DIE for <code>m'</code> at level 1 in the Java CU. The declaration serves as the
  * <code>abstract_origin</code> for any corresponding inlined method DIEs appearing as children
  * of <code>m</code>.
- *
- * TODO - ensure we only generate per inlined method rather than per class per method inlined by that class
  *
  * The <code>abstract_inline_method</code> DIE should inherit attributes from
  * the method_definition DIE referenced as its <code>abstract_origin</code> attribute without the

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfAbbrevSectionImpl.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfAbbrevSectionImpl.java
@@ -579,9 +579,9 @@ import org.graalvm.compiler.debug.DebugContext;
  * caller. So, if compiled method M inlines a call to m1 at source position f0:l0, m1 inlines a call
  * to method m2 at source position f1:l1 and m2 inlines a call to m3 at source position f2:l2 then
  * there will be a level 2 DIE for the inline code range derived from m1 referencing the declaration
- * DIE for m1 with f0 and l0 as file and line, a level 3 DIE for the inline code range derived
- * from m2 referencing the declaration DIE for m2 with f1 and l1 as file and line and a level 3 DIE
- * for the inline code range derived from m3 referencing the declaration DIE for m3 with f2 and l2 as
+ * DIE for m1 with f0 and l0 as file and line, a level 3 DIE for the inline code range derived from
+ * m2 referencing the declaration DIE for m2 with f1 and l1 as file and line and a level 3 DIE for
+ * the inline code range derived from m3 referencing the declaration DIE for m3 with f2 and l2 as
  * file and line.
  *
  * <ul>

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfDebugInfo.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfDebugInfo.java
@@ -341,14 +341,6 @@ public class DwarfDebugInfo extends DebugInfoBase {
     private final EconomicMap<MethodEntry, DwarfMethodProperties> methodPropertiesIndex = EconomicMap.create();
 
     /**
-     * A collection of local variable properties associated with a generated method record,
-     * potentially including a method which is abstract (hence why it is not indexed off the primary
-     * range).
-     */
-
-    private final EconomicMap<MethodEntry, DwarfLocalProperties> methodLocalPropertiesIndex = EconomicMap.create();
-
-    /**
      * A collection of local variable properties associated with an inlined subrange.
      */
     private final EconomicMap<Range, DwarfLocalProperties> rangeLocalPropertiesIndex = EconomicMap.create();

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfDebugInfo.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfDebugInfo.java
@@ -481,17 +481,12 @@ public class DwarfDebugInfo extends DebugInfoBase {
          * Map from field names to info section index for the field declaration.
          */
         private EconomicMap<String, Integer> fieldDeclarationIndex;
-        /**
-         * Map from method entries to associated method local properties index.
-         */
-        private EconomicMap<MethodEntry, DwarfLocalProperties> methodLocalPropertiesIndex;
 
         DwarfClassProperties(StructureTypeEntry entry) {
             super(entry);
             this.layoutIndex = -1;
             this.indirectLayoutIndex = -1;
             fieldDeclarationIndex = null;
-            methodLocalPropertiesIndex = null;
         }
     }
 

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfDebugInfo.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfDebugInfo.java
@@ -70,53 +70,50 @@ public class DwarfDebugInfo extends DebugInfoBase {
      */
     @SuppressWarnings("unused") public static final int DW_ABBREV_CODE_null = 0;
     /* Level 0 DIEs. */
-    public static final int DW_ABBREV_CODE_builtin_unit = 1;
-    public static final int DW_ABBREV_CODE_class_unit1 = 2;
-    public static final int DW_ABBREV_CODE_class_unit2 = 3;
-    public static final int DW_ABBREV_CODE_array_unit = 4;
+    public static final int DW_ABBREV_CODE_class_unit = 1;
     /* Level 1 DIEs. */
-    public static final int DW_ABBREV_CODE_primitive_type = 5;
-    public static final int DW_ABBREV_CODE_void_type = 6;
-    public static final int DW_ABBREV_CODE_object_header = 7;
-    public static final int DW_ABBREV_CODE_namespace = 8;
-    public static final int DW_ABBREV_CODE_class_layout1 = 9;
-    public static final int DW_ABBREV_CODE_class_layout2 = 10;
-    public static final int DW_ABBREV_CODE_class_pointer = 11;
-    public static final int DW_ABBREV_CODE_method_location = 12;
-    public static final int DW_ABBREV_CODE_abstract_inline_method = 13;
-    public static final int DW_ABBREV_CODE_static_field_location = 14;
-    public static final int DW_ABBREV_CODE_array_layout = 15;
-    public static final int DW_ABBREV_CODE_array_pointer = 16;
-    public static final int DW_ABBREV_CODE_interface_layout = 17;
-    public static final int DW_ABBREV_CODE_interface_pointer = 18;
-    public static final int DW_ABBREV_CODE_indirect_layout = 19;
-    public static final int DW_ABBREV_CODE_indirect_pointer = 20;
+    public static final int DW_ABBREV_CODE_primitive_type = 2;
+    public static final int DW_ABBREV_CODE_void_type = 3;
+    public static final int DW_ABBREV_CODE_object_header = 4;
+    public static final int DW_ABBREV_CODE_namespace = 5;
+    public static final int DW_ABBREV_CODE_class_layout1 = 6;
+    public static final int DW_ABBREV_CODE_class_layout2 = 7;
+    public static final int DW_ABBREV_CODE_class_pointer = 8;
+    public static final int DW_ABBREV_CODE_method_location = 9;
+    public static final int DW_ABBREV_CODE_abstract_inline_method = 10;
+    public static final int DW_ABBREV_CODE_static_field_location = 11;
+    public static final int DW_ABBREV_CODE_array_layout = 12;
+    public static final int DW_ABBREV_CODE_array_pointer = 13;
+    public static final int DW_ABBREV_CODE_interface_layout = 14;
+    public static final int DW_ABBREV_CODE_interface_pointer = 15;
+    public static final int DW_ABBREV_CODE_indirect_layout = 16;
+    public static final int DW_ABBREV_CODE_indirect_pointer = 17;
     /* Level 2 DIEs. */
-    public static final int DW_ABBREV_CODE_method_declaration = 21;
-    public static final int DW_ABBREV_CODE_method_declaration_static = 22;
-    public static final int DW_ABBREV_CODE_field_declaration1 = 23;
-    public static final int DW_ABBREV_CODE_field_declaration2 = 24;
-    public static final int DW_ABBREV_CODE_field_declaration3 = 25;
-    public static final int DW_ABBREV_CODE_field_declaration4 = 26;
-    public static final int DW_ABBREV_CODE_class_constant = 42;
-    public static final int DW_ABBREV_CODE_header_field = 27;
-    public static final int DW_ABBREV_CODE_array_data_type = 28;
-    public static final int DW_ABBREV_CODE_super_reference = 29;
-    public static final int DW_ABBREV_CODE_interface_implementor = 30;
+    public static final int DW_ABBREV_CODE_method_declaration = 18;
+    public static final int DW_ABBREV_CODE_method_declaration_static = 19;
+    public static final int DW_ABBREV_CODE_field_declaration1 = 20;
+    public static final int DW_ABBREV_CODE_field_declaration2 = 21;
+    public static final int DW_ABBREV_CODE_field_declaration3 = 22;
+    public static final int DW_ABBREV_CODE_field_declaration4 = 23;
+    public static final int DW_ABBREV_CODE_class_constant = 24;
+    public static final int DW_ABBREV_CODE_header_field = 25;
+    public static final int DW_ABBREV_CODE_array_data_type = 26;
+    public static final int DW_ABBREV_CODE_super_reference = 27;
+    public static final int DW_ABBREV_CODE_interface_implementor = 28;
     /* Level 2+K DIEs (where inline depth K >= 0) */
-    public static final int DW_ABBREV_CODE_inlined_subroutine = 31;
-    public static final int DW_ABBREV_CODE_inlined_subroutine_with_children = 32;
+    public static final int DW_ABBREV_CODE_inlined_subroutine = 29;
+    public static final int DW_ABBREV_CODE_inlined_subroutine_with_children = 30;
     /* Level 2 DIEs. */
-    public static final int DW_ABBREV_CODE_method_parameter_declaration1 = 33;
-    public static final int DW_ABBREV_CODE_method_parameter_declaration2 = 34;
-    public static final int DW_ABBREV_CODE_method_parameter_declaration3 = 35;
-    public static final int DW_ABBREV_CODE_method_local_declaration1 = 36;
-    public static final int DW_ABBREV_CODE_method_local_declaration2 = 37;
+    public static final int DW_ABBREV_CODE_method_parameter_declaration1 = 31;
+    public static final int DW_ABBREV_CODE_method_parameter_declaration2 = 32;
+    public static final int DW_ABBREV_CODE_method_parameter_declaration3 = 33;
+    public static final int DW_ABBREV_CODE_method_local_declaration1 = 34;
+    public static final int DW_ABBREV_CODE_method_local_declaration2 = 35;
     /* Level 3 DIEs. */
-    public static final int DW_ABBREV_CODE_method_parameter_location1 = 38;
-    public static final int DW_ABBREV_CODE_method_parameter_location2 = 39;
-    public static final int DW_ABBREV_CODE_method_local_location1 = 40;
-    public static final int DW_ABBREV_CODE_method_local_location2 = 41;
+    public static final int DW_ABBREV_CODE_method_parameter_location1 = 36;
+    public static final int DW_ABBREV_CODE_method_parameter_location2 = 37;
+    public static final int DW_ABBREV_CODE_method_local_location1 = 38;
+    public static final int DW_ABBREV_CODE_method_local_location2 = 39;
 
     /*
      * Define all the Dwarf tags we need for our DIEs.
@@ -473,14 +470,6 @@ public class DwarfDebugInfo extends DebugInfoBase {
 
     static class DwarfClassProperties extends DwarfTypeProperties {
         /**
-         * Index of debug_info section compilation unit for this class.
-         */
-        private int cuIndex;
-        /**
-         * index of debug_info section compilation unit for deopt target methods.
-         */
-        private int deoptCUIndex;
-        /**
          * Index of the class entry's class_layout DIE in the debug_info section.
          */
         private int layoutIndex;
@@ -488,18 +477,6 @@ public class DwarfDebugInfo extends DebugInfoBase {
          * Index of the class entry's indirect layout DIE in the debug_info section.
          */
         private int indirectLayoutIndex;
-        /**
-         * Index into debug_line section for associated compilation unit.
-         */
-        private int lineIndex;
-        /**
-         * Size of line number info prologue region for associated compilation unit.
-         */
-        private int linePrologueSize;
-        /**
-         * Total size of line number info region for associated compilation unit.
-         */
-        private int lineSectionSize;
         /**
          * Map from field names to info section index for the field declaration.
          */
@@ -516,13 +493,8 @@ public class DwarfDebugInfo extends DebugInfoBase {
 
         DwarfClassProperties(StructureTypeEntry entry) {
             super(entry);
-            this.cuIndex = -1;
-            this.deoptCUIndex = -1;
             this.layoutIndex = -1;
             this.indirectLayoutIndex = -1;
-            this.lineIndex = -1;
-            this.linePrologueSize = -1;
-            this.lineSectionSize = -1;
             fieldDeclarationIndex = null;
             abstractInlineMethodIndex = null;
             methodLocalPropertiesIndex = null;
@@ -653,37 +625,6 @@ public class DwarfDebugInfo extends DebugInfoBase {
         return typeProperties.getIndirectTypeInfoIndex();
     }
 
-    void setCUIndex(ClassEntry classEntry, int idx) {
-        DwarfClassProperties classProperties = lookupClassProperties(classEntry);
-        assert classProperties.getTypeEntry() == classEntry;
-        assert classProperties.cuIndex == -1 || classProperties.cuIndex == idx;
-        classProperties.cuIndex = idx;
-    }
-
-    int getCUIndex(ClassEntry classEntry) {
-        DwarfClassProperties classProperties;
-        classProperties = lookupClassProperties(classEntry);
-        assert classProperties.getTypeEntry() == classEntry;
-        assert classProperties.cuIndex >= 0;
-        return classProperties.cuIndex;
-    }
-
-    void setDeoptCUIndex(ClassEntry classEntry, int idx) {
-        DwarfClassProperties classProperties;
-        classProperties = lookupClassProperties(classEntry);
-        assert classProperties.getTypeEntry() == classEntry;
-        assert (classProperties.deoptCUIndex == -1 || classProperties.deoptCUIndex == idx);
-        classProperties.deoptCUIndex = idx;
-    }
-
-    int getDeoptCUIndex(ClassEntry classEntry) {
-        DwarfClassProperties classProperties;
-        classProperties = lookupClassProperties(classEntry);
-        assert classProperties.getTypeEntry() == classEntry;
-        assert classProperties.deoptCUIndex >= 0;
-        return classProperties.deoptCUIndex;
-    }
-
     void setLayoutIndex(ClassEntry classEntry, int idx) {
         DwarfClassProperties classProperties = lookupClassProperties(classEntry);
         assert classProperties.getTypeEntry() == classEntry;
@@ -712,55 +653,6 @@ public class DwarfDebugInfo extends DebugInfoBase {
         assert classProperties.getTypeEntry() == classEntry;
         assert classProperties.indirectLayoutIndex >= 0;
         return classProperties.indirectLayoutIndex;
-    }
-
-    void setLineIndex(ClassEntry classEntry, int idx) {
-        DwarfClassProperties classProperties;
-        classProperties = lookupClassProperties(classEntry);
-        assert classProperties.getTypeEntry() == classEntry;
-        assert (classProperties.lineIndex == -1 || classProperties.lineIndex == idx);
-        classProperties.lineIndex = idx;
-    }
-
-    public int getLineIndex(ClassEntry classEntry) {
-        DwarfClassProperties classProperties;
-        classProperties = lookupClassProperties(classEntry);
-        assert classProperties.getTypeEntry() == classEntry;
-        /* line index may be fetched without being set */
-        assert classProperties.lineIndex >= -1;
-        return classProperties.lineIndex;
-    }
-
-    public void setLinePrologueSize(ClassEntry classEntry, int prologueSize) {
-        DwarfClassProperties classProperties;
-        classProperties = lookupClassProperties(classEntry);
-        assert classProperties.getTypeEntry() == classEntry;
-        assert (classProperties.linePrologueSize == -1 || classProperties.linePrologueSize == prologueSize);
-        classProperties.linePrologueSize = prologueSize;
-    }
-
-    public int getLinePrologueSize(ClassEntry classEntry) {
-        DwarfClassProperties classProperties;
-        classProperties = lookupClassProperties(classEntry);
-        assert classProperties.getTypeEntry() == classEntry;
-        assert classProperties.linePrologueSize >= 0;
-        return classProperties.linePrologueSize;
-    }
-
-    public void setLineSectionSize(ClassEntry classEntry, int totalSize) {
-        DwarfClassProperties classProperties;
-        classProperties = lookupClassProperties(classEntry);
-        assert classProperties.getTypeEntry() == classEntry;
-        assert (classProperties.lineSectionSize == -1 || classProperties.lineSectionSize == totalSize);
-        classProperties.lineSectionSize = totalSize;
-    }
-
-    public int getLineSectionSize(ClassEntry classEntry) {
-        DwarfClassProperties classProperties;
-        classProperties = lookupClassProperties(classEntry);
-        assert classProperties.getTypeEntry() == classEntry;
-        assert classProperties.lineSectionSize >= 0;
-        return classProperties.lineSectionSize;
     }
 
     public void setFieldDeclarationIndex(StructureTypeEntry entry, String fieldName, int pos) {

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfDebugInfo.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfDebugInfo.java
@@ -80,40 +80,39 @@ public class DwarfDebugInfo extends DebugInfoBase {
     public static final int DW_ABBREV_CODE_class_layout2 = 7;
     public static final int DW_ABBREV_CODE_class_pointer = 8;
     public static final int DW_ABBREV_CODE_method_location = 9;
-    public static final int DW_ABBREV_CODE_abstract_inline_method = 10;
-    public static final int DW_ABBREV_CODE_static_field_location = 11;
-    public static final int DW_ABBREV_CODE_array_layout = 12;
-    public static final int DW_ABBREV_CODE_array_pointer = 13;
-    public static final int DW_ABBREV_CODE_interface_layout = 14;
-    public static final int DW_ABBREV_CODE_interface_pointer = 15;
-    public static final int DW_ABBREV_CODE_indirect_layout = 16;
-    public static final int DW_ABBREV_CODE_indirect_pointer = 17;
+    public static final int DW_ABBREV_CODE_static_field_location = 10;
+    public static final int DW_ABBREV_CODE_array_layout = 11;
+    public static final int DW_ABBREV_CODE_array_pointer = 12;
+    public static final int DW_ABBREV_CODE_interface_layout = 13;
+    public static final int DW_ABBREV_CODE_interface_pointer = 14;
+    public static final int DW_ABBREV_CODE_indirect_layout = 15;
+    public static final int DW_ABBREV_CODE_indirect_pointer = 16;
     /* Level 2 DIEs. */
-    public static final int DW_ABBREV_CODE_method_declaration = 18;
-    public static final int DW_ABBREV_CODE_method_declaration_static = 19;
-    public static final int DW_ABBREV_CODE_field_declaration1 = 20;
-    public static final int DW_ABBREV_CODE_field_declaration2 = 21;
-    public static final int DW_ABBREV_CODE_field_declaration3 = 22;
-    public static final int DW_ABBREV_CODE_field_declaration4 = 23;
-    public static final int DW_ABBREV_CODE_class_constant = 24;
-    public static final int DW_ABBREV_CODE_header_field = 25;
-    public static final int DW_ABBREV_CODE_array_data_type = 26;
-    public static final int DW_ABBREV_CODE_super_reference = 27;
-    public static final int DW_ABBREV_CODE_interface_implementor = 28;
+    public static final int DW_ABBREV_CODE_method_declaration = 17;
+    public static final int DW_ABBREV_CODE_method_declaration_static = 18;
+    public static final int DW_ABBREV_CODE_field_declaration1 = 19;
+    public static final int DW_ABBREV_CODE_field_declaration2 = 20;
+    public static final int DW_ABBREV_CODE_field_declaration3 = 21;
+    public static final int DW_ABBREV_CODE_field_declaration4 = 22;
+    public static final int DW_ABBREV_CODE_class_constant = 23;
+    public static final int DW_ABBREV_CODE_header_field = 24;
+    public static final int DW_ABBREV_CODE_array_data_type = 25;
+    public static final int DW_ABBREV_CODE_super_reference = 26;
+    public static final int DW_ABBREV_CODE_interface_implementor = 27;
     /* Level 2+K DIEs (where inline depth K >= 0) */
-    public static final int DW_ABBREV_CODE_inlined_subroutine = 29;
-    public static final int DW_ABBREV_CODE_inlined_subroutine_with_children = 30;
+    public static final int DW_ABBREV_CODE_inlined_subroutine = 28;
+    public static final int DW_ABBREV_CODE_inlined_subroutine_with_children = 29;
     /* Level 2 DIEs. */
-    public static final int DW_ABBREV_CODE_method_parameter_declaration1 = 31;
-    public static final int DW_ABBREV_CODE_method_parameter_declaration2 = 32;
-    public static final int DW_ABBREV_CODE_method_parameter_declaration3 = 33;
-    public static final int DW_ABBREV_CODE_method_local_declaration1 = 34;
-    public static final int DW_ABBREV_CODE_method_local_declaration2 = 35;
+    public static final int DW_ABBREV_CODE_method_parameter_declaration1 = 30;
+    public static final int DW_ABBREV_CODE_method_parameter_declaration2 = 31;
+    public static final int DW_ABBREV_CODE_method_parameter_declaration3 = 32;
+    public static final int DW_ABBREV_CODE_method_local_declaration1 = 33;
+    public static final int DW_ABBREV_CODE_method_local_declaration2 = 34;
     /* Level 3 DIEs. */
-    public static final int DW_ABBREV_CODE_method_parameter_location1 = 36;
-    public static final int DW_ABBREV_CODE_method_parameter_location2 = 37;
-    public static final int DW_ABBREV_CODE_method_local_location1 = 38;
-    public static final int DW_ABBREV_CODE_method_local_location2 = 39;
+    public static final int DW_ABBREV_CODE_method_parameter_location1 = 35;
+    public static final int DW_ABBREV_CODE_method_parameter_location2 = 36;
+    public static final int DW_ABBREV_CODE_method_local_location1 = 37;
+    public static final int DW_ABBREV_CODE_method_local_location2 = 38;
 
     /*
      * Define all the Dwarf tags we need for our DIEs.
@@ -490,10 +489,6 @@ public class DwarfDebugInfo extends DebugInfoBase {
          * The index in the info section at which the method's declaration resides.
          */
         private int methodDeclarationIndex;
-        /**
-         * The index in the info section at which the method's abstract inline declaration resides.
-         */
-        private int abstractInlineMethodIndex;
 
         /**
          * Index of info locations for params/locals belonging to a method.
@@ -502,7 +497,6 @@ public class DwarfDebugInfo extends DebugInfoBase {
 
         DwarfMethodProperties() {
             methodDeclarationIndex = -1;
-            abstractInlineMethodIndex = -1;
             localProperties = null;
         }
 
@@ -511,19 +505,9 @@ public class DwarfDebugInfo extends DebugInfoBase {
             return methodDeclarationIndex;
         }
 
-        public int getAbstractInlineMethodIndex() {
-            assert abstractInlineMethodIndex >= 0 : "unset inline index";
-            return abstractInlineMethodIndex;
-        }
-
         public void setMethodDeclarationIndex(int pos) {
             assert methodDeclarationIndex == -1 || methodDeclarationIndex == pos : "bad declaration index";
             methodDeclarationIndex = pos;
-        }
-
-        public void setAbstractInlineMethodIndex(int pos) {
-            assert abstractInlineMethodIndex == -1 || abstractInlineMethodIndex == pos : "bad inline index";
-            abstractInlineMethodIndex = pos;
         }
 
         public DwarfLocalProperties getLocalProperties() {
@@ -682,16 +666,6 @@ public class DwarfDebugInfo extends DebugInfoBase {
     public int getMethodDeclarationIndex(MethodEntry methodEntry) {
         DwarfMethodProperties methodProperties = lookupMethodProperties(methodEntry);
         return methodProperties.getMethodDeclarationIndex();
-    }
-
-    public void setAbstractInlineMethodIndex(MethodEntry methodEntry, int pos) {
-        DwarfMethodProperties methodProperties = lookupMethodProperties(methodEntry);
-        methodProperties.setAbstractInlineMethodIndex(pos);
-    }
-
-    public int getAbstractInlineMethodIndex(MethodEntry methodEntry) {
-        DwarfMethodProperties methodProperties = lookupMethodProperties(methodEntry);
-        return methodProperties.getAbstractInlineMethodIndex();
     }
 
     /**

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfDebugInfo.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfDebugInfo.java
@@ -509,20 +509,14 @@ public class DwarfDebugInfo extends DebugInfoBase {
         private int abstractInlineMethodIndex;
 
         /**
-         * Index of info locations for params/locals belonging to a method
+         * Index of info locations for params/locals belonging to a method.
          */
-        private DwarfLocalProperties normalLocalProperties;
-
-        /**
-         * Index of info locations for params/locals declared belonging to an abstract inline method
-         */
-        private  DwarfLocalProperties inlineLocalProperties;
+        private DwarfLocalProperties localProperties;
 
         DwarfMethodProperties() {
             methodDeclarationIndex = -1;
             abstractInlineMethodIndex = -1;
-            normalLocalProperties = null;
-            inlineLocalProperties = null;
+            localProperties = null;
         }
 
         public int getMethodDeclarationIndex() {
@@ -545,20 +539,9 @@ public class DwarfDebugInfo extends DebugInfoBase {
             abstractInlineMethodIndex = pos;
         }
 
-        public DwarfLocalProperties getLocalProperties(boolean isInlined) {
-            DwarfLocalProperties localProperties;
-            if (isInlined) {
-                localProperties = normalLocalProperties;
-            } else {
-                localProperties = inlineLocalProperties;
-            }
+        public DwarfLocalProperties getLocalProperties() {
             if (localProperties == null) {
                 localProperties = new DwarfLocalProperties();
-                if (isInlined) {
-                    normalLocalProperties = localProperties;
-                } else {
-                    inlineLocalProperties = localProperties;
-                }
             }
             return localProperties;
         }
@@ -755,17 +738,17 @@ public class DwarfDebugInfo extends DebugInfoBase {
         return localProperties;
     }
 
-    public DwarfLocalProperties lookupLocalProperties(MethodEntry methodEntry, boolean isInlined) {
-        return lookupMethodProperties(methodEntry).getLocalProperties(isInlined);
+    public DwarfLocalProperties lookupLocalProperties(MethodEntry methodEntry) {
+        return lookupMethodProperties(methodEntry).getLocalProperties();
     }
 
-    public void setMethodLocalIndex(MethodEntry methodEntry, boolean isInlined, DebugLocalInfo localInfo, int index) {
-        DwarfLocalProperties localProperties = lookupLocalProperties(methodEntry, isInlined);
+    public void setMethodLocalIndex(MethodEntry methodEntry, DebugLocalInfo localInfo, int index) {
+        DwarfLocalProperties localProperties = lookupLocalProperties(methodEntry);
         localProperties.setIndex(localInfo, index);
     }
 
-    public int getMethodLocalIndex(MethodEntry methodEntry, boolean isInlined, DebugLocalInfo localInfo) {
-        DwarfLocalProperties localProperties = lookupLocalProperties(methodEntry, isInlined);
+    public int getMethodLocalIndex(MethodEntry methodEntry, DebugLocalInfo localInfo) {
+        DwarfLocalProperties localProperties = lookupLocalProperties(methodEntry);
         assert localProperties != null : "get of non-existent local index";
         int index = localProperties.getIndex(localInfo);
         assert index >= 0 : "get of local index before it was set";

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfDebugInfo.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfDebugInfo.java
@@ -310,22 +310,22 @@ public class DwarfDebugInfo extends DebugInfoBase {
      */
     public static final String HUB_TYPE_NAME = "java.lang.Class";
 
-    private DwarfStrSectionImpl dwarfStrSection;
-    private DwarfAbbrevSectionImpl dwarfAbbrevSection;
-    private DwarfInfoSectionImpl dwarfInfoSection;
-    private DwarfLocSectionImpl dwarfLocSection;
-    private DwarfARangesSectionImpl dwarfARangesSection;
-    private DwarfLineSectionImpl dwarfLineSection;
-    private DwarfFrameSectionImpl dwarfFameSection;
+    private final DwarfStrSectionImpl dwarfStrSection;
+    private final DwarfAbbrevSectionImpl dwarfAbbrevSection;
+    private final DwarfInfoSectionImpl dwarfInfoSection;
+    private final DwarfLocSectionImpl dwarfLocSection;
+    private final DwarfARangesSectionImpl dwarfARangesSection;
+    private final DwarfLineSectionImpl dwarfLineSection;
+    private final DwarfFrameSectionImpl dwarfFameSection;
     public final ELFMachine elfMachine;
     /**
      * Register used to hold the heap base.
      */
-    private byte heapbaseRegister;
+    private final byte heapbaseRegister;
     /**
      * Register used to hold the current thread.
      */
-    private byte threadRegister;
+    private final byte threadRegister;
 
     /**
      * A collection of properties associated with each generated type record indexed by type name.

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfFrameSectionImpl.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfFrameSectionImpl.java
@@ -152,17 +152,8 @@ public abstract class DwarfFrameSectionImpl extends DwarfSectionImpl {
 
     private int writeMethodFrames(byte[] buffer, int p) {
         Cursor cursor = new Cursor(p);
-        /* Write frames for normal methods. */
-        instanceClassStream().filter(ClassEntry::hasCompiledEntries).forEach(classEntry -> {
-            classEntry.normalCompiledEntries().forEach(compiledEntry -> {
-                cursor.set(writeMethodFrame(compiledEntry, buffer, cursor.get()));
-            });
-        });
-        /* Now write frames for deopt targets. */
-        instanceClassStream().filter(ClassEntry::hasDeoptCompiledEntries).forEach(classEntry -> {
-            classEntry.deoptCompiledEntries().forEach(compiledEntry -> {
-                cursor.set(writeMethodFrame(compiledEntry, buffer, cursor.get()));
-            });
+        compiledMethodsStream().forEach(compiledMethod -> {
+            cursor.set(writeMethodFrame(compiledMethod, buffer, cursor.get()));
         });
         return cursor.get();
     }

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfFrameSectionImpl.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfFrameSectionImpl.java
@@ -27,7 +27,6 @@
 package com.oracle.objectfile.elf.dwarf;
 
 import com.oracle.objectfile.LayoutDecision;
-import com.oracle.objectfile.debugentry.ClassEntry;
 import com.oracle.objectfile.debugentry.CompiledMethodEntry;
 import com.oracle.objectfile.debugentry.range.Range;
 import com.oracle.objectfile.debuginfo.DebugInfoProvider;

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfInfoSectionImpl.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfInfoSectionImpl.java
@@ -600,13 +600,6 @@ public class DwarfInfoSectionImpl extends DwarfSectionImpl {
                  */
                 pos = writeMethodDeclaration(context, classEntry, method, buffer, pos);
             }
-            if (method.isInlined()) {
-                /*
-                 * We also need an abstract inlined method as a target for any inline tree that
-                 * includes the method
-                 */
-                pos = writeAbstractInlineMethod(context, classEntry, method, buffer, pos);
-            }
         }
 
         return pos;
@@ -1341,7 +1334,7 @@ public class DwarfInfoSectionImpl extends DwarfSectionImpl {
         MethodEntry methodEntry = callee.getMethodEntry();
         String methodKey = methodEntry.getSymbolName();
         /* the abstract index was written in the method's class entry */
-        int abstractOriginIndex = getAbstractInlineMethodIndex(methodEntry);
+        int abstractOriginIndex = getMethodDeclarationIndex(methodEntry);
 
         int pos = p;
         log(context, "  [0x%08x] concrete inline subroutine [0x%x, 0x%x] %s", pos, caller.getLo(), caller.getHi(), methodKey);
@@ -1374,26 +1367,6 @@ public class DwarfInfoSectionImpl extends DwarfSectionImpl {
         pos = writeAttrData4(fileIndex, buffer, pos);
         log(context, "  [0x%08x]     call_line  %d", pos, callLine);
         pos = writeAttrData4(callLine, buffer, pos);
-        return pos;
-    }
-
-    private int writeAbstractInlineMethod(DebugContext context, ClassEntry classEntry, MethodEntry method, byte[] buffer, int p) {
-        int pos = p;
-        setAbstractInlineMethodIndex(method, pos);
-        log(context, "  [0x%08x] abstract inline method %s::%s", pos, classEntry.getTypeName(), method.methodName());
-        int abbrevCode = DwarfDebugInfo.DW_ABBREV_CODE_abstract_inline_method;
-        log(context, "  [0x%08x] <1> Abbrev Number %d", pos, abbrevCode);
-        pos = writeAbbrevCode(abbrevCode, buffer, pos);
-        log(context, "  [0x%08x]     inline  0x%x", pos, DwarfDebugInfo.DW_INL_inlined);
-        pos = writeAttrData1(DwarfDebugInfo.DW_INL_inlined, buffer, pos);
-        /*
-         * Should pass true only if method is non-private.
-         */
-        log(context, "  [0x%08x]     external  true", pos);
-        pos = writeFlag(DwarfDebugInfo.DW_FLAG_true, buffer, pos);
-        int methodSpecOffset = getMethodDeclarationIndex(method);
-        log(context, "  [0x%08x]     specification  0x%x", pos, methodSpecOffset);
-        pos = writeInfoSectionOffset(methodSpecOffset, buffer, pos);
         return pos;
     }
 

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfInfoSectionImpl.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfInfoSectionImpl.java
@@ -29,10 +29,8 @@ package com.oracle.objectfile.elf.dwarf;
 import java.lang.reflect.Modifier;
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
-import java.util.stream.Stream;
 
 import jdk.vm.ci.meta.JavaConstant;
 import jdk.vm.ci.meta.JavaKind;
@@ -155,7 +153,8 @@ public class DwarfInfoSectionImpl extends DwarfSectionImpl {
         log(context, "  [0x%08x]     comp_dir  0x%x (%s)", pos, debugStringIndex(compilationDirectory), compilationDirectory);
         pos = writeStrSectionOffset(compilationDirectory, buffer, pos);
         /*
-         * Code addresses start at offset 0 and range up to the limit defined by the code cache size.
+         * Code addresses start at offset 0 and range up to the limit defined by the code cache
+         * size.
          */
         int lo = 0;
         int hi = dwarfSections.compiledCodeMax();
@@ -207,14 +206,14 @@ public class DwarfInfoSectionImpl extends DwarfSectionImpl {
         /* Write child entries for primitive Java types. */
 
         pos = primitiveTypeStream().reduce(pos,
-                (pos1, primitiveTypeEntry) -> {
-                    if (primitiveTypeEntry.getBitCount() > 0) {
-                        return writePrimitiveType(context, primitiveTypeEntry, buffer, pos1);
-                    } else {
-                        return writeVoidType(context, primitiveTypeEntry, buffer, pos1);
-                    }
-                },
-                (oldpos, newpos) -> newpos);
+                        (pos1, primitiveTypeEntry) -> {
+                            if (primitiveTypeEntry.getBitCount() > 0) {
+                                return writePrimitiveType(context, primitiveTypeEntry, buffer, pos1);
+                            } else {
+                                return writeVoidType(context, primitiveTypeEntry, buffer, pos1);
+                            }
+                        },
+                        (oldpos, newpos) -> newpos);
 
         /* Write child entry for object/array header struct. */
 
@@ -223,8 +222,8 @@ public class DwarfInfoSectionImpl extends DwarfSectionImpl {
         /* write class constants for primitive type classes */
 
         pos = primitiveTypeStream().reduce(pos,
-                (pos1, primitiveTypeEntry) -> writeClassConstantDeclaration(context, primitiveTypeEntry, buffer, pos1),
-                (oldpos, newpos) -> newpos);
+                        (pos1, primitiveTypeEntry) -> writeClassConstantDeclaration(context, primitiveTypeEntry, buffer, pos1),
+                        (oldpos, newpos) -> newpos);
 
         return pos;
     }
@@ -304,8 +303,8 @@ public class DwarfInfoSectionImpl extends DwarfSectionImpl {
 
     private int writeHeaderFields(DebugContext context, HeaderTypeEntry headerTypeEntry, byte[] buffer, int p) {
         return headerTypeEntry.fields().reduce(p,
-                (pos, fieldEntry) -> writeHeaderField(context, fieldEntry, buffer, pos),
-                (oldPos, newPos) -> newPos);
+                        (pos, fieldEntry) -> writeHeaderField(context, fieldEntry, buffer, pos),
+                        (oldPos, newPos) -> newPos);
     }
 
     private int writeHeaderField(DebugContext context, FieldEntry fieldEntry, byte[] buffer, int p) {
@@ -525,8 +524,8 @@ public class DwarfInfoSectionImpl extends DwarfSectionImpl {
 
     private int writeFields(DebugContext context, ClassEntry classEntry, byte[] buffer, int p) {
         return classEntry.fields().filter(DwarfInfoSectionImpl::isManifestedField).reduce(p,
-                (pos, fieldEntry) -> writeField(context, classEntry, fieldEntry, buffer, pos),
-                (oldPos, newPos) -> newPos);
+                        (pos, fieldEntry) -> writeField(context, classEntry, fieldEntry, buffer, pos),
+                        (oldPos, newPos) -> newPos);
     }
 
     private static boolean isManifestedField(FieldEntry fieldEntry) {
@@ -603,7 +602,8 @@ public class DwarfInfoSectionImpl extends DwarfSectionImpl {
             }
             if (method.isInlined()) {
                 /*
-                 * We also need an abstract inlined method as a target for any inline tree that includes the method
+                 * We also need an abstract inlined method as a target for any inline tree that
+                 * includes the method
                  */
                 pos = writeAbstractInlineMethod(context, classEntry, method, buffer, pos);
             }
@@ -670,35 +670,35 @@ public class DwarfInfoSectionImpl extends DwarfSectionImpl {
             writeInfoSectionOffset(pos, buffer, objectPointerIndex);
         }
         /* Write method parameter declarations. */
-        pos = writeMethodParameterDeclarations(context, false, method, fileIdx, 3, buffer, pos);
+        pos = writeMethodParameterDeclarations(context, method, fileIdx, 3, buffer, pos);
         /* write method local declarations */
-        pos = writeMethodLocalDeclarations(context, false, method, fileIdx, 3, buffer, pos);
+        pos = writeMethodLocalDeclarations(context, method, fileIdx, 3, buffer, pos);
         /*
          * Write a terminating null attribute.
          */
         return writeAttrNull(buffer, pos);
     }
 
-    private int writeMethodParameterDeclarations(DebugContext context, boolean isInlined, MethodEntry method, int fileIdx, int level, byte[] buffer, int p) {
+    private int writeMethodParameterDeclarations(DebugContext context, MethodEntry method, int fileIdx, int level, byte[] buffer, int p) {
         int pos = p;
         int refAddr;
         if (!Modifier.isStatic(method.getModifiers())) {
             refAddr = pos;
             DebugLocalInfo paramInfo = method.getThisParam();
-            setMethodLocalIndex(method, isInlined, paramInfo, refAddr);
+            setMethodLocalIndex(method, paramInfo, refAddr);
             pos = writeMethodParameterDeclaration(context, paramInfo, fileIdx, true, level, buffer, pos);
         }
         for (int i = 0; i < method.getParamCount(); i++) {
             refAddr = pos;
             DebugLocalInfo paramInfo = method.getParam(i);
-            setMethodLocalIndex(method, isInlined, paramInfo, refAddr);
+            setMethodLocalIndex(method, paramInfo, refAddr);
             pos = writeMethodParameterDeclaration(context, paramInfo, fileIdx, false, level, buffer, pos);
         }
         return pos;
     }
 
     private int writeMethodParameterDeclaration(DebugContext context, DebugLocalInfo paramInfo, int fileIdx, boolean artificial, int level, byte[] buffer,
-                                                int p) {
+                    int p) {
         int pos = p;
         log(context, "  [0x%08x] method parameter declaration", pos);
         int abbrevCode;
@@ -734,20 +734,20 @@ public class DwarfInfoSectionImpl extends DwarfSectionImpl {
         return pos;
     }
 
-    private int writeMethodLocalDeclarations(DebugContext context, boolean isInlined, MethodEntry method, int fileIdx, int level, byte[] buffer, int p) {
+    private int writeMethodLocalDeclarations(DebugContext context, MethodEntry method, int fileIdx, int level, byte[] buffer, int p) {
         int pos = p;
         int refAddr;
         for (int i = 0; i < method.getLocalCount(); i++) {
             refAddr = pos;
             DebugLocalInfo localInfo = method.getLocal(i);
-            setMethodLocalIndex(method, isInlined, localInfo, refAddr);
+            setMethodLocalIndex(method, localInfo, refAddr);
             pos = writeMethodLocalDeclaration(context, localInfo, fileIdx, level, buffer, pos);
         }
         return pos;
     }
 
     private int writeMethodLocalDeclaration(DebugContext context, DebugLocalInfo paramInfo, int fileIdx, int level, byte[] buffer,
-                                            int p) {
+                    int p) {
         int pos = p;
         log(context, "  [0x%08x] method local declaration", pos);
         int abbrevCode;
@@ -833,8 +833,8 @@ public class DwarfInfoSectionImpl extends DwarfSectionImpl {
 
     private int writeInterfaceImplementors(DebugContext context, InterfaceClassEntry interfaceClassEntry, byte[] buffer, int p) {
         return interfaceClassEntry.implementors().reduce(p,
-                (pos, classEntry) -> writeInterfaceImplementor(context, classEntry, buffer, pos),
-                (oldPos, newPos) -> newPos);
+                        (pos, classEntry) -> writeInterfaceImplementor(context, classEntry, buffer, pos),
+                        (oldPos, newPos) -> newPos);
     }
 
     private int writeInterfaceImplementor(DebugContext context, ClassEntry classEntry, byte[] buffer, int p) {
@@ -944,9 +944,9 @@ public class DwarfInfoSectionImpl extends DwarfSectionImpl {
          */
         Cursor cursor = new Cursor(p);
         classEntry.fields().filter(DwarfInfoSectionImpl::isManifestedStaticField)
-                .forEach(fieldEntry ->  {
-                    cursor.set(writeClassStaticFieldLocation(context, classEntry, fieldEntry, buffer, cursor.get()));
-                });
+                        .forEach(fieldEntry -> {
+                            cursor.set(writeClassStaticFieldLocation(context, classEntry, fieldEntry, buffer, cursor.get()));
+                        });
         return cursor.get();
     }
 
@@ -1041,9 +1041,9 @@ public class DwarfInfoSectionImpl extends DwarfSectionImpl {
     private int writeFields(DebugContext context, ArrayTypeEntry arrayTypeEntry, byte[] buffer, int p) {
         Cursor cursor = new Cursor(p);
         arrayTypeEntry.fields().filter(DwarfInfoSectionImpl::isManifestedField)
-                .forEach( fieldEntry -> {
-                    cursor.set(writeField(context, arrayTypeEntry, fieldEntry, buffer, cursor.get()));
-                });
+                        .forEach(fieldEntry -> {
+                            cursor.set(writeField(context, arrayTypeEntry, fieldEntry, buffer, cursor.get()));
+                        });
         return cursor.get();
     }
 
@@ -1188,8 +1188,8 @@ public class DwarfInfoSectionImpl extends DwarfSectionImpl {
         log(context, "  [0x%08x]     specification  0x%x (%s)", pos, methodSpecOffset, methodKey);
         pos = writeInfoSectionOffset(methodSpecOffset, buffer, pos);
         HashMap<DebugLocalInfo, List<SubRange>> varRangeMap = primary.getVarRangeMap();
-        pos = writeMethodParameterLocations(context, false, varRangeMap, primary, 2, buffer, pos);
-        pos = writeMethodLocalLocations(context, false, varRangeMap, primary, 2, buffer, pos);
+        pos = writeMethodParameterLocations(context, varRangeMap, primary, 2, buffer, pos);
+        pos = writeMethodLocalLocations(context, varRangeMap, primary, 2, buffer, pos);
         if (primary.includesInlineRanges()) {
             /*
              * the method has inlined ranges so write concrete inlined method entries as its
@@ -1203,7 +1203,7 @@ public class DwarfInfoSectionImpl extends DwarfSectionImpl {
         return writeAttrNull(buffer, pos);
     }
 
-    private int writeMethodParameterLocations(DebugContext context, boolean isInlined, HashMap<DebugLocalInfo, List<SubRange>> varRangeMap, Range range, int depth, byte[] buffer, int p) {
+    private int writeMethodParameterLocations(DebugContext context, HashMap<DebugLocalInfo, List<SubRange>> varRangeMap, Range range, int depth, byte[] buffer, int p) {
         int pos = p;
         MethodEntry methodEntry;
         if (range.isPrimary()) {
@@ -1214,20 +1214,20 @@ public class DwarfInfoSectionImpl extends DwarfSectionImpl {
         }
         if (!Modifier.isStatic(methodEntry.getModifiers())) {
             DebugLocalInfo thisParamInfo = methodEntry.getThisParam();
-            int refAddr = getMethodLocalIndex(methodEntry, isInlined, thisParamInfo);
+            int refAddr = getMethodLocalIndex(methodEntry, thisParamInfo);
             List<SubRange> ranges = varRangeMap.get(thisParamInfo);
             pos = writeMethodLocalLocation(context, range, thisParamInfo, refAddr, ranges, depth, true, buffer, pos);
         }
         for (int i = 0; i < methodEntry.getParamCount(); i++) {
             DebugLocalInfo paramInfo = methodEntry.getParam(i);
-            int refAddr = getMethodLocalIndex(methodEntry, isInlined, paramInfo);
+            int refAddr = getMethodLocalIndex(methodEntry, paramInfo);
             List<SubRange> ranges = varRangeMap.get(paramInfo);
             pos = writeMethodLocalLocation(context, range, paramInfo, refAddr, ranges, depth, true, buffer, pos);
         }
         return pos;
     }
 
-    private int writeMethodLocalLocations(DebugContext context, boolean isInlined, HashMap<DebugLocalInfo, List<SubRange>> varRangeMap, Range range, int depth, byte[] buffer, int p) {
+    private int writeMethodLocalLocations(DebugContext context, HashMap<DebugLocalInfo, List<SubRange>> varRangeMap, Range range, int depth, byte[] buffer, int p) {
         int pos = p;
         MethodEntry methodEntry;
         if (range.isPrimary()) {
@@ -1239,7 +1239,7 @@ public class DwarfInfoSectionImpl extends DwarfSectionImpl {
         int count = methodEntry.getLocalCount();
         for (int i = 0; i < count; i++) {
             DebugLocalInfo localInfo = methodEntry.getLocal(i);
-            int refAddr = getMethodLocalIndex(methodEntry, isInlined, localInfo);
+            int refAddr = getMethodLocalIndex(methodEntry, localInfo);
             List<SubRange> ranges = varRangeMap.get(localInfo);
             pos = writeMethodLocalLocation(context, range, localInfo, refAddr, ranges, depth, false, buffer, pos);
         }
@@ -1321,8 +1321,8 @@ public class DwarfInfoSectionImpl extends DwarfSectionImpl {
             HashMap<DebugLocalInfo, List<SubRange>> varRangeMap = subrange.getVarRangeMap();
             // increment depth to account for parameter and method locations
             depth++;
-            pos = writeMethodParameterLocations(context, true, varRangeMap, subrange, depth + 2, buffer, pos);
-            pos = writeMethodLocalLocations(context, true, varRangeMap, subrange, depth + 2, buffer, pos);
+            pos = writeMethodParameterLocations(context, varRangeMap, subrange, depth + 2, buffer, pos);
+            pos = writeMethodLocalLocations(context, varRangeMap, subrange, depth + 2, buffer, pos);
         }
         // if we just stepped out of a child range write nulls for each step up
         while (depth > 0) {
@@ -1396,22 +1396,7 @@ public class DwarfInfoSectionImpl extends DwarfSectionImpl {
         int methodSpecOffset = getMethodDeclarationIndex(method);
         log(context, "  [0x%08x]     specification  0x%x", pos, methodSpecOffset);
         pos = writeInfoSectionOffset(methodSpecOffset, buffer, pos);
-        /*
-         * Write parameter and local declarations
-         */
-        FileEntry fileEntry = method.getFileEntry();
-        if (fileEntry == null) {
-            fileEntry = classEntry.getFileEntry();
-        }
-        assert fileEntry != null;
-        int fileIdx = fileEntry.getIdx();
-        int level = 3;
-        pos = writeMethodParameterDeclarations(context, true, method, fileIdx, level, buffer, pos);
-        pos = writeMethodLocalDeclarations(context, true, method, fileIdx, level, buffer, pos);
-        /*
-         * Write a terminating null attribute.
-         */
-        return writeAttrNull(buffer, pos);
+        return pos;
     }
 
     private int writeAttrRef4(int reference, byte[] buffer, int p) {

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfInfoSectionImpl.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfInfoSectionImpl.java
@@ -1302,7 +1302,6 @@ public class DwarfInfoSectionImpl extends DwarfSectionImpl {
         }
         int pos = p;
         log(context, "  [0x%08x] concrete entries [0x%x,0x%x] %s", pos, primary.getLo(), primary.getHi(), primary.getFullMethodName());
-        ClassEntry classEntry = compiledEntry.getClassEntry();
         int depth = 0;
         Iterator<SubRange> iterator = compiledEntry.topDownRangeIterator();
         while (iterator.hasNext()) {
@@ -1340,7 +1339,6 @@ public class DwarfInfoSectionImpl extends DwarfSectionImpl {
         // identify the inlined method by looking at the first callee
         Range callee = caller.getFirstCallee();
         MethodEntry methodEntry = callee.getMethodEntry();
-        ClassEntry classEntry = methodEntry.ownerType();
         String methodKey = methodEntry.getSymbolName();
         /* the abstract index was written in the method's class entry */
         int abstractOriginIndex = getAbstractInlineMethodIndex(methodEntry);

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfInfoSectionImpl.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfInfoSectionImpl.java
@@ -63,7 +63,7 @@ public class DwarfInfoSectionImpl extends DwarfSectionImpl {
     /**
      * The name of a special DWARF struct type used to model an object header.
      */
-    public static final String OBJECT_HEADER_STRUCT_NAME = "_objhdr";
+    private static final String OBJECT_HEADER_STRUCT_NAME = "_objhdr";
 
     /**
      * An info header section always contains a fixed number of bytes.

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfLineSectionImpl.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfLineSectionImpl.java
@@ -140,8 +140,11 @@ public class DwarfLineSectionImpl extends DwarfSectionImpl {
      */
     private static final byte DW_LNE_define_file = 3;
 
+    private int linePrologueSize;
+
     DwarfLineSectionImpl(DwarfDebugInfo dwarfSections) {
         super(dwarfSections);
+        linePrologueSize = 0;
     }
 
     @Override
@@ -159,27 +162,16 @@ public class DwarfLineSectionImpl extends DwarfSectionImpl {
          */
 
         /*
-         * Write line info for each instance class. We do this even when a class has no compiled
-         * methods ane hence no line records. This avoids bail outs by tools when a class's methods
-         * crop up inline-only but the tool still expects a line info entry to provide a file and
-         * dir table.
+         * Write line info for all compiled methods.
          */
-        Cursor cursor = new Cursor();
-        instanceClassStream().forEach(classEntry -> {
-            assert classEntry.getFileName().length() != 0;
-            int startPos = cursor.get();
-            setLineIndex(classEntry, startPos);
-            int headerSize = headerSize();
-            int dirTableSize = computeDirTableSize(classEntry);
-            int fileTableSize = computeFileTableSize(classEntry);
-            int prologueSize = headerSize + dirTableSize + fileTableSize;
-            setLinePrologueSize(classEntry, prologueSize);
-            int lineNumberTableSize = computeLineNUmberTableSize(classEntry);
-            int totalSize = prologueSize + lineNumberTableSize;
-            setLineSectionSize(classEntry, totalSize);
-            cursor.add(totalSize);
-        });
-        byte[] buffer = new byte[cursor.get()];
+        int headerSize = headerSize();
+        int dirTableSize = computeDirTableSize();
+        int fileTableSize = computeFileTableSize();
+        int prologueSize = headerSize + dirTableSize + fileTableSize;
+        setLinePrologueSize(prologueSize);
+        int lineNumberTableSize = computeLineNUmberTableSize();
+        int totalSize = prologueSize + lineNumberTableSize;
+        byte[] buffer = new byte[totalSize];
         super.setContent(buffer);
     }
 
@@ -215,62 +207,58 @@ public class DwarfLineSectionImpl extends DwarfSectionImpl {
         return DW_LN_HEADER_SIZE;
     }
 
-    private static int computeDirTableSize(ClassEntry classEntry) {
+    private int computeDirTableSize() {
         /*
          * Table contains a sequence of 'nul'-terminated UTF8 dir name bytes followed by an extra
          * 'nul'.
-         *
-         * For now we assume dir and file names are ASCII byte strings.
          */
-        int dirSize = 0;
-        for (DirEntry dir : classEntry.getLocalDirs()) {
-            dirSize += countUTF8Bytes(dir.getPathString()) + 1;
-        }
+        Cursor cursor = new Cursor();
+        dirStream().forEach( dirEntry -> {
+            if (dirEntry.getIdx() > 0) {
+                cursor.add(countUTF8Bytes(dirEntry.getPathString()) + 1);
+            }
+        });
         /*
-         * Allow for separator nul.
+         * Allow for terminator nul.
          */
-        dirSize++;
-        return dirSize;
+        cursor.add(1);
+        return cursor.get();
     }
 
-    private int computeFileTableSize(ClassEntry classEntry) {
+    private int computeFileTableSize() {
         /*
          * Table contains a sequence of file entries followed by an extra 'nul'
          *
          * each file entry consists of a 'nul'-terminated UTF8 file name, a dir entry idx and two 0
          * time stamps
          */
-        int fileSize = 0;
-        for (FileEntry localEntry : classEntry.getLocalFiles()) {
-            /*
-             * We want the file base name excluding path.
-             */
-            String baseName = localEntry.getFileName();
+        Cursor cursor = new Cursor();
+        fileStream().forEach( fileEntry -> {
+             // We want the file base name excluding path.
+            String baseName = fileEntry.getFileName();
             int length = countUTF8Bytes(baseName);
-            /* We should never have a null or zero length entry in local files. */
+            // We should never have a null or zero length entry in local files.
             assert length > 0;
-            fileSize += length + 1;
-            DirEntry dirEntry = localEntry.getDirEntry();
-            int idx = classEntry.localDirsIdx(dirEntry);
-            fileSize += writeULEB(idx, scratch, 0);
-            /*
-             * The two zero timestamps require 1 byte each.
-             */
-            fileSize += 2;
-        }
+            cursor.add(length + 1);
+            // The dir index gets written as a ULEB
+            int dirIdx = fileEntry.getDirEntry().getIdx();
+            cursor.add(writeULEB(dirIdx, scratch, 0));
+            // The two zero timestamps require 1 byte each
+            cursor.add(2);
+        });
         /*
          * Allow for terminator nul.
          */
-        fileSize++;
-        return fileSize;
+        cursor.add(1);
+        return cursor.get();
     }
 
-    private int computeLineNUmberTableSize(ClassEntry classEntry) {
+    private int computeLineNUmberTableSize() {
         /*
          * Sigh -- we have to do this by generating the content even though we cannot write it into
          * a byte[].
          */
-        return writeLineNumberTable(null, classEntry, null, 0);
+        return writeLineNumberTable(null, null, 0);
     }
 
     @Override
@@ -296,38 +284,31 @@ public class DwarfLineSectionImpl extends DwarfSectionImpl {
 
         byte[] buffer = getContent();
 
-        Cursor cursor = new Cursor();
-        enableLog(context, cursor.get());
-        log(context, "  [0x%08x] DEBUG_LINE", cursor.get());
+        int pos = 0;
 
-        instanceClassStream().forEach(classEntry -> {
-            int pos = cursor.get();
-            int startPos = pos;
-            assert getLineIndex(classEntry) == startPos;
-            log(context, "  [0x%08x] Compile Unit for %s", pos, classEntry.getFileName());
-            pos = writeHeader(classEntry, buffer, pos);
-            log(context, "  [0x%08x] headerSize = 0x%08x", pos, pos - startPos);
-            int dirTablePos = pos;
-            pos = writeDirTable(context, classEntry, buffer, pos);
-            log(context, "  [0x%08x] dirTableSize = 0x%08x", pos, pos - dirTablePos);
-            int fileTablePos = pos;
-            pos = writeFileTable(context, classEntry, buffer, pos);
-            log(context, "  [0x%08x] fileTableSize = 0x%08x", pos, pos - fileTablePos);
-            int lineNumberTablePos = pos;
-            pos = writeLineNumberTable(context, classEntry, buffer, pos);
-            log(context, "  [0x%08x] lineNumberTableSize = 0x%x", pos, pos - lineNumberTablePos);
-            log(context, "  [0x%08x] size = 0x%x", pos, pos - startPos);
-            cursor.set(pos);
-        });
-        assert cursor.get() == buffer.length;
+        enableLog(context, pos);
+        log(context, "  [0x%08x] DEBUG_LINE", pos);
+        pos = writeHeader(buffer, pos);
+        log(context, "  [0x%08x] headerSize = 0x%08x", pos, pos);
+        int dirTablePos = pos;
+        pos = writeDirTable(context, buffer, pos);
+        log(context, "  [0x%08x] dirTableSize = 0x%08x", pos, pos - dirTablePos);
+        int fileTablePos = pos;
+        pos = writeFileTable(context, buffer, pos);
+        log(context, "  [0x%08x] fileTableSize = 0x%08x", pos, pos - fileTablePos);
+        int lineNumberTablePos = pos;
+        pos = writeLineNumberTable(context, buffer, pos);
+        log(context, "  [0x%08x] lineNumberTableSize = 0x%x", pos, pos - lineNumberTablePos);
+        log(context, "  [0x%08x] size = 0x%x", pos, pos);
+        assert pos == buffer.length;
     }
 
-    private int writeHeader(ClassEntry classEntry, byte[] buffer, int p) {
+    private int writeHeader(byte[] buffer, int p) {
         int pos = p;
         /*
          * 4 ubyte length field.
          */
-        pos = writeInt(getLineSectionSize(classEntry) - 4, buffer, pos);
+        pos = writeInt(buffer.length - 4, buffer, pos);
         /*
          * 2 ubyte version is always 2.
          */
@@ -335,7 +316,7 @@ public class DwarfLineSectionImpl extends DwarfSectionImpl {
         /*
          * 4 ubyte prologue length includes rest of header and dir + file table section.
          */
-        int prologueSize = getLinePrologueSize(classEntry) - (4 + 2 + 4);
+        int prologueSize = getLinePrologueSize() - (4 + 2 + 4);
         pos = writeInt(prologueSize, buffer, pos);
         /*
          * 1 ubyte min instruction length is always 1.
@@ -391,57 +372,58 @@ public class DwarfLineSectionImpl extends DwarfSectionImpl {
         return pos;
     }
 
-    private int writeDirTable(DebugContext context, ClassEntry classEntry, byte[] buffer, int p) {
-        int pos = p;
-        verboseLog(context, "  [0x%08x] Dir  Name", pos);
+    private int writeDirTable(DebugContext context, byte[] buffer, int p) {
+        verboseLog(context, "  [0x%08x] Dir Name", p);
         /*
-         * Write out the list of dirs referenced form this file entry.
+         * Write out the list of dirs
          */
-        int dirIdx = 1;
-        for (DirEntry dir : classEntry.getLocalDirs()) {
-            /*
-             * write nul terminated string text.
-             */
-            verboseLog(context, "  [0x%08x] %-4d %s", pos, dirIdx, dir.getPath());
-            pos = writeUTF8StringBytes(dir.getPathString(), buffer, pos);
-            dirIdx++;
-        }
+        Cursor cursor = new Cursor(p);
+        dirStream().forEach( dirEntry -> {
+            int dirIdx = dirEntry.getIdx();
+            if (dirIdx > 0) {
+                String dirPath = dirEntry.getPathString();
+                verboseLog(context, "  [0x%08x] %-4d %s", cursor.get(), dirIdx, dirPath);
+                cursor.set(writeUTF8StringBytes(dirPath, buffer, cursor.get()));
+            }
+        });
         /*
          * Separate dirs from files with a nul.
          */
-        pos = writeByte((byte) 0, buffer, pos);
-        return pos;
+        cursor.set(writeByte((byte) 0, buffer, cursor.get()));
+        return cursor.get();
     }
 
-    private int writeFileTable(DebugContext context, ClassEntry classEntry, byte[] buffer, int p) {
-        int pos = p;
-        int fileIdx = 1;
-        verboseLog(context, "  [0x%08x] Entry Dir  Name", pos);
-        for (FileEntry localEntry : classEntry.getLocalFiles()) {
-            /*
-             * We need the file name minus path, the associated dir index, and 0 for time stamps.
-             */
-            String baseName = localEntry.getFileName();
-            DirEntry dirEntry = localEntry.getDirEntry();
-            int dirIdx = classEntry.localDirsIdx(dirEntry);
+    private int writeFileTable(DebugContext context, byte[] buffer, int p) {
+        verboseLog(context, "  [0x%08x] Entry Dir  Name", p);
+        /*
+         * Write out the list of files
+         */
+        Cursor cursor = new Cursor(p);
+        fileStream().forEach( fileEntry -> {
+            int pos = cursor.get();
+            String baseName = fileEntry.getFileName();
+            DirEntry dirEntry = fileEntry.getDirEntry();
+            int fileIdx = fileEntry.getIdx();
+            int dirIdx = dirEntry.getIdx();
             verboseLog(context, "  [0x%08x] %-5d %-5d %s", pos, fileIdx, dirIdx, baseName);
             pos = writeUTF8StringBytes(baseName, buffer, pos);
             pos = writeULEB(dirIdx, buffer, pos);
             pos = writeULEB(0, buffer, pos);
             pos = writeULEB(0, buffer, pos);
-            fileIdx++;
-        }
+            cursor.set(pos);
+
+        });
         /*
          * Terminate files with a nul.
          */
-        pos = writeByte((byte) 0, buffer, pos);
-        return pos;
+        cursor.set(writeByte((byte) 0, buffer, cursor.get()));
+        return cursor.get();
     }
 
     private long debugLine = 1;
     private int debugCopyCount = 0;
 
-    private int writeCompiledMethodLineInfo(DebugContext context, ClassEntry classEntry, CompiledMethodEntry compiledEntry, byte[] buffer, int p) {
+    private int writeCompiledMethodLineInfo(DebugContext context, CompiledMethodEntry compiledEntry, byte[] buffer, int p) {
         int pos = p;
         Range primaryRange = compiledEntry.getPrimary();
         // the compiled method might be a substitution and not in the file of the class entry
@@ -452,7 +434,7 @@ public class DwarfLineSectionImpl extends DwarfSectionImpl {
             return pos;
         }
         String file = fileEntry.getFileName();
-        int fileIdx = classEntry.localFilesIdx(fileEntry);
+        int fileIdx = fileEntry.getIdx();
         /*
          * Each primary represents a method i.e. a contiguous sequence of subranges. For normal
          * methods we expect the first leaf range to start at offset 0 covering the method prologue.
@@ -468,7 +450,7 @@ public class DwarfLineSectionImpl extends DwarfSectionImpl {
             if (line > 0) {
                 FileEntry firstFileEntry = prologueRange.getFileEntry();
                 if (firstFileEntry != null) {
-                    fileIdx = classEntry.localFilesIdx(firstFileEntry);
+                    fileIdx = firstFileEntry.getIdx();
                 }
             }
         }
@@ -519,7 +501,7 @@ public class DwarfLineSectionImpl extends DwarfSectionImpl {
                 continue;
             }
             String subfile = subFileEntry.getFileName();
-            int subFileIdx = classEntry.localFilesIdx(subFileEntry);
+            int subFileIdx = subFileEntry.getIdx();
             assert subFileIdx > 0;
             long subLine = subrange.getLine();
             long subAddressLo = subrange.getLo();
@@ -637,24 +619,17 @@ public class DwarfLineSectionImpl extends DwarfSectionImpl {
         return pos;
     }
 
-    private int writeLineNumberTable(DebugContext context, ClassEntry classEntry, byte[] buffer, int p) {
-        int pos = p;
-        /*
-         * The class file entry should always be first in the local files list.
-         */
-        assert classEntry.localFilesIdx() == 1;
-        String className = classEntry.getTypeName();
-        String fileName = classEntry.getFileName();
-        String classLabel = classEntry.hasCompiledEntries() ? "compiled class" : "non-compiled class";
-        log(context, "  [0x%08x] %s %s", pos, classLabel, className);
-        log(context, "  [0x%08x] %s file %s", pos, className, fileName);
-        // generate for both non-deopt and deopt entries so they share the file + dir table
-        pos = classEntry.compiledEntries().reduce(pos,
-                        (p1, compiledEntry) -> writeCompiledMethodLineInfo(context, classEntry, compiledEntry, buffer, p1),
-                        (oldPos, newPos) -> newPos);
-        log(context, "  [0x%08x] processed %s %s", pos, classLabel, className);
-
-        return pos;
+    private int writeLineNumberTable(DebugContext context, byte[] buffer, int p) {
+        Cursor cursor = new Cursor(p);
+        compiledMethodsStream().forEach( compiledMethod -> {
+            int pos = cursor.get();
+            String methodName = compiledMethod.getPrimary().getFullMethodNameWithParams();
+            String fileName = compiledMethod.getClassEntry().getFullFileName();
+            log(context, "  [0x%08x] %s %s", pos, methodName, fileName);
+            pos = writeCompiledMethodLineInfo(context, compiledMethod, buffer, pos);
+            cursor.set(pos);
+        });
+        return cursor.get();
     }
 
     private static SubRange prologueLeafRange(CompiledMethodEntry compiledEntry) {
@@ -868,6 +843,15 @@ public class DwarfLineSectionImpl extends DwarfSectionImpl {
 
     private static boolean isFixedAdvancePC(long addressDiff) {
         return addressDiff >= 0 && addressDiff < 0xffff;
+    }
+
+    protected int getLinePrologueSize() {
+        return linePrologueSize;
+    }
+
+    protected void setLinePrologueSize(int size) {
+        assert linePrologueSize == 0 : "prologue size set twice!";
+        linePrologueSize = size;
     }
 
     /**

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfLineSectionImpl.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfLineSectionImpl.java
@@ -34,7 +34,6 @@ import org.graalvm.compiler.debug.DebugContext;
 import com.oracle.objectfile.LayoutDecision;
 import com.oracle.objectfile.LayoutDecisionMap;
 import com.oracle.objectfile.ObjectFile;
-import com.oracle.objectfile.debugentry.ClassEntry;
 import com.oracle.objectfile.debugentry.CompiledMethodEntry;
 import com.oracle.objectfile.debugentry.DirEntry;
 import com.oracle.objectfile.debugentry.FileEntry;
@@ -213,7 +212,7 @@ public class DwarfLineSectionImpl extends DwarfSectionImpl {
          * 'nul'.
          */
         Cursor cursor = new Cursor();
-        dirStream().forEach( dirEntry -> {
+        dirStream().forEach(dirEntry -> {
             if (dirEntry.getIdx() > 0) {
                 cursor.add(countUTF8Bytes(dirEntry.getPathString()) + 1);
             }
@@ -233,8 +232,8 @@ public class DwarfLineSectionImpl extends DwarfSectionImpl {
          * time stamps
          */
         Cursor cursor = new Cursor();
-        fileStream().forEach( fileEntry -> {
-             // We want the file base name excluding path.
+        fileStream().forEach(fileEntry -> {
+            // We want the file base name excluding path.
             String baseName = fileEntry.getFileName();
             int length = countUTF8Bytes(baseName);
             // We should never have a null or zero length entry in local files.
@@ -378,7 +377,7 @@ public class DwarfLineSectionImpl extends DwarfSectionImpl {
          * Write out the list of dirs
          */
         Cursor cursor = new Cursor(p);
-        dirStream().forEach( dirEntry -> {
+        dirStream().forEach(dirEntry -> {
             int dirIdx = dirEntry.getIdx();
             if (dirIdx > 0) {
                 String dirPath = dirEntry.getPathString();
@@ -399,7 +398,7 @@ public class DwarfLineSectionImpl extends DwarfSectionImpl {
          * Write out the list of files
          */
         Cursor cursor = new Cursor(p);
-        fileStream().forEach( fileEntry -> {
+        fileStream().forEach(fileEntry -> {
             int pos = cursor.get();
             String baseName = fileEntry.getFileName();
             DirEntry dirEntry = fileEntry.getDirEntry();
@@ -621,7 +620,7 @@ public class DwarfLineSectionImpl extends DwarfSectionImpl {
 
     private int writeLineNumberTable(DebugContext context, byte[] buffer, int p) {
         Cursor cursor = new Cursor(p);
-        compiledMethodsStream().forEach( compiledMethod -> {
+        compiledMethodsStream().forEach(compiledMethod -> {
             int pos = cursor.get();
             String methodName = compiledMethod.getPrimary().getFullMethodNameWithParams();
             String fileName = compiledMethod.getClassEntry().getFullFileName();

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfLocSectionImpl.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfLocSectionImpl.java
@@ -35,7 +35,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.stream.Stream;
 
 import com.oracle.objectfile.debugentry.range.SubRange;
 import org.graalvm.compiler.debug.DebugContext;
@@ -44,7 +43,6 @@ import com.oracle.objectfile.BuildDependency;
 import com.oracle.objectfile.LayoutDecision;
 import com.oracle.objectfile.LayoutDecisionMap;
 import com.oracle.objectfile.ObjectFile;
-import com.oracle.objectfile.debugentry.ClassEntry;
 import com.oracle.objectfile.debugentry.CompiledMethodEntry;
 import com.oracle.objectfile.debugentry.range.Range;
 import com.oracle.objectfile.debuginfo.DebugInfoProvider.DebugLocalInfo;
@@ -127,8 +125,8 @@ public class DwarfLocSectionImpl extends DwarfSectionImpl {
 
     private int generateContent(DebugContext context, byte[] buffer) {
         Cursor cursor = new Cursor();
-        compiledMethodsStream().forEach( compiledMethod -> {
-             cursor.set(writeCompiledMethodLocations(context, compiledMethod, buffer, cursor.get()));
+        compiledMethodsStream().forEach(compiledMethod -> {
+            cursor.set(writeCompiledMethodLocations(context, compiledMethod, buffer, cursor.get()));
         });
         return cursor.get();
     }

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfSectionImpl.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfSectionImpl.java
@@ -63,7 +63,7 @@ import static com.oracle.objectfile.elf.dwarf.DwarfDebugInfo.DW_OP_stack_value;
 public abstract class DwarfSectionImpl extends BasicProgbitsSectionImpl {
     // auxiliary class used to track byte array positions
     protected class Cursor {
-        int pos;
+        private int pos;
 
         public Cursor() {
             this(0);
@@ -90,7 +90,7 @@ public abstract class DwarfSectionImpl extends BasicProgbitsSectionImpl {
         }
     }
 
-    protected DwarfDebugInfo dwarfSections;
+    protected final DwarfDebugInfo dwarfSections;
     protected boolean debug = false;
     protected long debugTextBase = 0;
     protected long debugAddress = 0;

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfSectionImpl.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfSectionImpl.java
@@ -733,7 +733,7 @@ public abstract class DwarfSectionImpl extends BasicProgbitsSectionImpl {
     }
 
     protected int compiledMethodsCount() {
-        return  dwarfSections.getCompiledMethods().size();
+        return dwarfSections.getCompiledMethods().size();
     }
 
     protected Stream<FileEntry> fileStream() {
@@ -741,7 +741,7 @@ public abstract class DwarfSectionImpl extends BasicProgbitsSectionImpl {
     }
 
     protected int fileCount() {
-        return  dwarfSections.getFiles().size();
+        return dwarfSections.getFiles().size();
     }
 
     protected Stream<DirEntry> dirStream() {
@@ -749,7 +749,7 @@ public abstract class DwarfSectionImpl extends BasicProgbitsSectionImpl {
     }
 
     protected int dirCount() {
-        return  dwarfSections.getDirs().size();
+        return dwarfSections.getDirs().size();
     }
 
     /**
@@ -859,34 +859,30 @@ public abstract class DwarfSectionImpl extends BasicProgbitsSectionImpl {
     }
 
     /**
-     * Record the info section offset of a local (or parameter) declaration DIE. The local (or
-     * parameter) can be a child of a standard method declaration or of an abstract inline method
-     * declaration.
+     * Record the info section offset of a local (or parameter) declaration DIE appearing as a child
+     * of a standard method declaration.
      * 
      * @param methodEntry the method being declared or inlined.
-     * @param isInlined true if this is a parameter of a standard declaration false if it belongs to an abstract inlined method
      * @param localInfo the local or param whose index is to be recorded.
      * @param index the info section offset to be recorded.
      */
-    protected void setMethodLocalIndex(MethodEntry methodEntry, boolean isInlined, DebugLocalInfo localInfo, int index) {
-        dwarfSections.setMethodLocalIndex(methodEntry, isInlined, localInfo, index);
+    protected void setMethodLocalIndex(MethodEntry methodEntry, DebugLocalInfo localInfo, int index) {
+        dwarfSections.setMethodLocalIndex(methodEntry, localInfo, index);
     }
 
     /**
-     * Retrieve the info section offset of a local (or parameter) declaration DIE. The local (or
-     * parameter) can be a child of a standard method declaration or of an abstract inline method
-     * declaration.
-     * 
+     * Retrieve the info section offset of a local (or parameter) declaration DIE appearing as a
+     * child of a standard method declaration.
+     *
      * @param methodEntry the method being declared or imported
-     * @param isInlined true if this is a parameter of a standard declaration false if it belongs to an abstract inlined method
      * @param localInfo the local or param whose index is to be retrieved.
      * @return the associated info section offset.
      */
-    protected int getMethodLocalIndex(MethodEntry methodEntry, boolean isInlined, DebugLocalInfo localInfo) {
+    protected int getMethodLocalIndex(MethodEntry methodEntry, DebugLocalInfo localInfo) {
         if (!contentByteArrayCreated()) {
             return 0;
         }
-        return dwarfSections.getMethodLocalIndex(methodEntry, isInlined, localInfo);
+        return dwarfSections.getMethodLocalIndex(methodEntry, localInfo);
     }
 
     /**

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfSectionImpl.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfSectionImpl.java
@@ -847,50 +847,46 @@ public abstract class DwarfSectionImpl extends BasicProgbitsSectionImpl {
         return dwarfSections.getMethodDeclarationIndex(methodEntry);
     }
 
-    protected void setAbstractInlineMethodIndex(ClassEntry classEntry, MethodEntry methodEntry, int pos) {
-        dwarfSections.setAbstractInlineMethodIndex(classEntry, methodEntry, pos);
+    protected void setAbstractInlineMethodIndex(MethodEntry methodEntry, int pos) {
+        dwarfSections.setAbstractInlineMethodIndex(methodEntry, pos);
     }
 
-    protected int getAbstractInlineMethodIndex(ClassEntry classEntry, MethodEntry methodEntry) {
+    protected int getAbstractInlineMethodIndex(MethodEntry methodEntry) {
         if (!contentByteArrayCreated()) {
             return 0;
         }
-        return dwarfSections.getAbstractInlineMethodIndex(classEntry, methodEntry);
+        return dwarfSections.getAbstractInlineMethodIndex(methodEntry);
     }
 
     /**
      * Record the info section offset of a local (or parameter) declaration DIE. The local (or
-     * parameter) can be a child of a standard method declaration in the CU of its owning class.
-     * Alternatively, it can be as a child of an abstract inline method declaration in the CU of a
-     * class into which the original's code needs to be inlined.
+     * parameter) can be a child of a standard method declaration or of an abstract inline method
+     * declaration.
      * 
-     * @param classEntry null if the local declaration belongs to a standard method declaration
-     *            otherwise the entry for the class importing the inline code.
      * @param methodEntry the method being declared or inlined.
+     * @param isInlined true if this is a parameter of a standard declaration false if it belongs to an abstract inlined method
      * @param localInfo the local or param whose index is to be recorded.
      * @param index the info section offset to be recorded.
      */
-    protected void setMethodLocalIndex(ClassEntry classEntry, MethodEntry methodEntry, DebugLocalInfo localInfo, int index) {
-        dwarfSections.setMethodLocalIndex(classEntry, methodEntry, localInfo, index);
+    protected void setMethodLocalIndex(MethodEntry methodEntry, boolean isInlined, DebugLocalInfo localInfo, int index) {
+        dwarfSections.setMethodLocalIndex(methodEntry, isInlined, localInfo, index);
     }
 
     /**
      * Retrieve the info section offset of a local (or parameter) declaration DIE. The local (or
-     * parameter) can be a child of a standard method declaration in the CU of its owning class.
-     * Alternatively, it can be as a child of an abstract inline method declaration in the CU of a
-     * class into which the original's code needs to be inlined.
+     * parameter) can be a child of a standard method declaration or of an abstract inline method
+     * declaration.
      * 
-     * @param classEntry null if the local declaration belongs to a standard method declaration
-     *            otherwise the entry for the class importing the inline code.
      * @param methodEntry the method being declared or imported
+     * @param isInlined true if this is a parameter of a standard declaration false if it belongs to an abstract inlined method
      * @param localInfo the local or param whose index is to be retrieved.
      * @return the associated info section offset.
      */
-    protected int getMethodLocalIndex(ClassEntry classEntry, MethodEntry methodEntry, DebugLocalInfo localInfo) {
+    protected int getMethodLocalIndex(MethodEntry methodEntry, boolean isInlined, DebugLocalInfo localInfo) {
         if (!contentByteArrayCreated()) {
             return 0;
         }
-        return dwarfSections.getMethodLocalIndex(classEntry, methodEntry, localInfo);
+        return dwarfSections.getMethodLocalIndex(methodEntry, isInlined, localInfo);
     }
 
     /**

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfSectionImpl.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfSectionImpl.java
@@ -33,6 +33,9 @@ import com.oracle.objectfile.LayoutDecisionMap;
 import com.oracle.objectfile.ObjectFile;
 import com.oracle.objectfile.debugentry.ArrayTypeEntry;
 import com.oracle.objectfile.debugentry.ClassEntry;
+import com.oracle.objectfile.debugentry.CompiledMethodEntry;
+import com.oracle.objectfile.debugentry.DirEntry;
+import com.oracle.objectfile.debugentry.FileEntry;
 import com.oracle.objectfile.debugentry.HeaderTypeEntry;
 import com.oracle.objectfile.debugentry.MethodEntry;
 import com.oracle.objectfile.debugentry.PrimitiveTypeEntry;
@@ -713,11 +716,40 @@ public abstract class DwarfSectionImpl extends BasicProgbitsSectionImpl {
     /**
      * Retrieve a stream of all instance classes, including interfaces and enums, notified via the
      * DebugTypeInfo API.
-     * 
+     *
      * @return a stream of all instance classes notified via the DebugTypeInfo API.
      */
     protected Stream<ClassEntry> instanceClassStream() {
         return dwarfSections.getInstanceClasses().stream();
+    }
+
+    /**
+     * Retrieve a stream of all compiled methods notified via the DebugTypeInfo API.
+     *
+     * @return a stream of all compiled methods notified via the DebugTypeInfo API.
+     */
+    protected Stream<CompiledMethodEntry> compiledMethodsStream() {
+        return dwarfSections.getCompiledMethods().stream();
+    }
+
+    protected int compiledMethodsCount() {
+        return  dwarfSections.getCompiledMethods().size();
+    }
+
+    protected Stream<FileEntry> fileStream() {
+        return dwarfSections.getFiles().stream();
+    }
+
+    protected int fileCount() {
+        return  dwarfSections.getFiles().size();
+    }
+
+    protected Stream<DirEntry> dirStream() {
+        return dwarfSections.getDirs().stream();
+    }
+
+    protected int dirCount() {
+        return  dwarfSections.getDirs().size();
     }
 
     /**
@@ -769,61 +801,6 @@ public abstract class DwarfSectionImpl extends BasicProgbitsSectionImpl {
 
     protected void setIndirectTypeIndex(TypeEntry typeEntry, int pos) {
         dwarfSections.setIndirectTypeIndex(typeEntry, pos);
-    }
-
-    protected int getCUIndex(ClassEntry classEntry) {
-        if (!contentByteArrayCreated()) {
-            return 0;
-        }
-        return dwarfSections.getCUIndex(classEntry);
-    }
-
-    protected void setCUIndex(ClassEntry classEntry, int pos) {
-        dwarfSections.setCUIndex(classEntry, pos);
-    }
-
-    protected int getDeoptCUIndex(ClassEntry classEntry) {
-        if (!contentByteArrayCreated()) {
-            return 0;
-        }
-        return dwarfSections.getDeoptCUIndex(classEntry);
-    }
-
-    protected void setDeoptCUIndex(ClassEntry classEntry, int pos) {
-        dwarfSections.setDeoptCUIndex(classEntry, pos);
-    }
-
-    protected int getLineIndex(ClassEntry classEntry) {
-        if (!contentByteArrayCreated()) {
-            return 0;
-        }
-        return dwarfSections.getLineIndex(classEntry);
-    }
-
-    protected void setLineIndex(ClassEntry classEntry, int pos) {
-        dwarfSections.setLineIndex(classEntry, pos);
-    }
-
-    protected int getLineSectionSize(ClassEntry classEntry) {
-        if (!contentByteArrayCreated()) {
-            return 0;
-        }
-        return dwarfSections.getLineSectionSize(classEntry);
-    }
-
-    protected void setLineSectionSize(ClassEntry classEntry, int pos) {
-        dwarfSections.setLineSectionSize(classEntry, pos);
-    }
-
-    protected int getLinePrologueSize(ClassEntry classEntry) {
-        if (!contentByteArrayCreated()) {
-            return 0;
-        }
-        return dwarfSections.getLinePrologueSize(classEntry);
-    }
-
-    protected void setLinePrologueSize(ClassEntry classEntry, int pos) {
-        dwarfSections.setLinePrologueSize(classEntry, pos);
     }
 
     protected int getLayoutIndex(ClassEntry classEntry) {

--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfSectionImpl.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/dwarf/DwarfSectionImpl.java
@@ -847,17 +847,6 @@ public abstract class DwarfSectionImpl extends BasicProgbitsSectionImpl {
         return dwarfSections.getMethodDeclarationIndex(methodEntry);
     }
 
-    protected void setAbstractInlineMethodIndex(MethodEntry methodEntry, int pos) {
-        dwarfSections.setAbstractInlineMethodIndex(methodEntry, pos);
-    }
-
-    protected int getAbstractInlineMethodIndex(MethodEntry methodEntry) {
-        if (!contentByteArrayCreated()) {
-            return 0;
-        }
-        return dwarfSections.getAbstractInlineMethodIndex(methodEntry);
-    }
-
     /**
      * Record the info section offset of a local (or parameter) declaration DIE appearing as a child
      * of a standard method declaration.

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/image/NativeImageDebugInfoProvider.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/image/NativeImageDebugInfoProvider.java
@@ -212,6 +212,11 @@ class NativeImageDebugInfoProvider implements DebugInfoProvider {
     }
 
     @Override
+    public int compiledCodeMax() {
+        return codeCache.getCodeCacheSize();
+    }
+
+    @Override
     public int oopTagsMask() {
         return tagsMask;
     }


### PR DESCRIPTION
This PR reorganizes the DWARF debug info layout so that all info is all contained in a single compile unit (CU) rather than employing a CU for every Java class type.

It profits from that reorganization to achieve several important goals:
 - reduce the overall size of debug info by avoiding replication of DIEs shared by multiple classes
 - reduce the overall size of debug info by omitting unnecessary CU boiler plate
 - decouple compiled method info and definition order from class declaration order, thereby freeing the image builder to order method code ranges without respect to class grouping

The re-implementation also has the benefit that it simplifies many of the DWARF generation steps, both when iterating the generic debug model to write specific debug sections and when cross-indexing location references within and across sections.


