### PR TITLE
Implement containerized native image building for native image bundles

### DIFF
--- a/docs/reference-manual/native-image/Bundles.md
+++ b/docs/reference-manual/native-image/Bundles.md
@@ -225,8 +225,10 @@ The full option help of `--bundle-apply` shows a more advanced use case that wil
 Another addition to the `--bundle-create` and `--bundle-apply` options, as mentioned above, is to perform image building inside a container image.
 This ensures that during the image build `native-image` can not access any resources that were not explicitly specified via the classpath or module path.
 Modify the `--bundle-create` argument in the `native-maven-plugin` configuration to `<buildArg>--bundle-create,container<buildArg>`.
-This still creates the same bundle as before. However, a container image is built and then used for building the native image executable.
-If the container image is newly created, you can also see the build output from the container tool. The name of the container image is the hash of the used Dockerfile.
+This still creates the same bundle as before. 
+However, a container image is built and then used for building the native image executable.
+If the container image is newly created, you can also see the build output from the container tool. 
+The name of the container image is the hash of the used Dockerfile.
 If the container image already exists you will see the following line in the build output instead:
 
 ```shell
@@ -234,9 +236,11 @@ Native Image Bundles: Reusing container image c253ca50f50b380da0e23b168349271976
 ```
 
 For building in a container you require either _podman_ or _rootless docker_ to be available on your system.
-Additionally, building in a container is currently only supported for Linux, if using any other OS native image will not create and use a container image.
+Additionally, building in a container is currently only supported for Linux.
+Using any other OS native image will not create and use a container image.
 The container tool used for running the image build can be specified with `<buildArg>--bundle-create,container=podman<buildArg>` or `<buildArg>--bundle-create,container=docker<buildArg>`.
-If not specified, `native-image` uses one of the supported tools. If available, `podman` is preferred and rootless `docker` is the fallback.
+If not specified, `native-image` uses one of the supported tools. 
+If available, `podman` is preferred and rootless `docker` is the fallback.
 
 The Dockerfile used to build the container image may also be explicitly specified with `--bundle-create,container,dockerfile=<path-to-dockerfile>`.
 If no Dockerfile was specified, a default Dockerfile is used, which is based on the Oracle Linux 8 container images for GraalVM from [here](https://github.com/graalvm/container).
@@ -412,12 +416,12 @@ where options include:
 Running the bundled application with the `--with-native-image-agent` argument requires a `native-image-agent` library to be available.
 The output of the `native-image-agent` is written to _<bundle-name>.output/launcher/META-INF/native-image/<bundle-name>-agent_.
 If native image agents output should be inserted into the bundle with `,update-bundle`, the launcher then also requires `native-image`.
-The `update-bundle` option makes executes the command `native-image --bundle-apply=<bundle-name>.nib --bundle-create=<bundle-name>.nib -cp <bundle-name>.output/launcher` after executing the bundled application with the `native-image-agent` attached.
+The `update-bundle` option executes the command `native-image --bundle-apply=<bundle-name>.nib --bundle-create=<bundle-name>.nib -cp <bundle-name>.output/launcher` after executing the bundled application with the `native-image-agent` attached.
 
 The `container` option realizes a similar behavior to [containerized image builds](#building-in-a-container).
 However, the only exception is that in this case the application is executed inside the container instead of `native-image`.
 Every bundle contains a Dockerfile which is used for executing the bundled application in a container.
-However, this Dockerfile can be overwritten by adding `,dockerile=<path-to-dockerfile>` to the `--container` argument.
+However, this Dockerfile can be overwritten by adding `,dockerfile=<path-to-dockerfile>` to the `--container` argument.
 
 The bundle launcher only consumes options it knows, all other arguments are passed on to the bundled application.
 If the bundle launcher parses ` -- ` without a specified option, the launcher stops parsing arguments.

--- a/docs/reference-manual/native-image/Bundles.md
+++ b/docs/reference-manual/native-image/Bundles.md
@@ -22,6 +22,7 @@ Using Native Image bundles is a safe solution to encapsulate all this input requ
 * [Building with Bundles](#building-with-bundles)
 * [Environment Variables](#capturing-environment-variables)
 * [Creating New Bundles from Existing Bundles](#combining---bundle-create-and---bundle-apply)
+* [Executing the bundled application](#executing-the-bundled-application)
 * [Bundle File Format](#bundle-file-format)
 
 ## Creating Bundles
@@ -31,13 +32,19 @@ This will cause `native-image` to create a _*.nib_ file in addition to the actua
 
 Here is the option description:
 ```
---bundle-create[=new-bundle.nib]
+--bundle-create[=new-bundle.nib][,dry-run][,container[=<container-tool>][,dockerfile=<Dockerfile>]]
                       in addition to image building, create a Native Image bundle file (*.nib
                       file) that allows rebuilding of that image again at a later point. If a
                       bundle-file gets passed, the bundle will be created with the given
                       name. Otherwise, the bundle-file name is derived from the image name.
-                      Note both bundle options can be combined with --dry-run to only perform
-                      the bundle operations without any actual image building.
+                      Note both bundle options can be extended with ",dry-run" and ",container"
+                      * 'dry-run': only perform the bundle operations without any actual image building.
+                      * 'container': sets up a container image for image building and performs image building
+                        from inside that container. Requires podman or rootless docker to be installed.
+                        If available, 'podman' is preferred and rootless 'docker' is the fallback. Specifying
+                        one or the other as '=<container-tool>' forces the use of a specific tool.
+                      * 'dockerfile=<Dockerfile>': Use a user provided 'Dockerfile' instead of the default based on
+                        Oracle Linux 8 base images for GraalVM (see https://github.com/graalvm/container)
 ```
 
 For example, assuming a Micronaut application is built with Maven, make sure the `--bundle-create` option is used.
@@ -82,6 +89,18 @@ $ jar tf micronautguide.nib
 META-INF/MANIFEST.MF
 META-INF/nibundle.properties
 output/default/micronautguide
+com/oracle/svm/driver/launcher/BundleLauncherUtil.class
+com/oracle/svm/driver/launcher/ContainerSupport$TargetPath.class
+com/oracle/svm/driver/launcher/BundleLauncherHelp.txt
+com/oracle/svm/driver/launcher/BundleLauncher.class
+com/oracle/svm/driver/launcher/configuration/BundleConfigurationParser.class
+com/oracle/svm/driver/launcher/configuration/BundleEnvironmentParser.class
+com/oracle/svm/driver/launcher/configuration/BundleArgsParser.class
+com/oracle/svm/driver/launcher/configuration/BundlePathMapParser.class
+com/oracle/svm/driver/launcher/configuration/BundleContainerSettingsParser.class
+com/oracle/svm/driver/launcher/ContainerSupport.class
+com/oracle/svm/driver/launcher/json/BundleJSONParser.class
+com/oracle/svm/driver/launcher/json/BundleJSONParserException.class
 input/classes/cp/micronaut-core-3.8.7.jar
 input/classes/cp/netty-buffer-4.1.87.Final.jar
 input/classes/cp/jackson-databind-2.14.1.jar
@@ -93,10 +112,12 @@ input/classes/cp/micronaut-jdbc-4.7.2.jar
 input/classes/cp/jackson-core-2.14.0.jar
 input/classes/cp/micronaut-runtime-3.8.7.jar
 input/classes/cp/micronautguide-0.1.jar
-input/stage/build.json
-input/stage/environment.json
 input/stage/path_substitutions.json
 input/stage/path_canonicalizations.json
+input/stage/build.json
+input/stage/run.json
+input/stage/environment.json
+input/stage/Dockerfile
 ```
 
 As you can see, a bundle is just a JAR file with a specific layout.
@@ -113,11 +134,11 @@ target/micronautguide.output
 └── other
 ```
 
-### Combining --bundle-create with --dry-run
+### Combining --bundle-create with dry-run
 
 As mentioned in the `--bundle-create` option description, it is also possible to let `native-image` build a bundle but not actually perform the image building.
 This might be useful if a user wants to move the bundle to a more powerful machine and build the image there.
-Modify the above `native-maven-plugin` configuration to also contain the argument `<buildArg>--dry-run</buildArg>`. 
+Modify the `--bundle-create` argument in the `native-maven-plugin` configuration above to `<buildArg>--bundle-create,dry-run</buildArg>`.
 Then running `./mvnw package -Dpackaging=native-image` takes only seconds and the created bundle is much smaller: 
 ```
 Native Image Bundles: Bundle written to /home/testuser/micronaut-data-jdbc-repository-maven-java/target/micronautguide.nib
@@ -147,7 +168,7 @@ Since no executable is created, no bundle build output is available.
 
 ## Building with Bundles
 
-Assuming that the native executable is used in production and once in a while an unexpected exception is thrown at run time.
+Assuming that the native executable is used in production and once in a while, an unexpected exception is thrown at run time.
 Since you still have the bundle that was used to create the executable, it is trivial to build a variant of that executable with debugging support.
 Use `--bundle-apply=micronautguide.nib` like this:
 ```shell
@@ -186,24 +207,83 @@ You successfully rebuilt the application from the bundle with debug info enabled
 
 The full option help of `--bundle-apply` shows a more advanced use case that will be discussed [later](#combining---bundle-create-and---bundle-apply) in detail:
 ```
---bundle-apply=some-bundle.nib
+--bundle-apply=some-bundle.nib[,dry-run][,container[=<container-tool>][,dockerfile=<Dockerfile>]]
                       an image will be built from the given bundle file with the exact same
                       arguments and files that have been passed to native-image originally
                       to create the bundle. Note that if an extra --bundle-create gets passed
                       after --bundle-apply, a new bundle will be written based on the given
-                      bundle args plus any additional arguments that haven been passed
+                      bundle args plus any additional arguments that have been passed
                       afterwards. For example:
                       > native-image --bundle-apply=app.nib --bundle-create=app_dbg.nib -g
                       creates a new bundle app_dbg.nib based on the given app.nib bundle.
                       Both bundles are the same except the new one also uses the -g option.
 ```
 
+
+### Building in a Container
+
+Another addition to the `--bundle-create` and `--bundle-apply` options, as mentioned above, is to perform image building inside a container image.
+This ensures that during the image build `native-image` can not access any resources that were not explicitly specified via the classpath or module path.
+Modify the `--bundle-create` argument in the `native-maven-plugin` configuration to `<buildArg>--bundle-create,container<buildArg>`.
+This still creates the same bundle as before. However, a container image is built and then used for building the native image executable.
+If the container image is newly created, you can also see the build output from the container tool. The name of the container image is the hash of the used Dockerfile.
+If the container image already exists you will see the following line in the build output instead:
+
+```shell
+Native Image Bundles: Reusing container image c253ca50f50b380da0e23b168349271976d57e4e.
+```
+
+For building in a container you require either _podman_ or _rootless docker_ to be available on your system.
+Additionally, building in a container is currently only supported for Linux, if using any other OS native image will not create and use a container image.
+The container tool used for running the image build can be specified with `<buildArg>--bundle-create,container=podman<buildArg>` or `<buildArg>--bundle-create,container=docker<buildArg>`.
+If not specified, `native-image` uses one of the supported tools. If available, `podman` is preferred and rootless `docker` is the fallback.
+
+The Dockerfile used to build the container image may also be explicitly specified with `--bundle-create,container,dockerfile=<path-to-dockerfile>`.
+If no Dockerfile was specified, a default Dockerfile is used, which is based on the Oracle Linux 8 container images for GraalVM from [here](https://github.com/graalvm/container).
+Whichever Dockerfile is finally used to build the container image is stored in the bundle.
+Even if you do not use the `container` option, `native-image` creates a Dockerfile and stores it in the bundle.
+
+Other than creating a container image on the host system, building inside a container does not create any additional build output.
+However, the created bundle contains some additional files:
+```shell
+$ jar tf micronautguide.nib
+META-INF/MANIFEST.MF
+META-INF/nibundle.properties
+...
+input/classes/cp/micronaut-management-3.8.7.jar
+input/stage/path_substitutions.json
+input/stage/path_canonicalizations.json
+input/stage/build.json
+input/stage/run.json
+input/stage/environment.json
+input/stage/Dockerfile
+input/stage/container.json
+```
+The bundle contains the Dockerfile used for building the container image and stores the used container tool, its version and the name of the container image in `container.json`:
+```json
+{
+    "containerTool":"podman",
+    "containerToolVersion":"podman version 3.4.4",
+    "containerImage":"c253ca50f50b380da0e23b168349271976d57e4e"
+}
+```
+
+The `container` option may also be combined with `dry-run`, in this case `native-image` does neither create an executable nor a container image.
+It does not even check if the selected container tool is available.
+In this case, _container.json_ is omitted, or, if you explicitly specified a container tool, just contains the _containerTool_ field without any additional information.
+
+Containerized builds are sticky, which means that if a bundle was created with `--bundle-create,container` the bundle is marked as a container build.
+If you now use `--bundle-apply` with this bundle, it is automatically built in a container again.
+However, this does not apply to [executing a bundle](#executing-the-bundled-application), a bundled application is still executed outside a container by default.
+
+The extended command line interface for containerized builds is shown in the option help texts for `--bundle-create` and `--bundle-apply` above.
+
 ## Capturing Environment Variables
 
 Before bundle support was added, all environment variables were visible to the  `native-image` builder.
 This approach does not work well with bundles and is problematic for image building without bundles.
 Consider having an environment variable that holds sensitive information from your build machine.
-Due to Native Image's ability to run code at build time that can create data to be available at run time, it is very easy to build an image were you accidentally leak the contents of such variables.
+Due to Native Image's ability to run code at build time that can create data to be available at run time, it is very easy to build an image where you accidentally leak the contents of such variables.
 
 Passing environment variables to `native-image` now requires explicit arguments.
 
@@ -252,7 +332,7 @@ $ ls -lh  *.iprof
 The file `default.iprof` contains the profiling information that was created because you ran the Micronaut application from the executable built with `--pgo-instrument`.
 Now you can create a new optimized bundle out of the existing one:
 ```shell
-native-image --bundle-apply=micronautguide.nib --bundle-create=micronautguide-pgo-optimized.nib --dry-run --pgo
+native-image --bundle-apply=micronautguide.nib --bundle-create=micronautguide-pgo-optimized.nib,dry-run --pgo
 ```
 
 Now take a look how _micronautguide-pgo-optimized.nib_ is different from _micronautguide.nib_:
@@ -297,6 +377,52 @@ $ native-image --bundle-apply=micronautguide-pgo-optimized.nib
 ...
 ```
 
+## Executing the bundled application
+
+As described later in [Bundle File Format](#bundle-file-format), a bundle file is a JAR file with a contained launcher for launching the bundled application.
+This means you can use a native image bundle with any JDK and execute it as a JAR file with `<jdk>/bin/java -jar [bundle-file.nib]`.
+The launcher uses the command line arguments stored in _run.json_ and adds all JAR files and folders in _input/classes/cp_ and _input/classes/p_ to the classpath and module path respectively.
+
+The launcher also comes with a separate command line interface described in its help text:
+```
+This native image bundle can be used to launch the bundled application.
+
+Usage: java -jar bundle-file [options] [bundle-application-options]
+
+where options include:
+
+    --with-native-image-agent[,update-bundle[=<new-bundle-name>]]
+                runs the application with a native-image-agent attached
+                'update-bundle' adds the agents output to the bundle-files classpath.
+                '=<new-bundle-name>' creates a new bundle with the agent output instead.
+                Note 'update-bundle' requires native-image to be installed
+
+    --container[=<container-tool>][,dockerfile=<Dockerfile>]
+                sets up a container image for execution and executes the bundled application
+                from inside that container. Requires podman or rootless docker to be installed.
+                If available, 'podman' is preferred and rootless 'docker' is the fallback. Specifying
+                one or the other as '=<container-tool>' forces the use of a specific tool.
+                'dockerfile=<Dockerfile>': Use a user provided 'Dockerfile' instead of the Dockerfile
+                bundled with the application
+
+    --verbose   enable verbose output
+    --help      print this help message
+```
+
+Running the bundled application with the `--with-native-image-agent` argument requires a `native-image-agent` library to be available.
+The output of the `native-image-agent` is written to _<bundle-name>.output/launcher/META-INF/native-image/<bundle-name>-agent_.
+If native image agents output should be inserted into the bundle with `,update-bundle`, the launcher then also requires `native-image`.
+The `update-bundle` option makes executes the command `native-image --bundle-apply=<bundle-name>.nib --bundle-create=<bundle-name>.nib -cp <bundle-name>.output/launcher` after executing the bundled application with the `native-image-agent` attached.
+
+The `container` option realizes a similar behavior to [containerized image builds](#building-in-a-container).
+However, the only exception is that in this case the application is executed inside the container instead of `native-image`.
+Every bundle contains a Dockerfile which is used for executing the bundled application in a container.
+However, this Dockerfile can be overwritten by adding `,dockerile=<path-to-dockerfile>` to the `--container` argument.
+
+The bundle launcher only consumes options it knows, all other arguments are passed on to the bundled application.
+If the bundle launcher parses ` -- ` without a specified option, the launcher stops parsing arguments.
+All remaining arguments are then also passed on to the bundled application.
+
 ## Bundle File Format
 
 A bundle file is a JAR file with a well-defined internal layout.
@@ -310,6 +436,7 @@ Inside a bundle you can find the following inner structure:
 │                              * Bundle format version (BundleFileVersion{Major,Minor})
 │                              * Platform and architecture the bundle was created on 
 │                              * GraalVM / Native-image version used for bundle creation
+├── com.oracle.svm.driver.launcher <- launcher for executing the bundled application
 ├── input <- All information required to rebuild the image
 │   ├── auxiliary <- Contains auxiliary files passed to native-image via arguments
 │   │                (e.g. external `config-*.json` files or PGO `*.iprof`-files)
@@ -318,11 +445,16 @@ Inside a bundle you can find the following inner structure:
 │   │   └── p
 │   └── stage
 │       ├── build.json          <- Full native-image command line (minus --bundle options)
+│       ├── container.json            <- Containerization tool, tool version and container
+│       │                                image name (not available information is omitted)
+│       ├── Dockerfile                 <- Dockerfile used for building the container image
 │       ├── environment.json              <- Environment variables used in the image build
 │       ├── path_canonicalizations.json  <- Record of path-canonicalizations that happened
-│       │                                       during bundle creation for the input files  
-│       └── path_substitutions.json          <- Record of path-substitutions that happened
-│                                               during bundle creation for the input files
+│       │                                       during bundle creation for the input files
+│       ├── path_substitutions.json          <- Record of path-substitutions that happened
+│       │                                       during bundle creation for the input files                                        
+│       └── run.json            <- Full command line for executing the bundled application
+│                                                        (minus classpath and module path)
 └── output
     ├── default
     │   ├── myimage         <- Created image and other output created by the image builder 
@@ -355,12 +487,12 @@ These include:
 * `--dry-run`
 
 The state of environment variables that are relevant for the build are captured in _input/stage/environment.json_.
-For every `-E` argument that were seen when the bundle was created, a snapshot of its key-value pair is recorded in the file.
+For every `-E` argument that was seen when the bundle was created, a snapshot of its key-value pair is recorded in the file.
 The remaining files _path_canonicalizations.json_ and _path_substitutions.json_ contain a record of the file-path transformations that were performed by the `native-image` tool based on the input file paths as specified by the original command line arguments.
 
 ### output
 
-If a native executable is built as part of building the bundle (for example, the `--dry-run` option was not used), you also have an _output_ directory in the bundle.
+If a native executable is built as part of building the bundle (for example, the `,dry-run` option was not used), you also have an _output_ directory in the bundle.
 It contains the executable that was built along with any other files that were generated as part of building.
 Most output files are located in the directory _output/default_ (the executable, its debug info, and debug sources).
 Builder output files, that would have been written to arbitrary absolute paths if the executable had not been built in the bundle mode, can be found in _output/other_.

--- a/substratevm/CHANGELOG.md
+++ b/substratevm/CHANGELOG.md
@@ -16,6 +16,8 @@ This changelog summarizes major changes to GraalVM Native Image.
 * (GR-46740) Add support for foreign downcalls (part of "Project Panama") on the AMD64 platform.
 * (GR-27034) Add `-H:ImageBuildID` option to generate Image Build ID, which is a 128-bit UUID string generated randomly, once per bundle or digest of input args when bundles are not used.
 * (GR-47647) Add `-H:±UnlockExperimentalVMOptions` for unlocking access to experimental options similar to HotSpot's `-XX:UnlockExperimentalVMOptions`. Explicit unlocking will be required in a future release, which can be tested with the env setting `NATIVE_IMAGE_EXPERIMENTAL_OPTIONS_ARE_FATAL=true`. For more details, see [issue #7105](https://github.com/oracle/graal/issues/7105).
+* (GR-43920) Add support for executing native image bundles as jar files with extra options `--with-native-image-agent` and `--container`.
+* (GR-43920) Add `,container[=<container-tool>]`, `,dockerfile=<dockerfile>` and `,dry-run` options to `--bundle-create`and `--bundle-apply`.
 
 ## GraalVM for JDK 17 and GraalVM for JDK 20 (Internal Version 23.0.0)
 * (GR-40187) Report invalid use of SVM specific classes on image class- or module-path as error. As a temporary workaround, `-H:+AllowDeprecatedBuilderClassesOnImageClasspath` allows turning the error into a warning.

--- a/substratevm/mx.substratevm/mx_substratevm.py
+++ b/substratevm/mx.substratevm/mx_substratevm.py
@@ -1016,6 +1016,7 @@ driver_build_args = [
     '--features=com.oracle.svm.driver.APIOptionFeature',
     '--initialize-at-build-time=com.oracle.svm.driver',
     '--link-at-build-time=com.oracle.svm.driver,com.oracle.svm.driver.metainf',
+    '-H:IncludeResources=com/oracle/svm/driver/launcher/.*',
 ] + svm_experimental_options([
     '-H:-ParseRuntimeOptions',
 ])
@@ -1056,9 +1057,7 @@ mx_sdk_vm.register_graalvm_component(mx_sdk_vm.GraalVmJreComponent(
             destination="bin/<exe:native-image>",
             jar_distributions=["substratevm:SVM_DRIVER"],
             main_class=_native_image_launcher_main_class(),
-            build_args=driver_build_args + [
-                '-H:IncludeResources=com/oracle/svm/driver/launcher/.*',
-            ],
+            build_args=driver_build_args,
             extra_jvm_args=_native_image_launcher_extra_jvm_args(),
             home_finder=False,
         ),

--- a/substratevm/mx.substratevm/mx_substratevm.py
+++ b/substratevm/mx.substratevm/mx_substratevm.py
@@ -1056,7 +1056,9 @@ mx_sdk_vm.register_graalvm_component(mx_sdk_vm.GraalVmJreComponent(
             destination="bin/<exe:native-image>",
             jar_distributions=["substratevm:SVM_DRIVER"],
             main_class=_native_image_launcher_main_class(),
-            build_args=driver_build_args,
+            build_args=driver_build_args + [
+                '-H:IncludeResources=com/oracle/svm/driver/launcher/.*',
+            ],
             extra_jvm_args=_native_image_launcher_extra_jvm_args(),
             home_finder=False,
         ),

--- a/substratevm/mx.substratevm/suite.py
+++ b/substratevm/mx.substratevm/suite.py
@@ -842,9 +842,26 @@ suite = {
             ],
             "dependencies": [
                 "com.oracle.svm.hosted",
+                "com.oracle.svm.driver.launcher",
             ],
             "requires" : [
                 "jdk.management",
+            ],
+            "checkstyle": "com.oracle.svm.hosted",
+            "workingSets": "SVM",
+            "annotationProcessors": [
+                "compiler:GRAAL_PROCESSOR",
+                "SVM_PROCESSOR",
+            ],
+            "javaCompliance" : "17+",
+            "spotbugs": "false",
+            "jacoco" : "exclude",
+        },
+
+        "com.oracle.svm.driver.launcher": {
+            "subDir": "src",
+            "sourceDirs": [
+                "src"
             ],
             "checkstyle": "com.oracle.svm.hosted",
             "workingSets": "SVM",
@@ -1690,6 +1707,7 @@ suite = {
             "mainClass": "com.oracle.svm.driver.NativeImage",
             "dependencies": [
                 "com.oracle.svm.driver",
+                "com.oracle.svm.driver.launcher",
                 "svm-compiler-flags-builder",
             ],
             "distDependencies": [

--- a/substratevm/mx.substratevm/suite.py
+++ b/substratevm/mx.substratevm/suite.py
@@ -861,7 +861,8 @@ suite = {
         "com.oracle.svm.driver.launcher": {
             "subDir": "src",
             "sourceDirs": [
-                "src"
+                "src",
+                "resources"
             ],
             "checkstyle": "com.oracle.svm.hosted",
             "workingSets": "SVM",

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/NativeImageClassLoaderOptions.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/NativeImageClassLoaderOptions.java
@@ -35,12 +35,12 @@ public class NativeImageClassLoaderOptions {
 
     public static final String AddReadsFormat = "<module>=<target-module>(,<target-module>)*";
 
-    @APIOption(name = "add-exports", extra = true, valueSeparator = {APIOption.WHITESPACE_SEPARATOR, '='})//
+    @APIOption(name = "add-exports", extra = true, launcherOption = true, valueSeparator = {APIOption.WHITESPACE_SEPARATOR, '='})//
     @Option(help = "Value " + AddExportsAndOpensFormat + " updates <module> to export <package> to <target-module>, regardless of module declaration." +
                     " <target-module> can be ALL-UNNAMED to export to all unnamed modules.")//
     public static final HostedOptionKey<LocatableMultiOptionValue.Strings> AddExports = new HostedOptionKey<>(LocatableMultiOptionValue.Strings.build());
 
-    @APIOption(name = "add-opens", extra = true, valueSeparator = {APIOption.WHITESPACE_SEPARATOR, '='})//
+    @APIOption(name = "add-opens", extra = true, launcherOption = true, valueSeparator = {APIOption.WHITESPACE_SEPARATOR, '='})//
     @Option(help = "Value " + AddExportsAndOpensFormat + " updates <module> to open <package> to <target-module>, regardless of module declaration.")//
     public static final HostedOptionKey<LocatableMultiOptionValue.Strings> AddOpens = new HostedOptionKey<>(LocatableMultiOptionValue.Strings.build());
 

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/RuntimeAssertionsSupport.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/RuntimeAssertionsSupport.java
@@ -91,15 +91,15 @@ public final class RuntimeAssertionsSupport {
 
         private static final char VALUE_SEPARATOR = ':';
 
-        @APIOption(name = {"-ea", "-enableassertions"}, valueSeparator = VALUE_SEPARATOR, valueTransformer = RuntimeAssertionsOptionTransformer.Enable.class, defaultValue = "", //
+        @APIOption(name = {"-ea", "-enableassertions"}, launcherOption = true, valueSeparator = VALUE_SEPARATOR, valueTransformer = RuntimeAssertionsOptionTransformer.Enable.class, defaultValue = "", //
                         customHelp = "also -ea[:[packagename]...|:classname] or -enableassertions[:[packagename]...|:classname]. Enable assertions with specified granularity at run time.")//
-        @APIOption(name = {"-da", "-disableassertions"}, valueSeparator = VALUE_SEPARATOR, valueTransformer = RuntimeAssertionsOptionTransformer.Disable.class, defaultValue = "", //
+        @APIOption(name = {"-da", "-disableassertions"}, launcherOption = true, valueSeparator = VALUE_SEPARATOR, valueTransformer = RuntimeAssertionsOptionTransformer.Disable.class, defaultValue = "", //
                         customHelp = "also -da[:[packagename]...|:classname] or -disableassertions[:[packagename]...|:classname]. Disable assertions with specified granularity at run time.")//
         @Option(help = "Enable or disable Java assert statements at run time") //
         public static final HostedOptionKey<LocatableMultiOptionValue.Strings> RuntimeAssertions = new HostedOptionKey<>(LocatableMultiOptionValue.Strings.build());
 
-        @APIOption(name = {"-esa", "-enablesystemassertions"}, customHelp = "also -enablesystemassertions. Enables assertions in all system classes at run time.") //
-        @APIOption(name = {"-dsa", "-disablesystemassertions"}, kind = APIOption.APIOptionKind.Negated, //
+        @APIOption(name = {"-esa", "-enablesystemassertions"}, launcherOption = true, customHelp = "also -enablesystemassertions. Enables assertions in all system classes at run time.") //
+        @APIOption(name = {"-dsa", "-disablesystemassertions"}, launcherOption = true, kind = APIOption.APIOptionKind.Negated, //
                         customHelp = "also -disablesystemassertions. Disables assertions in all system classes at run time.") //
         @Option(help = "Enable or disable Java system assertions at run time") //
         public static final HostedOptionKey<Boolean> RuntimeSystemAssertions = new HostedOptionKey<>(false);

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/RuntimeAssertionsSupport.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/RuntimeAssertionsSupport.java
@@ -93,7 +93,8 @@ public final class RuntimeAssertionsSupport {
 
         @APIOption(name = {"-ea", "-enableassertions"}, launcherOption = true, valueSeparator = VALUE_SEPARATOR, valueTransformer = RuntimeAssertionsOptionTransformer.Enable.class, defaultValue = "", //
                         customHelp = "also -ea[:[packagename]...|:classname] or -enableassertions[:[packagename]...|:classname]. Enable assertions with specified granularity at run time.")//
-        @APIOption(name = {"-da", "-disableassertions"}, launcherOption = true, valueSeparator = VALUE_SEPARATOR, valueTransformer = RuntimeAssertionsOptionTransformer.Disable.class, defaultValue = "", //
+        @APIOption(name = {"-da",
+                        "-disableassertions"}, launcherOption = true, valueSeparator = VALUE_SEPARATOR, valueTransformer = RuntimeAssertionsOptionTransformer.Disable.class, defaultValue = "", //
                         customHelp = "also -da[:[packagename]...|:classname] or -disableassertions[:[packagename]...|:classname]. Disable assertions with specified granularity at run time.")//
         @Option(help = "Enable or disable Java assert statements at run time") //
         public static final HostedOptionKey<LocatableMultiOptionValue.Strings> RuntimeAssertions = new HostedOptionKey<>(LocatableMultiOptionValue.Strings.build());

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/SubstrateOptions.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/SubstrateOptions.java
@@ -116,6 +116,26 @@ public class SubstrateOptions {
     @Option(help = "Build statically linked executable (requires static libc and zlib)")//
     public static final HostedOptionKey<Boolean> StaticExecutable = new HostedOptionKey<>(false);
 
+    @APIOption(name = "libc")//
+    @Option(help = "Selects the libc implementation to use. Available implementations: glibc, musl, bionic")//
+    public static final HostedOptionKey<String> UseLibC = new HostedOptionKey<>(null) {
+        @Override
+        public String getValueOrDefault(UnmodifiableEconomicMap<OptionKey<?>, Object> values) {
+            if (!values.containsKey(this)) {
+                return Platform.includedIn(Platform.ANDROID.class)
+                                ? "bionic"
+                                : System.getProperty("substratevm.HostLibC", "glibc");
+            }
+            return (String) values.get(this);
+        }
+
+        @Override
+        public String getValue(OptionValues values) {
+            assert checkDescriptorExists();
+            return getValueOrDefault(values.getMap());
+        }
+    };
+
     @APIOption(name = "target")//
     @Option(help = "Selects native-image compilation target (in <OS>-<architecture> format). Defaults to host's OS-architecture pair.")//
     public static final HostedOptionKey<String> TargetPlatform = new HostedOptionKey<>("") {

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/option/APIOption.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/option/APIOption.java
@@ -62,7 +62,8 @@ public @interface APIOption {
     boolean extra() default false;
 
     /**
-     * This option should be stored in a native image bundle and passed to the jvm when executed with {@code com.oracle.svm.driver.launcher.BundleLauncher}.
+     * This option should be stored in a native image bundle and passed to the jvm when executed
+     * with {@code com.oracle.svm.driver.launcher.BundleLauncher}.
      */
     boolean launcherOption() default false;
 

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/option/APIOption.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/option/APIOption.java
@@ -62,6 +62,11 @@ public @interface APIOption {
     boolean extra() default false;
 
     /**
+     * This option should be stored in a native image bundle and passed to the jvm when executed with {@code com.oracle.svm.driver.launcher.BundleLauncher}.
+     */
+    boolean launcherOption() default false;
+
+    /**
      * Make a boolean option part of a group of boolean options.
      **/
     Class<? extends APIOptionGroup> group() default NullGroup.class;

--- a/substratevm/src/com.oracle.svm.driver.launcher/resources/com/oracle/svm/driver/launcher/BundleLauncherHelp.txt
+++ b/substratevm/src/com.oracle.svm.driver.launcher/resources/com/oracle/svm/driver/launcher/BundleLauncherHelp.txt
@@ -1,4 +1,4 @@
-This tool can ahead-of-time compile Java code to native executables.
+This native image bundle can be used to launch the bundled application.
 
 Usage: java -jar bundle-file [options] [bundle-application-options]
 
@@ -15,7 +15,7 @@ where options include:
                 from inside that container. Requires podman or rootless docker to be installed.
                 If available, 'podman' is preferred and rootless 'docker' is the fallback. Specifying
                 one or the other as '=<container-tool>' forces the use of a specific tool.
-                'dockerfile=<Dockerfile>': Use a user provided 'Dockerfile' instead of the Dockerfile
+                'dockerfile=<Dockerfile>': Use a user-provided 'Dockerfile' instead of the Dockerfile
                 bundled with the application
 
     --verbose   enable verbose output

--- a/substratevm/src/com.oracle.svm.driver.launcher/resources/com/oracle/svm/driver/launcher/BundleLauncherHelp.txt
+++ b/substratevm/src/com.oracle.svm.driver.launcher/resources/com/oracle/svm/driver/launcher/BundleLauncherHelp.txt
@@ -1,0 +1,22 @@
+This tool can ahead-of-time compile Java code to native executables.
+
+Usage: java -jar bundle-file [options] [bundle-application-options]
+
+where options include:
+
+    --with-native-image-agent[,update-bundle[=<new-bundle-name>]]
+                runs the application with a native-image-agent attached
+                'update-bundle' adds the agents output to the bundle-files classpath.
+                '=<new-bundle-name>' creates a new bundle with the agent output instead.
+                Note 'update-bundle' requires native-image to be installed
+
+    --container[=<container-tool>][,dockerfile=<Dockerfile>]
+                sets up a container image for execution and executes the bundled application
+                from inside that container. Requires podman or rootless docker to be installed.
+                If available, 'podman' is preferred and rootless 'docker' is the fallback. Specifying
+                one or the other as '=<container-tool>' forces the use of a specific tool.
+                'dockerfile=<Dockerfile>': Use a user provided 'Dockerfile' instead of the Dockerfile
+                bundled with the application
+
+    --verbose   enable verbose output
+    --help      print this help message

--- a/substratevm/src/com.oracle.svm.driver.launcher/src/com/oracle/svm/driver/launcher/BundleLauncher.java
+++ b/substratevm/src/com.oracle.svm.driver.launcher/src/com/oracle/svm/driver/launcher/BundleLauncher.java
@@ -24,9 +24,13 @@
  */
 package com.oracle.svm.driver.launcher;
 
+import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
 import java.io.Reader;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -42,6 +46,7 @@ import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import com.oracle.svm.driver.launcher.configuration.BundleArgsParser;
@@ -52,6 +57,7 @@ public class BundleLauncher {
     static final String BUNDLE_INFO_MESSAGE_PREFIX = "Native Image Bundles: ";
     private static final String BUNDLE_TEMP_DIR_PREFIX = "bundleRoot-";
     private static final String BUNDLE_FILE_EXTENSION = ".nib";
+    private static final String HELP_TEXT = getResource("/com/oracle/svm/driver/launcher/BundleLauncherHelp.txt");
 
     private static Path rootDir;
     private static Path inputDir;
@@ -74,6 +80,15 @@ public class BundleLauncher {
     private static final List<String> launchArgs = new ArrayList<>();
     private static final List<String> applicationArgs = new ArrayList<>();
     private static final Map<String, String> launcherEnvironment = new HashMap<>();
+
+    static String getResource(String resourceName) {
+        try (InputStream input = BundleLauncher.class.getResourceAsStream(resourceName)) {
+            BufferedReader reader = new BufferedReader(new InputStreamReader(input, StandardCharsets.UTF_8));
+            return reader.lines().collect(Collectors.joining("\n"));
+        } catch (IOException e) {
+            throw new Error(e);
+        }
+    }
 
     public static void main(String[] args) {
         bundleFilePath = Paths.get(BundleLauncher.class.getProtectionDomain().getCodeSource().getLocation().getPath());
@@ -294,6 +309,10 @@ public class BundleLauncher {
                 }
             } else {
                 switch (arg) {
+                    case "--help" -> {
+                        showMessage(HELP_TEXT);
+                        System.exit(0);
+                    }
                     case "--verbose" -> verbose = true;
                     case "--" -> {
                         applicationArgs.addAll(argQueue);

--- a/substratevm/src/com.oracle.svm.driver.launcher/src/com/oracle/svm/driver/launcher/BundleLauncher.java
+++ b/substratevm/src/com.oracle.svm.driver.launcher/src/com/oracle/svm/driver/launcher/BundleLauncher.java
@@ -1,3 +1,27 @@
+/*
+ * Copyright (c) 2023, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
 package com.oracle.svm.driver.launcher;
 
 import java.io.File;

--- a/substratevm/src/com.oracle.svm.driver.launcher/src/com/oracle/svm/driver/launcher/BundleLauncher.java
+++ b/substratevm/src/com.oracle.svm.driver.launcher/src/com/oracle/svm/driver/launcher/BundleLauncher.java
@@ -1,0 +1,363 @@
+package com.oracle.svm.driver.launcher;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.Reader;
+import java.nio.file.Files;
+import java.nio.file.InvalidPathException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.Enumeration;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.jar.JarEntry;
+import java.util.jar.JarFile;
+import java.util.stream.Stream;
+
+
+public class BundleLauncher {
+    private static final String BUNDLE_TEMP_DIR_PREFIX = "bundleRoot-";
+
+    private static Path rootDir;
+    private static Path inputDir;
+    private static Path stageDir;
+    private static Path auxiliaryDir;
+    private static Path classPathDir;
+    private static Path modulePathDir;
+
+
+    public static void main(String[] args) {
+        List<String> command = new ArrayList<>();
+        Path javaExecutable = getJavaExecutable().toAbsolutePath().normalize();
+        command.add(javaExecutable.toString());
+
+        String bundleFilePath = BundleLauncher.class.getProtectionDomain().getCodeSource().getLocation().getPath();
+        unpackBundle(Path.of(bundleFilePath));
+
+        Path environmentFile = stageDir.resolve("environment.json");
+        if (Files.isReadable(environmentFile)) {
+            try (Reader reader = Files.newBufferedReader(environmentFile)) {
+                //new EnvironmentParser(nativeImage.imageBuilderEnvironment).parseAndRegister(reader);
+            } catch (IOException e) {
+                throw new RuntimeException("Failed to read bundle-file " + environmentFile, e);
+            }
+        }
+
+
+        List<String> classpath = new ArrayList<>();
+        if (Files.isDirectory(classPathDir)) {
+            try (Stream<Path> walk = Files.walk(classPathDir, 1)) {
+                walk.filter(path -> path.toString().endsWith(".jar") || (Files.isDirectory(path) && !path.equals(classPathDir)))
+                        .map(Path::toString)
+                        .forEach(classpath::add);
+            } catch (IOException e) {
+                throw new RuntimeException("Failed to iterate through directory " + classPathDir, e);
+            }
+
+            classpath.add(classPathDir.toString());
+            command.add("-cp");
+            command.add(String.join(File.pathSeparator, classpath));
+        }
+
+
+        List<String> modulePath = new ArrayList<>();
+        if (Files.isDirectory(modulePathDir)) {
+            try (Stream<Path> walk = Files.walk(modulePathDir, 1)) {
+                walk.filter(Files::isDirectory)
+                        .filter(path -> !path.equals(modulePathDir))
+                        .map(Path::toString)
+                        .forEach(modulePath::add);
+            } catch (IOException e) {
+                throw new RuntimeException("Failed to iterate through directory " + modulePathDir, e);
+            }
+
+            if(!modulePath.isEmpty()) {
+                command.add("-p");
+                command.add(String.join(File.pathSeparator, modulePath));
+            }
+        }
+
+        Path buildArgsFile = stageDir.resolve("run.json");
+        try (Reader reader = Files.newBufferedReader(buildArgsFile)) {
+            command.addAll(parseArray(readFully(reader)));
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to read bundle-file " + buildArgsFile, e);
+        }
+
+        if (System.getenv("BUNDLE_LAUNCHER_VERBOSE") != null) {
+            System.out.println("Exec: " + String.join(" ", command));
+        }
+
+        ProcessBuilder pb = new ProcessBuilder(command);
+        Process p = null;
+        try {
+            p = pb.inheritIO().start();
+            p.waitFor();
+        } catch (IOException | InterruptedException e) {
+            showError("Failed to run bundled application");
+        } finally {
+            if(p != null) {
+                p.destroy();
+            }
+        }
+    }
+
+
+    private static final Path buildTimeJavaHome = Paths.get(System.getProperty("java.home"));
+
+    private static Path getJavaExecutable() {
+        Path binJava = Paths.get("bin", System.getProperty("os.name").contains("Windows") ? "java.exe" : "java");
+
+        Path javaCandidate = buildTimeJavaHome.resolve(binJava);
+        if (Files.isExecutable(javaCandidate)) {
+            return javaCandidate;
+        }
+
+        javaCandidate = Paths.get(".").resolve(binJava);
+        if (Files.isExecutable(javaCandidate)) {
+            return javaCandidate;
+        }
+
+        String javaHome = System.getenv("JAVA_HOME");
+        if (javaHome == null) {
+            showError("No " + binJava + " and no environment variable JAVA_HOME");
+        }
+        try {
+            javaCandidate = Paths.get(javaHome).resolve(binJava);
+            if (Files.isExecutable(javaCandidate)) {
+                return javaCandidate;
+            }
+        } catch (InvalidPathException e) {
+            /* fallthrough */
+        }
+        showError("No " + binJava + " and invalid JAVA_HOME=" + javaHome);
+        return null;
+    }
+
+    private static void showError(String s) {
+        System.err.println("Error: " + s);
+        System.exit(1);
+    }
+
+    private static String readFully(final Reader reader) throws IOException {
+        final char[] arr = new char[1024];
+        final StringBuilder sb = new StringBuilder();
+
+        try {
+            int numChars;
+            while ((numChars = reader.read(arr, 0, arr.length)) > 0) {
+                sb.append(arr, 0, numChars);
+            }
+        } finally {
+            reader.close();
+        }
+
+        return sb.toString();
+    }
+
+
+    private static final int STATE_EMPTY = 0;
+    private static final int STATE_ELEMENT_PARSED = 1;
+    private static final int STATE_COMMA_PARSED = 2;
+
+    private static int pos;
+
+    private static List<String> parseArray(String jsonArray) {
+        List<String> result = new ArrayList<>();
+        int state = STATE_EMPTY;
+        pos = 0;
+
+        skipWhiteSpace(jsonArray);
+        if(jsonArray.charAt(pos) != '[') {
+            throw new RuntimeException("Expected [ but found " + jsonArray.charAt(pos));
+        }
+        pos++;
+
+        while (pos < jsonArray.length()) {
+            pos = skipWhiteSpace(jsonArray);
+
+            switch (jsonArray.charAt(pos)) {
+                case ',' -> {
+                    if (state != STATE_ELEMENT_PARSED) {
+                        throw new RuntimeException("Trailing comma is not allowed in JSON");
+                    }
+                    state = STATE_COMMA_PARSED;
+                    pos++;
+                }
+                case ']' -> {
+                    if (state == STATE_COMMA_PARSED) {
+                        throw new RuntimeException("Trailing comma is not allowed in JSON");
+                    }
+                    return result;
+                }
+                default -> {
+                    if (state == STATE_ELEMENT_PARSED) {
+                        throw new RuntimeException("Expected , or ] but found " + jsonArray.charAt(pos));
+                    }
+                    result.add(parseString(jsonArray));
+                    state = STATE_ELEMENT_PARSED;
+                }
+            }
+        }
+
+        throw new RuntimeException("Expected , or ] but found eof");
+    }
+
+    private static String parseString(String json) {
+        // String buffer is only instantiated if string contains escape sequences.
+        int start = ++pos;
+        StringBuilder sb = null;
+
+        while (pos < json.length()) {
+            final int c = json.charAt(pos);
+            pos++;
+            if (c <= 0x1f) {
+                // Characters < 0x1f are not allowed in JSON strings.
+                throw new RuntimeException("String contains control character");
+
+            } else if (c == '\\') {
+                if (sb == null) {
+                    sb = new StringBuilder(pos - start + 16);
+                }
+                sb.append(json, start, pos - 1);
+                sb.append(parseEscapeSequence(json));
+                start = pos;
+
+            } else if (c == '"') {
+                if (sb != null) {
+                    sb.append(json, start, pos - 1);
+                    return sb.toString();
+                }
+                return json.substring(start, pos - 1);
+            }
+        }
+
+        throw new RuntimeException("Missing close quote");
+    }
+
+    private static char parseEscapeSequence(String json) {
+        final int c = json.charAt(pos);
+        pos++;
+        return switch (c) {
+            case '"' -> '"';
+            case '\\' -> '\\';
+            case '/' -> '/';
+            case 'b' -> '\b';
+            case 'f' -> '\f';
+            case 'n' -> '\n';
+            case 'r' -> '\r';
+            case 't' -> '\t';
+            case 'u' -> parseUnicodeEscape(json);
+            default -> throw new RuntimeException("Invalid escape character");
+        };
+    }
+
+    private static char parseUnicodeEscape(String json) {
+        return (char) (parseHexDigit(json) << 12 | parseHexDigit(json) << 8 | parseHexDigit(json) << 4 | parseHexDigit(json));
+    }
+
+    private static int parseHexDigit(String json) {
+        final int c = json.charAt(pos);
+        pos++;
+        if (c >= '0' && c <= '9') {
+            return c - '0';
+        } else if (c >= 'A' && c <= 'F') {
+            return c + 10 - 'A';
+        } else if (c >= 'a' && c <= 'f') {
+            return c + 10 - 'a';
+        }
+        throw new RuntimeException("Invalid hex digit");
+    }
+
+    private static int skipWhiteSpace(String str) {
+        while (pos < str.length()) {
+            switch (str.charAt(pos)) {
+                case '\t', '\r', '\n', ' ' -> pos++;
+                default -> {
+                    return pos;
+                }
+            }
+        }
+
+        return pos;
+    }
+
+    private static final AtomicBoolean deleteBundleRoot = new AtomicBoolean();
+    private static Path createBundleRootDir() throws IOException {
+        Path bundleRoot = Files.createTempDirectory(BUNDLE_TEMP_DIR_PREFIX);
+        Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+            deleteBundleRoot.set(true);
+            deleteAllFiles(bundleRoot);
+        }));
+        return bundleRoot;
+    }
+
+
+    private static final String deletedFileSuffix = ".deleted";
+    private static boolean isDeletedPath(Path toDelete) {
+        return toDelete.getFileName().toString().endsWith(deletedFileSuffix);
+    }
+
+    private static void deleteAllFiles(Path toDelete) {
+        try {
+            Path deletedPath = toDelete;
+            if (!isDeletedPath(deletedPath)) {
+                deletedPath = toDelete.resolveSibling(toDelete.getFileName() + deletedFileSuffix);
+                Files.move(toDelete, deletedPath);
+            }
+            Files.walk(deletedPath).sorted(Comparator.reverseOrder()).map(Path::toFile).forEach(File::delete);
+        } catch (IOException e) {
+            //if (isVerbose()) {
+                System.out.println("Could not recursively delete path: " + toDelete);
+                e.printStackTrace();
+            //}
+        }
+    }
+
+
+    private static void unpackBundle(Path bundleFilePath) {
+        try {
+            rootDir = createBundleRootDir();
+            inputDir = rootDir.resolve("input");
+
+            try (JarFile archive = new JarFile(bundleFilePath.toFile())) {
+                Enumeration<JarEntry> jarEntries = archive.entries();
+                while (jarEntries.hasMoreElements() && !deleteBundleRoot.get()) {
+                    JarEntry jarEntry = jarEntries.nextElement();
+                    Path bundleEntry = rootDir.resolve(jarEntry.getName());
+                    if (bundleEntry.startsWith(inputDir)) {
+                        try {
+                            Path bundleFileParent = bundleEntry.getParent();
+                            if (bundleFileParent != null) {
+                                Files.createDirectories(bundleFileParent);
+                            }
+                            Files.copy(archive.getInputStream(jarEntry), bundleEntry);
+                        } catch (IOException e) {
+                            throw new RuntimeException("Unable to copy " + jarEntry.getName() + " from bundle " + bundleEntry + " to " + bundleEntry, e);
+                        }
+                    }
+                }
+            }
+        } catch (IOException e) {
+            throw new RuntimeException("Unable to expand bundle directory layout from bundle file " + bundleFilePath, e);
+        }
+
+        if (deleteBundleRoot.get()) {
+            /* Abort image build request without error message and exit with 0 */
+            throw new RuntimeException("");
+        }
+
+        try {
+            inputDir = rootDir.resolve("input");
+            stageDir = Files.createDirectories(inputDir.resolve("stage"));
+            auxiliaryDir = Files.createDirectories(inputDir.resolve("auxiliary"));
+            Path classesDir = inputDir.resolve("classes");
+            classPathDir = Files.createDirectories(classesDir.resolve("cp"));
+            modulePathDir = Files.createDirectories(classesDir.resolve("p"));
+        } catch (IOException e) {
+            throw new RuntimeException("Unable to create bundle directory layout", e);
+        }
+    }
+}

--- a/substratevm/src/com.oracle.svm.driver.launcher/src/com/oracle/svm/driver/launcher/BundleLauncher.java
+++ b/substratevm/src/com.oracle.svm.driver.launcher/src/com/oracle/svm/driver/launcher/BundleLauncher.java
@@ -321,6 +321,7 @@ public class BundleLauncher {
         }
     }
 
+    // Checkstyle: Allow raw info or warning printing - begin
     private static void showMessage(String msg) {
         System.out.println(msg);
     }
@@ -328,6 +329,7 @@ public class BundleLauncher {
     private static void showWarning(String msg) {
         System.out.println("Warning: " + msg);
     }
+    // Checkstyle: Allow raw info or warning printing - end
 
     private static final Path buildTimeJavaHome = Paths.get(System.getProperty("java.home"));
 

--- a/substratevm/src/com.oracle.svm.driver.launcher/src/com/oracle/svm/driver/launcher/BundleLauncher.java
+++ b/substratevm/src/com.oracle.svm.driver.launcher/src/com/oracle/svm/driver/launcher/BundleLauncher.java
@@ -81,7 +81,7 @@ public class BundleLauncher {
         bundleFilePath = Paths.get(BundleLauncher.class.getProtectionDomain().getCodeSource().getLocation().getPath());
         bundleName = bundleFilePath.getFileName().toString().replace(BUNDLE_FILE_EXTENSION, "");
         agentOutputDir = bundleFilePath.getParent().resolve(Paths.get(bundleName + ".output", "launcher"));
-        unpackBundle(bundleFilePath);
+        unpackBundle();
 
         // if we did not create a run.json bundle is not executable, e.g. shared library bundles
         if (!Files.exists(stageDir.resolve("run.json"))) {
@@ -257,11 +257,11 @@ public class BundleLauncher {
                     }
                 }
 
-                Path outputDir = agentOutputDir.resolve(Paths.get("META-INF", "native-image", bundleName + "-agent"));
+                Path configOutputDir = agentOutputDir.resolve(Paths.get("META-INF", "native-image", bundleName + "-agent"));
                 try {
-                    Files.createDirectories(outputDir);
+                    Files.createDirectories(configOutputDir);
                     showMessage(BUNDLE_INFO_MESSAGE_PREFIX + "Native image agent output written to " + agentOutputDir);
-                    launchArgs.add("-agentlib:native-image-agent=config-output-dir=" + outputDir);
+                    launchArgs.add("-agentlib:native-image-agent=config-output-dir=" + configOutputDir);
                 } catch (IOException e) {
                     throw new Error("Failed to create native image agent output dir");
                 }
@@ -388,7 +388,7 @@ public class BundleLauncher {
         }
     }
 
-    private static void unpackBundle(Path bundleFilePath) {
+    private static void unpackBundle() {
         try {
             rootDir = createBundleRootDir();
             inputDir = rootDir.resolve("input");

--- a/substratevm/src/com.oracle.svm.driver.launcher/src/com/oracle/svm/driver/launcher/BundleLauncher.java
+++ b/substratevm/src/com.oracle.svm.driver.launcher/src/com/oracle/svm/driver/launcher/BundleLauncher.java
@@ -283,16 +283,16 @@ public class BundleLauncher {
                 } else if (!System.getProperty("os.name").equals("Linux")) {
                     throw new Error("container option is only supported for Linux");
                 }
-                Path dockerfile;
+                containerSupport = new ContainerSupport(stageDir, Error::new, BundleLauncher::showWarning, BundleLauncher::showMessage);
                 if (arg.indexOf(',') != -1) {
                     String option = arg.substring(arg.indexOf(',') + 1);
                     arg = arg.substring(0, arg.indexOf(','));
 
                     if (option.startsWith("dockerfile")) {
                         if (option.indexOf('=') != -1) {
-                            dockerfile = Paths.get(option.substring(option.indexOf('=') + 1));
-                            if (!Files.isReadable(dockerfile)) {
-                                throw new Error(String.format("Dockerfile '%s' is not readable", dockerfile.toAbsolutePath()));
+                            containerSupport.dockerfile = Paths.get(option.substring(option.indexOf('=') + 1));
+                            if (!Files.isReadable(containerSupport.dockerfile)) {
+                                throw new Error(String.format("Dockerfile '%s' is not readable", containerSupport.dockerfile.toAbsolutePath()));
                             }
                         } else {
                             throw new Error("container option dockerfile requires a dockerfile argument. E.g. dockerfile=path/to/Dockerfile.");
@@ -300,10 +300,7 @@ public class BundleLauncher {
                     } else {
                         throw new Error(String.format("Unknown option %s. Valid option is: dockerfile=path/to/Dockerfile.", option));
                     }
-                } else {
-                    dockerfile = stageDir.resolve("Dockerfile");
                 }
-                containerSupport = new ContainerSupport(dockerfile, stageDir, Error::new, BundleLauncher::showWarning, BundleLauncher::showMessage);
                 if (arg.indexOf('=') != -1) {
                     containerSupport.tool = arg.substring(arg.indexOf('=') + 1);
                 }

--- a/substratevm/src/com.oracle.svm.driver.launcher/src/com/oracle/svm/driver/launcher/BundleLauncher.java
+++ b/substratevm/src/com.oracle.svm.driver.launcher/src/com/oracle/svm/driver/launcher/BundleLauncher.java
@@ -77,14 +77,13 @@ public class BundleLauncher {
         List<String> classpath = new ArrayList<>();
         if (Files.isDirectory(classPathDir)) {
             try (Stream<Path> walk = Files.walk(classPathDir, 1)) {
-                walk.filter(path -> path.toString().endsWith(".jar") || (Files.isDirectory(path) && !path.equals(classPathDir)))
+                walk.filter(path -> path.toString().endsWith(".jar") || Files.isDirectory(path))
                         .map(Path::toString)
                         .forEach(classpath::add);
             } catch (IOException e) {
                 throw new RuntimeException("Failed to iterate through directory " + classPathDir, e);
             }
 
-            classpath.add(classPathDir.toString());
             command.add("-cp");
             command.add(String.join(File.pathSeparator, classpath));
         }

--- a/substratevm/src/com.oracle.svm.driver.launcher/src/com/oracle/svm/driver/launcher/BundleLauncher.java
+++ b/substratevm/src/com.oracle.svm.driver.launcher/src/com/oracle/svm/driver/launcher/BundleLauncher.java
@@ -195,7 +195,7 @@ public class BundleLauncher {
         List<String> modulePath = new ArrayList<>();
         if (Files.isDirectory(modulePathDir)) {
             try (Stream<Path> walk = Files.walk(modulePathDir, 1)) {
-                walk.filter(path -> Files.isDirectory(path) && !path.equals(modulePathDir))
+                walk.filter(path -> (Files.isDirectory(path) && !path.equals(modulePathDir)) || path.toString().endsWith(".jar"))
                                 .map(path -> useContainer() ? Paths.get("/").resolve(rootDir.relativize(path)) : path)
                                 .map(Path::toString)
                                 .forEach(modulePath::add);

--- a/substratevm/src/com.oracle.svm.driver.launcher/src/com/oracle/svm/driver/launcher/BundleLauncher.java
+++ b/substratevm/src/com.oracle.svm.driver.launcher/src/com/oracle/svm/driver/launcher/BundleLauncher.java
@@ -24,9 +24,6 @@
  */
 package com.oracle.svm.driver.launcher;
 
-import com.oracle.svm.driver.launcher.configuration.BundleArgsParser;
-import com.oracle.svm.driver.launcher.configuration.BundleEnvironmentParser;
-
 import java.io.File;
 import java.io.IOException;
 import java.io.Reader;
@@ -47,6 +44,8 @@ import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
 import java.util.stream.Stream;
 
+import com.oracle.svm.driver.launcher.configuration.BundleArgsParser;
+import com.oracle.svm.driver.launcher.configuration.BundleEnvironmentParser;
 
 public class BundleLauncher {
 
@@ -75,7 +74,6 @@ public class BundleLauncher {
     private static final List<String> launchArgs = new ArrayList<>();
     private static final List<String> applicationArgs = new ArrayList<>();
     private static final Map<String, String> launcherEnvironment = new HashMap<>();
-
 
     public static void main(String[] args) {
         bundleFilePath = Paths.get(BundleLauncher.class.getProtectionDomain().getCodeSource().getLocation().getPath());
@@ -106,11 +104,11 @@ public class BundleLauncher {
 
         if (verbose) {
             List<String> environmentList = pb.environment()
-                    .entrySet()
-                    .stream()
-                    .map(e -> e.getKey() + "=" + e.getValue())
-                    .sorted()
-                    .toList();
+                            .entrySet()
+                            .stream()
+                            .map(e -> e.getKey() + "=" + e.getValue())
+                            .sorted()
+                            .toList();
             showMessage("Executing [");
             showMessage(String.join(" \\\n", environmentList));
             showMessage(String.join(" \\\n", pb.command()));
@@ -168,9 +166,9 @@ public class BundleLauncher {
         if (Files.isDirectory(classPathDir)) {
             try (Stream<Path> walk = Files.walk(classPathDir, 1)) {
                 walk.filter(path -> path.toString().endsWith(".jar") || Files.isDirectory(path))
-                        .map(path -> useContainer() ? Paths.get("/").resolve(rootDir.relativize(path)) : path)
-                        .map(Path::toString)
-                        .forEach(classpath::add);
+                                .map(path -> useContainer() ? Paths.get("/").resolve(rootDir.relativize(path)) : path)
+                                .map(Path::toString)
+                                .forEach(classpath::add);
             } catch (IOException e) {
                 throw new Error("Failed to iterate through directory " + classPathDir, e);
             }
@@ -179,14 +177,13 @@ public class BundleLauncher {
             command.add(String.join(File.pathSeparator, classpath));
         }
 
-
         List<String> modulePath = new ArrayList<>();
         if (Files.isDirectory(modulePathDir)) {
             try (Stream<Path> walk = Files.walk(modulePathDir, 1)) {
                 walk.filter(path -> Files.isDirectory(path) && !path.equals(modulePathDir))
-                        .map(path -> useContainer() ? Paths.get("/").resolve(rootDir.relativize(path)) : path)
-                        .map(Path::toString)
-                        .forEach(modulePath::add);
+                                .map(path -> useContainer() ? Paths.get("/").resolve(rootDir.relativize(path)) : path)
+                                .map(Path::toString)
+                                .forEach(modulePath::add);
             } catch (IOException e) {
                 throw new Error("Failed to iterate through directory " + modulePathDir, e);
             }
@@ -311,6 +308,7 @@ public class BundleLauncher {
     private static void showMessage(String msg) {
         System.out.println(msg);
     }
+
     private static void showWarning(String msg) {
         System.out.println("Warning: " + msg);
     }
@@ -359,6 +357,7 @@ public class BundleLauncher {
     }
 
     private static final AtomicBoolean deleteBundleRoot = new AtomicBoolean();
+
     private static Path createBundleRootDir() throws IOException {
         Path bundleRoot = Files.createTempDirectory(BUNDLE_TEMP_DIR_PREFIX);
         Runtime.getRuntime().addShutdownHook(new Thread(() -> {
@@ -369,9 +368,11 @@ public class BundleLauncher {
     }
 
     private static final String deletedFileSuffix = ".deleted";
+
     private static boolean isDeletedPath(Path toDelete) {
         return toDelete.getFileName().toString().endsWith(deletedFileSuffix);
     }
+
     private static void deleteAllFiles(Path toDelete) {
         try {
             Path deletedPath = toDelete;

--- a/substratevm/src/com.oracle.svm.driver.launcher/src/com/oracle/svm/driver/launcher/BundleLauncherUtil.java
+++ b/substratevm/src/com.oracle.svm.driver.launcher/src/com/oracle/svm/driver/launcher/BundleLauncherUtil.java
@@ -33,6 +33,7 @@ import java.util.regex.Pattern;
 public class BundleLauncherUtil {
 
     private static final char[] HEX = "0123456789abcdef".toCharArray();
+
     static String digest(String value) {
         try {
             MessageDigest md = MessageDigest.getInstance("SHA-1");
@@ -42,6 +43,7 @@ public class BundleLauncherUtil {
             throw new Error(ex);
         }
     }
+
     static String toHex(byte[] data) {
         StringBuilder r = new StringBuilder(data.length * 2);
         for (byte b : data) {
@@ -52,6 +54,7 @@ public class BundleLauncherUtil {
     }
 
     private static final Pattern SAFE_SHELL_ARG = Pattern.compile("[A-Za-z0-9@%_\\-+=:,./]+");
+
     static String quoteShellArg(String arg) {
         if (arg.isEmpty()) {
             return "''";

--- a/substratevm/src/com.oracle.svm.driver.launcher/src/com/oracle/svm/driver/launcher/BundleLauncherUtil.java
+++ b/substratevm/src/com.oracle.svm.driver.launcher/src/com/oracle/svm/driver/launcher/BundleLauncherUtil.java
@@ -33,7 +33,7 @@ import java.util.regex.Pattern;
 public class BundleLauncherUtil {
 
     private static final char[] HEX = "0123456789abcdef".toCharArray();
-    public static String digest(String value) {
+    static String digest(String value) {
         try {
             MessageDigest md = MessageDigest.getInstance("SHA-1");
             md.update(value.getBytes(StandardCharsets.UTF_8));
@@ -42,7 +42,7 @@ public class BundleLauncherUtil {
             throw new Error(ex);
         }
     }
-    public static String toHex(byte[] data) {
+    static String toHex(byte[] data) {
         StringBuilder r = new StringBuilder(data.length * 2);
         for (byte b : data) {
             r.append(HEX[(b >> 4) & 0xf]);
@@ -52,7 +52,7 @@ public class BundleLauncherUtil {
     }
 
     private static final Pattern SAFE_SHELL_ARG = Pattern.compile("[A-Za-z0-9@%_\\-+=:,./]+");
-    public static String quoteShellArg(String arg) {
+    static String quoteShellArg(String arg) {
         if (arg.isEmpty()) {
             return "''";
         }

--- a/substratevm/src/com.oracle.svm.driver.launcher/src/com/oracle/svm/driver/launcher/BundleLauncherUtil.java
+++ b/substratevm/src/com.oracle.svm.driver.launcher/src/com/oracle/svm/driver/launcher/BundleLauncherUtil.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2023, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package com.oracle.svm.driver.launcher;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class BundleLauncherUtil {
+
+    private static final char[] HEX = "0123456789abcdef".toCharArray();
+    public static String digest(String value) {
+        try {
+            MessageDigest md = MessageDigest.getInstance("SHA-1");
+            md.update(value.getBytes(StandardCharsets.UTF_8));
+            return toHex(md.digest());
+        } catch (NoSuchAlgorithmException ex) {
+            throw new Error(ex);
+        }
+    }
+    public static String toHex(byte[] data) {
+        StringBuilder r = new StringBuilder(data.length * 2);
+        for (byte b : data) {
+            r.append(HEX[(b >> 4) & 0xf]);
+            r.append(HEX[b & 0xf]);
+        }
+        return r.toString();
+    }
+
+    private static final Pattern SAFE_SHELL_ARG = Pattern.compile("[A-Za-z0-9@%_\\-+=:,./]+");
+    public static String quoteShellArg(String arg) {
+        if (arg.isEmpty()) {
+            return "''";
+        }
+        Matcher m = SAFE_SHELL_ARG.matcher(arg);
+        if (m.matches()) {
+            return arg;
+        }
+        return "'" + arg.replace("'", "'\"'\"'") + "'";
+    }
+}

--- a/substratevm/src/com.oracle.svm.driver.launcher/src/com/oracle/svm/driver/launcher/ContainerSupport.java
+++ b/substratevm/src/com.oracle.svm.driver.launcher/src/com/oracle/svm/driver/launcher/ContainerSupport.java
@@ -24,8 +24,6 @@
  */
 package com.oracle.svm.driver.launcher;
 
-import com.oracle.svm.driver.launcher.configuration.BundleContainerSettingsParser;
-
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
@@ -40,6 +38,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
+
+import com.oracle.svm.driver.launcher.configuration.BundleContainerSettingsParser;
 
 public class ContainerSupport {
     public String tool;
@@ -81,7 +81,8 @@ public class ContainerSupport {
                 }
                 if (bundleTool != null) {
                     String containerToolVersionString = bundleToolVersion == null ? "" : String.format(" (%s)", bundleToolVersion);
-                    messagePrinter.accept(String.format("%sBundled native-image was created in a container with %s%s.%n", BundleLauncher.BUNDLE_INFO_MESSAGE_PREFIX, bundleTool, containerToolVersionString));
+                    messagePrinter.accept(
+                                    String.format("%sBundled native-image was created in a container with %s%s.%n", BundleLauncher.BUNDLE_INFO_MESSAGE_PREFIX, bundleTool, containerToolVersionString));
                 }
             }
         }
@@ -170,8 +171,8 @@ public class ContainerSupport {
 
     private static boolean isToolAvailable(String toolName) {
         return Arrays.stream(System.getenv("PATH").split(":"))
-                .map(str -> Path.of(str).resolve(toolName))
-                .anyMatch(Files::isExecutable);
+                        .map(str -> Path.of(str).resolve(toolName))
+                        .anyMatch(Files::isExecutable);
     }
 
     private String getToolVersion() {
@@ -231,9 +232,9 @@ public class ContainerSupport {
 
         // inject environment variables into container
         containerEnvironment.forEach((key, value) -> {
-                    containerCommand.add("-e");
-                    containerCommand.add(key + "=" + BundleLauncherUtil.quoteShellArg(value));
-                });
+            containerCommand.add("-e");
+            containerCommand.add(key + "=" + BundleLauncherUtil.quoteShellArg(value));
+        });
 
         // mount java home, input and output directories and argument files for native image build
         mountMapping.forEach((source, target) -> {
@@ -256,8 +257,7 @@ public class ContainerSupport {
 
     public static void replacePaths(List<String> arguments, Path javaHome, Path bundleRoot) {
         arguments.replaceAll(arg -> arg
-                .replace(javaHome.toString(), GRAAL_VM_HOME.toString())
-                .replace(bundleRoot.toString(), "")
-        );
+                        .replace(javaHome.toString(), GRAAL_VM_HOME.toString())
+                        .replace(bundleRoot.toString(), ""));
     }
 }

--- a/substratevm/src/com.oracle.svm.driver.launcher/src/com/oracle/svm/driver/launcher/ContainerSupport.java
+++ b/substratevm/src/com.oracle.svm.driver.launcher/src/com/oracle/svm/driver/launcher/ContainerSupport.java
@@ -32,15 +32,16 @@ import java.io.InputStreamReader;
 import java.io.Reader;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.BiFunction;
+import java.util.function.Consumer;
 
 public class ContainerSupport {
-    // TODO put anything container related in here, maybe even with function references(for logging), take care
-
     public String containerTool;
     public String bundleContainerTool;
     public String containerToolVersion;
@@ -49,17 +50,28 @@ public class ContainerSupport {
     public String bundleContainerImage;
     public Path dockerfile;
 
-    private static final List<String> SUPPORTED_CONTAINER_TOOLS = List.of("podman", "docker");
-    private static final String CONTAINER_TOOL_JSON_KEY = "containerTool";
-    private static final String CONTAINER_TOOL_VERSION_JSON_KEY = "containerToolVersion";
-    private static final String CONTAINER_IMAGE_JSON_KEY = "containerImage";
+    public static final List<String> SUPPORTED_CONTAINER_TOOLS = List.of("podman", "docker");
+    public static final String CONTAINER_TOOL_JSON_KEY = "containerTool";
+    public static final String CONTAINER_TOOL_VERSION_JSON_KEY = "containerToolVersion";
+    public static final String CONTAINER_IMAGE_JSON_KEY = "containerImage";
 
     private static final String BUNDLE_INFO_MESSAGE_PREFIX = "Native Image Bundles: ";
 
     public static final Path CONTAINER_GRAAL_VM_HOME = Path.of("/graalvm");
 
+    private final BiFunction<String, Throwable, Error> errorFunction;
+    private final Consumer<String> warningPrinter;
+    private final Consumer<String> messagePrinter;
+
     public ContainerSupport(Path dockerfile, Path bundleStageDir) {
+        this(dockerfile, bundleStageDir, Error::new, (msg) -> System.out.println("Warning: " + msg), System.out::println);
+    }
+
+    public ContainerSupport(Path dockerfile, Path bundleStageDir, BiFunction<String, Throwable, Error> errorFunction, Consumer<String> warningPrinter, Consumer<String> messagePrinter) {
         this.dockerfile = dockerfile;
+        this.errorFunction = errorFunction;
+        this.warningPrinter = warningPrinter;
+        this.messagePrinter = messagePrinter;
 
         if (bundleStageDir != null) {
             Path containerFile = bundleStageDir.resolve("container.json");
@@ -71,11 +83,11 @@ public class ContainerSupport {
                     bundleContainerTool = containerSettings.getOrDefault(CONTAINER_TOOL_JSON_KEY, bundleContainerTool);
                     bundleContainerToolVersion = containerSettings.getOrDefault(CONTAINER_TOOL_VERSION_JSON_KEY, bundleContainerToolVersion);
                 } catch (IOException e) {
-                    throw new Error("Failed to read bundle-file " + containerFile, e);
+                    throw errorFunction.apply("Failed to read bundle-file " + containerFile, e);
                 }
                 if (bundleContainerTool != null) {
                     String containerToolVersionString = bundleContainerToolVersion == null ? "" : String.format(" (%s)", bundleContainerToolVersion);
-                    System.out.printf("%sBundled native-image was created in a container with %s%s.%n", BUNDLE_INFO_MESSAGE_PREFIX, bundleContainerTool, containerToolVersionString);
+                    messagePrinter.accept(String.format("%sBundled native-image was created in a container with %s%s.%n", BUNDLE_INFO_MESSAGE_PREFIX, bundleContainerTool, containerToolVersionString));
                 }
             }
         }
@@ -85,11 +97,11 @@ public class ContainerSupport {
         try {
             containerImage = BundleLauncherUtil.digest(Files.readString(dockerfile));
         } catch (IOException e) {
-            throw new Error("Could not read Dockerfile " + dockerfile);
+            throw errorFunction.apply("Could not read Dockerfile " + dockerfile, e);
         }
 
         if (bundleContainerImage != null && !bundleContainerImage.equals(containerImage)) {
-            System.out.println("Warning: The bundled image was created with a different dockerfile.");
+            warningPrinter.accept("The bundled image was created with a different dockerfile.");
         }
 
         if (bundleContainerTool != null && containerTool == null) {
@@ -98,24 +110,24 @@ public class ContainerSupport {
 
         if (containerTool != null) {
             if (!isToolAvailable(containerTool)) {
-                throw new Error("Configured container tool not available.");
+                throw errorFunction.apply("Configured container tool not available.", null);
             } else if (containerTool.equals("docker") && !isRootlessDocker()) {
-                throw new Error("Only rootless docker is supported for containerized builds.");
+                throw errorFunction.apply("Only rootless docker is supported for containerized builds.", null);
             }
             containerToolVersion = getContainerToolVersion(containerTool);
 
             if (bundleContainerTool != null) {
                 if (!containerTool.equals(bundleContainerTool)) {
-                    System.out.printf("Warning: The bundled image was created with container tool '%s' (using '%s').%n", bundleContainerTool, containerTool);
+                    warningPrinter.accept(String.format("The bundled image was created with container tool '%s' (using '%s').%n", bundleContainerTool, containerTool));
                 } else if (containerToolVersion != null && bundleContainerToolVersion != null && !containerToolVersion.equals(bundleContainerToolVersion)) {
-                    System.out.printf("Warning: The bundled image was created with different %s version '%s' (installed '%s').%n", containerTool, bundleContainerToolVersion, containerToolVersion);
+                    warningPrinter.accept(String.format("The bundled image was created with different %s version '%s' (installed '%s').%n", containerTool, bundleContainerToolVersion, containerToolVersion));
                 }
             }
         } else {
             for (String tool : SUPPORTED_CONTAINER_TOOLS) {
                 if (isToolAvailable(tool)) {
                     if (tool.equals("docker") && !isRootlessDocker()) {
-                        System.out.println(BUNDLE_INFO_MESSAGE_PREFIX + "Rootless context missing for docker.");
+                        messagePrinter.accept(BUNDLE_INFO_MESSAGE_PREFIX + "Rootless context missing for docker.");
                         continue;
                     }
                     containerTool = tool;
@@ -124,7 +136,7 @@ public class ContainerSupport {
                 }
             }
             if (containerTool == null) {
-                throw new Error(String.format("Please install one of the following tools before running containerized native image builds: %s", SUPPORTED_CONTAINER_TOOLS));
+                throw errorFunction.apply(String.format("Please install one of the following tools before running containerized native image builds: %s", SUPPORTED_CONTAINER_TOOLS), null);
             }
         }
 
@@ -139,7 +151,7 @@ public class ContainerSupport {
         if (imageId == null) {
             pb.inheritIO();
         } else {
-            System.out.printf("%sReusing container image %s.%n", BUNDLE_INFO_MESSAGE_PREFIX, containerImage);
+            messagePrinter.accept(String.format("%sReusing container image %s.%n", BUNDLE_INFO_MESSAGE_PREFIX, containerImage));
         }
 
         Process p = null;
@@ -148,13 +160,13 @@ public class ContainerSupport {
             int status = p.waitFor();
             if (status == 0 && imageId != null && !imageId.equals(getFirstProcessResultLine(pbCheckForImage))) {
                 try (var processResult = new BufferedReader(new InputStreamReader(p.getInputStream()))) {
-                    System.out.printf("%sUpdated container image %s.%n", BUNDLE_INFO_MESSAGE_PREFIX, containerImage);
-                    processResult.lines().forEach(System.out::println);
+                    messagePrinter.accept(String.format("%sUpdated container image %s.%n", BUNDLE_INFO_MESSAGE_PREFIX, containerImage));
+                    processResult.lines().forEach(messagePrinter);
                 }
             }
             return status;
         } catch (IOException | InterruptedException e) {
-            throw new Error(e.getMessage());
+            throw errorFunction.apply(e.getMessage(), e);
         } finally {
             if (p != null) {
                 p.destroy();
@@ -162,23 +174,23 @@ public class ContainerSupport {
         }
     }
 
-    private static boolean isToolAvailable(String tool) {
+    private boolean isToolAvailable(String tool) {
         return Arrays.stream(System.getenv("PATH").split(":"))
                 .map(str -> Path.of(str).resolve(tool))
                 .anyMatch(Files::isExecutable);
     }
 
-    private static String getContainerToolVersion(String tool) {
+    private String getContainerToolVersion(String tool) {
         ProcessBuilder pb = new ProcessBuilder(tool, "--version");
         return getFirstProcessResultLine(pb);
     }
 
-    private static boolean isRootlessDocker() {
+    private boolean isRootlessDocker() {
         ProcessBuilder pb = new ProcessBuilder("docker", "context", "show");
         return getFirstProcessResultLine(pb).equals("rootless");
     }
 
-    private static String getFirstProcessResultLine(ProcessBuilder pb) {
+    private String getFirstProcessResultLine(ProcessBuilder pb) {
         Process p = null;
         try {
             p = pb.start();
@@ -187,7 +199,7 @@ public class ContainerSupport {
                 return processResult.readLine();
             }
         } catch (IOException | InterruptedException e) {
-            throw new RuntimeException(e.getMessage());
+            throw errorFunction.apply(e.getMessage(), e);
         } finally {
             if (p != null) {
                 p.destroy();
@@ -196,6 +208,22 @@ public class ContainerSupport {
     }
 
     public record TargetPath(Path path, boolean readonly) {
+        public static TargetPath readonly(Path target) {
+            return of(target, true);
+        }
+
+        public static TargetPath of(Path target, boolean readonly) {
+            return new TargetPath(target, readonly);
+        }
+    }
+
+    public static Map<Path, TargetPath> mountMappingFor(Path javaHome, Path inputDir, Path outputDir) {
+        Map<Path, TargetPath> mountMapping = new HashMap<>();
+        Path containerRoot = Paths.get("/");
+        mountMapping.put(javaHome, TargetPath.readonly(containerRoot.resolve(CONTAINER_GRAAL_VM_HOME)));
+        mountMapping.put(inputDir, ContainerSupport.TargetPath.readonly(containerRoot.resolve(BundleLauncher.INPUT_DIR_NAME)));
+        mountMapping.put(outputDir, ContainerSupport.TargetPath.of(containerRoot.resolve(BundleLauncher.OUTPUT_DIR_NAME), false));
+        return mountMapping;
     }
 
     public List<String> createContainerCommand(Map<String, String> containerEnvironment, Map<Path, TargetPath> mountMapping) {

--- a/substratevm/src/com.oracle.svm.driver.launcher/src/com/oracle/svm/driver/launcher/ContainerSupport.java
+++ b/substratevm/src/com.oracle.svm.driver.launcher/src/com/oracle/svm/driver/launcher/ContainerSupport.java
@@ -108,7 +108,7 @@ public class ContainerSupport {
             } else if (tool.equals("docker") && !isRootlessDocker()) {
                 throw errorFunction.apply("Only rootless docker is supported for containerized builds.", null);
             }
-            toolVersion = getToolVersion(tool);
+            toolVersion = getToolVersion();
 
             if (bundleTool != null) {
                 if (!tool.equals(bundleTool)) {
@@ -118,14 +118,14 @@ public class ContainerSupport {
                 }
             }
         } else {
-            for (String tool : SUPPORTED_TOOLS) {
-                if (isToolAvailable(tool)) {
-                    if (tool.equals("docker") && !isRootlessDocker()) {
+            for (String supportedTool : SUPPORTED_TOOLS) {
+                if (isToolAvailable(supportedTool)) {
+                    if (supportedTool.equals("docker") && !isRootlessDocker()) {
                         messagePrinter.accept(BundleLauncher.BUNDLE_INFO_MESSAGE_PREFIX + "Rootless context missing for docker.");
                         continue;
                     }
-                    this.tool = tool;
-                    toolVersion = getToolVersion(tool);
+                    tool = supportedTool;
+                    toolVersion = getToolVersion();
                     break;
                 }
             }
@@ -168,13 +168,13 @@ public class ContainerSupport {
         }
     }
 
-    private boolean isToolAvailable(String tool) {
+    private static boolean isToolAvailable(String toolName) {
         return Arrays.stream(System.getenv("PATH").split(":"))
-                .map(str -> Path.of(str).resolve(tool))
+                .map(str -> Path.of(str).resolve(toolName))
                 .anyMatch(Files::isExecutable);
     }
 
-    private String getToolVersion(String tool) {
+    private String getToolVersion() {
         ProcessBuilder pb = new ProcessBuilder(tool, "--version");
         return getFirstProcessResultLine(pb);
     }

--- a/substratevm/src/com.oracle.svm.driver.launcher/src/com/oracle/svm/driver/launcher/ContainerSupport.java
+++ b/substratevm/src/com.oracle.svm.driver.launcher/src/com/oracle/svm/driver/launcher/ContainerSupport.java
@@ -1,0 +1,241 @@
+/*
+ * Copyright (c) 2023, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package com.oracle.svm.driver.launcher;
+
+import com.oracle.svm.driver.launcher.configuration.BundleContainerSettingsParser;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class ContainerSupport {
+    // TODO put anything container related in here, maybe even with function references(for logging), take care
+
+    public String containerTool;
+    public String bundleContainerTool;
+    public String containerToolVersion;
+    public String bundleContainerToolVersion;
+    public String containerImage;
+    public String bundleContainerImage;
+    public Path dockerfile;
+
+    private static final List<String> SUPPORTED_CONTAINER_TOOLS = List.of("podman", "docker");
+    private static final String CONTAINER_TOOL_JSON_KEY = "containerTool";
+    private static final String CONTAINER_TOOL_VERSION_JSON_KEY = "containerToolVersion";
+    private static final String CONTAINER_IMAGE_JSON_KEY = "containerImage";
+
+    private static final String BUNDLE_INFO_MESSAGE_PREFIX = "Native Image Bundles: ";
+
+    public static final Path CONTAINER_GRAAL_VM_HOME = Path.of("/graalvm");
+
+    public ContainerSupport(Path dockerfile, Path bundleStageDir) {
+        this.dockerfile = dockerfile;
+
+        if (bundleStageDir != null) {
+            Path containerFile = bundleStageDir.resolve("container.json");
+            if (Files.exists(containerFile)) {
+                try (Reader reader = Files.newBufferedReader(containerFile)) {
+                    Map<String, String> containerSettings = new HashMap<>();
+                    new BundleContainerSettingsParser(containerSettings).parseAndRegister(reader);
+                    bundleContainerImage = containerSettings.getOrDefault(CONTAINER_IMAGE_JSON_KEY, bundleContainerImage);
+                    bundleContainerTool = containerSettings.getOrDefault(CONTAINER_TOOL_JSON_KEY, bundleContainerTool);
+                    bundleContainerToolVersion = containerSettings.getOrDefault(CONTAINER_TOOL_VERSION_JSON_KEY, bundleContainerToolVersion);
+                } catch (IOException e) {
+                    throw new Error("Failed to read bundle-file " + containerFile, e);
+                }
+                if (bundleContainerTool != null) {
+                    String containerToolVersionString = bundleContainerToolVersion == null ? "" : String.format(" (%s)", bundleContainerToolVersion);
+                    System.out.printf("%sBundled native-image was created in a container with %s%s.%n", BUNDLE_INFO_MESSAGE_PREFIX, bundleContainerTool, containerToolVersionString);
+                }
+            }
+        }
+    }
+
+    public int initializeContainerImage() {
+        try {
+            containerImage = BundleLauncherUtil.digest(Files.readString(dockerfile));
+        } catch (IOException e) {
+            throw new Error("Could not read Dockerfile " + dockerfile);
+        }
+
+        if (bundleContainerImage != null && !bundleContainerImage.equals(containerImage)) {
+            System.out.println("Warning: The bundled image was created with a different dockerfile.");
+        }
+
+        if (bundleContainerTool != null && containerTool == null) {
+            containerTool = bundleContainerTool;
+        }
+
+        if (containerTool != null) {
+            if (!isToolAvailable(containerTool)) {
+                throw new Error("Configured container tool not available.");
+            } else if (containerTool.equals("docker") && !isRootlessDocker()) {
+                throw new Error("Only rootless docker is supported for containerized builds.");
+            }
+            containerToolVersion = getContainerToolVersion(containerTool);
+
+            if (bundleContainerTool != null) {
+                if (!containerTool.equals(bundleContainerTool)) {
+                    System.out.printf("Warning: The bundled image was created with container tool '%s' (using '%s').%n", bundleContainerTool, containerTool);
+                } else if (containerToolVersion != null && bundleContainerToolVersion != null && !containerToolVersion.equals(bundleContainerToolVersion)) {
+                    System.out.printf("Warning: The bundled image was created with different %s version '%s' (installed '%s').%n", containerTool, bundleContainerToolVersion, containerToolVersion);
+                }
+            }
+        } else {
+            for (String tool : SUPPORTED_CONTAINER_TOOLS) {
+                if (isToolAvailable(tool)) {
+                    if (tool.equals("docker") && !isRootlessDocker()) {
+                        System.out.println(BUNDLE_INFO_MESSAGE_PREFIX + "Rootless context missing for docker.");
+                        continue;
+                    }
+                    containerTool = tool;
+                    containerToolVersion = getContainerToolVersion(tool);
+                    break;
+                }
+            }
+            if (containerTool == null) {
+                throw new Error(String.format("Please install one of the following tools before running containerized native image builds: %s", SUPPORTED_CONTAINER_TOOLS));
+            }
+        }
+
+        return createContainer();
+    }
+
+    private int createContainer() {
+        ProcessBuilder pbCheckForImage = new ProcessBuilder(containerTool, "images", "-q", containerImage + ":latest");
+        ProcessBuilder pb = new ProcessBuilder(containerTool, "build", "-f", dockerfile.toString(), "-t", containerImage, ".");
+
+        String imageId = getFirstProcessResultLine(pbCheckForImage);
+        if (imageId == null) {
+            pb.inheritIO();
+        } else {
+            System.out.printf("%sReusing container image %s.%n", BUNDLE_INFO_MESSAGE_PREFIX, containerImage);
+        }
+
+        Process p = null;
+        try {
+            p = pb.start();
+            int status = p.waitFor();
+            if (status == 0 && imageId != null && !imageId.equals(getFirstProcessResultLine(pbCheckForImage))) {
+                try (var processResult = new BufferedReader(new InputStreamReader(p.getInputStream()))) {
+                    System.out.printf("%sUpdated container image %s.%n", BUNDLE_INFO_MESSAGE_PREFIX, containerImage);
+                    processResult.lines().forEach(System.out::println);
+                }
+            }
+            return status;
+        } catch (IOException | InterruptedException e) {
+            throw new Error(e.getMessage());
+        } finally {
+            if (p != null) {
+                p.destroy();
+            }
+        }
+    }
+
+    private static boolean isToolAvailable(String tool) {
+        return Arrays.stream(System.getenv("PATH").split(":"))
+                .map(str -> Path.of(str).resolve(tool))
+                .anyMatch(Files::isExecutable);
+    }
+
+    private static String getContainerToolVersion(String tool) {
+        ProcessBuilder pb = new ProcessBuilder(tool, "--version");
+        return getFirstProcessResultLine(pb);
+    }
+
+    private static boolean isRootlessDocker() {
+        ProcessBuilder pb = new ProcessBuilder("docker", "context", "show");
+        return getFirstProcessResultLine(pb).equals("rootless");
+    }
+
+    private static String getFirstProcessResultLine(ProcessBuilder pb) {
+        Process p = null;
+        try {
+            p = pb.start();
+            p.waitFor();
+            try (var processResult = new BufferedReader(new InputStreamReader(p.getInputStream()))) {
+                return processResult.readLine();
+            }
+        } catch (IOException | InterruptedException e) {
+            throw new RuntimeException(e.getMessage());
+        } finally {
+            if (p != null) {
+                p.destroy();
+            }
+        }
+    }
+
+    public record TargetPath(Path path, boolean readonly) {
+    }
+
+    public List<String> createContainerCommand(Map<String, String> containerEnvironment, Map<Path, TargetPath> mountMapping) {
+        List<String> containerCommand = new ArrayList<>();
+
+        // run docker tool without network access and remove container after image build is finished
+        containerCommand.add(containerTool);
+        containerCommand.add("run");
+        containerCommand.add("--network=none");
+        containerCommand.add("--rm");
+
+        // inject environment variables into container
+        containerEnvironment.forEach((key, value) -> {
+                    containerCommand.add("-e");
+                    containerCommand.add(key + "=" + BundleLauncherUtil.quoteShellArg(value));
+                });
+
+        // mount java home, input and output directories and argument files for native image build
+        mountMapping.forEach((source, target) -> {
+            containerCommand.add("--mount");
+            List<String> mountArgs = new ArrayList<>();
+            mountArgs.add("type=bind");
+            mountArgs.add("source=" + source);
+            mountArgs.add("target=" + target.path);
+            if (target.readonly) {
+                mountArgs.add("readonly");
+            }
+            containerCommand.add(BundleLauncherUtil.quoteShellArg(String.join(",", mountArgs)));
+        });
+
+        // specify container name
+        containerCommand.add(containerImage);
+
+        return containerCommand;
+    }
+
+    public static void replaceContainerPaths(List<String> arguments, Path javaHome, Path bundleRoot) {
+        arguments.replaceAll(arg -> arg
+                .replace(javaHome.toString(), CONTAINER_GRAAL_VM_HOME.toString())
+                .replace(bundleRoot.toString(), "")
+        );
+    }
+}

--- a/substratevm/src/com.oracle.svm.driver.launcher/src/com/oracle/svm/driver/launcher/ContainerSupport.java
+++ b/substratevm/src/com.oracle.svm.driver.launcher/src/com/oracle/svm/driver/launcher/ContainerSupport.java
@@ -61,13 +61,13 @@ public class ContainerSupport {
     private final Consumer<String> warningPrinter;
     private final Consumer<String> messagePrinter;
 
-    public ContainerSupport(Path dockerfile, Path bundleStageDir, BiFunction<String, Throwable, Error> errorFunction, Consumer<String> warningPrinter, Consumer<String> messagePrinter) {
-        this.dockerfile = dockerfile;
+    public ContainerSupport(Path bundleStageDir, BiFunction<String, Throwable, Error> errorFunction, Consumer<String> warningPrinter, Consumer<String> messagePrinter) {
         this.errorFunction = errorFunction;
         this.warningPrinter = warningPrinter;
         this.messagePrinter = messagePrinter;
 
         if (bundleStageDir != null) {
+            dockerfile = bundleStageDir.resolve("Dockerfile");
             Path containerFile = bundleStageDir.resolve("container.json");
             if (Files.exists(containerFile)) {
                 try (Reader reader = Files.newBufferedReader(containerFile)) {

--- a/substratevm/src/com.oracle.svm.driver.launcher/src/com/oracle/svm/driver/launcher/configuration/ArgsParser.java
+++ b/substratevm/src/com.oracle.svm.driver.launcher/src/com/oracle/svm/driver/launcher/configuration/ArgsParser.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2023, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package com.oracle.svm.driver.launcher.configuration;
+
+import java.net.URI;
+import java.util.List;
+
+public class ArgsParser extends BundleConfigurationParser {
+
+    private final List<String> args;
+
+    public ArgsParser(List<String> args) {
+        this.args = args;
+    }
+
+    @Override
+    public void parseAndRegister(Object json, URI origin) {
+        for (var arg : asList(json, "Expected a list of arguments")) {
+            args.add(arg.toString());
+        }
+    }
+}

--- a/substratevm/src/com.oracle.svm.driver.launcher/src/com/oracle/svm/driver/launcher/configuration/BundleArgsParser.java
+++ b/substratevm/src/com.oracle.svm.driver.launcher/src/com/oracle/svm/driver/launcher/configuration/BundleArgsParser.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2023, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package com.oracle.svm.driver.launcher.configuration;
+
+import java.net.URI;
+import java.util.List;
+
+public class BundleArgsParser extends BundleConfigurationParser {
+
+    private final List<String> args;
+
+    public BundleArgsParser(List<String> args) {
+        this.args = args;
+    }
+
+    @Override
+    public void parseAndRegister(Object json, URI origin) {
+        for (var arg : asList(json, "Expected a list of arguments")) {
+            args.add(arg.toString());
+        }
+    }
+}

--- a/substratevm/src/com.oracle.svm.driver.launcher/src/com/oracle/svm/driver/launcher/configuration/BundleConfigurationParser.java
+++ b/substratevm/src/com.oracle.svm.driver.launcher/src/com/oracle/svm/driver/launcher/configuration/BundleConfigurationParser.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2023, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package com.oracle.svm.driver.launcher.configuration;
+
+import com.oracle.svm.driver.launcher.json.BundleJSONParser;
+import com.oracle.svm.driver.launcher.json.BundleJSONParserException;
+
+import java.io.IOException;
+import java.io.Reader;
+import java.net.URI;
+import java.util.List;
+import java.util.Map;
+
+public abstract class BundleConfigurationParser {
+
+        public void parseAndRegister(Reader reader) throws IOException {
+            parseAndRegister(new BundleJSONParser(reader).parse(), null);
+        }
+
+        public abstract void parseAndRegister(Object json, URI origin) throws IOException;
+
+        @SuppressWarnings("unchecked")
+        public static List<Object> asList(Object data, String errorMessage) {
+            if (data instanceof List) {
+                return (List<Object>) data;
+            }
+            throw new BundleJSONParserException(errorMessage);
+        }
+
+        @SuppressWarnings("unchecked")
+        public static Map<String, Object> asMap(Object data, String errorMessage) {
+            if (data instanceof Map) {
+                return (Map<String, Object>) data;
+            }
+            throw new BundleJSONParserException(errorMessage);
+        }
+}

--- a/substratevm/src/com.oracle.svm.driver.launcher/src/com/oracle/svm/driver/launcher/configuration/BundleConfigurationParser.java
+++ b/substratevm/src/com.oracle.svm.driver.launcher/src/com/oracle/svm/driver/launcher/configuration/BundleConfigurationParser.java
@@ -24,36 +24,36 @@
  */
 package com.oracle.svm.driver.launcher.configuration;
 
-import com.oracle.svm.driver.launcher.json.BundleJSONParser;
-import com.oracle.svm.driver.launcher.json.BundleJSONParserException;
-
 import java.io.IOException;
 import java.io.Reader;
 import java.net.URI;
 import java.util.List;
 import java.util.Map;
 
+import com.oracle.svm.driver.launcher.json.BundleJSONParser;
+import com.oracle.svm.driver.launcher.json.BundleJSONParserException;
+
 public abstract class BundleConfigurationParser {
 
-        public void parseAndRegister(Reader reader) throws IOException {
-            parseAndRegister(new BundleJSONParser(reader).parse(), null);
-        }
+    public void parseAndRegister(Reader reader) throws IOException {
+        parseAndRegister(new BundleJSONParser(reader).parse(), null);
+    }
 
-        public abstract void parseAndRegister(Object json, URI origin) throws IOException;
+    public abstract void parseAndRegister(Object json, URI origin) throws IOException;
 
-        @SuppressWarnings("unchecked")
-        public static List<Object> asList(Object data, String errorMessage) {
-            if (data instanceof List) {
-                return (List<Object>) data;
-            }
-            throw new BundleJSONParserException(errorMessage);
+    @SuppressWarnings("unchecked")
+    public static List<Object> asList(Object data, String errorMessage) {
+        if (data instanceof List) {
+            return (List<Object>) data;
         }
+        throw new BundleJSONParserException(errorMessage);
+    }
 
-        @SuppressWarnings("unchecked")
-        public static Map<String, Object> asMap(Object data, String errorMessage) {
-            if (data instanceof Map) {
-                return (Map<String, Object>) data;
-            }
-            throw new BundleJSONParserException(errorMessage);
+    @SuppressWarnings("unchecked")
+    public static Map<String, Object> asMap(Object data, String errorMessage) {
+        if (data instanceof Map) {
+            return (Map<String, Object>) data;
         }
+        throw new BundleJSONParserException(errorMessage);
+    }
 }

--- a/substratevm/src/com.oracle.svm.driver.launcher/src/com/oracle/svm/driver/launcher/configuration/BundleContainerSettingsParser.java
+++ b/substratevm/src/com.oracle.svm.driver.launcher/src/com/oracle/svm/driver/launcher/configuration/BundleContainerSettingsParser.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2023, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package com.oracle.svm.driver.launcher.configuration;
+
+import java.net.URI;
+import java.util.Map;
+
+public class BundleContainerSettingsParser extends BundleConfigurationParser {
+    private final Map<String, String> containerSettings;
+
+    public BundleContainerSettingsParser(Map<String, String> containerSettings) {
+        this.containerSettings = containerSettings;
+    }
+
+    @Override
+    public void parseAndRegister(Object json, URI origin) {
+        Map<String, Object> jsonMap = asMap(json, "Expected a map of container settings and values");
+        jsonMap.forEach((k, v) -> containerSettings.put(k, v.toString()));
+    }
+}

--- a/substratevm/src/com.oracle.svm.driver.launcher/src/com/oracle/svm/driver/launcher/configuration/BundleEnvironmentParser.java
+++ b/substratevm/src/com.oracle.svm.driver.launcher/src/com/oracle/svm/driver/launcher/configuration/BundleEnvironmentParser.java
@@ -29,12 +29,12 @@ import com.oracle.svm.driver.launcher.json.BundleJSONParserException;
 import java.net.URI;
 import java.util.Map;
 
-public class EnvironmentParser extends BundleConfigurationParser {
+public class BundleEnvironmentParser extends BundleConfigurationParser {
     private static final String environmentKeyField = "key";
     private static final String environmentValueField = "val";
     private final Map<String, String> environment;
 
-    public EnvironmentParser(Map<String, String> environment) {
+    public BundleEnvironmentParser(Map<String, String> environment) {
         environment.clear();
         this.environment = environment;
     }

--- a/substratevm/src/com.oracle.svm.driver.launcher/src/com/oracle/svm/driver/launcher/configuration/BundleEnvironmentParser.java
+++ b/substratevm/src/com.oracle.svm.driver.launcher/src/com/oracle/svm/driver/launcher/configuration/BundleEnvironmentParser.java
@@ -24,10 +24,10 @@
  */
 package com.oracle.svm.driver.launcher.configuration;
 
-import com.oracle.svm.driver.launcher.json.BundleJSONParserException;
-
 import java.net.URI;
 import java.util.Map;
+
+import com.oracle.svm.driver.launcher.json.BundleJSONParserException;
 
 public class BundleEnvironmentParser extends BundleConfigurationParser {
     private static final String environmentKeyField = "key";

--- a/substratevm/src/com.oracle.svm.driver.launcher/src/com/oracle/svm/driver/launcher/configuration/BundlePathMapParser.java
+++ b/substratevm/src/com.oracle.svm.driver.launcher/src/com/oracle/svm/driver/launcher/configuration/BundlePathMapParser.java
@@ -24,11 +24,11 @@
  */
 package com.oracle.svm.driver.launcher.configuration;
 
-import com.oracle.svm.driver.launcher.json.BundleJSONParserException;
-
 import java.net.URI;
 import java.nio.file.Path;
 import java.util.Map;
+
+import com.oracle.svm.driver.launcher.json.BundleJSONParserException;
 
 public class BundlePathMapParser extends BundleConfigurationParser {
 

--- a/substratevm/src/com.oracle.svm.driver.launcher/src/com/oracle/svm/driver/launcher/configuration/EnvironmentParser.java
+++ b/substratevm/src/com.oracle.svm.driver.launcher/src/com/oracle/svm/driver/launcher/configuration/EnvironmentParser.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2023, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package com.oracle.svm.driver.launcher.configuration;
+
+import com.oracle.svm.driver.launcher.json.BundleJSONParserException;
+
+import java.net.URI;
+import java.util.Map;
+
+public class EnvironmentParser extends BundleConfigurationParser {
+    private static final String environmentKeyField = "key";
+    private static final String environmentValueField = "val";
+    private final Map<String, String> environment;
+
+    public EnvironmentParser(Map<String, String> environment) {
+        environment.clear();
+        this.environment = environment;
+    }
+
+    @Override
+    public void parseAndRegister(Object json, URI origin) {
+        for (var rawEntry : asList(json, "Expected a list of environment variable objects")) {
+            var entry = asMap(rawEntry, "Expected a environment variable object");
+            Object envVarKeyString = entry.get(environmentKeyField);
+            if (envVarKeyString == null) {
+                throw new BundleJSONParserException("Expected " + environmentKeyField + "-field in environment variable object");
+            }
+            Object envVarValueString = entry.get(environmentValueField);
+            if (envVarValueString == null) {
+                throw new BundleJSONParserException("Expected " + environmentValueField + "-field in environment variable object");
+            }
+            environment.put(envVarKeyString.toString(), envVarValueString.toString());
+        }
+    }
+}

--- a/substratevm/src/com.oracle.svm.driver.launcher/src/com/oracle/svm/driver/launcher/json/BundleJSONParser.java
+++ b/substratevm/src/com.oracle.svm.driver.launcher/src/com/oracle/svm/driver/launcher/json/BundleJSONParser.java
@@ -1,0 +1,458 @@
+/*
+ * Copyright (c) 2023, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package com.oracle.svm.driver.launcher.json;
+
+import java.io.IOException;
+import java.io.Reader;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class BundleJSONParser {
+
+        private final String source;
+        private final int length;
+        private int pos = 0;
+
+        private static final int EOF = -1;
+
+        private static final String TRUE = "true";
+        private static final String FALSE = "false";
+        private static final String NULL = "null";
+
+        private static final int STATE_EMPTY = 0;
+        private static final int STATE_ELEMENT_PARSED = 1;
+        private static final int STATE_COMMA_PARSED = 2;
+
+        public BundleJSONParser(String source) {
+            this.source = source;
+            this.length = source.length();
+        }
+
+        public BundleJSONParser(Reader source) throws IOException {
+            this(readFully(source));
+        }
+
+        /**
+         * Public parse method. Parse a string into a JSON object.
+         *
+         * @return the parsed JSON Object
+         */
+        public Object parse() {
+            final Object value = parseLiteral();
+            skipWhiteSpace();
+            if (pos < length) {
+                throw expectedError(pos, "eof", toString(peek()));
+            }
+            return value;
+        }
+
+        private Object parseLiteral() {
+            skipWhiteSpace();
+
+            final int c = peek();
+            if (c == EOF) {
+                throw expectedError(pos, "json literal", "eof");
+            }
+            return switch (c) {
+                case '{' -> parseObject();
+                case '[' -> parseArray();
+                case '"' -> parseString();
+                case 'f' -> parseKeyword(FALSE, Boolean.FALSE);
+                case 't' -> parseKeyword(TRUE, Boolean.TRUE);
+                case 'n' -> parseKeyword(NULL, null);
+                default -> {
+                    if (isDigit(c) || c == '-') {
+                        yield parseNumber();
+                    } else if (c == '.') {
+                        throw numberError(pos);
+                    } else {
+                        throw expectedError(pos, "json literal", toString(c));
+                    }
+                }
+            };
+        }
+
+        private Object parseObject() {
+            Map<String, Object> result = new HashMap<>();
+            int state = STATE_EMPTY;
+
+            assert peek() == '{';
+            pos++;
+
+            while (pos < length) {
+                skipWhiteSpace();
+                final int c = peek();
+
+                switch (c) {
+                    case '"' -> {
+                        if (state == STATE_ELEMENT_PARSED) {
+                            throw expectedError(pos, ", or }", toString(c));
+                        }
+                        final String id = parseString();
+                        expectColon();
+                        final Object value = parseLiteral();
+                        result.put(id, value);
+                        state = STATE_ELEMENT_PARSED;
+                    }
+                    case ',' -> {
+                        if (state != STATE_ELEMENT_PARSED) {
+                            throw error("Trailing comma is not allowed in JSON", pos);
+                        }
+                        state = STATE_COMMA_PARSED;
+                        pos++;
+                    }
+                    case '}' -> {
+                        if (state == STATE_COMMA_PARSED) {
+                            throw error("Trailing comma is not allowed in JSON", pos);
+                        }
+                        pos++;
+                        return result;
+                    }
+                    default -> throw expectedError(pos, ", or }", toString(c));
+                }
+            }
+            throw expectedError(pos, ", or }", "eof");
+        }
+
+        private void expectColon() {
+            skipWhiteSpace();
+            final int n = next();
+            if (n != ':') {
+                throw expectedError(pos - 1, ":", toString(n));
+            }
+        }
+
+        private Object parseArray() {
+            List<Object> result = new ArrayList<>();
+            int state = STATE_EMPTY;
+
+            assert peek() == '[';
+            pos++;
+
+            while (pos < length) {
+                skipWhiteSpace();
+                final int c = peek();
+
+                switch (c) {
+                    case ',' -> {
+                        if (state != STATE_ELEMENT_PARSED) {
+                            throw error("Trailing comma is not allowed in JSON", pos);
+                        }
+                        state = STATE_COMMA_PARSED;
+                        pos++;
+                    }
+                    case ']' -> {
+                        if (state == STATE_COMMA_PARSED) {
+                            throw error("Trailing comma is not allowed in JSON", pos);
+                        }
+                        pos++;
+                        return result;
+                    }
+                    default -> {
+                        if (state == STATE_ELEMENT_PARSED) {
+                            throw expectedError(pos, ", or ]", toString(c));
+                        }
+                        result.add(parseLiteral());
+                        state = STATE_ELEMENT_PARSED;
+                    }
+                }
+            }
+
+            throw expectedError(pos, ", or ]", "eof");
+        }
+
+        private String parseString() {
+            // String buffer is only instantiated if string contains escape sequences.
+            int start = ++pos;
+            StringBuilder sb = null;
+
+            while (pos < length) {
+                final int c = next();
+                if (c <= 0x1f) {
+                    // Characters < 0x1f are not allowed in JSON strings.
+                    throw syntaxError(pos, "String contains control character");
+
+                } else if (c == '\\') {
+                    if (sb == null) {
+                        sb = new StringBuilder(pos - start + 16);
+                    }
+                    sb.append(source, start, pos - 1);
+                    sb.append(parseEscapeSequence());
+                    start = pos;
+
+                } else if (c == '"') {
+                    if (sb != null) {
+                        sb.append(source, start, pos - 1);
+                        return sb.toString();
+                    }
+                    return source.substring(start, pos - 1);
+                }
+            }
+
+            throw error("Missing close quote", pos);
+        }
+
+        private char parseEscapeSequence() {
+            final int c = next();
+            return switch (c) {
+                case '"' -> '"';
+                case '\\' -> '\\';
+                case '/' -> '/';
+                case 'b' -> '\b';
+                case 'f' -> '\f';
+                case 'n' -> '\n';
+                case 'r' -> '\r';
+                case 't' -> '\t';
+                case 'u' -> parseUnicodeEscape();
+                default -> throw error("Invalid escape character", pos - 1);
+            };
+        }
+
+        private char parseUnicodeEscape() {
+            return (char) (parseHexDigit() << 12 | parseHexDigit() << 8 | parseHexDigit() << 4 | parseHexDigit());
+        }
+
+        private int parseHexDigit() {
+            final int c = next();
+            if (c >= '0' && c <= '9') {
+                return c - '0';
+            } else if (c >= 'A' && c <= 'F') {
+                return c + 10 - 'A';
+            } else if (c >= 'a' && c <= 'f') {
+                return c + 10 - 'a';
+            }
+            throw error("Invalid hex digit", pos - 1);
+        }
+
+        private static boolean isDigit(final int c) {
+            return c >= '0' && c <= '9';
+        }
+
+        private void skipDigits() {
+            while (pos < length) {
+                final int c = peek();
+                if (!isDigit(c)) {
+                    break;
+                }
+                pos++;
+            }
+        }
+
+        private Number parseNumber() {
+            boolean isFloating = false;
+            final int start = pos;
+            int c = next();
+
+            if (c == '-') {
+                c = next();
+            }
+            if (!isDigit(c)) {
+                throw numberError(start);
+            }
+            // no more digits allowed after 0
+            if (c != '0') {
+                skipDigits();
+            }
+
+            // fraction
+            if (peek() == '.') {
+                isFloating = true;
+                pos++;
+                if (!isDigit(next())) {
+                    throw numberError(pos - 1);
+                }
+                skipDigits();
+            }
+
+            // exponent
+            c = peek();
+            if (c == 'e' || c == 'E') {
+                pos++;
+                c = next();
+                if (c == '-' || c == '+') {
+                    c = next();
+                }
+                if (!isDigit(c)) {
+                    throw numberError(pos - 1);
+                }
+                skipDigits();
+            }
+
+            String literalValue = source.substring(start, pos);
+            if (isFloating) {
+                return Double.parseDouble(literalValue);
+            } else {
+                final long l = Long.parseLong(literalValue);
+                if ((int) l == l) {
+                    return (int) l;
+                } else {
+                    return l;
+                }
+            }
+        }
+
+        private Object parseKeyword(final String keyword, final Object value) {
+            if (!source.regionMatches(pos, keyword, 0, keyword.length())) {
+                throw expectedError(pos, "json literal", "ident");
+            }
+            pos += keyword.length();
+            return value;
+        }
+
+        private int peek() {
+            if (pos >= length) {
+                return -1;
+            }
+            return source.charAt(pos);
+        }
+
+        private int next() {
+            final int next = peek();
+            pos++;
+            return next;
+        }
+
+        private void skipWhiteSpace() {
+            while (pos < length) {
+                switch (peek()) {
+                    case '\t', '\r', '\n', ' ' -> pos++;
+                    default -> {
+                        return;
+                    }
+                }
+            }
+        }
+
+        private static String toString(final int c) {
+            return c == EOF ? "eof" : String.valueOf((char) c);
+        }
+
+        private BundleJSONParserException error(final String message, final int start) {
+            final int lineNum = getLine(start);
+            final int columnNum = getColumn(start);
+            final String formatted = format(message, lineNum, columnNum);
+            return new BundleJSONParserException(formatted);
+        }
+
+        /**
+         * Return line number of character position.
+         *
+         * <p>
+         * This method can be expensive for large sources as it iterates through all characters up to
+         * {@code position}.
+         * </p>
+         *
+         * @param position Position of character in source content.
+         * @return Line number.
+         */
+        private int getLine(final int position) {
+            final CharSequence d = source;
+            // Line count starts at 1.
+            int line = 1;
+
+            for (int i = 0; i < position; i++) {
+                final char ch = d.charAt(i);
+                // Works for both \n and \r\n.
+                if (ch == '\n') {
+                    line++;
+                }
+            }
+
+            return line;
+        }
+
+        /**
+         * Return column number of character position.
+         *
+         * @param position Position of character in source content.
+         * @return Column number.
+         */
+        private int getColumn(final int position) {
+            return position - findBOLN(position);
+        }
+
+        /**
+         * Find the beginning of the line containing position.
+         *
+         * @param position Index to offending token.
+         * @return Index of first character of line.
+         */
+        private int findBOLN(final int position) {
+            final CharSequence d = source;
+            for (int i = position - 1; i > 0; i--) {
+                final char ch = d.charAt(i);
+
+                if (ch == '\n' || ch == '\r') {
+                    return i + 1;
+                }
+            }
+
+            return 0;
+        }
+
+        /**
+         * Format an error message to include source and line information.
+         *
+         * @param message Error message string.
+         * @param line Source line number.
+         * @param column Source column number.
+         * @return formatted string
+         */
+        private static String format(final String message, final int line, final int column) {
+            return "line " + line + " column " + column + " " + message;
+        }
+
+        private BundleJSONParserException numberError(final int start) {
+            return error("Invalid JSON number format", start);
+        }
+
+        private BundleJSONParserException expectedError(final int start, final String expected, final String found) {
+            return error("Expected " + expected + " but found " + found, start);
+        }
+
+        private BundleJSONParserException syntaxError(final int start, final String reason) {
+            return error("Invalid JSON: " + reason, start);
+        }
+
+        /**
+         * Utility function to read all contents of a {@link Reader}, because the JSON parser does not
+         * support streaming yet.
+         */
+        private static String readFully(final Reader reader) throws IOException {
+            final char[] arr = new char[1024];
+            final StringBuilder sb = new StringBuilder();
+
+            try (reader) {
+                int numChars;
+                while ((numChars = reader.read(arr, 0, arr.length)) > 0) {
+                    sb.append(arr, 0, numChars);
+                }
+            }
+
+            return sb.toString();
+        }
+}

--- a/substratevm/src/com.oracle.svm.driver.launcher/src/com/oracle/svm/driver/launcher/json/BundleJSONParser.java
+++ b/substratevm/src/com.oracle.svm.driver.launcher/src/com/oracle/svm/driver/launcher/json/BundleJSONParser.java
@@ -33,426 +33,426 @@ import java.util.Map;
 
 public class BundleJSONParser {
 
-        private final String source;
-        private final int length;
-        private int pos = 0;
+    private final String source;
+    private final int length;
+    private int pos = 0;
 
-        private static final int EOF = -1;
+    private static final int EOF = -1;
 
-        private static final String TRUE = "true";
-        private static final String FALSE = "false";
-        private static final String NULL = "null";
+    private static final String TRUE = "true";
+    private static final String FALSE = "false";
+    private static final String NULL = "null";
 
-        private static final int STATE_EMPTY = 0;
-        private static final int STATE_ELEMENT_PARSED = 1;
-        private static final int STATE_COMMA_PARSED = 2;
+    private static final int STATE_EMPTY = 0;
+    private static final int STATE_ELEMENT_PARSED = 1;
+    private static final int STATE_COMMA_PARSED = 2;
 
-        public BundleJSONParser(String source) {
-            this.source = source;
-            this.length = source.length();
+    public BundleJSONParser(String source) {
+        this.source = source;
+        this.length = source.length();
+    }
+
+    public BundleJSONParser(Reader source) throws IOException {
+        this(readFully(source));
+    }
+
+    /**
+     * Public parse method. Parse a string into a JSON object.
+     *
+     * @return the parsed JSON Object
+     */
+    public Object parse() {
+        final Object value = parseLiteral();
+        skipWhiteSpace();
+        if (pos < length) {
+            throw expectedError(pos, "eof", toString(peek()));
         }
+        return value;
+    }
 
-        public BundleJSONParser(Reader source) throws IOException {
-            this(readFully(source));
+    private Object parseLiteral() {
+        skipWhiteSpace();
+
+        final int c = peek();
+        if (c == EOF) {
+            throw expectedError(pos, "json literal", "eof");
         }
-
-        /**
-         * Public parse method. Parse a string into a JSON object.
-         *
-         * @return the parsed JSON Object
-         */
-        public Object parse() {
-            final Object value = parseLiteral();
-            skipWhiteSpace();
-            if (pos < length) {
-                throw expectedError(pos, "eof", toString(peek()));
+        return switch (c) {
+            case '{' -> parseObject();
+            case '[' -> parseArray();
+            case '"' -> parseString();
+            case 'f' -> parseKeyword(FALSE, Boolean.FALSE);
+            case 't' -> parseKeyword(TRUE, Boolean.TRUE);
+            case 'n' -> parseKeyword(NULL, null);
+            default -> {
+                if (isDigit(c) || c == '-') {
+                    yield parseNumber();
+                } else if (c == '.') {
+                    throw numberError(pos);
+                } else {
+                    throw expectedError(pos, "json literal", toString(c));
+                }
             }
-            return value;
-        }
+        };
+    }
 
-        private Object parseLiteral() {
+    private Object parseObject() {
+        Map<String, Object> result = new HashMap<>();
+        int state = STATE_EMPTY;
+
+        assert peek() == '{';
+        pos++;
+
+        while (pos < length) {
             skipWhiteSpace();
-
             final int c = peek();
-            if (c == EOF) {
-                throw expectedError(pos, "json literal", "eof");
-            }
-            return switch (c) {
-                case '{' -> parseObject();
-                case '[' -> parseArray();
-                case '"' -> parseString();
-                case 'f' -> parseKeyword(FALSE, Boolean.FALSE);
-                case 't' -> parseKeyword(TRUE, Boolean.TRUE);
-                case 'n' -> parseKeyword(NULL, null);
-                default -> {
-                    if (isDigit(c) || c == '-') {
-                        yield parseNumber();
-                    } else if (c == '.') {
-                        throw numberError(pos);
-                    } else {
-                        throw expectedError(pos, "json literal", toString(c));
+
+            switch (c) {
+                case '"' -> {
+                    if (state == STATE_ELEMENT_PARSED) {
+                        throw expectedError(pos, ", or }", toString(c));
                     }
+                    final String id = parseString();
+                    expectColon();
+                    final Object value = parseLiteral();
+                    result.put(id, value);
+                    state = STATE_ELEMENT_PARSED;
                 }
-            };
-        }
-
-        private Object parseObject() {
-            Map<String, Object> result = new HashMap<>();
-            int state = STATE_EMPTY;
-
-            assert peek() == '{';
-            pos++;
-
-            while (pos < length) {
-                skipWhiteSpace();
-                final int c = peek();
-
-                switch (c) {
-                    case '"' -> {
-                        if (state == STATE_ELEMENT_PARSED) {
-                            throw expectedError(pos, ", or }", toString(c));
-                        }
-                        final String id = parseString();
-                        expectColon();
-                        final Object value = parseLiteral();
-                        result.put(id, value);
-                        state = STATE_ELEMENT_PARSED;
+                case ',' -> {
+                    if (state != STATE_ELEMENT_PARSED) {
+                        throw error("Trailing comma is not allowed in JSON", pos);
                     }
-                    case ',' -> {
-                        if (state != STATE_ELEMENT_PARSED) {
-                            throw error("Trailing comma is not allowed in JSON", pos);
-                        }
-                        state = STATE_COMMA_PARSED;
-                        pos++;
-                    }
-                    case '}' -> {
-                        if (state == STATE_COMMA_PARSED) {
-                            throw error("Trailing comma is not allowed in JSON", pos);
-                        }
-                        pos++;
-                        return result;
-                    }
-                    default -> throw expectedError(pos, ", or }", toString(c));
+                    state = STATE_COMMA_PARSED;
+                    pos++;
                 }
+                case '}' -> {
+                    if (state == STATE_COMMA_PARSED) {
+                        throw error("Trailing comma is not allowed in JSON", pos);
+                    }
+                    pos++;
+                    return result;
+                }
+                default -> throw expectedError(pos, ", or }", toString(c));
             }
-            throw expectedError(pos, ", or }", "eof");
         }
+        throw expectedError(pos, ", or }", "eof");
+    }
 
-        private void expectColon() {
+    private void expectColon() {
+        skipWhiteSpace();
+        final int n = next();
+        if (n != ':') {
+            throw expectedError(pos - 1, ":", toString(n));
+        }
+    }
+
+    private Object parseArray() {
+        List<Object> result = new ArrayList<>();
+        int state = STATE_EMPTY;
+
+        assert peek() == '[';
+        pos++;
+
+        while (pos < length) {
             skipWhiteSpace();
-            final int n = next();
-            if (n != ':') {
-                throw expectedError(pos - 1, ":", toString(n));
-            }
-        }
+            final int c = peek();
 
-        private Object parseArray() {
-            List<Object> result = new ArrayList<>();
-            int state = STATE_EMPTY;
-
-            assert peek() == '[';
-            pos++;
-
-            while (pos < length) {
-                skipWhiteSpace();
-                final int c = peek();
-
-                switch (c) {
-                    case ',' -> {
-                        if (state != STATE_ELEMENT_PARSED) {
-                            throw error("Trailing comma is not allowed in JSON", pos);
-                        }
-                        state = STATE_COMMA_PARSED;
-                        pos++;
+            switch (c) {
+                case ',' -> {
+                    if (state != STATE_ELEMENT_PARSED) {
+                        throw error("Trailing comma is not allowed in JSON", pos);
                     }
-                    case ']' -> {
-                        if (state == STATE_COMMA_PARSED) {
-                            throw error("Trailing comma is not allowed in JSON", pos);
-                        }
-                        pos++;
-                        return result;
+                    state = STATE_COMMA_PARSED;
+                    pos++;
+                }
+                case ']' -> {
+                    if (state == STATE_COMMA_PARSED) {
+                        throw error("Trailing comma is not allowed in JSON", pos);
                     }
-                    default -> {
-                        if (state == STATE_ELEMENT_PARSED) {
-                            throw expectedError(pos, ", or ]", toString(c));
-                        }
-                        result.add(parseLiteral());
-                        state = STATE_ELEMENT_PARSED;
+                    pos++;
+                    return result;
+                }
+                default -> {
+                    if (state == STATE_ELEMENT_PARSED) {
+                        throw expectedError(pos, ", or ]", toString(c));
                     }
+                    result.add(parseLiteral());
+                    state = STATE_ELEMENT_PARSED;
                 }
             }
-
-            throw expectedError(pos, ", or ]", "eof");
         }
 
-        private String parseString() {
-            // String buffer is only instantiated if string contains escape sequences.
-            int start = ++pos;
-            StringBuilder sb = null;
+        throw expectedError(pos, ", or ]", "eof");
+    }
 
-            while (pos < length) {
-                final int c = next();
-                if (c <= 0x1f) {
-                    // Characters < 0x1f are not allowed in JSON strings.
-                    throw syntaxError(pos, "String contains control character");
+    private String parseString() {
+        // String buffer is only instantiated if string contains escape sequences.
+        int start = ++pos;
+        StringBuilder sb = null;
 
-                } else if (c == '\\') {
-                    if (sb == null) {
-                        sb = new StringBuilder(pos - start + 16);
-                    }
+        while (pos < length) {
+            final int c = next();
+            if (c <= 0x1f) {
+                // Characters < 0x1f are not allowed in JSON strings.
+                throw syntaxError(pos, "String contains control character");
+
+            } else if (c == '\\') {
+                if (sb == null) {
+                    sb = new StringBuilder(pos - start + 16);
+                }
+                sb.append(source, start, pos - 1);
+                sb.append(parseEscapeSequence());
+                start = pos;
+
+            } else if (c == '"') {
+                if (sb != null) {
                     sb.append(source, start, pos - 1);
-                    sb.append(parseEscapeSequence());
-                    start = pos;
-
-                } else if (c == '"') {
-                    if (sb != null) {
-                        sb.append(source, start, pos - 1);
-                        return sb.toString();
-                    }
-                    return source.substring(start, pos - 1);
+                    return sb.toString();
                 }
-            }
-
-            throw error("Missing close quote", pos);
-        }
-
-        private char parseEscapeSequence() {
-            final int c = next();
-            return switch (c) {
-                case '"' -> '"';
-                case '\\' -> '\\';
-                case '/' -> '/';
-                case 'b' -> '\b';
-                case 'f' -> '\f';
-                case 'n' -> '\n';
-                case 'r' -> '\r';
-                case 't' -> '\t';
-                case 'u' -> parseUnicodeEscape();
-                default -> throw error("Invalid escape character", pos - 1);
-            };
-        }
-
-        private char parseUnicodeEscape() {
-            return (char) (parseHexDigit() << 12 | parseHexDigit() << 8 | parseHexDigit() << 4 | parseHexDigit());
-        }
-
-        private int parseHexDigit() {
-            final int c = next();
-            if (c >= '0' && c <= '9') {
-                return c - '0';
-            } else if (c >= 'A' && c <= 'F') {
-                return c + 10 - 'A';
-            } else if (c >= 'a' && c <= 'f') {
-                return c + 10 - 'a';
-            }
-            throw error("Invalid hex digit", pos - 1);
-        }
-
-        private static boolean isDigit(final int c) {
-            return c >= '0' && c <= '9';
-        }
-
-        private void skipDigits() {
-            while (pos < length) {
-                final int c = peek();
-                if (!isDigit(c)) {
-                    break;
-                }
-                pos++;
+                return source.substring(start, pos - 1);
             }
         }
 
-        private Number parseNumber() {
-            boolean isFloating = false;
-            final int start = pos;
-            int c = next();
+        throw error("Missing close quote", pos);
+    }
 
-            if (c == '-') {
+    private char parseEscapeSequence() {
+        final int c = next();
+        return switch (c) {
+            case '"' -> '"';
+            case '\\' -> '\\';
+            case '/' -> '/';
+            case 'b' -> '\b';
+            case 'f' -> '\f';
+            case 'n' -> '\n';
+            case 'r' -> '\r';
+            case 't' -> '\t';
+            case 'u' -> parseUnicodeEscape();
+            default -> throw error("Invalid escape character", pos - 1);
+        };
+    }
+
+    private char parseUnicodeEscape() {
+        return (char) (parseHexDigit() << 12 | parseHexDigit() << 8 | parseHexDigit() << 4 | parseHexDigit());
+    }
+
+    private int parseHexDigit() {
+        final int c = next();
+        if (c >= '0' && c <= '9') {
+            return c - '0';
+        } else if (c >= 'A' && c <= 'F') {
+            return c + 10 - 'A';
+        } else if (c >= 'a' && c <= 'f') {
+            return c + 10 - 'a';
+        }
+        throw error("Invalid hex digit", pos - 1);
+    }
+
+    private static boolean isDigit(final int c) {
+        return c >= '0' && c <= '9';
+    }
+
+    private void skipDigits() {
+        while (pos < length) {
+            final int c = peek();
+            if (!isDigit(c)) {
+                break;
+            }
+            pos++;
+        }
+    }
+
+    private Number parseNumber() {
+        boolean isFloating = false;
+        final int start = pos;
+        int c = next();
+
+        if (c == '-') {
+            c = next();
+        }
+        if (!isDigit(c)) {
+            throw numberError(start);
+        }
+        // no more digits allowed after 0
+        if (c != '0') {
+            skipDigits();
+        }
+
+        // fraction
+        if (peek() == '.') {
+            isFloating = true;
+            pos++;
+            if (!isDigit(next())) {
+                throw numberError(pos - 1);
+            }
+            skipDigits();
+        }
+
+        // exponent
+        c = peek();
+        if (c == 'e' || c == 'E') {
+            pos++;
+            c = next();
+            if (c == '-' || c == '+') {
                 c = next();
             }
             if (!isDigit(c)) {
-                throw numberError(start);
+                throw numberError(pos - 1);
             }
-            // no more digits allowed after 0
-            if (c != '0') {
-                skipDigits();
-            }
+            skipDigits();
+        }
 
-            // fraction
-            if (peek() == '.') {
-                isFloating = true;
-                pos++;
-                if (!isDigit(next())) {
-                    throw numberError(pos - 1);
-                }
-                skipDigits();
-            }
-
-            // exponent
-            c = peek();
-            if (c == 'e' || c == 'E') {
-                pos++;
-                c = next();
-                if (c == '-' || c == '+') {
-                    c = next();
-                }
-                if (!isDigit(c)) {
-                    throw numberError(pos - 1);
-                }
-                skipDigits();
-            }
-
-            String literalValue = source.substring(start, pos);
-            if (isFloating) {
-                return Double.parseDouble(literalValue);
+        String literalValue = source.substring(start, pos);
+        if (isFloating) {
+            return Double.parseDouble(literalValue);
+        } else {
+            final long l = Long.parseLong(literalValue);
+            if ((int) l == l) {
+                return (int) l;
             } else {
-                final long l = Long.parseLong(literalValue);
-                if ((int) l == l) {
-                    return (int) l;
-                } else {
-                    return l;
+                return l;
+            }
+        }
+    }
+
+    private Object parseKeyword(final String keyword, final Object value) {
+        if (!source.regionMatches(pos, keyword, 0, keyword.length())) {
+            throw expectedError(pos, "json literal", "ident");
+        }
+        pos += keyword.length();
+        return value;
+    }
+
+    private int peek() {
+        if (pos >= length) {
+            return -1;
+        }
+        return source.charAt(pos);
+    }
+
+    private int next() {
+        final int next = peek();
+        pos++;
+        return next;
+    }
+
+    private void skipWhiteSpace() {
+        while (pos < length) {
+            switch (peek()) {
+                case '\t', '\r', '\n', ' ' -> pos++;
+                default -> {
+                    return;
                 }
             }
         }
+    }
 
-        private Object parseKeyword(final String keyword, final Object value) {
-            if (!source.regionMatches(pos, keyword, 0, keyword.length())) {
-                throw expectedError(pos, "json literal", "ident");
+    private static String toString(final int c) {
+        return c == EOF ? "eof" : String.valueOf((char) c);
+    }
+
+    private BundleJSONParserException error(final String message, final int start) {
+        final int lineNum = getLine(start);
+        final int columnNum = getColumn(start);
+        final String formatted = format(message, lineNum, columnNum);
+        return new BundleJSONParserException(formatted);
+    }
+
+    /**
+     * Return line number of character position.
+     *
+     * <p>
+     * This method can be expensive for large sources as it iterates through all characters up to
+     * {@code position}.
+     * </p>
+     *
+     * @param position Position of character in source content.
+     * @return Line number.
+     */
+    private int getLine(final int position) {
+        final CharSequence d = source;
+        // Line count starts at 1.
+        int line = 1;
+
+        for (int i = 0; i < position; i++) {
+            final char ch = d.charAt(i);
+            // Works for both \n and \r\n.
+            if (ch == '\n') {
+                line++;
             }
-            pos += keyword.length();
-            return value;
         }
 
-        private int peek() {
-            if (pos >= length) {
-                return -1;
+        return line;
+    }
+
+    /**
+     * Return column number of character position.
+     *
+     * @param position Position of character in source content.
+     * @return Column number.
+     */
+    private int getColumn(final int position) {
+        return position - findBOLN(position);
+    }
+
+    /**
+     * Find the beginning of the line containing position.
+     *
+     * @param position Index to offending token.
+     * @return Index of first character of line.
+     */
+    private int findBOLN(final int position) {
+        final CharSequence d = source;
+        for (int i = position - 1; i > 0; i--) {
+            final char ch = d.charAt(i);
+
+            if (ch == '\n' || ch == '\r') {
+                return i + 1;
             }
-            return source.charAt(pos);
         }
 
-        private int next() {
-            final int next = peek();
-            pos++;
-            return next;
-        }
+        return 0;
+    }
 
-        private void skipWhiteSpace() {
-            while (pos < length) {
-                switch (peek()) {
-                    case '\t', '\r', '\n', ' ' -> pos++;
-                    default -> {
-                        return;
-                    }
-                }
+    /**
+     * Format an error message to include source and line information.
+     *
+     * @param message Error message string.
+     * @param line Source line number.
+     * @param column Source column number.
+     * @return formatted string
+     */
+    private static String format(final String message, final int line, final int column) {
+        return "line " + line + " column " + column + " " + message;
+    }
+
+    private BundleJSONParserException numberError(final int start) {
+        return error("Invalid JSON number format", start);
+    }
+
+    private BundleJSONParserException expectedError(final int start, final String expected, final String found) {
+        return error("Expected " + expected + " but found " + found, start);
+    }
+
+    private BundleJSONParserException syntaxError(final int start, final String reason) {
+        return error("Invalid JSON: " + reason, start);
+    }
+
+    /**
+     * Utility function to read all contents of a {@link Reader}, because the JSON parser does not
+     * support streaming yet.
+     */
+    private static String readFully(final Reader reader) throws IOException {
+        final char[] arr = new char[1024];
+        final StringBuilder sb = new StringBuilder();
+
+        try (reader) {
+            int numChars;
+            while ((numChars = reader.read(arr, 0, arr.length)) > 0) {
+                sb.append(arr, 0, numChars);
             }
         }
 
-        private static String toString(final int c) {
-            return c == EOF ? "eof" : String.valueOf((char) c);
-        }
-
-        private BundleJSONParserException error(final String message, final int start) {
-            final int lineNum = getLine(start);
-            final int columnNum = getColumn(start);
-            final String formatted = format(message, lineNum, columnNum);
-            return new BundleJSONParserException(formatted);
-        }
-
-        /**
-         * Return line number of character position.
-         *
-         * <p>
-         * This method can be expensive for large sources as it iterates through all characters up to
-         * {@code position}.
-         * </p>
-         *
-         * @param position Position of character in source content.
-         * @return Line number.
-         */
-        private int getLine(final int position) {
-            final CharSequence d = source;
-            // Line count starts at 1.
-            int line = 1;
-
-            for (int i = 0; i < position; i++) {
-                final char ch = d.charAt(i);
-                // Works for both \n and \r\n.
-                if (ch == '\n') {
-                    line++;
-                }
-            }
-
-            return line;
-        }
-
-        /**
-         * Return column number of character position.
-         *
-         * @param position Position of character in source content.
-         * @return Column number.
-         */
-        private int getColumn(final int position) {
-            return position - findBOLN(position);
-        }
-
-        /**
-         * Find the beginning of the line containing position.
-         *
-         * @param position Index to offending token.
-         * @return Index of first character of line.
-         */
-        private int findBOLN(final int position) {
-            final CharSequence d = source;
-            for (int i = position - 1; i > 0; i--) {
-                final char ch = d.charAt(i);
-
-                if (ch == '\n' || ch == '\r') {
-                    return i + 1;
-                }
-            }
-
-            return 0;
-        }
-
-        /**
-         * Format an error message to include source and line information.
-         *
-         * @param message Error message string.
-         * @param line Source line number.
-         * @param column Source column number.
-         * @return formatted string
-         */
-        private static String format(final String message, final int line, final int column) {
-            return "line " + line + " column " + column + " " + message;
-        }
-
-        private BundleJSONParserException numberError(final int start) {
-            return error("Invalid JSON number format", start);
-        }
-
-        private BundleJSONParserException expectedError(final int start, final String expected, final String found) {
-            return error("Expected " + expected + " but found " + found, start);
-        }
-
-        private BundleJSONParserException syntaxError(final int start, final String reason) {
-            return error("Invalid JSON: " + reason, start);
-        }
-
-        /**
-         * Utility function to read all contents of a {@link Reader}, because the JSON parser does not
-         * support streaming yet.
-         */
-        private static String readFully(final Reader reader) throws IOException {
-            final char[] arr = new char[1024];
-            final StringBuilder sb = new StringBuilder();
-
-            try (reader) {
-                int numChars;
-                while ((numChars = reader.read(arr, 0, arr.length)) > 0) {
-                    sb.append(arr, 0, numChars);
-                }
-            }
-
-            return sb.toString();
-        }
+        return sb.toString();
+    }
 }

--- a/substratevm/src/com.oracle.svm.driver.launcher/src/com/oracle/svm/driver/launcher/json/BundleJSONParserException.java
+++ b/substratevm/src/com.oracle.svm.driver.launcher/src/com/oracle/svm/driver/launcher/json/BundleJSONParserException.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2023, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package com.oracle.svm.driver.launcher.json;
+
+@SuppressWarnings("serial")
+public final class BundleJSONParserException extends RuntimeException {
+    public BundleJSONParserException(final String msg) {
+        super(msg);
+    }
+}

--- a/substratevm/src/com.oracle.svm.driver/resources/HelpExtra.txt
+++ b/substratevm/src/com.oracle.svm.driver/resources/HelpExtra.txt
@@ -21,14 +21,20 @@ Non-standard options help:
     --diagnostics-mode    Enables logging of image-build information to a diagnostics folder.
     --dry-run             output the command line that would be used for building
 
-    --bundle-create[=new-bundle.nib]
+    --bundle-create[=new-bundle.nib][,dry-run][,container[=<container-tool>][,dockerfile=<Dockerfile>]]
                           in addition to image building, create a Native Image bundle file (*.nib
                           file) that allows rebuilding of that image again at a later point. If a
                           bundle-file gets passed, the bundle will be created with the given
                           name. Otherwise, the bundle-file name is derived from the image name.
-                          Note both bundle options can be combined with --dry-run to only perform
-                          the bundle operations without any actual image building.
-    --bundle-apply=some-bundle.nib
+                          Note both bundle options can be extended with ",dry-run" and ",container"
+                          * 'dry-run': only perform the bundle operations without any actual image building.
+                          * 'container': sets up a container image for image building and performs image building
+                            from inside that container. Requires podman or rootless docker to be installed.
+                            If available, 'podman' is preferred and rootless 'docker' is the fallback. Specifying
+                            one or the other as '=<container-tool>' forces the use of a specific tool.
+                          * 'dockerfile=<Dockerfile>': Use a user provided 'Dockerfile' instead of the default based on
+                            Oracle Linux 8 base images for GraalVM (see https://github.com/graalvm/container)
+    --bundle-apply=some-bundle.nib[,dry-run][,container[=<container-tool>][,dockerfile=<Dockerfile>]]
                           an image will be built from the given bundle file with the exact same
                           arguments and files that have been passed to native-image originally
                           to create the bundle. Note that if an extra --bundle-create gets passed

--- a/substratevm/src/com.oracle.svm.driver/resources/container-default/Dockerfile
+++ b/substratevm/src/com.oracle.svm.driver/resources/container-default/Dockerfile
@@ -1,3 +1,26 @@
+# Copyright (c) 2023, 2023, Oracle and/or its affiliates. All rights reserved.
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+#
+# This code is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 only, as
+# published by the Free Software Foundation.  Oracle designates this
+# particular file as subject to the "Classpath" exception as provided
+# by Oracle in the LICENSE file that accompanied this code.
+#
+# This code is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+# version 2 for more details (a copy is included in the LICENSE file that
+# accompanied this code).
+#
+# You should have received a copy of the GNU General Public License version
+# 2 along with this work; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+# or visit www.oracle.com if you need additional information or have any
+# questions.
+
 ARG BASE_IMAGE=container-registry.oracle.com/os/oraclelinux:8-slim
 
 FROM ${BASE_IMAGE} as base

--- a/substratevm/src/com.oracle.svm.driver/resources/container-default/Dockerfile
+++ b/substratevm/src/com.oracle.svm.driver/resources/container-default/Dockerfile
@@ -1,0 +1,14 @@
+ARG BASE_IMAGE=container-registry.oracle.com/os/oraclelinux:8-slim
+
+FROM ${BASE_IMAGE} as base
+
+RUN microdnf update -y oraclelinux-release-el8 \
+    && microdnf --enablerepo ol8_codeready_builder install bzip2-devel ed gcc gcc-c++ gcc-gfortran gzip file fontconfig less libcurl-devel make openssl openssl-devel readline-devel tar glibc-langpack-en \
+    vi which xz-devel zlib-devel findutils glibc-static libstdc++ libstdc++-devel libstdc++-static zlib-static \
+    && microdnf clean all
+RUN fc-cache -f -v
+
+ENV LANG=en_US.UTF-8 \
+    JAVA_HOME=/graalvm
+
+WORKDIR /

--- a/substratevm/src/com.oracle.svm.driver/resources/container-default/Dockerfile_muslib_extension
+++ b/substratevm/src/com.oracle.svm.driver/resources/container-default/Dockerfile_muslib_extension
@@ -1,3 +1,26 @@
+# Copyright (c) 2023, 2023, Oracle and/or its affiliates. All rights reserved.
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+#
+# This code is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 only, as
+# published by the Free Software Foundation.  Oracle designates this
+# particular file as subject to the "Classpath" exception as provided
+# by Oracle in the LICENSE file that accompanied this code.
+#
+# This code is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+# version 2 for more details (a copy is included in the LICENSE file that
+# accompanied this code).
+#
+# You should have received a copy of the GNU General Public License version
+# 2 along with this work; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+# or visit www.oracle.com if you need additional information or have any
+# questions.
+
 FROM base as muslib
 
 ARG TEMP_REGION=""

--- a/substratevm/src/com.oracle.svm.driver/resources/container-default/Dockerfile_muslib_extension
+++ b/substratevm/src/com.oracle.svm.driver/resources/container-default/Dockerfile_muslib_extension
@@ -38,7 +38,7 @@ RUN echo "$TEMP_REGION" > /etc/dnf/vars/ociregion \
     && wget $ZLIB_LOCATION && tar -xvf zlib-1.2.11.tar.gz \
     && cd zlib-1.2.11 \
     && ./configure --prefix=$TOOLCHAIN_DIR --static \
-    && make && make install \
+    && make && make install
 
 
 FROM base as final
@@ -48,5 +48,6 @@ COPY --from=muslib /usr/local/musl /usr/local/musl
 RUN echo "" > /etc/dnf/vars/ociregion
 
 ENV TOOLCHAIN_DIR=/usr/local/musl \
-    CC=$TOOLCHAIN_DIR/bin/gcc \
-    PATH=$TOOLCHAIN_DIR/bin:$PATH
+    CC=$TOOLCHAIN_DIR/bin/gcc
+
+ENV PATH=$TOOLCHAIN_DIR/bin:$PATH

--- a/substratevm/src/com.oracle.svm.driver/resources/container-default/Dockerfile_muslib_extension
+++ b/substratevm/src/com.oracle.svm.driver/resources/container-default/Dockerfile_muslib_extension
@@ -1,0 +1,29 @@
+FROM base as muslib
+
+ARG TEMP_REGION=""
+ARG MUSL_LOCATION=http://more.musl.cc/10/x86_64-linux-musl/x86_64-linux-musl-native.tgz
+ARG ZLIB_LOCATION=https://zlib.net/fossils/zlib-1.2.11.tar.gz
+
+ENV TOOLCHAIN_DIR=/usr/local/musl \
+    CC=$TOOLCHAIN_DIR/bin/gcc
+
+RUN echo "$TEMP_REGION" > /etc/dnf/vars/ociregion \
+    && rm -rf /etc/yum.repos.d/ol8_graalvm_community.repo \
+    && mkdir -p $TOOLCHAIN_DIR \
+    && microdnf install -y wget tar gzip make \
+    && wget $MUSL_LOCATION && tar -xvf  x86_64-linux-musl-native.tgz -C $TOOLCHAIN_DIR --strip-components=1  \
+    && wget $ZLIB_LOCATION && tar -xvf zlib-1.2.11.tar.gz \
+    && cd zlib-1.2.11 \
+    && ./configure --prefix=$TOOLCHAIN_DIR --static \
+    && make && make install \
+
+
+FROM base as final
+
+COPY --from=muslib /usr/local/musl /usr/local/musl
+
+RUN echo "" > /etc/dnf/vars/ociregion
+
+ENV TOOLCHAIN_DIR=/usr/local/musl \
+    CC=$TOOLCHAIN_DIR/bin/gcc \
+    PATH=$TOOLCHAIN_DIR/bin:$PATH

--- a/substratevm/src/com.oracle.svm.driver/src/com/oracle/svm/driver/APIOptionHandler.java
+++ b/substratevm/src/com.oracle.svm.driver/src/com/oracle/svm/driver/APIOptionHandler.java
@@ -393,16 +393,10 @@ class APIOptionHandler extends NativeImage.OptionHandler<NativeImage> {
             }
 
             if (nativeImage.useBundle() && option.launcherOption) {
-                String optionName = optionNameAndOptionValue[0];
-                if (optionValue != null) {
-                    if (whitespaceSeparated) {
-                        nativeImage.bundleSupport.bundleLauncherArgs.add(optionName);
-                        nativeImage.bundleSupport.bundleLauncherArgs.add(optionValue);
-                    } else {
-                        nativeImage.bundleSupport.bundleLauncherArgs.add(optionName + optionValue);
-                    }
+                if (whitespaceSeparated) {
+                    nativeImage.bundleSupport.bundleLauncherArgs.addAll(List.of(optionNameAndOptionValue));
                 } else {
-                    nativeImage.bundleSupport.bundleLauncherArgs.add(optionName);
+                    nativeImage.bundleSupport.bundleLauncherArgs.add(argQueue.peek());
                 }
             }
 

--- a/substratevm/src/com.oracle.svm.driver/src/com/oracle/svm/driver/APIOptionHandler.java
+++ b/substratevm/src/com.oracle.svm.driver/src/com/oracle/svm/driver/APIOptionHandler.java
@@ -390,6 +390,10 @@ class APIOptionHandler extends NativeImage.OptionHandler<NativeImage> {
                 builderOption += transformed.toString();
             }
 
+            if (option.launcherOption) {
+                nativeImage.bundleLauncherArgs.add(argQueue.peek());
+            }
+
             return builderOption;
         }
         return null;

--- a/substratevm/src/com.oracle.svm.driver/src/com/oracle/svm/driver/APIOptionHandler.java
+++ b/substratevm/src/com.oracle.svm.driver/src/com/oracle/svm/driver/APIOptionHandler.java
@@ -76,7 +76,7 @@ class APIOptionHandler extends NativeImage.OptionHandler<NativeImage> {
     private static final String LEAVE_UNLOCK_SCOPE = SubstrateOptionsParser.commandArgument(SubstrateOptions.UnlockExperimentalVMOptions, "-");
 
     record OptionInfo(String[] variants, char[] valueSeparator, String builderOption, String defaultValue, String helpText, boolean defaultFinal, String deprecationWarning,
-                    List<Function<Object, Object>> valueTransformers, APIOptionGroup group, boolean extra) {
+                    List<Function<Object, Object>> valueTransformers, APIOptionGroup group, boolean extra, boolean launcherOption) {
         boolean isDeprecated() {
             return deprecationWarning.length() > 0;
         }
@@ -259,7 +259,7 @@ class APIOptionHandler extends NativeImage.OptionHandler<NativeImage> {
             boolean defaultFinal = booleanOption || hasFixedValue;
             apiOptions.put(apiOptionName,
                             new APIOptionHandler.OptionInfo(apiAnnotation.name(), apiAnnotation.valueSeparator(), builderOption, defaultValue, helpText,
-                                            defaultFinal, apiAnnotation.deprecated(), valueTransformers, group, apiAnnotation.extra()));
+                                            defaultFinal, apiAnnotation.deprecated(), valueTransformers, group, apiAnnotation.extra(), apiAnnotation.launcherOption()));
         }
 
         if (optionDescriptor.getStability() == OptionStability.STABLE) {

--- a/substratevm/src/com.oracle.svm.driver/src/com/oracle/svm/driver/APIOptionHandler.java
+++ b/substratevm/src/com.oracle.svm.driver/src/com/oracle/svm/driver/APIOptionHandler.java
@@ -328,6 +328,7 @@ class APIOptionHandler extends NativeImage.OptionHandler<NativeImage> {
 
     String translateOption(ArgumentQueue argQueue) {
         OptionInfo option = null;
+        boolean whitespaceSeparated = false;
         String[] optionNameAndOptionValue = null;
         OptionOrigin argumentOrigin = OptionOrigin.from(argQueue.argumentOrigin);
         found: for (OptionInfo optionInfo : apiOptions.values()) {
@@ -353,6 +354,7 @@ class APIOptionHandler extends NativeImage.OptionHandler<NativeImage> {
                         }
                         option = optionInfo;
                         optionNameAndOptionValue = new String[]{headArg, optionValue};
+                        whitespaceSeparated = true;
                         break found;
                     } else {
                         boolean withSeparator = valueSeparator != APIOption.NO_SEPARATOR;
@@ -390,8 +392,18 @@ class APIOptionHandler extends NativeImage.OptionHandler<NativeImage> {
                 builderOption += transformed.toString();
             }
 
-            if (option.launcherOption) {
-                nativeImage.bundleLauncherArgs.add(argQueue.peek());
+            if (nativeImage.useBundle() && option.launcherOption) {
+                String optionName = optionNameAndOptionValue[0];
+                if (optionValue != null) {
+                    if (whitespaceSeparated) {
+                        nativeImage.bundleSupport.bundleLauncherArgs.add(optionName);
+                        nativeImage.bundleSupport.bundleLauncherArgs.add(optionValue);
+                    } else {
+                        nativeImage.bundleSupport.bundleLauncherArgs.add(optionName + optionValue);
+                    }
+                } else {
+                    nativeImage.bundleSupport.bundleLauncherArgs.add(optionName);
+                }
             }
 
             return builderOption;

--- a/substratevm/src/com.oracle.svm.driver/src/com/oracle/svm/driver/BundleSupport.java
+++ b/substratevm/src/com.oracle.svm.driver/src/com/oracle/svm/driver/BundleSupport.java
@@ -786,7 +786,7 @@ final class BundleSupport {
                     createDockerfile(dockerfilePath);
                 }
             } else if (!dockerfilePath.equals(containerSupport.dockerfile)) {
-                Files.copy(containerSupport.dockerfile, dockerfilePath);
+                Files.copy(containerSupport.dockerfile, dockerfilePath, StandardCopyOption.REPLACE_EXISTING);
             }
         } catch (IOException e) {
             throw NativeImage.showError("Failed to write bundle-file " + dockerfilePath, e);

--- a/substratevm/src/com.oracle.svm.driver/src/com/oracle/svm/driver/BundleSupport.java
+++ b/substratevm/src/com.oracle.svm.driver/src/com/oracle/svm/driver/BundleSupport.java
@@ -289,7 +289,7 @@ final class BundleSupport {
     }
 
     private void initializeContainerImage() {
-        String bundleFileName = bundlePath.resolve(bundleName + BUNDLE_FILE_EXTENSION).toString();
+        String bundleFileName = bundlePath == null ? "" : bundlePath.resolve(bundleName + BUNDLE_FILE_EXTENSION).toString();
 
         if(bundleDockerfile != null && dockerfile == null) {
             dockerfile = bundleDockerfile;

--- a/substratevm/src/com.oracle.svm.driver/src/com/oracle/svm/driver/BundleSupport.java
+++ b/substratevm/src/com.oracle.svm.driver/src/com/oracle/svm/driver/BundleSupport.java
@@ -1035,7 +1035,7 @@ final class BundleSupport {
 
         Path runArgsFile = stageDir.resolve("run.json");
         try (JsonWriter writer = new JsonWriter(runArgsFile)) {
-            List<String> equalsRunArg = List.of("-jar", "-m", "--module");
+            List<String> equalsRunArg = List.of("-m", "--module");
             List<String> runArgs = new ArrayList<>();
             ListIterator<String> bundleArgsIterator = bundleArgs.listIterator();
             while (bundleArgsIterator.hasNext()) {

--- a/substratevm/src/com.oracle.svm.driver/src/com/oracle/svm/driver/BundleSupport.java
+++ b/substratevm/src/com.oracle.svm.driver/src/com/oracle/svm/driver/BundleSupport.java
@@ -325,7 +325,7 @@ final class BundleSupport {
                 if (!containerTool.equals(bundleContainerTool)) {
                     NativeImage.showWarning(String.format("The given bundle file %s was created with container tool '%s' (using '%s').", bundleFileName, bundleContainerTool, containerTool));
                 } else if (containerToolVersion != null && bundleContainerToolVersion != null && !containerToolVersion.equals(bundleContainerToolVersion)) {
-                    NativeImage.showWarning(String.format("The given bundle file %s was created with %s version '%s' (installed '%s').", bundleFileName, containerTool, bundleContainerToolVersion, containerToolVersion));
+                    NativeImage.showWarning(String.format("The given bundle file %s was created with different %s version '%s' (installed '%s').", bundleFileName, containerTool, bundleContainerToolVersion, containerToolVersion));
                 }
             }
         } else {
@@ -560,8 +560,11 @@ final class BundleSupport {
                 throw NativeImage.showError("Failed to read bundle-file " + pathSubstitutionsFile, e);
             }
             if(bundleContainerTool != null) {
-                String containerToolVersionString = bundleContainerToolVersion == null ? "" : String.format(" version: %s", bundleContainerToolVersion);
-                nativeImage.showMessage(String.format("%sUsing %s%s. Specify other container tool with option '%s'.", BUNDLE_INFO_MESSAGE_PREFIX, bundleContainerTool, containerToolVersionString, ExtendedBundleOptions.container));
+                String containerToolVersionString = bundleContainerToolVersion == null ? "" : String.format(" (%s)", bundleContainerToolVersion);
+                nativeImage.showMessage(String.format("%sBundled native-image was created in a container with %s%s.", BUNDLE_INFO_MESSAGE_PREFIX, bundleContainerTool, containerToolVersionString));
+                if(useContainer) {
+                    nativeImage.showMessage(String.format("%sUsing %s for native-image container build. Specify other container tool with option '%s'.", BUNDLE_INFO_MESSAGE_PREFIX, bundleContainerTool, ExtendedBundleOptions.container));
+                }
             }
         }
 

--- a/substratevm/src/com.oracle.svm.driver/src/com/oracle/svm/driver/BundleSupport.java
+++ b/substratevm/src/com.oracle.svm.driver/src/com/oracle/svm/driver/BundleSupport.java
@@ -99,6 +99,7 @@ final class BundleSupport {
     private final boolean forceBuilderOnClasspath;
     private final List<String> nativeImageArgs;
     private List<String> updatedNativeImageArgs;
+    final ArrayList<String> bundleLauncherArgs = new ArrayList<>();
 
     boolean loadBundle;
     boolean writeBundle;
@@ -833,7 +834,7 @@ final class BundleSupport {
         if (nativeImage.buildExecutable) {
             Path runArgsFile = stageDir.resolve("run.json");
             try (JsonWriter writer = new JsonWriter(runArgsFile)) {
-                List<String> runArgs = new ArrayList<>(nativeImage.bundleLauncherArgs);
+                List<String> runArgs = new ArrayList<>(bundleLauncherArgs);
                 boolean hasMainClassModule = nativeImage.mainClassModule != null && !nativeImage.mainClassModule.isEmpty();
                 boolean hasMainClass = nativeImage.mainClass != null && !nativeImage.mainClass.isEmpty();
                 if (hasMainClassModule) {

--- a/substratevm/src/com.oracle.svm.driver/src/com/oracle/svm/driver/BundleSupport.java
+++ b/substratevm/src/com.oracle.svm.driver/src/com/oracle/svm/driver/BundleSupport.java
@@ -487,13 +487,13 @@ final class BundleSupport {
         Path containerRoot = Path.of("/");
         List<String> containerCommand = new ArrayList<>(List.of(containerTool, "run", "--network=none", "--rm"));
         nativeImage.imageBuilderEnvironment
-                .forEach((key, value) -> containerCommand.addAll(List.of("-e", key + "=" + value)));
+                .forEach((key, value) -> containerCommand.addAll(List.of("-e", key + "=" + SubstrateUtil.quoteShellArg(value))));
         containerCommand.addAll(List.of(
-                "--mount", "type=bind,source=" + nativeImage.config.getJavaHome() + ",target=" + CONTAINER_GRAAL_VM_HOME + ",readonly",
-                "--mount", "type=bind,source=" + inputDir + ",target=" + containerRoot.resolve(rootDir.relativize(inputDir)) + ",readonly",
-                "--mount", "type=bind,source=" + outputDir + ",target=" + containerRoot.resolve(rootDir.relativize(outputDir)),
-                "--mount", "type=bind,source=" + argFile + ",target=" + argFile + ",readonly",
-                "--mount", "type=bind,source=" + builderArgFile + ",target=" + builderArgFile + ",readonly",
+                "--mount", SubstrateUtil.quoteShellArg("type=bind,source=" + nativeImage.config.getJavaHome() + ",target=" + CONTAINER_GRAAL_VM_HOME.toString() + ",readonly"),
+                "--mount", SubstrateUtil.quoteShellArg("type=bind,source=" + inputDir + ",target=" + containerRoot.resolve(rootDir.relativize(inputDir)) + ",readonly"),
+                "--mount", SubstrateUtil.quoteShellArg("type=bind,source=" + outputDir + ",target=" + containerRoot.resolve(rootDir.relativize(outputDir))),
+                "--mount", SubstrateUtil.quoteShellArg("type=bind,source=" + argFile + ",target=" + argFile + ",readonly"),
+                "--mount", SubstrateUtil.quoteShellArg("type=bind,source=" + builderArgFile + ",target=" + builderArgFile + ",readonly"),
                 containerImage)
         );
         return containerCommand;

--- a/substratevm/src/com.oracle.svm.driver/src/com/oracle/svm/driver/BundleSupport.java
+++ b/substratevm/src/com.oracle.svm.driver/src/com/oracle/svm/driver/BundleSupport.java
@@ -884,7 +884,7 @@ final class BundleSupport {
         return bundleFilePath;
     }
 
-    private Manifest createManifest() {
+    private static Manifest createManifest() {
         Manifest mf = new Manifest();
         Attributes attributes = mf.getMainAttributes();
         attributes.put(Attributes.Name.MANIFEST_VERSION, "1.0");

--- a/substratevm/src/com.oracle.svm.driver/src/com/oracle/svm/driver/BundleSupport.java
+++ b/substratevm/src/com.oracle.svm.driver/src/com/oracle/svm/driver/BundleSupport.java
@@ -833,8 +833,7 @@ final class BundleSupport {
         if (nativeImage.buildExecutable) {
             Path runArgsFile = stageDir.resolve("run.json");
             try (JsonWriter writer = new JsonWriter(runArgsFile)) {
-                List<String> runArgs = new ArrayList<>();
-
+                List<String> runArgs = new ArrayList<>(nativeImage.bundleLauncherArgs);
                 boolean hasMainClassModule = nativeImage.mainClassModule != null && !nativeImage.mainClassModule.isEmpty();
                 boolean hasMainClass = nativeImage.mainClass != null && !nativeImage.mainClass.isEmpty();
                 if (hasMainClassModule) {

--- a/substratevm/src/com.oracle.svm.driver/src/com/oracle/svm/driver/BundleSupport.java
+++ b/substratevm/src/com.oracle.svm.driver/src/com/oracle/svm/driver/BundleSupport.java
@@ -128,8 +128,13 @@ final class BundleSupport {
     private Path dockerfile;
     private Path bundleDockerfile;
     private static final List<String> SUPPORTED_CONTAINER_TOOLS = List.of("podman", "docker");
-    private static final String DEFAULT_DOCKERFILE = "FROM registry.fedoraproject.org/fedora-minimal:latest" + System.lineSeparator() +
-            "RUN microdnf -y install gcc g++ zlib-static --nodocs --setopt install_weak_deps=0 && microdnf clean all -y";
+    private static final String DEFAULT_DOCKERFILE = "ARG BASE_IMAGE=container-registry.oracle.com/os/oraclelinux:8-slim" + System.lineSeparator() +
+            "FROM ${BASE_IMAGE}" + System.lineSeparator() +
+            "RUN microdnf update -y oraclelinux-release-el8 \\" + System.lineSeparator() +
+            "&& microdnf --enablerepo ol8_codeready_builder install bzip2-devel ed gcc gcc-c++ gcc-gfortran gzip file fontconfig less libcurl-devel make openssl openssl-devel readline-devel tar glibc-langpack-en \\" + System.lineSeparator() +
+            "vi which xz-devel zlib-devel findutils glibc-static libstdc++ libstdc++-devel libstdc++-static zlib-static \\" + System.lineSeparator() +
+            "&& microdnf clean all" + System.lineSeparator() +
+            "RUN fc-cache -f -v";
     private final String containerToolJsonKey = "containerTool";
     private final String containerToolVersionJsonKey = "containerToolVersion";
     private final String containerImageJsonKey = "containerImage";
@@ -292,7 +297,6 @@ final class BundleSupport {
 
         // create Dockerfile if not available for writing or loading bundle
         try {
-            // TODO load graalvm docker base
             if (dockerfile == null) {
                 dockerfile = Files.createTempFile("Dockerfile", null);
                 Files.write(dockerfile, DEFAULT_DOCKERFILE.getBytes());

--- a/substratevm/src/com.oracle.svm.driver/src/com/oracle/svm/driver/BundleSupport.java
+++ b/substratevm/src/com.oracle.svm.driver/src/com/oracle/svm/driver/BundleSupport.java
@@ -1038,7 +1038,14 @@ final class BundleSupport {
                     bundleArgsIterator.remove();
                     bundleArgsIterator.next();
                     bundleArgsIterator.remove();
+                } else if (arg.equals("-jar")) {
+                    bundleArgsIterator.next();
+                } else if (arg.startsWith("-") || arg.equals(nativeImage.imageName)) {
+                    bundleArgsIterator.remove();
                 }
+            }
+            if (bundleArgs.isEmpty()) {
+                bundleArgs.add(nativeImage.mainClass);
             }
             /* Printing as list with defined sort-order ensures useful diffs are possible */
             JsonPrinter.printCollection(writer, bundleArgs, null, BundleSupport::printBuildArg);

--- a/substratevm/src/com.oracle.svm.driver/src/com/oracle/svm/driver/BundleSupport.java
+++ b/substratevm/src/com.oracle.svm.driver/src/com/oracle/svm/driver/BundleSupport.java
@@ -301,7 +301,7 @@ final class BundleSupport {
                 if(nativeImage.getNativeImageArgs().contains("--static") && nativeImage.getNativeImageArgs().contains("--libc=musl")) {
                     dockerfileText += System.lineSeparator() + DEFAULT_DOCKERFILE_MUSLIB;
                 }
-                Files.write(dockerfile, dockerfileText.getBytes());
+                Files.writeString(dockerfile, dockerfileText);
                 dockerfile.toFile().deleteOnExit();
                 containerImage = SubstrateUtil.digest(dockerfileText);
             } else {

--- a/substratevm/src/com.oracle.svm.driver/src/com/oracle/svm/driver/BundleSupport.java
+++ b/substratevm/src/com.oracle.svm.driver/src/com/oracle/svm/driver/BundleSupport.java
@@ -36,8 +36,6 @@ import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
@@ -67,7 +65,6 @@ import java.util.stream.Stream;
 
 import com.oracle.svm.core.util.ExitStatus;
 import org.graalvm.collections.EconomicMap;
-import org.graalvm.compiler.debug.GraalError;
 import org.graalvm.util.json.JSONParser;
 import org.graalvm.util.json.JSONParserException;
 
@@ -395,17 +392,9 @@ final class BundleSupport {
     }
 
     private boolean isToolAvailable(String tool) {
-        String[] paths = SubstrateUtil.split(System.getenv("PATH"), ":");
-        for (String path : paths) {
-            try (Stream<Path> walk = Files.walk(Path.of(path))) {
-                if(walk.anyMatch(p -> p.endsWith(tool))) {
-                    return true;
-                }
-            } catch (IOException e) {
-                throw new RuntimeException(e);
-            }
-        }
-        return false;
+        return Arrays.stream(SubstrateUtil.split(System.getenv("PATH"), ":"))
+                .map(str -> Path.of(str).resolve(tool))
+                .anyMatch(Files::isExecutable);
     }
 
     private String getContainerToolVersion(String tool) {

--- a/substratevm/src/com.oracle.svm.driver/src/com/oracle/svm/driver/BundleSupport.java
+++ b/substratevm/src/com.oracle.svm.driver/src/com/oracle/svm/driver/BundleSupport.java
@@ -128,37 +128,8 @@ final class BundleSupport {
     private Path dockerfile;
     private Path bundleDockerfile;
     private static final List<String> SUPPORTED_CONTAINER_TOOLS = List.of("podman", "docker");
-    private static final String DEFAULT_DOCKERFILE = "ARG BASE_IMAGE=container-registry.oracle.com/os/oraclelinux:8-slim" + System.lineSeparator() +
-            "FROM ${BASE_IMAGE} as base" + System.lineSeparator() +
-            "RUN microdnf update -y oraclelinux-release-el8 \\" + System.lineSeparator() +
-            "   && microdnf --enablerepo ol8_codeready_builder install bzip2-devel ed gcc gcc-c++ gcc-gfortran gzip file fontconfig less libcurl-devel make openssl openssl-devel readline-devel tar glibc-langpack-en \\" + System.lineSeparator() +
-            "   vi which xz-devel zlib-devel findutils glibc-static libstdc++ libstdc++-devel libstdc++-static zlib-static \\" + System.lineSeparator() +
-            "   && microdnf clean all" + System.lineSeparator() +
-            "RUN fc-cache -f -v" + System.lineSeparator() +
-            "ENV LANG=en_US.UTF-8 \\" + System.lineSeparator() +
-            "   JAVA_HOME=" + CONTAINER_GRAAL_VM_HOME + System.lineSeparator() +
-            "WORKDIR /";
-    private static final String DEFAULT_DOCKERFILE_MUSLIB = "FROM base as muslib" + System.lineSeparator() +
-            "ARG TEMP_REGION=\"\"" + System.lineSeparator() +
-            "ARG MUSL_LOCATION=http://more.musl.cc/10/x86_64-linux-musl/x86_64-linux-musl-native.tgz" + System.lineSeparator() +
-            "ARG ZLIB_LOCATION=https://zlib.net/fossils/zlib-1.2.11.tar.gz" + System.lineSeparator() +
-            "ENV TOOLCHAIN_DIR=/usr/local/musl \\" + System.lineSeparator() +
-            "   CC=$TOOLCHAIN_DIR/bin/gcc" + System.lineSeparator() +
-            "RUN echo \"$TEMP_REGION\" > /etc/dnf/vars/ociregion \\" + System.lineSeparator() +
-            "   && rm -rf /etc/yum.repos.d/ol8_graalvm_community.repo \\" + System.lineSeparator() +
-            "   && mkdir -p $TOOLCHAIN_DIR \\" + System.lineSeparator() +
-            "   && microdnf install -y wget tar gzip make \\" + System.lineSeparator() +
-            "   && wget $MUSL_LOCATION && tar -xvf  x86_64-linux-musl-native.tgz -C $TOOLCHAIN_DIR --strip-components=1  \\" + System.lineSeparator() +
-            "   && wget $ZLIB_LOCATION && tar -xvf zlib-1.2.11.tar.gz \\" + System.lineSeparator() +
-            "   && cd zlib-1.2.11 \\" + System.lineSeparator() +
-            "   && ./configure --prefix=$TOOLCHAIN_DIR --static \\" + System.lineSeparator() +
-            "   && make && make install" + System.lineSeparator() +
-            "FROM base as final" + System.lineSeparator() +
-            "COPY --from=muslib /usr/local/musl /usr/local/musl" + System.lineSeparator() +
-            "RUN echo \"\" > /etc/dnf/vars/ociregion" + System.lineSeparator() +
-            "ENV TOOLCHAIN_DIR=/usr/local/musl \\" + System.lineSeparator() +
-            "   CC=$TOOLCHAIN_DIR/bin/gcc" + System.lineSeparator() +
-            "ENV PATH=$TOOLCHAIN_DIR/bin:$PATH";
+    private static final String DEFAULT_DOCKERFILE = NativeImage.getResource("/container-default/Dockerfile");
+    private static final String DEFAULT_DOCKERFILE_MUSLIB = NativeImage.getResource("/container-default/Dockerfile_muslib_extension");
     private static final String CONTAINER_TOOL_JSON_KEY = "containerTool";
     private static final String CONTAINER_TOOL_VERSION_JSON_KEY = "containerToolVersion";
     private static final String CONTAINER_IMAGE_JSON_KEY = "containerImage";

--- a/substratevm/src/com.oracle.svm.driver/src/com/oracle/svm/driver/BundleSupport.java
+++ b/substratevm/src/com.oracle.svm.driver/src/com/oracle/svm/driver/BundleSupport.java
@@ -360,7 +360,7 @@ final class BundleSupport {
 
         int exitStatusCode = createContainer();
         switch (ExitStatus.of(exitStatusCode)) {
-            case OK -> {}
+            case OK -> { }
             case BUILDER_ERROR ->
                 /* Exit, builder has handled error reporting. */
                     throw NativeImage.showError(null, null, exitStatusCode);

--- a/substratevm/src/com.oracle.svm.driver/src/com/oracle/svm/driver/BundleSupport.java
+++ b/substratevm/src/com.oracle.svm.driver/src/com/oracle/svm/driver/BundleSupport.java
@@ -1030,25 +1030,21 @@ final class BundleSupport {
 
         Path runArgsFile = stageDir.resolve("run.json");
         try (JsonWriter writer = new JsonWriter(runArgsFile)) {
-            List<String> isPathArg = List.of("-cp", "-p", "-classpath", "--module-path");
+            List<String> equalsRunArg = List.of("-jar", "-m", "--module");
+            List<String> runArgs = new ArrayList<>();
             ListIterator<String> bundleArgsIterator = bundleArgs.listIterator();
             while (bundleArgsIterator.hasNext()) {
                 String arg = bundleArgsIterator.next();
-                if (isPathArg.contains(arg)) {
-                    bundleArgsIterator.remove();
-                    bundleArgsIterator.next();
-                    bundleArgsIterator.remove();
-                } else if (arg.equals("-jar")) {
-                    bundleArgsIterator.next();
-                } else if (arg.startsWith("-") || arg.equals(nativeImage.imageName)) {
-                    bundleArgsIterator.remove();
+                if (equalsRunArg.contains(arg)) {
+                    runArgs.add(arg);
+                    runArgs.add(bundleArgsIterator.next());
                 }
             }
-            if (bundleArgs.isEmpty()) {
-                bundleArgs.add(nativeImage.mainClass);
+            if (runArgs.isEmpty()) {
+                runArgs.add(nativeImage.mainClass);
             }
             /* Printing as list with defined sort-order ensures useful diffs are possible */
-            JsonPrinter.printCollection(writer, bundleArgs, null, BundleSupport::printBuildArg);
+            JsonPrinter.printCollection(writer, runArgs, null, BundleSupport::printBuildArg);
         } catch (IOException e) {
             throw NativeImage.showError("Failed to write bundle-file " + runArgsFile, e);
         }

--- a/substratevm/src/com.oracle.svm.driver/src/com/oracle/svm/driver/BundleSupport.java
+++ b/substratevm/src/com.oracle.svm.driver/src/com/oracle/svm/driver/BundleSupport.java
@@ -213,7 +213,7 @@ final class BundleSupport {
 
             if (!bundleSupport.useContainer && bundleSupport.bundleProperties.requireContainerBuild()) {
                 if (!OS.LINUX.isCurrent()) {
-                    LogUtils.warning(BUNDLE_INFO_MESSAGE_PREFIX, "Bundle was built in a container, but container builds are only supported for Linux.");
+                    LogUtils.warning(BUNDLE_INFO_MESSAGE_PREFIX + "Bundle was built in a container, but container builds are only supported for Linux.");
                 } else {
                     bundleSupport.useContainer = true;
                     bundleSupport.containerSupport = new ContainerSupport(bundleSupport.stageDir, NativeImage::showError, LogUtils::warning, nativeImage::showMessage);
@@ -222,7 +222,7 @@ final class BundleSupport {
 
             if (bundleSupport.useContainer) {
                 if (!OS.LINUX.isCurrent()) {
-                    nativeImage.showMessage(BUNDLE_INFO_MESSAGE_PREFIX, "Skipping containerized build, only supported for Linux.");
+                    nativeImage.showMessage(BUNDLE_INFO_MESSAGE_PREFIX + "Skipping containerized build, only supported for Linux.");
                     bundleSupport.useContainer = false;
                 } else if (nativeImage.isDryRun()) {
                     nativeImage.showMessage(BUNDLE_INFO_MESSAGE_PREFIX + "Skipping container creation for native-image bundle with dry-run option.");

--- a/substratevm/src/com.oracle.svm.driver/src/com/oracle/svm/driver/BundleSupport.java
+++ b/substratevm/src/com.oracle.svm.driver/src/com/oracle/svm/driver/BundleSupport.java
@@ -64,18 +64,17 @@ import java.util.jar.Manifest;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import com.oracle.svm.core.OS;
+import com.oracle.svm.core.SubstrateUtil;
+import com.oracle.svm.core.option.BundleMember;
 import com.oracle.svm.core.util.ExitStatus;
+import com.oracle.svm.core.util.json.JsonPrinter;
+import com.oracle.svm.core.util.json.JsonWriter;
 import com.oracle.svm.driver.launcher.BundleLauncher;
 import com.oracle.svm.driver.launcher.ContainerSupport;
 import com.oracle.svm.driver.launcher.configuration.BundleArgsParser;
 import com.oracle.svm.driver.launcher.configuration.BundleEnvironmentParser;
 import com.oracle.svm.driver.launcher.configuration.BundlePathMapParser;
-
-import com.oracle.svm.core.OS;
-import com.oracle.svm.core.SubstrateUtil;
-import com.oracle.svm.core.option.BundleMember;
-import com.oracle.svm.core.util.json.JsonPrinter;
-import com.oracle.svm.core.util.json.JsonWriter;
 import com.oracle.svm.util.ClassUtil;
 import com.oracle.svm.util.LogUtils;
 import com.oracle.svm.util.StringUtil;
@@ -124,7 +123,6 @@ final class BundleSupport {
 
     private static final String DEFAULT_DOCKERFILE = getDockerfile("Dockerfile");
     private static final String DEFAULT_DOCKERFILE_MUSLIB = getDockerfile("Dockerfile_muslib_extension");
-
 
     private static String getDockerfile(String name) {
         return NativeImage.getResource("/container-default/" + name);
@@ -210,8 +208,8 @@ final class BundleSupport {
             }
 
             Arrays.stream(options)
-                    .skip(1)
-                    .forEach(bundleSupport::parseExtendedOption);
+                            .skip(1)
+                            .forEach(bundleSupport::parseExtendedOption);
 
             if (bundleSupport.useContainer) {
                 if (!OS.LINUX.isCurrent()) {
@@ -229,14 +227,14 @@ final class BundleSupport {
                         }
                         case BUILDER_ERROR ->
                             /* Exit, builder has handled error reporting. */
-                                throw NativeImage.showError(null, null, exitStatusCode);
+                            throw NativeImage.showError(null, null, exitStatusCode);
                         case OUT_OF_MEMORY -> {
                             nativeImage.showOutOfMemoryWarning();
                             throw NativeImage.showError(null, null, exitStatusCode);
                         }
                         default -> {
                             String message = String.format("Container build request for '%s' failed with exit status %d",
-                                    nativeImage.imageName, exitStatusCode);
+                                            nativeImage.imageName, exitStatusCode);
                             throw NativeImage.showError(message, null, exitStatusCode);
                         }
                     }
@@ -312,8 +310,8 @@ final class BundleSupport {
             }
             default -> {
                 String suggestedOptions = Arrays.stream(ExtendedBundleOptions.values())
-                        .map(Enum::toString)
-                        .collect(Collectors.joining(", "));
+                                .map(Enum::toString)
+                                .collect(Collectors.joining(", "));
                 throw NativeImage.showError(String.format("Unknown option %s. Valid options are: %s.", optionKey, suggestedOptions));
             }
         }
@@ -479,7 +477,6 @@ final class BundleSupport {
         nativeImage.showVerboseMessage(after != null && nativeImage.isVVerbose(), "RestoreCanonicalization src: " + before + ", dst: " + after);
         return after;
     }
-
 
     Path substituteAuxiliaryPath(Path origPath, BundleMember.Role bundleMemberRole) {
         Path destinationDir = switch (bundleMemberRole) {
@@ -733,22 +730,21 @@ final class BundleSupport {
 
         Path bundleLauncherFile = Paths.get("/").resolve(BundleLauncher.class.getName().replace(".", "/") + ".class");
         try (FileSystem fs = FileSystems.newFileSystem(BundleSupport.class.getResource(bundleLauncherFile.toString()).toURI(), new HashMap<>());
-                 Stream<Path> walk = Files.walk(fs.getPath(bundleLauncherFile.getParent().toString()))
-        ) {
+                        Stream<Path> walk = Files.walk(fs.getPath(bundleLauncherFile.getParent().toString()))) {
             walk.filter(Predicate.not(Files::isDirectory))
-                    .map(Path::toString)
-                    .forEach(sourcePath -> {
-                        Path target = rootDir.resolve(Paths.get("/").relativize(Paths.get(sourcePath)));
-                        try (InputStream source = BundleSupport.class.getResourceAsStream(sourcePath)) {
-                            Path bundleFileParent = target.getParent();
-                            if (bundleFileParent != null) {
-                                Files.createDirectories(bundleFileParent);
-                            }
-                            Files.copy(source, target, StandardCopyOption.REPLACE_EXISTING);
-                        } catch (Exception e) {
-                            throw NativeImage.showError("Failed to write bundle-file " + target, e);
-                        }
-                    });
+                            .map(Path::toString)
+                            .forEach(sourcePath -> {
+                                Path target = rootDir.resolve(Paths.get("/").relativize(Paths.get(sourcePath)));
+                                try (InputStream source = BundleSupport.class.getResourceAsStream(sourcePath)) {
+                                    Path bundleFileParent = target.getParent();
+                                    if (bundleFileParent != null) {
+                                        Files.createDirectories(bundleFileParent);
+                                    }
+                                    Files.copy(source, target, StandardCopyOption.REPLACE_EXISTING);
+                                } catch (Exception e) {
+                                    throw NativeImage.showError("Failed to write bundle-file " + target, e);
+                                }
+                            });
         } catch (Exception e) {
             throw NativeImage.showError("Failed to read bundle launcher resources '" + bundleLauncherFile.getParent() + "'", e);
         }
@@ -958,7 +954,7 @@ final class BundleSupport {
                 fileVersionKey = PROPERTY_KEY_BUNDLE_FILE_VERSION_MINOR;
                 int minor = Integer.parseInt(properties.getOrDefault(fileVersionKey, "-1"));
                 String message = String.format("The given bundle file %s was created with newer bundle-file-format version %d.%d" +
-                        " (current %d.%d). Update to the latest version of native-image.", bundleFileName, major, minor, BUNDLE_FILE_FORMAT_VERSION_MAJOR, BUNDLE_FILE_FORMAT_VERSION_MINOR);
+                                " (current %d.%d). Update to the latest version of native-image.", bundleFileName, major, minor, BUNDLE_FILE_FORMAT_VERSION_MAJOR, BUNDLE_FILE_FORMAT_VERSION_MINOR);
                 if (major > BUNDLE_FILE_FORMAT_VERSION_MAJOR) {
                     throw NativeImage.showError(message);
                 } else if (major == BUNDLE_FILE_FORMAT_VERSION_MAJOR) {
@@ -989,9 +985,9 @@ final class BundleSupport {
             nativeImage.showMessage("%sLoaded Bundle from %s", BUNDLE_INFO_MESSAGE_PREFIX, bundleFileName);
             nativeImage.showMessage("%sBundle created at '%s'", BUNDLE_INFO_MESSAGE_PREFIX, localDateStr);
             nativeImage.showMessage("%sUsing version: '%s'%s (vendor '%s'%s) on platform: '%s'%s", BUNDLE_INFO_MESSAGE_PREFIX,
-                    bundleVersion, currentVersion,
-                    bundleVendor, currentVendor,
-                    bundlePlatform, currentPlatform);
+                            bundleVersion, currentVersion,
+                            bundleVendor, currentVendor,
+                            bundlePlatform, currentPlatform);
         }
 
         private boolean forceBuilderOnClasspath() {

--- a/substratevm/src/com.oracle.svm.driver/src/com/oracle/svm/driver/NativeImage.java
+++ b/substratevm/src/com.oracle.svm.driver/src/com/oracle/svm/driver/NativeImage.java
@@ -69,7 +69,6 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import com.oracle.svm.core.option.OptionOrigin;
-import com.oracle.svm.driver.launcher.ContainerSupport;
 import org.graalvm.compiler.options.OptionKey;
 import org.graalvm.compiler.serviceprovider.JavaVersionUtil;
 import org.graalvm.nativeimage.Platform;
@@ -92,6 +91,7 @@ import com.oracle.svm.core.util.ExitStatus;
 import com.oracle.svm.core.util.VMError;
 import com.oracle.svm.driver.MacroOption.EnabledOption;
 import com.oracle.svm.driver.MacroOption.Registry;
+import com.oracle.svm.driver.launcher.ContainerSupport;
 import com.oracle.svm.driver.metainf.MetaInfFileType;
 import com.oracle.svm.driver.metainf.NativeImageMetaInfResourceProcessor;
 import com.oracle.svm.driver.metainf.NativeImageMetaInfWalker;
@@ -2155,7 +2155,7 @@ public class NativeImage {
     }
 
     private void enableModulePathBuild() {
-        if (config.modulePathBuild == false) {
+        if (!config.modulePathBuild) {
             NativeImage.showError("Module options not allowed in this image build. Reason: " + config.imageBuilderModeEnforcer);
         }
         config.modulePathBuild = true;
@@ -2430,7 +2430,7 @@ public class NativeImage {
         return source.replace(target, replacement);
     }
 
-    private static String deletedFileSuffix = ".deleted";
+    private static final String deletedFileSuffix = ".deleted";
 
     protected static boolean isDeletedPath(Path toDelete) {
         return toDelete.getFileName().toString().endsWith(deletedFileSuffix);

--- a/substratevm/src/com.oracle.svm.driver/src/com/oracle/svm/driver/NativeImage.java
+++ b/substratevm/src/com.oracle.svm.driver/src/com/oracle/svm/driver/NativeImage.java
@@ -69,6 +69,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import com.oracle.svm.core.option.OptionOrigin;
+import com.oracle.svm.driver.launcher.ContainerSupport;
 import org.graalvm.compiler.options.OptionKey;
 import org.graalvm.compiler.serviceprovider.JavaVersionUtil;
 import org.graalvm.nativeimage.Platform;
@@ -101,10 +102,6 @@ import com.oracle.svm.util.LogUtils;
 import com.oracle.svm.util.ModuleSupport;
 import com.oracle.svm.util.ReflectionUtil;
 import com.oracle.svm.util.StringUtil;
-
-import static com.oracle.svm.driver.launcher.ContainerSupport.replaceContainerPaths;
-import static com.oracle.svm.driver.launcher.ContainerSupport.mountMappingFor;
-import static com.oracle.svm.driver.launcher.ContainerSupport.TargetPath;
 
 public class NativeImage {
 
@@ -1564,22 +1561,22 @@ public class NativeImage {
         List<String> command = new ArrayList<>();
         List<String> completeCommandList = new ArrayList<>();
 
-        if (useBundle() && bundleSupport.useContainer()) {
-            replaceContainerPaths(arguments, config.getJavaHome(), bundleSupport.rootDir);
-            replaceContainerPaths(finalImageBuilderArgs, config.getJavaHome(), bundleSupport.rootDir);
+        if (useBundle() && bundleSupport.useContainer) {
+            ContainerSupport.replacePaths(arguments, config.getJavaHome(), bundleSupport.rootDir);
+            ContainerSupport.replacePaths(finalImageBuilderArgs, config.getJavaHome(), bundleSupport.rootDir);
             Path binJava = Paths.get("bin", "java");
-            javaExecutable = BundleSupport.CONTAINER_GRAAL_VM_HOME.resolve(binJava).toString();
+            javaExecutable = ContainerSupport.GRAAL_VM_HOME.resolve(binJava).toString();
         }
 
         Path argFile = createVMInvocationArgumentFile(arguments);
         Path builderArgFile = createImageBuilderArgumentFile(finalImageBuilderArgs);
 
-        if (useBundle() && bundleSupport.useContainer()) {
-            Map<Path, TargetPath> mountMapping = mountMappingFor(config.getJavaHome(), bundleSupport.inputDir, bundleSupport.outputDir);
-            mountMapping.put(argFile, TargetPath.readonly(argFile));
-            mountMapping.put(builderArgFile, TargetPath.readonly(builderArgFile));
+        if (useBundle() && bundleSupport.useContainer) {
+            Map<Path, ContainerSupport.TargetPath> mountMapping = ContainerSupport.mountMappingFor(config.getJavaHome(), bundleSupport.inputDir, bundleSupport.outputDir);
+            mountMapping.put(argFile, ContainerSupport.TargetPath.readonly(argFile));
+            mountMapping.put(builderArgFile, ContainerSupport.TargetPath.readonly(builderArgFile));
 
-            List<String> containerCommand = bundleSupport.containerSupport.createContainerCommand(imageBuilderEnvironment, mountMapping);
+            List<String> containerCommand = bundleSupport.containerSupport.createCommand(imageBuilderEnvironment, mountMapping);
             command.addAll(containerCommand);
             completeCommandList.addAll(containerCommand);
         }

--- a/substratevm/src/com.oracle.svm.driver/src/com/oracle/svm/driver/NativeImage.java
+++ b/substratevm/src/com.oracle.svm.driver/src/com/oracle/svm/driver/NativeImage.java
@@ -267,7 +267,6 @@ public class NativeImage {
     static final String oHNumberOfThreads = oH(NativeImageOptions.NumberOfThreads);
 
     final Map<String, String> imageBuilderEnvironment = new HashMap<>();
-    final ArrayList<String> bundleLauncherArgs = new ArrayList<>();
     private final ArrayList<String> imageBuilderArgs = new ArrayList<>();
     private final LinkedHashSet<Path> imageBuilderModulePath = new LinkedHashSet<>();
     private final LinkedHashSet<Path> imageBuilderClasspath = new LinkedHashSet<>();

--- a/substratevm/src/com.oracle.svm.driver/src/com/oracle/svm/driver/NativeImage.java
+++ b/substratevm/src/com.oracle.svm.driver/src/com/oracle/svm/driver/NativeImage.java
@@ -1576,7 +1576,12 @@ public class NativeImage {
         command.add(NativeImageGeneratorRunner.IMAGE_BUILDER_ARG_FILE_OPTION + builderArgFile);
         ProcessBuilder pb = new ProcessBuilder();
         pb.command(command);
-        Map<String, String> environment = pb.environment();
+        Map<String, String> environment;
+        if(useBundle() && bundleSupport.useContainer) {
+            environment = bundleSupport.containerEnvironment;
+        } else {
+            environment = pb.environment();
+        }
         String deprecatedSanitationKey = "NATIVE_IMAGE_DEPRECATED_BUILDER_SANITATION";
         String deprecatedSanitationValue = System.getenv().getOrDefault(deprecatedSanitationKey, "false");
         if (Boolean.parseBoolean(deprecatedSanitationValue)) {

--- a/substratevm/src/com.oracle.svm.driver/src/com/oracle/svm/driver/NativeImage.java
+++ b/substratevm/src/com.oracle.svm.driver/src/com/oracle/svm/driver/NativeImage.java
@@ -1602,7 +1602,7 @@ public class NativeImage {
 
         List<String> completeCommandList = new ArrayList<>();
         completeCommandList.addAll(environment.entrySet().stream().map(e -> e.getKey() + "=" + e.getValue()).sorted().toList());
-        if (useBundle() && bundleSupport.useContainer) {
+        if (!isDryRun() && useBundle() && bundleSupport.useContainer) {
             completeCommandList.addAll(bundleSupport.createContainerCommand(argFile, builderArgFile));
         }
         completeCommandList.add(javaExecutable);

--- a/substratevm/src/com.oracle.svm.driver/src/com/oracle/svm/driver/NativeImage.java
+++ b/substratevm/src/com.oracle.svm.driver/src/com/oracle/svm/driver/NativeImage.java
@@ -267,6 +267,7 @@ public class NativeImage {
     static final String oHNumberOfThreads = oH(NativeImageOptions.NumberOfThreads);
 
     final Map<String, String> imageBuilderEnvironment = new HashMap<>();
+    final ArrayList<String> bundleLauncherArgs = new ArrayList<>();
     private final ArrayList<String> imageBuilderArgs = new ArrayList<>();
     private final LinkedHashSet<Path> imageBuilderModulePath = new LinkedHashSet<>();
     private final LinkedHashSet<Path> imageBuilderClasspath = new LinkedHashSet<>();

--- a/substratevm/src/com.oracle.svm.driver/src/com/oracle/svm/driver/NativeImage.java
+++ b/substratevm/src/com.oracle.svm.driver/src/com/oracle/svm/driver/NativeImage.java
@@ -98,6 +98,7 @@ import com.oracle.svm.driver.metainf.NativeImageMetaInfWalker;
 import com.oracle.svm.hosted.NativeImageGeneratorRunner;
 import com.oracle.svm.hosted.NativeImageOptions;
 import com.oracle.svm.hosted.NativeImageSystemClassLoader;
+import com.oracle.svm.hosted.c.libc.HostedLibCFeature;
 import com.oracle.svm.util.LogUtils;
 import com.oracle.svm.util.ModuleSupport;
 import com.oracle.svm.util.ReflectionUtil;
@@ -249,6 +250,8 @@ public class NativeImage {
     final String oHClass = oH(SubstrateOptions.Class);
     final String oHName = oH(SubstrateOptions.Name);
     final String oHPath = oH(SubstrateOptions.Path);
+    final String oHUseLibC = oH(HostedLibCFeature.LibCOptions.UseLibC);
+    final String oHEnableStaticExecutable = oHEnabled(SubstrateOptions.StaticExecutable);
     final String oHEnableSharedLibraryFlagPrefix = oHEnabled + SubstrateOptions.SharedLibrary.getName();
     final String oHEnableBuildOutputColorful = oHEnabledByDriver(SubstrateOptions.BuildOutputColorful);
     final String oHEnableBuildOutputProgress = oHEnabledByDriver(SubstrateOptions.BuildOutputProgress);
@@ -1096,6 +1099,8 @@ public class NativeImage {
 
         mainClass = getHostedOptionFinalArgumentValue(imageBuilderArgs, oHClass);
         buildExecutable = imageBuilderArgs.stream().noneMatch(arg -> arg.startsWith(oHEnableSharedLibraryFlagPrefix));
+        staticExecutable = imageBuilderArgs.stream().anyMatch(arg -> arg.contains(oHEnableStaticExecutable));
+        libC = getHostedOptionFinalArgumentValue(imageBuilderArgs, oHUseLibC);
         boolean listModules = imageBuilderArgs.stream().anyMatch(arg -> arg.contains(oH + "+" + "ListModules"));
         printFlags |= imageBuilderArgs.stream().anyMatch(arg -> arg.matches("-H:MicroArchitecture(@[^=]*)?=list"));
 
@@ -1411,6 +1416,8 @@ public class NativeImage {
     }
 
     boolean buildExecutable;
+    boolean staticExecutable;
+    String libC;
     String mainClass;
     String mainClassModule;
     String imageName;
@@ -1572,6 +1579,27 @@ public class NativeImage {
         Path builderArgFile = createImageBuilderArgumentFile(finalImageBuilderArgs);
 
         if (useBundle() && bundleSupport.useContainer) {
+            if (!Files.exists(bundleSupport.containerSupport.dockerfile)) {
+                bundleSupport.createDockerfile(bundleSupport.containerSupport.dockerfile);
+            }
+            int exitStatusCode = bundleSupport.containerSupport.initializeImage();
+            switch (ExitStatus.of(exitStatusCode)) {
+                case OK -> {
+                }
+                case BUILDER_ERROR ->
+                    /* Exit, builder has handled error reporting. */
+                    throw NativeImage.showError(null, null, exitStatusCode);
+                case OUT_OF_MEMORY -> {
+                    showOutOfMemoryWarning();
+                    throw NativeImage.showError(null, null, exitStatusCode);
+                }
+                default -> {
+                    String message = String.format("Container build request for '%s' failed with exit status %d",
+                                    imageName, exitStatusCode);
+                    throw NativeImage.showError(message, null, exitStatusCode);
+                }
+            }
+
             Map<Path, ContainerSupport.TargetPath> mountMapping = ContainerSupport.mountMappingFor(config.getJavaHome(), bundleSupport.inputDir, bundleSupport.outputDir);
             mountMapping.put(argFile, ContainerSupport.TargetPath.readonly(argFile));
             mountMapping.put(builderArgFile, ContainerSupport.TargetPath.readonly(builderArgFile));

--- a/substratevm/src/com.oracle.svm.driver/src/com/oracle/svm/driver/NativeImage.java
+++ b/substratevm/src/com.oracle.svm.driver/src/com/oracle/svm/driver/NativeImage.java
@@ -1559,11 +1559,11 @@ public class NativeImage {
         Path argFile = createVMInvocationArgumentFile(arguments);
         Path builderArgFile = createImageBuilderArgumentFile(finalImageBuilderArgs);
         List<String> command = new ArrayList<>();
-        if(useBundle() && bundleSupport.containerizedBuild) {
+        if(useBundle() && bundleSupport.useContainer) {
             List<String> containerCommand = List.of(bundleSupport.containerTool, "run", "--network=none", "--rm",
-                    "--mount", "type=bind,source=" + config.getJavaHome() + ",target=/graalvm,readonly",
-                    "--mount", "type=bind,source=" + bundleSupport.inputDir + ",target=" + Path.of("/").resolve(bundleSupport.inputDir.getFileName()) + ",readonly",
-                    "--mount", "type=bind,source=" + bundleSupport.outputDir + ",target=" + Path.of("/").resolve(bundleSupport.outputDir.getFileName()),
+                    "--mount", "type=bind,source=" + config.getJavaHome() + ",target=" + bundleSupport.containerGraalVMHome + ",readonly",
+                    "--mount", "type=bind,source=" + bundleSupport.inputDir + ",target=" + bundleSupport.containerRootDir.resolve(bundleSupport.inputDir.getFileName()) + ",readonly",
+                    "--mount", "type=bind,source=" + bundleSupport.outputDir + ",target=" + bundleSupport.containerRootDir.resolve(bundleSupport.outputDir.getFileName()),
                     "--mount", "type=bind,source=" + argFile + ",target=" + argFile + ",readonly",
                     "--mount", "type=bind,source=" + builderArgFile + ",target=" + builderArgFile + ",readonly",
                     bundleSupport.containerImage);

--- a/substratevm/src/com.oracle.svm.driver/src/com/oracle/svm/driver/NativeImage.java
+++ b/substratevm/src/com.oracle.svm.driver/src/com/oracle/svm/driver/NativeImage.java
@@ -1576,12 +1576,7 @@ public class NativeImage {
         command.add(NativeImageGeneratorRunner.IMAGE_BUILDER_ARG_FILE_OPTION + builderArgFile);
         ProcessBuilder pb = new ProcessBuilder();
         pb.command(command);
-        Map<String, String> environment;
-        if (useBundle() && bundleSupport.useContainer) {
-            environment = bundleSupport.containerEnvironment;
-        } else {
-            environment = pb.environment();
-        }
+        Map<String, String> environment = pb.environment();
         String deprecatedSanitationKey = "NATIVE_IMAGE_DEPRECATED_BUILDER_SANITATION";
         String deprecatedSanitationValue = System.getenv().getOrDefault(deprecatedSanitationKey, "false");
         if (Boolean.parseBoolean(deprecatedSanitationValue)) {

--- a/substratevm/src/com.oracle.svm.driver/src/com/oracle/svm/driver/NativeImage.java
+++ b/substratevm/src/com.oracle.svm.driver/src/com/oracle/svm/driver/NativeImage.java
@@ -1561,7 +1561,7 @@ public class NativeImage {
             bundleSupport.replacePathsForContainerBuild(arguments);
             bundleSupport.replacePathsForContainerBuild(finalImageBuilderArgs);
             Path binJava = Paths.get("bin", "java");
-            javaExecutable = bundleSupport.containerGraalVMHome.resolve(binJava).toString();
+            javaExecutable = BundleSupport.CONTAINER_GRAAL_VM_HOME.resolve(binJava).toString();
         }
 
         Path argFile = createVMInvocationArgumentFile(arguments);

--- a/substratevm/src/com.oracle.svm.driver/src/com/oracle/svm/driver/NativeImage.java
+++ b/substratevm/src/com.oracle.svm.driver/src/com/oracle/svm/driver/NativeImage.java
@@ -909,9 +909,6 @@ public class NativeImage {
 
     private void processClasspathNativeImageMetaInf(Path classpathEntry) {
         try {
-            if (classpathEntry.startsWith(Path.of("/input"))) {
-                classpathEntry = bundleSupport.rootDir.resolve(Path.of("/").relativize(classpathEntry));
-            }
             NativeImageMetaInfWalker.walkMetaInfForCPEntry(classpathEntry, metaInfProcessor);
         } catch (NativeImageMetaInfWalker.MetaInfWalkException e) {
             throw showError(e.getMessage(), e.cause);
@@ -1492,8 +1489,10 @@ public class NativeImage {
         BiFunction<Path, BundleMember.Role, Path> substituteAuxiliaryPath = useBundle() ? bundleSupport::substituteAuxiliaryPath : (a, b) -> a;
         Function<String, String> imageArgsTransformer = rawArg -> apiOptionHandler.transformBuilderArgument(rawArg, substituteAuxiliaryPath);
         List<String> finalImageArgs = imageArgs.stream().map(imageArgsTransformer).collect(Collectors.toList());
+
         Function<Path, Path> substituteClassPath = useBundle() ? bundleSupport::substituteClassPath : Function.identity();
         List<Path> finalImageClassPath = imagecp.stream().map(substituteClassPath).collect(Collectors.toList());
+
         Function<Path, Path> substituteModulePath = useBundle() ? bundleSupport::substituteModulePath : Function.identity();
         List<Path> substitutedImageModulePath = imagemp.stream().map(substituteModulePath).toList();
 
@@ -1556,19 +1555,22 @@ public class NativeImage {
         List<String> finalImageBuilderArgs = createImageBuilderArgs(finalImageArgs, finalImageClassPath, finalImageModulePath);
 
         /* Construct ProcessBuilder command from final arguments */
+        List<String> command = new ArrayList<>();
+
+        if(useBundle() && bundleSupport.useContainer) {
+            bundleSupport.replacePathsForContainerBuild(arguments);
+            bundleSupport.replacePathsForContainerBuild(finalImageBuilderArgs);
+            Path binJava = Paths.get("bin", "java");
+            javaExecutable = bundleSupport.containerGraalVMHome.resolve(binJava).toString();
+        }
+
         Path argFile = createVMInvocationArgumentFile(arguments);
         Path builderArgFile = createImageBuilderArgumentFile(finalImageBuilderArgs);
-        List<String> command = new ArrayList<>();
-        if(useBundle() && bundleSupport.useContainer) {
-            List<String> containerCommand = List.of(bundleSupport.containerTool, "run", "--network=none", "--rm",
-                    "--mount", "type=bind,source=" + config.getJavaHome() + ",target=" + bundleSupport.containerGraalVMHome + ",readonly",
-                    "--mount", "type=bind,source=" + bundleSupport.inputDir + ",target=" + bundleSupport.containerRootDir.resolve(bundleSupport.inputDir.getFileName()) + ",readonly",
-                    "--mount", "type=bind,source=" + bundleSupport.outputDir + ",target=" + bundleSupport.containerRootDir.resolve(bundleSupport.outputDir.getFileName()),
-                    "--mount", "type=bind,source=" + argFile + ",target=" + argFile + ",readonly",
-                    "--mount", "type=bind,source=" + builderArgFile + ",target=" + builderArgFile + ",readonly",
-                    bundleSupport.containerImage);
-            command.addAll(containerCommand);
+
+        if(!isDryRun() && useBundle() && bundleSupport.useContainer) {
+            command.addAll(bundleSupport.createContainerCommand(argFile, builderArgFile));
         }
+
         command.add(javaExecutable);
         command.add("@" + argFile);
         command.add(NativeImageGeneratorRunner.IMAGE_BUILDER_ARG_FILE_OPTION + builderArgFile);

--- a/substratevm/src/com.oracle.svm.driver/src/com/oracle/svm/driver/NativeImage.java
+++ b/substratevm/src/com.oracle.svm.driver/src/com/oracle/svm/driver/NativeImage.java
@@ -1560,7 +1560,7 @@ public class NativeImage {
         Path builderArgFile = createImageBuilderArgumentFile(finalImageBuilderArgs);
         List<String> command = new ArrayList<>();
         if(useBundle() && bundleSupport.containerizedBuild) {
-            List<String> containerCommand = List.of(bundleSupport.containerizationTool, "run", "--network=none", "--rm",
+            List<String> containerCommand = List.of(bundleSupport.containerTool, "run", "--network=none", "--rm",
                     "--mount", "type=bind,source=" + config.getJavaHome() + ",target=/graalvm,readonly",
                     "--mount", "type=bind,source=" + bundleSupport.inputDir + ",target=" + Path.of("/").resolve(bundleSupport.inputDir.getFileName()) + ",readonly",
                     "--mount", "type=bind,source=" + bundleSupport.outputDir + ",target=" + Path.of("/").resolve(bundleSupport.outputDir.getFileName()),

--- a/substratevm/src/com.oracle.svm.driver/src/com/oracle/svm/driver/NativeImage.java
+++ b/substratevm/src/com.oracle.svm.driver/src/com/oracle/svm/driver/NativeImage.java
@@ -1557,7 +1557,7 @@ public class NativeImage {
         /* Construct ProcessBuilder command from final arguments */
         List<String> command = new ArrayList<>();
 
-        if(useBundle() && bundleSupport.useContainer) {
+        if (useBundle() && bundleSupport.useContainer) {
             bundleSupport.replacePathsForContainerBuild(arguments);
             bundleSupport.replacePathsForContainerBuild(finalImageBuilderArgs);
             Path binJava = Paths.get("bin", "java");
@@ -1567,7 +1567,7 @@ public class NativeImage {
         Path argFile = createVMInvocationArgumentFile(arguments);
         Path builderArgFile = createImageBuilderArgumentFile(finalImageBuilderArgs);
 
-        if(!isDryRun() && useBundle() && bundleSupport.useContainer) {
+        if (useBundle() && bundleSupport.useContainer) {
             command.addAll(bundleSupport.createContainerCommand(argFile, builderArgFile));
         }
 
@@ -1577,7 +1577,7 @@ public class NativeImage {
         ProcessBuilder pb = new ProcessBuilder();
         pb.command(command);
         Map<String, String> environment;
-        if(useBundle() && bundleSupport.useContainer) {
+        if (useBundle() && bundleSupport.useContainer) {
             environment = bundleSupport.containerEnvironment;
         } else {
             environment = pb.environment();
@@ -1607,6 +1607,9 @@ public class NativeImage {
 
         List<String> completeCommandList = new ArrayList<>();
         completeCommandList.addAll(environment.entrySet().stream().map(e -> e.getKey() + "=" + e.getValue()).sorted().toList());
+        if (useBundle() && bundleSupport.useContainer) {
+            completeCommandList.addAll(bundleSupport.createContainerCommand(argFile, builderArgFile));
+        }
         completeCommandList.add(javaExecutable);
         completeCommandList.addAll(arguments);
         completeCommandList.addAll(finalImageBuilderArgs);

--- a/substratevm/src/com.oracle.svm.driver/src/com/oracle/svm/driver/NativeImage.java
+++ b/substratevm/src/com.oracle.svm.driver/src/com/oracle/svm/driver/NativeImage.java
@@ -1094,7 +1094,7 @@ public class NativeImage {
         imageBuilderJavaArgs.addAll(getAgentArguments());
 
         mainClass = getHostedOptionFinalArgumentValue(imageBuilderArgs, oHClass);
-        boolean buildExecutable = imageBuilderArgs.stream().noneMatch(arg -> arg.startsWith(oHEnableSharedLibraryFlagPrefix));
+        buildExecutable = imageBuilderArgs.stream().noneMatch(arg -> arg.startsWith(oHEnableSharedLibraryFlagPrefix));
         boolean listModules = imageBuilderArgs.stream().anyMatch(arg -> arg.contains(oH + "+" + "ListModules"));
         printFlags |= imageBuilderArgs.stream().anyMatch(arg -> arg.matches("-H:MicroArchitecture(@[^=]*)?=list"));
 
@@ -1115,7 +1115,7 @@ public class NativeImage {
             if (!jarOptionMode) {
                 /* Main-class from customImageBuilderArgs counts as explicitMainClass */
                 boolean explicitMainClass = getHostedOptionFinalArgumentValue(imageBuilderArgs, oHClass) != null;
-                String mainClassModule = getHostedOptionFinalArgumentValue(imageBuilderArgs, oHModule);
+                mainClassModule = getHostedOptionFinalArgumentValue(imageBuilderArgs, oHModule);
 
                 boolean hasMainClassModule = mainClassModule != null && !mainClassModule.isEmpty();
                 boolean hasMainClass = mainClass != null && !mainClass.isEmpty();
@@ -1409,7 +1409,9 @@ public class NativeImage {
         }
     }
 
+    boolean buildExecutable;
     String mainClass;
+    String mainClassModule;
     String imageName;
     Path imagePath;
 

--- a/substratevm/src/com.oracle.svm.driver/src/com/oracle/svm/driver/NativeImage.java
+++ b/substratevm/src/com.oracle.svm.driver/src/com/oracle/svm/driver/NativeImage.java
@@ -98,7 +98,6 @@ import com.oracle.svm.driver.metainf.NativeImageMetaInfWalker;
 import com.oracle.svm.hosted.NativeImageGeneratorRunner;
 import com.oracle.svm.hosted.NativeImageOptions;
 import com.oracle.svm.hosted.NativeImageSystemClassLoader;
-import com.oracle.svm.hosted.c.libc.HostedLibCFeature;
 import com.oracle.svm.util.LogUtils;
 import com.oracle.svm.util.ModuleSupport;
 import com.oracle.svm.util.ReflectionUtil;
@@ -250,7 +249,7 @@ public class NativeImage {
     final String oHClass = oH(SubstrateOptions.Class);
     final String oHName = oH(SubstrateOptions.Name);
     final String oHPath = oH(SubstrateOptions.Path);
-    final String oHUseLibC = oH(HostedLibCFeature.LibCOptions.UseLibC);
+    final String oHUseLibC = oH(SubstrateOptions.UseLibC);
     final String oHEnableStaticExecutable = oHEnabled(SubstrateOptions.StaticExecutable);
     final String oHEnableSharedLibraryFlagPrefix = oHEnabled + SubstrateOptions.SharedLibrary.getName();
     final String oHEnableBuildOutputColorful = oHEnabledByDriver(SubstrateOptions.BuildOutputColorful);

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/c/libc/HostedLibCFeature.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/c/libc/HostedLibCFeature.java
@@ -26,18 +26,13 @@ package com.oracle.svm.hosted.c.libc;
 
 import java.util.ServiceLoader;
 
-import org.graalvm.collections.UnmodifiableEconomicMap;
-import org.graalvm.compiler.options.Option;
-import org.graalvm.compiler.options.OptionKey;
-import org.graalvm.compiler.options.OptionValues;
 import org.graalvm.nativeimage.ImageSingletons;
 import org.graalvm.nativeimage.Platform;
 
+import com.oracle.svm.core.SubstrateOptions;
 import com.oracle.svm.core.c.libc.LibCBase;
 import com.oracle.svm.core.feature.AutomaticallyRegisteredFeature;
 import com.oracle.svm.core.feature.InternalFeature;
-import com.oracle.svm.core.option.APIOption;
-import com.oracle.svm.core.option.HostedOptionKey;
 import com.oracle.svm.core.util.UserError;
 
 @AutomaticallyRegisteredFeature
@@ -47,31 +42,9 @@ public class HostedLibCFeature implements InternalFeature {
         return HostedLibCBase.isPlatformEquivalent(Platform.LINUX.class);
     }
 
-    public static class LibCOptions {
-        @APIOption(name = "libc")//
-        @Option(help = "Selects the libc implementation to use. Available implementations: glibc, musl, bionic")//
-        public static final HostedOptionKey<String> UseLibC = new HostedOptionKey<>(null) {
-            @Override
-            public String getValueOrDefault(UnmodifiableEconomicMap<OptionKey<?>, Object> values) {
-                if (!values.containsKey(this)) {
-                    return Platform.includedIn(Platform.ANDROID.class)
-                                    ? "bionic"
-                                    : System.getProperty("substratevm.HostLibC", "glibc");
-                }
-                return (String) values.get(this);
-            }
-
-            @Override
-            public String getValue(OptionValues values) {
-                assert checkDescriptorExists();
-                return getValueOrDefault(values.getMap());
-            }
-        };
-    }
-
     @Override
     public void afterRegistration(AfterRegistrationAccess access) {
-        String targetLibC = LibCOptions.UseLibC.getValue();
+        String targetLibC = SubstrateOptions.UseLibC.getValue();
         ServiceLoader<HostedLibCBase> loader = ServiceLoader.load(HostedLibCBase.class);
         for (HostedLibCBase libc : loader) {
             if (libc.getName().equals(targetLibC)) {


### PR DESCRIPTION
This PR contains two features: containerized native image builds for native image bundles and executable native image bundles

### Containerized native image building for native image building:
Native images can be built inside a container when creating or applying native image bundles. Mounts graalvm, classpath and module path into a container, injects environment variable from the native image bundle and initiates the native image build inside a container.
Only works on Linux and supports just docker and podman as container tool as they share a common command line interface.
Uses a default Dockerfile for creating the container which is the same as the base for creating graalvm container https://github.com/graalvm/container. For muslib builds, the default Dockerfile is extended similar to muslib Dockerfiles for graalvm container.
On bundle creation any information related to container builds that is not default variables is stored in a bundle (in input/stage/container.json for tool and version information and input/stage/Dockerfile for the Dockerfile). If bundle is applied with the option "container" the stored information is used except the user specifies something else.

Also specifies a bundle build option for building a bundle without creating a native image. This should then be used instead of the --dry-run for native image bundle builds

Additional options for --bundle-create or --bundle-apply separated with a comma ",".

- container[=containerTool]: this option needs to be specified for containerized native image builds, optionally allows to specify the use of a containerization tool (if nothing is selected searches for podman and docker on the PATH)
- dockerfile=fileName: to specify a Dockerfile that is different from the default
- dry-run: specify bundle creation without building a native image
- some examples:
  - --bundle-create,dry-run -> creates a bundle without building a native-image
  - --bundle-apply,container -> uses the bundle to build a native image within a container
  - --bundle-create,container=podman,dockerfile=MyDockerfile -> creates a bundle and additionally builds a podman container based on MyDockerfile and creates a native image inside this container

### Executable Bundles
On bundle creation a bundle launcher is injected into the bundle which can then be used to run the bundle as if it was a jar file.
The bundle launcher is set as Main-Class in the bundles Manifest file and loads the classpath and module path from inside the bundle and then executes the bundled application with any jdk.
Environment variables stored in the bundle are injected into the application execution.
All further command line arguments needed for executing the application are stored in the bundle (in input/stage/run.json).
If the bundle is not executable it does not contain the run.json file and the bundle launcher throws an error (e.g. shared library bundles)
The bundle launcher allows two options for launching bundles:
  - --with-native-image-agent[,update-bundle[=&lt;new-bundle-name>]] -> runs the launcher with the native image agent attached, the agent output is saved to &lt;bundle-name>.output/launcher/META-INF/native-image/&lt;bundle-name>-agent, if update-bundle is specified the created agent output is added to the bundles classpath (by applying and creating a new bundle with the old name or the new bundle name specified in update-bundle)
  - --container[=(podman | docker)][,dockerfile=&lt;Dockerfile-filename>] -> launches the application inside a container, supports also podman and docker (same as in the first feature), it uses the Dockerfile that got packaged into bundle except if another dockerfile is explicitly specified
