### PR TITLE
fix: force-uppercase C-standard flag, trim, drop quotes

### DIFF
--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/NativeImageOptions.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/NativeImageOptions.java
@@ -176,7 +176,7 @@ public class NativeImageOptions {
 
     public static CStandards getCStandard() {
         try {
-            return CStandards.valueOf(CStandard.getValue());
+            return CStandards.valueOf(CStandard.getValue().toUpperCase().trim().replace("\"", "").replace("'", ""));
         } catch (IllegalArgumentException e) {
             throw UserError.abort("C standard %s is not supported. Supported standards are: %s", CStandard.getValue(), Arrays.toString(CStandards.values()));
         }


### PR DESCRIPTION
This change drops single and double quotes from the C-standard flag lookup that occurs in `NativeImageOptions`; this will mean that passing `c99`, `C99`, `"C99"`, `'c99'`, and so on, all resolve via the `CStandards` enum.

Fixes and closes #6699