### PR TITLE
[Bug] Fix missing header in launcher

### DIFF
--- a/sdk/src/org.graalvm.launcher.native/src/launcher.cc
+++ b/sdk/src/org.graalvm.launcher.native/src/launcher.cc
@@ -45,6 +45,7 @@
 #include <iostream>
 #include <sstream>
 #include <vector>
+#include <inttypes.h>
 
 #define QUOTE(name) #name
 #define STR(macro) QUOTE(macro)


### PR DESCRIPTION
During `oracle/truffleruby` build (`jt build`) an error started to pop up making the build halt:

```
([1/2] CXX src/launcher.o
FAILED: src/launcher.o 
g++ -MMD -MF src/launcher.o.d -I/home/itarato/.mx/jdks/labsjdk-ce-17-jvmci-23.0-b10/include -I/home/itarato/.mx/jdks/labsjdk-ce-17-jvmci-23.0-b10/include/linux  -fdebug-prefix-map=/home/itarato/graal/graal=graal -fdebug-prefix-map=/home/itarato/.mx/jdks/labsjdk-ce-17-jvmci-23.0-b10=labsjdk-ce-17-jvmci-23.0-b10 -gno-record-gcc-switches -DCP_SEP=: -DDIR_SEP=/ -pthread -DLAUNCHER_CLASS=org.truffleruby.launcher.RubyLauncher -DLAUNCHER_CLASSPATH="{\"../truffleruby-annotations.jar\", \"../truffleruby-shared.jar\", \"../../../lib/graalvm/launcher-common.jar\", \"../../../lib/graalvm/truffleruby-launcher.jar\"}" -DLIBJVM_RELPATH=../../../lib/server/libjvm.so -DLIBLANG_RELPATH=../lib/librubyvm.so -DLAUNCHER_OPTION_VARS="{\"RUBYOPT\", \"TRUFFLERUBYOPT\"}" -c ../../../../src/org.graalvm.launcher.native/src/launcher.cc -o src/launcher.o
../../../../src/org.graalvm.launcher.native/src/launcher.cc: In function ‘int jvm_main_thread(int, char**, std::string, char*, bool, std::string)’:
../../../../src/org.graalvm.launcher.native/src/launcher.cc:592:89: error: ‘uintptr_t’ was not declared in this scope
  592 |     env->CallStaticVoidMethod(launcherClass, runLauncherMid, args, argc_native, (jlong)(uintptr_t)(void*)argv_native, relaunch);
      |                                                                                         ^~~~~~~~~
../../../../src/org.graalvm.launcher.native/src/launcher.cc:103:1: note: ‘uintptr_t’ is defined in header ‘<cstdint>’; did you forget to ‘#include <cstdint>’?
  102 |     #include <sys/stat.h>
  +++ |+#include <cstdint>
  103 | #elif defined (__APPLE__)
../../../../src/org.graalvm.launcher.native/src/launcher.cc:592:100: error: expected primary-expression before ‘void’
  592 |     env->CallStaticVoidMethod(launcherClass, runLauncherMid, args, argc_native, (jlong)(uintptr_t)(void*)argv_native, relaunch);
      |                                                                                                    ^~~~
ninja: build stopped: subcommand failed.
, -2)
Building org.graalvm.launcher.native.ruby_amd64 with Ninja: Failed due to error: 1
FAILED (pid 43994 exit 1): /home/itarato/graal/mx/mx --java-home /home/itarato/.mx/jdks/labsjdk-ce-17-jvmci-23.0-b10 -p /home/itarato/graal/truffleruby --env jvm-ce build
```

Environment:
- linux kernel version 6.3.1-arch2-1
- g++ version 13.1.1
- latest unchanged HEAD commit of oracle/truffleruby (`6f0ce7210ccdd42d1f890dce46c074a3c950c624`)

Applying the missing header for `uintptr_t` fixed the issue.