### PR TITLE
URLConnection.getContentType() returns null for html resource

### DIFF
--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/resources/ResourceURLConnection.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/resources/ResourceURLConnection.java
@@ -38,6 +38,8 @@ import com.oracle.svm.core.jdk.Resources;
 
 public final class ResourceURLConnection extends URLConnection {
 
+    private static final String CONTENT_TYPE = "content-type";
+
     private byte[] data;
 
     public ResourceURLConnection(URL url) {
@@ -115,5 +117,13 @@ public final class ResourceURLConnection extends URLConnection {
          */
         connect();
         return Resources.singleton().getLastModifiedTime();
+    }
+
+    @Override
+    public String getHeaderField(String name) {
+        if (CONTENT_TYPE.equalsIgnoreCase(name)) {
+            return guessContentTypeFromName(url.getPath());
+        }
+        return super.getHeaderField(name);
     }
 }

--- a/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/NativeImageResourceTest.java
+++ b/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/NativeImageResourceTest.java
@@ -28,6 +28,7 @@ package com.oracle.svm.test;
 import static com.oracle.svm.test.NativeImageResourceUtils.RESOURCE_DIR;
 import static com.oracle.svm.test.NativeImageResourceUtils.RESOURCE_FILE_1;
 import static com.oracle.svm.test.NativeImageResourceUtils.RESOURCE_FILE_2;
+import static com.oracle.svm.test.NativeImageResourceUtils.RESOURCE_FILE_3;
 import static com.oracle.svm.test.NativeImageResourceUtils.compareTwoURLs;
 import static com.oracle.svm.test.NativeImageResourceUtils.resourceNameToURL;
 
@@ -35,6 +36,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.net.URLConnection;
 import java.util.Enumeration;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -183,6 +185,39 @@ public class NativeImageResourceTest {
             Assert.assertNotNull("InputStream for resource java.base/java/lang/uniName.dat must not be null", in2);
         } catch (IOException e) {
             Assert.fail("IOException in module.getResourceAsStream(): " + e.getMessage());
+        }
+    }
+
+    /**
+     * <p>
+     * Check URLConnection content type.
+     * </p>
+     *
+     * <p>
+     * <b>Description: </b> Test inspired by issues: </br>
+     * <ol>
+     * <li><a href="https://github.com/oracle/graal/issues/6394">6394</a></li>
+     * </ol>
+     * </p>
+     */
+    @Test
+    public void testResourceURLConnectionContentType() {
+        try {
+            URL url2 = resourceNameToURL(RESOURCE_FILE_2, true);
+            URLConnection conn2 = url2.openConnection();
+            Assert.assertEquals(null, conn2.getHeaderField(null));
+            Assert.assertEquals("text/plain", conn2.getHeaderField("content-type"));
+            Assert.assertEquals("text/plain", conn2.getHeaderField("Content-Type"));
+            Assert.assertEquals("text/plain", conn2.getContentType());
+
+            URL url3 = resourceNameToURL(RESOURCE_FILE_3, true);
+            URLConnection conn3 = url3.openConnection();
+            Assert.assertEquals(null, conn3.getHeaderField(null));
+            Assert.assertEquals("text/html", conn3.getHeaderField("content-type"));
+            Assert.assertEquals("text/html", conn3.getHeaderField("Content-Type"));
+            Assert.assertEquals("text/html", conn3.getContentType());
+        } catch (IOException e) {
+            Assert.fail("IOException in url.openConnection(): " + e.getMessage());
         }
     }
 }

--- a/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/NativeImageResourceUtils.java
+++ b/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/NativeImageResourceUtils.java
@@ -44,6 +44,7 @@ public class NativeImageResourceUtils {
     public static final String RESOURCE_DIR = "/resources";
     public static final String RESOURCE_FILE_1 = RESOURCE_DIR + "/resource-test1.txt";
     public static final String RESOURCE_FILE_2 = RESOURCE_DIR + "/resource-test2.txt";
+    public static final String RESOURCE_FILE_3 = RESOURCE_DIR + "/resource-test3.html";
 
     // Register resources.
     public static final class TestFeature implements Feature {
@@ -54,6 +55,7 @@ public class NativeImageResourceUtils {
             RuntimeResourceAccess.addResource(resourceModule, RESOURCE_DIR.substring(1));
             RuntimeResourceAccess.addResource(resourceModule, RESOURCE_FILE_1.substring(1));
             RuntimeResourceAccess.addResource(resourceModule, RESOURCE_FILE_2.substring(1));
+            RuntimeResourceAccess.addResource(resourceModule, RESOURCE_FILE_3.substring(1));
 
             /** Needed for {@link #testURLExternalFormEquivalence()} */
             for (Module module : ModuleLayer.boot().modules()) {

--- a/substratevm/src/com.oracle.svm.test/src/resources/resource-test3.html
+++ b/substratevm/src/com.oracle.svm.test/src/resources/resource-test3.html
@@ -1,0 +1,1 @@
+<html> HTML Text </html>


### PR DESCRIPTION
This is a fix for the #6394 `URLConnection.getContentType() returns null for html resource`

`ResourceURLConnection` extends `URLConnection` but does not override `getHeaderField(String name)` which implementation always returns `null`.

The proposed fix overrides `getHeaderField(String name)` method and for the `content-type` name returns `guessContentTypeFromName()` with the url path as argument.