### PR TITLE
[GR-46055] Add Javadocs and reflection registrations for `ServerProvider` and `ClientProvider` in JMX Features

### DIFF
--- a/substratevm/mx.substratevm/suite.py
+++ b/substratevm/mx.substratevm/suite.py
@@ -620,6 +620,13 @@ suite = {
                     "sun.util.locale",
                     "sun.invoke.util",
                 ],
+                "java.management": [
+                    "com.sun.jmx.mbeanserver",
+                    "sun.management",
+                ],
+                "java.rmi": [
+                    "sun.rmi.server",
+                ],
                 "jdk.internal.vm.ci" : [
                     "jdk.vm.ci.meta",
                     "jdk.vm.ci.code",
@@ -633,6 +640,11 @@ suite = {
                 "jdk.jfr": [
                     "jdk.jfr.internal",
                     "jdk.jfr.internal.jfc",
+                ],
+                "java.management.rmi": [
+                    "com.sun.jmx.remote.internal.rmi",
+                    "com.sun.jmx.remote.protocol.rmi",
+                    "javax.management.remote.rmi",
                 ],
             },
             "javaCompliance" : "17+",

--- a/substratevm/mx.substratevm/suite.py
+++ b/substratevm/mx.substratevm/suite.py
@@ -621,11 +621,11 @@ suite = {
                     "sun.invoke.util",
                 ],
                 "java.management": [
-                    "com.sun.jmx.mbeanserver",
-                    "sun.management",
+                    "com.sun.jmx.mbeanserver", # Needed for javadoc links (MXBeanIntrospector,DefaultMXBeanMappingFactory, MXBeanProxy)
+                    "sun.management", # Needed for javadoc links (MappedMXBeanType)
                 ],
                 "java.rmi": [
-                    "sun.rmi.server",
+                    "sun.rmi.server",  # Needed for javadoc links (UnicastRef, UnicastRef2)
                 ],
                 "jdk.internal.vm.ci" : [
                     "jdk.vm.ci.meta",
@@ -642,9 +642,9 @@ suite = {
                     "jdk.jfr.internal.jfc",
                 ],
                 "java.management.rmi": [
-                    "com.sun.jmx.remote.internal.rmi",
-                    "com.sun.jmx.remote.protocol.rmi",
-                    "javax.management.remote.rmi",
+                    "com.sun.jmx.remote.internal.rmi", # Needed for javadoc links (ProxyRef)
+                    "com.sun.jmx.remote.protocol.rmi", # Needed for javadoc links (ClientProvider, ServerProvider)
+                    "javax.management.remote.rmi", # Needed for javadoc links (RMIServer, RMIServerImpl_Stub, RMIConnection, RMIConnectionImpl_Stub)
                 ],
             },
             "javaCompliance" : "17+",

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/jdk/JmxClientFeature.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/jdk/JmxClientFeature.java
@@ -35,6 +35,10 @@ import com.oracle.svm.core.jni.JNIRuntimeAccess;
 import com.oracle.svm.core.util.VMError;
 import com.oracle.svm.util.ReflectionUtil;
 
+import javax.management.remote.JMXServiceURL;
+import java.io.ObjectOutput;
+import java.util.Map;
+
 @AutomaticallyRegisteredFeature
 public class JmxClientFeature extends JNIRegistrationUtil implements InternalFeature {
     @Override
@@ -60,14 +64,13 @@ public class JmxClientFeature extends JNIRegistrationUtil implements InternalFea
     /**
      * This method configures reflection metadata only required by a JMX client.
      * <ul>
-     * <li>Register com.sun.jmx.remote.protocol.rmi.ClientProvider which can be reflectively looked
-     * up on a code path starting from
-     * javax.management.remote.JMXConnectorFactory.newJMXConnectorServer(JMXServiceURL,
-     * Map<String,?>)</li>
-     * <li>Register sun.rmi.server.UnicastRef2, which can be reflectively accessed with
-     * sun.rmi.server.UnicastRef2#getRefClass(ObjectOutput).</li>
-     * <li>Register sun.rmi.server.UnicastRef, which can be reflectively accessed with
-     * sun.rmi.server.UnicastRef#getRefClass(ObjectOutput).</li>
+     * <li>Register {@link com.sun.jmx.remote.protocol.rmi.ClientProvider} which can be reflectively
+     * looked up on a code path starting from
+     * {@link javax.management.remote.JMXConnectorFactory#newJMXConnector(JMXServiceURL, Map)}</li>
+     * <li>Register {@link sun.rmi.server.UnicastRef2}, which can be reflectively accessed with
+     * {@link sun.rmi.server.UnicastRef2#getRefClass(ObjectOutput)}.</li>
+     * <li>Register {@link sun.rmi.server.UnicastRef}, which can be reflectively accessed with
+     * {@link sun.rmi.server.UnicastRef#getRefClass(ObjectOutput)}.</li>
      * </ul>
      */
     private static void configureReflection(BeforeAnalysisAccess access) {

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/jdk/JmxClientFeature.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/jdk/JmxClientFeature.java
@@ -57,6 +57,19 @@ public class JmxClientFeature extends JNIRegistrationUtil implements InternalFea
         JNIRuntimeAccess.register(ReflectionUtil.lookupMethod(Boolean.class, "getBoolean", String.class));
     }
 
+    /**
+     * This method configures reflection metadata only required by a JMX client.
+     * <ul>
+     * <li>Register com.sun.jmx.remote.protocol.rmi.ClientProvider which can be reflectively looked
+     * up on a code path starting from
+     * javax.management.remote.JMXConnectorFactory.newJMXConnectorServer(JMXServiceURL,
+     * Map<String,?>)</li>
+     * <li>Register sun.rmi.server.UnicastRef2, which can be reflectively accessed with
+     * sun.rmi.server.UnicastRef2#getRefClass(ObjectOutput).</li>
+     * <li>Register sun.rmi.server.UnicastRef, which can be reflectively accessed with
+     * sun.rmi.server.UnicastRef#getRefClass(ObjectOutput).</li>
+     * </ul>
+     */
     private static void configureReflection(BeforeAnalysisAccess access) {
         RuntimeReflection.register(access.findClassByName("com.sun.jndi.url.rmi.rmiURLContextFactory"));
         RuntimeReflection.register(access.findClassByName("sun.rmi.server.UnicastRef"));

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/jdk/JmxClientFeature.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/jdk/JmxClientFeature.java
@@ -61,8 +61,10 @@ public class JmxClientFeature extends JNIRegistrationUtil implements InternalFea
         RuntimeReflection.register(access.findClassByName("com.sun.jndi.url.rmi.rmiURLContextFactory"));
         RuntimeReflection.register(access.findClassByName("sun.rmi.server.UnicastRef"));
 
+        RuntimeReflection.register(access.findClassByName("com.sun.jmx.remote.protocol.rmi.ClientProvider"));
         RuntimeReflection.register(access.findClassByName("com.sun.jndi.url.rmi.rmiURLContextFactory").getConstructors());
         RuntimeReflection.register(access.findClassByName("sun.rmi.server.UnicastRef").getConstructors());
         RuntimeReflection.register(access.findClassByName("sun.rmi.server.UnicastRef2").getConstructors());
+        RuntimeReflection.register(access.findClassByName("com.sun.jmx.remote.protocol.rmi.ClientProvider").getConstructors());
     }
 }

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/jdk/JmxCommonFeature.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/jdk/JmxCommonFeature.java
@@ -127,10 +127,8 @@ public class JmxCommonFeature implements InternalFeature {
      * This method handles proxy registrations for PlatformMXBeans. We are able to do the
      * registrations for PlatformMXBeans because they are known and there are a finite number of
      * them. If a user wishes to register a custom standard MBean with the MBeanServer, they will
-     * have to provide their own proxy configuration in a JSON file. This is documented in the
-     * <a href=
-     * "https://www.graalvm.org/dev/reference-manual/native-image/guides/build-and-run-native-executable-with-remote-jmx/">remote
-     * JMX guide</a>.
+     * have to provide their own proxy configuration in a JSON file. This is documented in <a href=
+     * "https://www.graalvm.org/dev/reference-manual/native-image/guides/build-and-run-native-executable-with-remote-jmx/">docs/reference-manual/native-image/guides/build-and-run-native-executable-with-remote-jmx.md</a>.
      * <p>
      * PlatformMXBeans require proxy configuration so that JMX client implementations can use
      * proxies to simplify the client's interaction with MBeans on the server (in a different

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/jdk/JmxCommonFeature.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/jdk/JmxCommonFeature.java
@@ -213,7 +213,9 @@ public class JmxCommonFeature implements InternalFeature {
         };
 
         String[] methods = {
-                        "com.sun.management.GcInfo", "java.lang.management.MemoryUsage", "java.lang.management.MonitorInfo",
+                        "com.sun.management.GcInfo", "java.lang.management.LockInfo",
+                        "java.lang.management.MemoryUsage", "java.lang.management.MonitorInfo",
+                        "java.lang.management.MemoryNotificationInfo",
                         "javax.management.remote.rmi.RMIConnection",
                         "javax.management.remote.rmi.RMIServer",
                         "java.lang.management.ThreadInfo", "jdk.management.jfr.ConfigurationInfo",

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/jdk/JmxCommonFeature.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/jdk/JmxCommonFeature.java
@@ -128,15 +128,16 @@ public class JmxCommonFeature implements InternalFeature {
      * registrations for PlatformMXBeans because they are known and there are a finite number of
      * them. If a user wishes to register a custom standard MBean with the MBeanServer, they will
      * have to provide their own proxy configuration in a JSON file. This is documented in the
-     * remote JMX guide.
-     *
-     * <P>
+     * <a href=
+     * "https://www.graalvm.org/dev/reference-manual/native-image/guides/build-and-run-native-executable-with-remote-jmx/">remote
+     * JMX guide</a>.
+     * <p>
      * PlatformMXBeans require proxy configuration so that JMX client implementations can use
      * proxies to simplify the client's interaction with MBeans on the server (in a different
      * application). Using proxies makes the connection/sending/receiving of data transparent.
-     * </P>
+     * </p>
      *
-     * <P>
+     * <p>
      * Proxy registration also registers the methods of these MXBeans for reflection. This is
      * important because they are accessed in many places in the JMX infrastructure. For example:
      * <ul>
@@ -147,7 +148,7 @@ public class JmxCommonFeature implements InternalFeature {
      * <li>{@link com.sun.jmx.mbeanserver.MXBeanProxy}</li>
      * <li>{@code javax.management.MBeanServerInvocationHandler#isLocal(Object, Method)}</li>
      * </ul>
-     * </P>
+     * </p>
      */
     private static void configureProxy(BeforeAnalysisAccess access) {
         DynamicProxyRegistry dynamicProxySupport = ImageSingletons.lookup(DynamicProxyRegistry.class);

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/jdk/JmxCommonFeature.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/jdk/JmxCommonFeature.java
@@ -127,8 +127,8 @@ public class JmxCommonFeature implements InternalFeature {
      * This method handles proxy registrations for PlatformMXBeans. We are able to do the
      * registrations for PlatformMXBeans because they are known and there are a finite number of
      * them. If a user wishes to register a custom standard MBean with the MBeanServer, they will
-     * have to provide their own proxy configuration in a JSON file. This is documented in the remote
-     * JMX guide.
+     * have to provide their own proxy configuration in a JSON file. This is documented in the
+     * remote JMX guide.
      *
      * <P>
      * PlatformMXBeans require proxy configuration so that JMX client implementations can use

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/jdk/JmxServerFeature.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/jdk/JmxServerFeature.java
@@ -92,11 +92,17 @@ public class JmxServerFeature implements InternalFeature {
         dynamicProxySupport.addProxyClass(access.findClassByName("javax.management.remote.rmi.RMIServer"));
     }
 
+    /**
+     * This method configures reflection metadata only required by a JMX server.
+     * <ul>
+     * <li>Here we register all the custom substrate MXBeans. They won't be accounted for by the
+     * native image tracing agent so a user may not know they need to register them.</li>
+     * <li>We also register com.sun.jmx.remote.protocol.rmi.ServerProvider which can be reflectively
+     * looked up on a code path starting from javax.management.remote.JMXConnectorServerFactory.
+     * newJMXConnectorServer(JMXServiceURL, Map<String,?>, MBeanServer)</li>
+     * </ul>
+     */
     private static void configureReflection(BeforeAnalysisAccess access) {
-        /*
-         * Register all the custom substrate MXBeans. They won't be accounted for by the native
-         * image tracing agent so a user may not know they need to register them.
-         */
         Set<PlatformManagedObject> platformManagedObjects = ManagementSupport.getSingleton().getPlatformManagedObjects();
         for (PlatformManagedObject p : platformManagedObjects) {
 

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/jdk/JmxServerFeature.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/jdk/JmxServerFeature.java
@@ -68,7 +68,7 @@ public class JmxServerFeature implements InternalFeature {
     public void beforeAnalysis(BeforeAnalysisAccess access) {
         handleNativeLibraries(access);
         registerJMXAgentResources();
-        configureReflection();
+        configureReflection(access);
         configureProxy(access);
         RuntimeSupport.getRuntimeSupport().addStartupHook(new ManagementAgentStartupHook());
     }
@@ -92,7 +92,7 @@ public class JmxServerFeature implements InternalFeature {
         dynamicProxySupport.addProxyClass(access.findClassByName("javax.management.remote.rmi.RMIServer"));
     }
 
-    private static void configureReflection() {
+    private static void configureReflection(BeforeAnalysisAccess access) {
         /*
          * Register all the custom substrate MXBeans. They won't be accounted for by the native
          * image tracing agent so a user may not know they need to register them.
@@ -108,5 +108,8 @@ public class JmxServerFeature implements InternalFeature {
             Class<?> clazz = p.getClass();
             RuntimeReflection.register(clazz);
         }
+
+        RuntimeReflection.register(access.findClassByName("com.sun.jmx.remote.protocol.rmi.ServerProvider"));
+        RuntimeReflection.register(access.findClassByName("com.sun.jmx.remote.protocol.rmi.ServerProvider").getConstructors());
     }
 }

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/jdk/JmxServerFeature.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/jdk/JmxServerFeature.java
@@ -99,7 +99,7 @@ public class JmxServerFeature implements InternalFeature {
     /**
      * This method configures reflection metadata only required by a JMX server.
      * <ul>
-     * <li>Here we register all the custom substrate MXBeans. They won't be accounted for by the
+     * <li>Here we register all the custom MXBeans of Substrate VM. They will not be accounted for by the
      * native image tracing agent so a user may not know they need to register them.</li>
      * <li>We also register {@link com.sun.jmx.remote.protocol.rmi.ServerProvider} which can be
      * reflectively looked up on a code path starting from

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/jdk/JmxServerFeature.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/jdk/JmxServerFeature.java
@@ -30,6 +30,7 @@ import com.oracle.svm.core.feature.InternalFeature;
 
 import java.lang.management.PlatformManagedObject;
 
+import java.util.Map;
 import java.util.Set;
 
 import com.oracle.svm.core.jdk.NativeLibrarySupport;
@@ -45,6 +46,9 @@ import com.oracle.svm.core.jdk.management.ManagementAgentStartupHook;
 import com.oracle.svm.core.feature.AutomaticallyRegisteredFeature;
 import com.oracle.svm.core.VMInspectionOptions;
 import com.oracle.svm.core.jdk.management.ManagementSupport;
+
+import javax.management.MBeanServer;
+import javax.management.remote.JMXServiceURL;
 
 @AutomaticallyRegisteredFeature
 public class JmxServerFeature implements InternalFeature {
@@ -97,9 +101,10 @@ public class JmxServerFeature implements InternalFeature {
      * <ul>
      * <li>Here we register all the custom substrate MXBeans. They won't be accounted for by the
      * native image tracing agent so a user may not know they need to register them.</li>
-     * <li>We also register com.sun.jmx.remote.protocol.rmi.ServerProvider which can be reflectively
-     * looked up on a code path starting from javax.management.remote.JMXConnectorServerFactory.
-     * newJMXConnectorServer(JMXServiceURL, Map<String,?>, MBeanServer)</li>
+     * <li>We also register {@link com.sun.jmx.remote.protocol.rmi.ServerProvider} which can be
+     * reflectively looked up on a code path starting from
+     * {@link javax.management.remote.JMXConnectorServerFactory#newJMXConnectorServer(JMXServiceURL, Map, MBeanServer)}
+     * </li>
      * </ul>
      */
     private static void configureReflection(BeforeAnalysisAccess access) {

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/jdk/JmxServerFeature.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/jdk/JmxServerFeature.java
@@ -99,8 +99,8 @@ public class JmxServerFeature implements InternalFeature {
     /**
      * This method configures reflection metadata only required by a JMX server.
      * <ul>
-     * <li>Here we register all the custom MXBeans of Substrate VM. They will not be accounted for by the
-     * native image tracing agent so a user may not know they need to register them.</li>
+     * <li>Here we register all the custom MXBeans of Substrate VM. They will not be accounted for
+     * by the native image tracing agent so a user may not know they need to register them.</li>
      * <li>We also register {@link com.sun.jmx.remote.protocol.rmi.ServerProvider} which can be
      * reflectively looked up on a code path starting from
      * {@link javax.management.remote.JMXConnectorServerFactory#newJMXConnectorServer(JMXServiceURL, Map, MBeanServer)}


### PR DESCRIPTION
This adds reflection configuration for `com.sun.jmx.remote.protocol.rmi.ClientProvider` and `com.sun.jmx.remote.protocol.rmi.ServerProvider`.

When the JMX mbean server is set up to  accept remote connections, [`JMXConnectorServerFactory.newJMXConnectorServer`](https://github.com/openjdk/jdk/blob/master/src/java.management/share/classes/javax/management/remote/JMXConnectorServerFactory.java#L275) is called, which eventually can result in a call to `Class.forName()` with `com.sun.jmx.remote.protocol.rmi.ServerProvider`.

A similar path starting from [`JMXConnectorFactory.newJMXConnector`](https://github.com/openjdk/jdk/blob/master/src/java.management/share/classes/javax/management/remote/JMXConnectorFactory.java#L327) can lead to requiring reflection metadata for `com.sun.jmx.remote.protocol.rmi.ClientProvider`.

Edit: Added reflection registration for methods of `java.lang.management.MemoryNotificationInfo` and `java.lang.management.LockInfo`. These are necessary for the same reason `java.lang.management.ThreadInfo,com.sun.management.GcInfo`,` java.lang.management.MonitorInfo`, `java.lang.management.MemoryUsage` are necessary (these already exist in the reflection configuration).  “Info” classes have their methods reflectively accessed from their static “from” methods.  Remote JMX infrastructure uses the following pattern: the "info" classes have a corresponding "CompositeData" class which is used to construct them [using the static "from" method](https://github.com/openjdk/jdk/blob/master/src/java.management/share/classes/sun/management/MappedMXBeanType.java#L622). (ie. `SomeInfo` → `SomeInfoCompositeData` extends `LazyCompositeData`).  I have not yet seen runtime errors related to these specific classes requiring  reflection registration (and the tracing agent has not suggested them), but based on the pattern JMX uses, it would be conservative to include them. Adding/omitting these registrations does not seem to make a difference in image size anyway.  

Edit: Added some java docs to try to document why certain classes need to be registered.

These additional reflection registrations should be backported to the GraalVM 23 release branch. 