### PR TITLE
Fix for JFR virtual thread tests

### DIFF
--- a/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/jfr/TestVirtualThreadsBasic.java
+++ b/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/jfr/TestVirtualThreadsBasic.java
@@ -31,6 +31,7 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assume.assumeTrue;
 
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -58,7 +59,7 @@ public class TestVirtualThreadsBasic extends JfrRecordingTest {
     private static final int EXPECTED_EVENTS = THREADS;
     private final MonitorWaitHelper helper = new MonitorWaitHelper();
     private final AtomicInteger emittedEventsPerType = new AtomicInteger(0);
-    private final Set<Long> expectedThreads = new HashSet<>();
+    private final Set<Long> expectedThreads = Collections.synchronizedSet(new HashSet<>());
 
     @Before
     public void checkJavaVersion() {

--- a/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/jfr/TestVirtualThreadsChunkRotation.java
+++ b/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/jfr/TestVirtualThreadsChunkRotation.java
@@ -31,6 +31,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assume.assumeTrue;
 
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -58,7 +59,7 @@ public class TestVirtualThreadsChunkRotation extends JfrRecordingTest {
     private static final int THREADS = 3;
     private static final int EXPECTED_EVENTS = THREADS;
     private final AtomicInteger emittedEventsPerType = new AtomicInteger(0);
-    private final Set<Long> expectedThreads = new HashSet<>();
+    private final Set<Long> expectedThreads = Collections.synchronizedSet(new HashSet<>());
     private final MonitorWaitHelper helper = new MonitorWaitHelper();
 
     private volatile boolean proceed;

--- a/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/jfr/TestVirtualThreadsJfrStreaming.java
+++ b/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/jfr/TestVirtualThreadsJfrStreaming.java
@@ -36,7 +36,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import org.graalvm.compiler.serviceprovider.JavaVersionUtil;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import com.oracle.svm.core.jfr.JfrEvent;
@@ -63,7 +62,6 @@ public class TestVirtualThreadsJfrStreaming extends JfrStreamingTest {
         assumeTrue("skipping JFR virtual thread tests", JavaVersionUtil.JAVA_SPEC >= 19);
     }
 
-    @Ignore("GR-46117")
     @Test
     public void test() throws Throwable {
         String[] events = new String[]{JfrEvent.JavaMonitorWait.getName()};


### PR DESCRIPTION
It's possible for threads to reuse IDs of inactive threads. This means that we have to replace the `expectedThreads` set with a map that records a count of seen threads for each ID. Additionally, the previous implementation of `expectedThreads` was not thread safe. Writes from some threads may not be immediately visible to other threads.  It's been changed to a `ConcurrentHashMap`. This should resolve some of the JFR virtual thread test failures.

This PR does not fix all the problems with `TestVirtualThreadsChunkRotation`. There is still a problem related to dumping snapshots I must investigate further, so it is still skipped for now.

This is related to : https://github.com/oracle/graal/pull/6464#issuecomment-1551367336 