### PR TITLE
Add JFR old object sample event

### DIFF
--- a/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/GCImpl.java
+++ b/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/GCImpl.java
@@ -29,6 +29,7 @@ import static com.oracle.svm.core.snippets.KnownIntrinsics.readReturnAddress;
 
 import java.lang.ref.Reference;
 
+import com.oracle.svm.core.heap.Heap;
 import org.graalvm.nativeimage.CurrentIsolate;
 import org.graalvm.nativeimage.IsolateThread;
 import org.graalvm.nativeimage.Platform;
@@ -222,6 +223,7 @@ public final class GCImpl implements GC {
         GenScavengeMemoryPoolMXBeans.singleton().notifyAfterCollection();
 
         printGCAfter(cause);
+        Heap.getHeap().updateUsedAtGC();
         JfrGCHeapSummaryEvent.emit(JfrGCWhen.AFTER_GC);
 
         collectionEpoch = collectionEpoch.add(1);

--- a/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/HeapAccounting.java
+++ b/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/HeapAccounting.java
@@ -95,6 +95,10 @@ public final class HeapAccounting {
         return edenUsedBytes.get();
     }
 
+    UnsignedWord getUncheckedYoungUsedBytes() {
+        return youngUsedBytes.get();
+    }
+
     @Uninterruptible(reason = "Necessary to return a reasonably consistent value (a GC can change the queried values).")
     @SuppressWarnings("static-method")
     public UnsignedWord getSurvivorUsedBytes() {

--- a/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/OldGeneration.java
+++ b/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/OldGeneration.java
@@ -180,4 +180,10 @@ public final class OldGeneration extends Generation {
         RememberedSet.get().enableRememberedSetForChunk(chunk);
         return chunk;
     }
+
+    UnsignedWord getUncheckedChunkBytes() {
+        UnsignedWord fromBytes = getFromSpace().getUncheckedChunkBytes();
+        UnsignedWord toBytes = getToSpace().getUncheckedChunkBytes();
+        return fromBytes.add(toBytes);
+    }
 }

--- a/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/Space.java
+++ b/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/Space.java
@@ -558,6 +558,11 @@ public final class Space {
         return accounting.getAlignedChunkBytes();
     }
 
+    @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
+    UnsignedWord getUncheckedChunkBytes() {
+        return getAlignedChunkBytes().add(accounting.getUnalignedChunkBytes());
+    }
+
     UnsignedWord computeObjectBytes() {
         assert !isEdenSpace() || areEdenBytesCorrect() : "eden bytes are only accurate during a GC, or at a safepoint after a TLAB flush";
         return computeAlignedObjectBytes().add(computeUnalignedObjectBytes());

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/SubstrateOptions.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/SubstrateOptions.java
@@ -914,6 +914,9 @@ public class SubstrateOptions {
     @Option(help = "file:doc-files/FlightRecorderLoggingHelp.txt")//
     public static final RuntimeOptionKey<String> FlightRecorderLogging = new RuntimeOptionKey<>("all=warning", Immutable);
 
+    @Option(help = "file:doc-files/FlightRecorderOptionsHelp.txt")//
+    public static final RuntimeOptionKey<String> FlightRecorderOptions = new RuntimeOptionKey<>("", Immutable);
+
     public static String reportsPath() {
         Path reportsPath = ImageSingletons.lookup(ReportingSupport.class).reportsPath;
         if (reportsPath.isAbsolute()) {

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/doc-files/FlightRecorderOptionsHelp.txt
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/doc-files/FlightRecorderOptionsHelp.txt
@@ -1,0 +1,7 @@
+Usage: -XX:FlightRecorderOptions=old-object-queue-size[=size]
+
+The JFR old object sample sample queue is initialized with a fixed-size array at runtime.
+The default size is 256 elements, but this can be configured at runtime using this option.
+For example:
+
+  -XX:FlightRecorderOptions=old-object-queue-size=1024

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/heap/Heap.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/heap/Heap.java
@@ -268,4 +268,9 @@ public abstract class Heap {
      */
     @Uninterruptible(reason = "Ensure that no GC can occur between this call and usage of the salt.", callerMustBe = true)
     public abstract long getIdentityHashSalt(Object obj);
+
+    @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
+    public abstract long getUsedAtLastGC();
+
+    public abstract void updateUsedAtGC();
 }

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/heap/ReferenceInternals.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/heap/ReferenceInternals.java
@@ -75,6 +75,7 @@ public final class ReferenceInternals {
     }
 
     @SuppressWarnings("unchecked")
+    @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
     public static <T> T getReferent(Reference<T> instance) {
         return (T) SubstrateUtil.cast(instance, Target_java_lang_ref_Reference.class).referent;
     }

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/UninterruptibleUtils.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/UninterruptibleUtils.java
@@ -590,6 +590,17 @@ public class UninterruptibleUtils {
             return result + (addNullTerminator ? 1 : 0);
         }
 
+        @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
+        public static int modifiedUTF8Length(char[] chars, int length) {
+            int result = 0;
+            for (int index = 0; index < length; index++) {
+                char ch = chars[index];
+                result += modifiedUTF8Length(ch);
+            }
+
+            return result;
+        }
+
         /**
          * Writes the encoded {@code string} into the given {@code buffer} using the modified UTF8
          * encoding (null characters that are present in the input will be encoded in a way that
@@ -599,13 +610,18 @@ public class UninterruptibleUtils {
          */
         @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
         public static Pointer toModifiedUTF8(java.lang.String string, Pointer buffer, Pointer bufferEnd, boolean addNullTerminator) {
-            return toModifiedUTF8(string, buffer, bufferEnd, addNullTerminator, null);
+            return toModifiedUTF8(string.length(), string, buffer, bufferEnd, addNullTerminator, null);
         }
 
         @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
         public static Pointer toModifiedUTF8(java.lang.String string, Pointer buffer, Pointer bufferEnd, boolean addNullTerminator, CharReplacer replacer) {
+            return toModifiedUTF8(string.length(), string, buffer, bufferEnd, addNullTerminator, replacer);
+        }
+
+        @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
+        public static Pointer toModifiedUTF8(int length, java.lang.String string, Pointer buffer, Pointer bufferEnd, boolean addNullTerminator, CharReplacer replacer) {
             Pointer pos = buffer;
-            for (int index = 0; index < string.length(); index++) {
+            for (int index = 0; index < length; index++) {
                 char ch = StringUtil.charAt(string, index);
                 if (replacer != null) {
                     ch = replacer.replace(ch);
@@ -617,6 +633,18 @@ public class UninterruptibleUtils {
                 pos.writeByte(0, (byte) 0);
                 pos = pos.add(1);
             }
+            VMError.guarantee(pos.belowOrEqual(bufferEnd), "Must not write out of bounds.");
+            return pos;
+        }
+
+        @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
+        public static Pointer toModifiedUTF8(int length, char[] chars, Pointer buffer, Pointer bufferEnd) {
+            Pointer pos = buffer;
+            for (int index = 0; index < length; index++) {
+                char ch = chars[index];
+                pos = writeModifiedUTF8(pos, ch);
+            }
+
             VMError.guarantee(pos.belowOrEqual(bufferEnd), "Must not write out of bounds.");
             return pos;
         }

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/JfrChunkFileWriter.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/JfrChunkFileWriter.java
@@ -29,6 +29,7 @@ import static com.oracle.svm.core.jfr.JfrThreadLocal.getNativeBufferList;
 
 import java.nio.charset.StandardCharsets;
 
+import com.oracle.svm.core.jfr.oldobject.JfrOldObjectRepository;
 import org.graalvm.nativeimage.IsolateThread;
 import org.graalvm.nativeimage.Platform;
 import org.graalvm.nativeimage.Platforms;
@@ -98,7 +99,7 @@ public final class JfrChunkFileWriter implements JfrChunkWriter {
 
     @Platforms(Platform.HOSTED_ONLY.class)
     public JfrChunkFileWriter(JfrGlobalMemory globalMemory, JfrStackTraceRepository stackTraceRepo, JfrMethodRepository methodRepo, JfrTypeRepository typeRepo, JfrSymbolRepository symbolRepo,
-                    JfrThreadRepository threadRepo) {
+                    JfrThreadRepository threadRepo, JfrOldObjectRepository oldObjectRepo) {
         this.lock = new VMMutex("jfrChunkWriter");
         this.globalMemory = globalMemory;
         this.metadata = new JfrMetadata(null);
@@ -109,7 +110,7 @@ public final class JfrChunkFileWriter implements JfrChunkWriter {
          * the write order. This ordering is required to prevent races during flushing without
          * changing epoch.
          */
-        this.flushCheckpointRepos = new JfrRepository[]{stackTraceRepo, methodRepo, typeRepo, symbolRepo};
+        this.flushCheckpointRepos = new JfrRepository[]{stackTraceRepo, methodRepo, oldObjectRepo, typeRepo, symbolRepo};
         this.threadCheckpointRepos = new JfrRepository[]{threadRepo};
     }
 

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/JfrEvent.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/JfrEvent.java
@@ -66,6 +66,7 @@ public final class JfrEvent {
     public static final JfrEvent ThreadAllocationStatistics = create("jdk.ThreadAllocationStatistics", false);
     public static final JfrEvent SystemGC = create("jdk.SystemGC", true);
     public static final JfrEvent AllocationRequiringGC = create("jdk.AllocationRequiringGC", false);
+    public static final JfrEvent OldObjectSample = create("jdk.OldObjectSample", false);
 
     private final long id;
     private final String name;

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/Target_jdk_jfr_internal_JVM.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/Target_jdk_jfr_internal_JVM.java
@@ -422,7 +422,7 @@ public final class Target_jdk_jfr_internal_JVM {
     @Substitute
     @TargetElement(onlyWith = JDK22OrLater.class)
     public static void emitOldObjectSamples(long cutoff, boolean emitAll, boolean skipBFS) {
-        // Not supported but this method is called during JFR shutdown, so we can't throw an error.
+        SubstrateJVM.get().emitOldObjectSamples(cutoff, emitAll, skipBFS);
     }
 
     /** See {@link JVM#shouldRotateDisk}. */

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/Target_jdk_jfr_internal_JVM_JDK21.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/Target_jdk_jfr_internal_JVM_JDK21.java
@@ -295,7 +295,7 @@ final class Target_jdk_jfr_internal_JVM_JDK21 {
     /** See {@link JVM#emitOldObjectSamples}. */
     @Substitute
     public void emitOldObjectSamples(long cutoff, boolean emitAll, boolean skipBFS) {
-        // Not supported but this method is called during JFR shutdown, so we can't throw an error.
+        SubstrateJVM.get().emitOldObjectSamples(cutoff, emitAll, skipBFS);
     }
 
     /** See {@link JVM#shouldRotateDisk}. */

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/events/OldObjectSampleEvent.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/events/OldObjectSampleEvent.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2023, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2023, Red Hat Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package com.oracle.svm.core.jfr.events;
+
+import com.oracle.svm.core.Uninterruptible;
+import com.oracle.svm.core.jfr.JfrEvent;
+import com.oracle.svm.core.jfr.JfrNativeEventWriter;
+import com.oracle.svm.core.jfr.JfrNativeEventWriterData;
+import com.oracle.svm.core.jfr.JfrNativeEventWriterDataAccess;
+import org.graalvm.nativeimage.StackValue;
+
+public class OldObjectSampleEvent {
+    @Uninterruptible(reason = "Accesses a JFR buffer.")
+    public static void emit(long timestamp, long objectId, long objectSize, long allocationTime, long threadId, long stackTraceId, long heapUsedAtLastGC, int arrayLength) {
+        if (JfrEvent.OldObjectSample.shouldEmit()) {
+            JfrNativeEventWriterData data = StackValue.get(JfrNativeEventWriterData.class);
+            JfrNativeEventWriterDataAccess.initializeThreadLocalNativeBuffer(data);
+
+            JfrNativeEventWriter.beginSmallEvent(data, JfrEvent.OldObjectSample);
+            JfrNativeEventWriter.putLong(data, timestamp); // start time
+            JfrNativeEventWriter.putLong(data, 0); // duration
+            JfrNativeEventWriter.putLong(data, threadId); // thread id
+            JfrNativeEventWriter.putLong(data, stackTraceId); // stack trace id
+            JfrNativeEventWriter.putLong(data, allocationTime); // allocation time
+            JfrNativeEventWriter.putLong(data, objectSize); // object size
+            JfrNativeEventWriter.putLong(data, timestamp - allocationTime); // object age
+            JfrNativeEventWriter.putLong(data, heapUsedAtLastGC); // used memory at last gc
+            JfrNativeEventWriter.putLong(data, objectId); // object id
+            JfrNativeEventWriter.putInt(data, arrayLength); // array length
+            JfrNativeEventWriter.putLong(data, 0); // todo gc root address (path-to-gc-roots)
+            JfrNativeEventWriter.endSmallEvent(data);
+        }
+    }
+}

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/oldobject/JfrOldObjectDescriptionWriter.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/oldobject/JfrOldObjectDescriptionWriter.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2023, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2023, Red Hat Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package com.oracle.svm.core.jfr.oldobject;
+
+import com.oracle.svm.core.Uninterruptible;
+import com.oracle.svm.core.jdk.JavaLangSubstitutions;
+import com.oracle.svm.core.jfr.JfrChunkFileWriter.StringEncoding;
+import com.oracle.svm.core.jfr.JfrNativeEventWriter;
+import com.oracle.svm.core.jfr.JfrNativeEventWriterData;
+import org.graalvm.nativeimage.Platform;
+import org.graalvm.nativeimage.Platforms;
+
+public class JfrOldObjectDescriptionWriter {
+    private static final int OBJECT_DESCRIPTION_MAX_SIZE = 100;
+    private final char[] buffer = new char[OBJECT_DESCRIPTION_MAX_SIZE];
+    private int index;
+    private StringEncoding encoding;
+
+    @Platforms(Platform.HOSTED_ONLY.class)
+    public JfrOldObjectDescriptionWriter() {
+    }
+
+    @Uninterruptible(reason = "Locking without transition and result is only valid until epoch changes.", callerMustBe = true)
+    void write(String text) {
+        if (text == null) {
+            encoding = StringEncoding.NULL;
+            return;
+        }
+
+        if (text.isEmpty()) {
+            encoding = StringEncoding.EMPTY_STRING;
+            return;
+        }
+
+        encoding = StringEncoding.UTF8_BYTE_ARRAY;
+        final int length = text.length();
+        for (int i = 0; i < length && index < buffer.length - 3; i++) {
+            char ch = JavaLangSubstitutions.StringUtil.charAt(text, i);
+            buffer[index] = ch;
+            index++;
+        }
+
+        if (index == buffer.length - 3) {
+            buffer[index++] = '.';
+            buffer[index++] = '.';
+            buffer[index++] = '.';
+        }
+    }
+
+    @Uninterruptible(reason = "Locking without transition and result is only valid until epoch changes.", callerMustBe = true)
+    void finish(JfrNativeEventWriterData data) {
+        switch (encoding) {
+            case NULL -> JfrNativeEventWriter.putChars(data, null, 0);
+            case EMPTY_STRING -> JfrNativeEventWriter.putChars(data, buffer, 0);
+            case UTF8_BYTE_ARRAY -> JfrNativeEventWriter.putChars(data, buffer, index);
+        }
+
+        index = 0;
+    }
+}

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/oldobject/JfrOldObjectProfiler.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/oldobject/JfrOldObjectProfiler.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright (c) 2023, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2023, Red Hat Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package com.oracle.svm.core.jfr.oldobject;
+
+import com.oracle.svm.core.Uninterruptible;
+import com.oracle.svm.core.heap.Heap;
+import com.oracle.svm.core.heap.ReferenceInternals;
+import com.oracle.svm.core.jfr.JfrEvent;
+import com.oracle.svm.core.jfr.JfrTicks;
+import com.oracle.svm.core.jfr.SubstrateJVM;
+import com.oracle.svm.core.jfr.events.OldObjectSampleEvent;
+import com.oracle.svm.core.thread.JavaSpinLockUtils;
+import com.oracle.svm.core.thread.JavaThreads;
+import jdk.internal.misc.Unsafe;
+import jdk.jfr.internal.LogLevel;
+import jdk.jfr.internal.LogTag;
+import jdk.jfr.internal.Logger;
+import org.graalvm.nativeimage.Platform;
+import org.graalvm.nativeimage.Platforms;
+
+import java.lang.ref.WeakReference;
+
+public final class JfrOldObjectProfiler {
+    private static final int DEFAULT_SAMPLER_SIZE = 256;
+
+    /*
+     * Moving locking to OldObjectProfiler class cannot easily be done. For starters Unsafe needs to
+     * be accessible there, but there might be other issues.
+     */
+    private static final Unsafe U = Unsafe.getUnsafe();
+    private static final long LOCK_OFFSET = U.objectFieldOffset(JfrOldObjectProfiler.class, "lock");
+    @SuppressWarnings("unused") private volatile int lock;
+
+    private int queueSize;
+    private OldObjectSampler sampler;
+    private OldObjectEventEmitter eventEmitter;
+
+    @Platforms(Platform.HOSTED_ONLY.class)
+    public JfrOldObjectProfiler() {
+        this.queueSize = JfrOldObjectProfiler.DEFAULT_SAMPLER_SIZE;
+    }
+
+    public void configure(int oldObjectQueueSize) {
+        this.queueSize = oldObjectQueueSize;
+    }
+
+    public void initialize() {
+        if (Logger.shouldLog(LogTag.JFR, LogLevel.DEBUG)) {
+            Logger.log(LogTag.JFR, LogLevel.DEBUG, "Initialize old object sampler: old-object-queue-size=" + queueSize);
+        }
+        OldObjectEffects effects = new DefaultEffects();
+        OldObjectList list = new OldObjectList();
+        this.sampler = new OldObjectSampler(queueSize, list, effects);
+        this.eventEmitter = new OldObjectEventEmitter(list, effects);
+    }
+
+    @Uninterruptible(reason = "Access protected by lock.")
+    public boolean sample(WeakReference<Object> ref, long allocatedSize, int arrayLength) {
+        final boolean success = JavaSpinLockUtils.tryLock(this, LOCK_OFFSET);
+        if (!success) {
+            return false;
+        }
+
+        try {
+            return sampler.sample(ref, allocatedSize, arrayLength);
+        } finally {
+            JavaSpinLockUtils.unlock(this, LOCK_OFFSET);
+        }
+    }
+
+    @Uninterruptible(reason = "Access protected by lock.")
+    public void emit(long cutoff) {
+        JavaSpinLockUtils.lockNoTransition(this, LOCK_OFFSET);
+
+        try {
+            eventEmitter.emit(cutoff);
+        } finally {
+            JavaSpinLockUtils.unlock(this, LOCK_OFFSET);
+        }
+    }
+
+    private static final class DefaultEffects implements OldObjectEffects {
+        @Override
+        @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
+        public long elapsedTicks() {
+            return JfrTicks.elapsedTicks();
+        }
+
+        @Override
+        @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
+        public Object getWeakReferent(WeakReference<?> ref) {
+            return ReferenceInternals.getReferent(ref);
+        }
+
+        @Override
+        @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
+        public void emit(Object aliveObject, long timestamp, long objectSize, long allocationTime, long threadId, long stackTraceId, long heapUsedAtLastGC, int arrayLength) {
+            final long objectId = SubstrateJVM.getJfrOldObjectRepository().serializeOldObject(aliveObject);
+            OldObjectSampleEvent.emit(timestamp, objectId, objectSize, allocationTime, threadId, stackTraceId, heapUsedAtLastGC, arrayLength);
+        }
+
+        @Override
+        @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
+        public boolean isDead(WeakReference<?> ref) {
+            return ReferenceInternals.refersTo(ref, null);
+        }
+
+        @Override
+        @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
+        public long getStackTraceId() {
+            return SubstrateJVM.get().getStackTraceId(JfrEvent.OldObjectSample, 0);
+        }
+
+        @Override
+        @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
+        public long getThreadId(Thread thread) {
+            return JavaThreads.getThreadId(thread);
+        }
+
+        @Override
+        @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
+        public long getHeapUsedAtLastGC() {
+            return Heap.getHeap().getUsedAtLastGC();
+        }
+    }
+}

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/oldobject/JfrOldObjectRepository.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/oldobject/JfrOldObjectRepository.java
@@ -1,0 +1,180 @@
+/*
+ * Copyright (c) 2023, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2023, Red Hat Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package com.oracle.svm.core.jfr.oldobject;
+
+import jdk.graal.compiler.word.Word;
+import com.oracle.svm.core.Uninterruptible;
+import com.oracle.svm.core.jfr.JfrBuffer;
+import com.oracle.svm.core.jfr.JfrBufferAccess;
+import com.oracle.svm.core.jfr.JfrBufferType;
+import com.oracle.svm.core.jfr.JfrChunkWriter;
+import com.oracle.svm.core.jfr.JfrNativeEventWriter;
+import com.oracle.svm.core.jfr.JfrNativeEventWriterData;
+import com.oracle.svm.core.jfr.JfrNativeEventWriterDataAccess;
+import com.oracle.svm.core.jfr.JfrRepository;
+import com.oracle.svm.core.jfr.JfrType;
+import com.oracle.svm.core.jfr.SubstrateJVM;
+import com.oracle.svm.core.jfr.traceid.JfrTraceIdEpoch;
+import com.oracle.svm.core.locks.VMMutex;
+import org.graalvm.nativeimage.Platform;
+import org.graalvm.nativeimage.Platforms;
+import org.graalvm.nativeimage.StackValue;
+import org.graalvm.word.WordFactory;
+
+public final class JfrOldObjectRepository implements JfrRepository {
+
+    private final VMMutex mutex;
+    private final JfrOldObjectEpochData epochData0;
+    private final JfrOldObjectEpochData epochData1;
+    private final JfrOldObjectDescriptionWriter descriptionWriter;
+    private long nextId = 1;
+
+    @Platforms(Platform.HOSTED_ONLY.class)
+    public JfrOldObjectRepository() {
+        this.mutex = new VMMutex("jfrOldObjectRepository");
+        this.epochData0 = new JfrOldObjectEpochData();
+        this.epochData1 = new JfrOldObjectEpochData();
+        this.descriptionWriter = new JfrOldObjectDescriptionWriter();
+    }
+
+    public void teardown() {
+        epochData0.teardown();
+        epochData1.teardown();
+    }
+
+    @Uninterruptible(reason = "Locking without transition and result is only valid until epoch changes.", callerMustBe = true)
+    public long serializeOldObject(Object obj) {
+        mutex.lockNoTransition();
+        try {
+            JfrOldObjectEpochData epochData = getEpochData(false);
+            if (epochData.buffer.isNull()) {
+                epochData.buffer = JfrBufferAccess.allocate(JfrBufferType.C_HEAP);
+            }
+
+            final Word pointer = Word.objectToUntrackedPointer(obj);
+            JfrNativeEventWriterData data = StackValue.get(JfrNativeEventWriterData.class);
+            JfrNativeEventWriterDataAccess.initialize(data, epochData.buffer);
+            final long objectId = nextId;
+            JfrNativeEventWriter.putLong(data, objectId);
+            nextId++;
+            JfrNativeEventWriter.putLong(data, pointer.rawValue());
+            JfrNativeEventWriter.putLong(data, SubstrateJVM.getTypeRepository().getClassId(obj.getClass()));
+            writeDescription(obj, data);
+            // todo parent address (path-to-gc-roots)
+            JfrNativeEventWriter.putLong(data, WordFactory.zero().rawValue());
+            if (!JfrNativeEventWriter.commit(data)) {
+                return 0L;
+            }
+
+            epochData.unflushedEntries++;
+            /* The buffer may have been replaced with a new one. */
+            epochData.buffer = data.getJfrBuffer();
+            return objectId;
+        } finally {
+            mutex.unlock();
+        }
+    }
+
+    @Uninterruptible(reason = "Locking without transition and result is only valid until epoch changes.", callerMustBe = true)
+    private void writeDescription(Object obj, JfrNativeEventWriterData data) {
+        if (obj instanceof ThreadGroup) {
+            String prefix = "Thread Group: ";
+            String threadGroupName = ((ThreadGroup) obj).getName();
+            descriptionWriter.write(prefix);
+            descriptionWriter.write(threadGroupName);
+            descriptionWriter.finish(data);
+            return;
+        }
+        if (obj instanceof Thread) {
+            String prefix = "Thread Name: ";
+            String threadName = ((Thread) obj).getName();
+            descriptionWriter.write(prefix);
+            descriptionWriter.write(threadName);
+            descriptionWriter.finish(data);
+            return;
+        }
+        if (obj instanceof Class) {
+            String prefix = "Class Name: ";
+            String className = ((Class<?>) obj).getName();
+            descriptionWriter.write(prefix);
+            descriptionWriter.write(className);
+            descriptionWriter.finish(data);
+            return;
+        }
+
+        // Size description not implemented since that relies on runtime reflection.
+        JfrNativeEventWriter.putLong(data, 0L);
+    }
+
+    @Override
+    @Uninterruptible(reason = "Locking without transition requires that the whole critical section is uninterruptible.")
+    public int write(JfrChunkWriter writer, boolean flushpoint) {
+        mutex.lockNoTransition();
+        try {
+            JfrOldObjectEpochData epochData = getEpochData(true);
+            int count = epochData.unflushedEntries;
+            if (count != 0) {
+                writer.writeCompressedLong(JfrType.OldObject.getId());
+                writer.writeCompressedInt(count);
+                writer.write(epochData.buffer);
+            }
+            epochData.clear();
+            return count == 0 ? EMPTY : NON_EMPTY;
+        } finally {
+            mutex.unlock();
+        }
+    }
+
+    @Uninterruptible(reason = "Result is only valid until epoch changes.", callerMustBe = true)
+    private JfrOldObjectEpochData getEpochData(boolean previousEpoch) {
+        boolean epoch = previousEpoch ? JfrTraceIdEpoch.getInstance().previousEpoch() : JfrTraceIdEpoch.getInstance().currentEpoch();
+        return epoch ? epochData0 : epochData1;
+    }
+
+    private static class JfrOldObjectEpochData {
+        private int unflushedEntries;
+        private JfrBuffer buffer;
+
+        @Platforms(Platform.HOSTED_ONLY.class)
+        JfrOldObjectEpochData() {
+            this.unflushedEntries = 0;
+        }
+
+        @Uninterruptible(reason = "May write current epoch data.")
+        void clear() {
+            unflushedEntries = 0;
+            JfrBufferAccess.reinitialize(buffer);
+        }
+
+        @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
+        void teardown() {
+            unflushedEntries = 0;
+            JfrBufferAccess.free(buffer);
+            buffer = WordFactory.nullPointer();
+        }
+    }
+}

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/oldobject/OldObject.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/oldobject/OldObject.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2023, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2023, Red Hat Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package com.oracle.svm.core.jfr.oldobject;
+
+import com.oracle.svm.core.Uninterruptible;
+
+import java.lang.ref.WeakReference;
+
+final class OldObject {
+    static final OldObject EMPTY = new OldObject();
+
+    WeakReference<?> reference;
+    long span;
+    long objectSize;
+    long allocationTime; // nanoseconds
+    long threadId;
+    long stackTraceId;
+    long heapUsedAtLastGC;
+    int arrayLength;
+    OldObject previous;
+
+    @Uninterruptible(reason = "Accesses allocation profiler.")
+    void set(WeakReference<?> ref, long allocatedSize, long allocatedTime, long threadId, long stackTraceId, long heapUsedAtLastGC, int arrayLength) {
+        this.reference = ref;
+        this.span = allocatedSize;
+        this.objectSize = allocatedSize;
+        this.allocationTime = allocatedTime;
+        this.threadId = threadId;
+        this.stackTraceId = stackTraceId;
+        this.heapUsedAtLastGC = heapUsedAtLastGC;
+        this.arrayLength = arrayLength;
+    }
+
+    @Uninterruptible(reason = "Accesses allocation profiler.")
+    void clear() {
+        this.reference = null;
+        this.span = 0L;
+        this.objectSize = 0L;
+        this.allocationTime = 0L;
+        this.threadId = 0L;
+        this.stackTraceId = 0L;
+        this.heapUsedAtLastGC = 0L;
+        this.arrayLength = 0;
+        this.previous = null;
+    }
+}

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/oldobject/OldObjectArray.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/oldobject/OldObjectArray.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2023, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2023, Red Hat Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package com.oracle.svm.core.jfr.oldobject;
+
+import com.oracle.svm.core.Uninterruptible;
+
+/**
+ * A class representing the underlying array to store old object samples. It's used by both
+ * {@link OldObjectPriorityQueue} and {@link OldObjectList} as the underlying storage for the data.
+ * All of its methods are marked as uninterruptible because they're accessed from the old object
+ * profiler sampling and emitting methods, which are protected by a lock.
+ */
+final class OldObjectArray {
+    private final OldObject[] samples;
+
+    OldObjectArray(int capacity) {
+        this.samples = new OldObject[capacity];
+        for (int i = 0; i < this.samples.length; i++) {
+            this.samples[i] = new OldObject();
+        }
+    }
+
+    @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
+    int getCapacity() {
+        return samples.length;
+    }
+
+    @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
+    void swap(int i, int j) {
+        final OldObject tmp = samples[i];
+        samples[i] = samples[j];
+        samples[j] = tmp;
+    }
+
+    @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
+    int indexOf(OldObject sample) {
+        for (int i = 0; i < samples.length; i++) {
+            if (sample == samples[i]) {
+                return i;
+            }
+        }
+
+        return -1;
+    }
+
+    @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
+    OldObject getSample(int index) {
+        return samples[index];
+    }
+}

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/oldobject/OldObjectEffects.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/oldobject/OldObjectEffects.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2023, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2023, Red Hat Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package com.oracle.svm.core.jfr.oldobject;
+
+import com.oracle.svm.core.Uninterruptible;
+
+import java.lang.ref.WeakReference;
+
+public interface OldObjectEffects {
+    @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
+    long elapsedTicks();
+
+    @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
+    Object getWeakReferent(WeakReference<?> ref);
+
+    @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
+    void emit(Object aliveObject, long timestamp, long allocatedSize, long allocationTime, long threadId, long stackTraceId, long heapUsedAtLastGC, int arrayLength);
+
+    @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
+    boolean isDead(WeakReference<?> ref);
+
+    @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
+    default boolean isAlive(WeakReference<?> ref) {
+        return !isDead(ref);
+    }
+
+    @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
+    long getStackTraceId();
+
+    @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
+    long getThreadId(Thread thread);
+
+    @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
+    long getHeapUsedAtLastGC();
+}

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/oldobject/OldObjectEventEmitter.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/oldobject/OldObjectEventEmitter.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2023, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2023, Red Hat Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package com.oracle.svm.core.jfr.oldobject;
+
+import com.oracle.svm.core.Uninterruptible;
+
+public final class OldObjectEventEmitter {
+    private final OldObjectList list;
+    private final OldObjectEffects effects;
+
+    public OldObjectEventEmitter(OldObjectList list, OldObjectEffects effects) {
+        this.list = list;
+        this.effects = effects;
+    }
+
+    @Uninterruptible(reason = "Access protected by lock.")
+    public void emit(long cutoff) {
+        if (cutoff <= 0) {
+            // No reference chains
+            emitUnchained();
+        }
+
+        // todo support cutoff > 0 (path-to-gc-roots)
+    }
+
+    @Uninterruptible(reason = "Access protected by lock.")
+    private void emitUnchained() {
+        final long timestamp = effects.elapsedTicks();
+
+        OldObject current = list.head();
+        while (current != null) {
+            if (current.reference != null) {
+                final Object obj = effects.getWeakReferent(current.reference);
+                final long allocationTime = current.allocationTime;
+                /*
+                 * Should delegate checking that the reference is alive, even if the weak referent
+                 * has already been retrieved.
+                 */
+                if (effects.isAlive(current.reference)) {
+                    final long objectSize = current.objectSize;
+                    final long threadId = current.threadId;
+                    final long stackTraceId = current.stackTraceId;
+                    final long heapUsedAtLastGC = current.heapUsedAtLastGC;
+                    final int arrayLength = current.arrayLength;
+                    effects.emit(obj, timestamp, objectSize, allocationTime, threadId, stackTraceId, heapUsedAtLastGC, arrayLength);
+                }
+            }
+
+            current = current.previous;
+        }
+    }
+}

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/oldobject/OldObjectList.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/oldobject/OldObjectList.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2023, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2023, Red Hat Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package com.oracle.svm.core.jfr.oldobject;
+
+import com.oracle.svm.core.Uninterruptible;
+
+/**
+ * A singly linked list view of the queue. An item's previous is the item that was added to the
+ * queue after the item itself. The list is iterated in FIFO order, starting with the element added
+ * first and following previous links to find elements added after. The traversal can also be used
+ * to discover entries that need removing, e.g. if references have been garbage collected. All of
+ * its methods are marked as uninterruptible because they're accessed from the old object profiler
+ * sampling and emitting methods, which are protected by a lock.
+ */
+public final class OldObjectList {
+    /*
+     * Points to the oldest entry added to the list. This would be the first FIFO iterated element.
+     * Only gets updated when an entry is removed.
+     */
+    private OldObject head;
+
+    /*
+     * Points to the youngest entry added to the list. This would be last FIFO iterated element.
+     * Prepending merely updates this pointer.
+     */
+    private OldObject tail;
+
+    @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
+    OldObject head() {
+        return head;
+    }
+
+    @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
+    void prepend(OldObject sample) {
+        assert sample.previous == null;
+        if (tail == null || head == null) {
+            tail = sample;
+            head = sample;
+            return;
+        }
+
+        tail.previous = sample;
+        tail = sample;
+    }
+
+    @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
+    void remove(OldObject sample) {
+        if (head == sample) {
+            head = sample.previous;
+            if (tail == sample) {
+                // Removing last remaining item.
+                tail = null;
+            }
+            return;
+        }
+
+        // Else, find an element whose previous is item; iow, find item's next element.
+        OldObject next = findNext(sample);
+
+        assert next != null;
+
+        // Then set that next's previous to item's previous
+        next.previous = sample.previous;
+        sample.previous = null;
+
+        // If the element removed is tail, update it to item's next.
+        if (tail == sample) {
+            tail = next;
+        }
+    }
+
+    @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
+    private OldObject findNext(OldObject target) {
+        OldObject current = head;
+        while (current != null) {
+            if (current.previous == target) {
+                return current;
+            }
+
+            current = current.previous;
+        }
+
+        return null;
+    }
+}

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/oldobject/OldObjectPriorityQueue.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/oldobject/OldObjectPriorityQueue.java
@@ -1,0 +1,181 @@
+/*
+ * Copyright (c) 2023, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2023, Red Hat Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package com.oracle.svm.core.jfr.oldobject;
+
+import com.oracle.svm.core.Uninterruptible;
+
+import java.lang.ref.WeakReference;
+
+/**
+ * A priority queue view over the old object samples stored inside {@link OldObjectArray}. The
+ * priority is based on a sample's span. When the queue gets full, it allows the
+ * {@link OldObjectSampler} to remove samples with lower span values and keep those with higher
+ * values. An old object sample's span is its allocation size initially, but it can increase as old
+ * object samples are garbage collected (see {@link OldObjectSampler} for details). All of its
+ * methods are marked as uninterruptible because they're accessed from the old object profiler
+ * sampling and emitting methods, which are protected by a lock.
+ */
+final class OldObjectPriorityQueue {
+    private final OldObjectArray samples;
+    private int count;
+    private long total;
+
+    OldObjectPriorityQueue(OldObjectArray samples) {
+        this.samples = samples;
+    }
+
+    @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
+    boolean isFull() {
+        return count == samples.getCapacity();
+    }
+
+    /**
+     * Inserts the specified old object into this queue.
+     * <p>
+     * This method does not check if the queue has enough capacity. It's up to the caller decide how
+     * to deal with a full queue.
+     */
+    @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
+    public void push(OldObject sample) {
+        push(sample.reference, sample.span, sample.allocationTime, sample.threadId, sample.stackTraceId, sample.heapUsedAtLastGC, sample.arrayLength);
+    }
+
+    /**
+     * Inserts the old object sample data into this queue.
+     * <p>
+     * This method does not check if the queue has enough capacity. It's up to the caller decide how
+     * to deal with a full queue.
+     */
+    @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
+    public OldObject push(WeakReference<?> ref, long allocatedSize, long allocatedTime, long threadId, long stackTraceId, long heapUsedAtLastGC, int arrayLength) {
+        final OldObject sample = samples.getSample(count);
+        sample.set(ref, allocatedSize, allocatedTime, threadId, stackTraceId, heapUsedAtLastGC, arrayLength);
+        count++;
+        moveUp(count - 1);
+        total += sample.span;
+        return sample;
+    }
+
+    @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
+    OldObject peek() {
+        return count == 0 ? OldObject.EMPTY : samples.getSample(0);
+    }
+
+    /**
+     * Removes and return the head of the queue. The head of the queue is the sample with the
+     * smallest span.
+     */
+    @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
+    OldObject poll() {
+        if (count == 0) {
+            return OldObject.EMPTY;
+        }
+
+        final OldObject head = peek();
+        samples.swap(0, count - 1);
+        count--;
+        moveDown(0);
+        total -= head.span;
+        return head;
+    }
+
+    /**
+     * Removes a sample from the queue. It moves the sample all the way to the top to become the
+     * head, then it polls it to remove it.
+     */
+    @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
+    void remove(OldObject sample) {
+        final long span = sample.span;
+        sample.span = 0L;
+        moveUp(samples.indexOf(sample));
+        sample.span = span;
+        poll();
+    }
+
+    @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
+    private void moveUp(final int i) {
+        int current = i;
+        int parent = parent(current);
+        while (current > 0 && getSpanAt(current) < getSpanAt(parent)) {
+            samples.swap(current, parent);
+            current = parent;
+            parent = parent(current);
+        }
+    }
+
+    @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
+    private long getSpanAt(int index) {
+        return samples.getSample(index).span;
+    }
+
+    @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
+    private static int parent(int i) {
+        return (i - 1) / 2;
+    }
+
+    @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
+    private void moveDown(final int i) {
+        int current = i;
+        do {
+            int j = -1;
+            int r = right(current);
+            if (r < count && getSpanAt(r) < getSpanAt(current)) {
+                int l = left(current);
+                if (getSpanAt(l) < getSpanAt(r)) {
+                    j = l;
+                } else {
+                    j = r;
+                }
+            } else {
+                int l = left(current);
+                if (l < count && getSpanAt(l) < getSpanAt(current)) {
+                    j = l;
+                }
+            }
+
+            if (j >= 0) {
+                samples.swap(current, j);
+            }
+            current = j;
+        } while (current >= 0);
+    }
+
+    @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
+    private static int left(int i) {
+        return 2 * i + 1;
+    }
+
+    @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
+    private static int right(int i) {
+        return 2 * i + 2;
+    }
+
+    @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
+    long total() {
+        return total;
+    }
+}

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/oldobject/OldObjectSampler.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/oldobject/OldObjectSampler.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright (c) 2023, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2023, Red Hat Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package com.oracle.svm.core.jfr.oldobject;
+
+import com.oracle.svm.core.Uninterruptible;
+
+import java.lang.ref.WeakReference;
+
+/**
+ * A sampler that tracks old objects in a {@link OldObjectPriorityQueue}. If the queue gets full, it
+ * can either evict old object samples with lower span, or it can iterate over the old object
+ * samples and remove those that have been garbage collected. It uses the {@link OldObjectList} to
+ * iterate over the old object samples that have queued via the {@link OldObjectPriorityQueue}.
+ */
+public final class OldObjectSampler {
+    private final OldObjectPriorityQueue queue;
+    private final OldObjectList list;
+    private final OldObjectEffects effects;
+    private long totalAllocated;
+
+    public OldObjectSampler(int queueSize, OldObjectList list, OldObjectEffects effects) {
+        OldObjectArray samples = new OldObjectArray(queueSize);
+        this.queue = new OldObjectPriorityQueue(samples);
+        this.list = list;
+        this.effects = effects;
+    }
+
+    @Uninterruptible(reason = "Access protected by lock.")
+    public boolean sample(WeakReference<Object> ref, long allocatedSize, int arrayLength) {
+        totalAllocated += allocatedSize;
+        long span = totalAllocated - queue.total();
+        if (queue.isFull()) {
+            if (queue.peek().span > span) {
+                /*
+                 * Sample will not fit, try to scavenge. HotSpot code scavenges when it gets
+                 * notified that a sample was GC'd, but such mechanism doesn't exist in substratevm.
+                 * So, instead just attempt to scavenge when the queue is full.
+                 */
+                int numDead = scavenge();
+                if (numDead == 0) {
+                    // Sample will not fit and all objects still in use, return early
+                    return false;
+                }
+            } else {
+                /*
+                 * Offered element has a higher priority, vacate from the lowest priority one and
+                 * insert the element.
+                 */
+                evict();
+            }
+        }
+
+        store(ref, allocatedSize, effects.elapsedTicks(), arrayLength);
+        return true;
+    }
+
+    @Uninterruptible(reason = "Access protected by lock.")
+    private int scavenge() {
+        int numDead = 0;
+        OldObject current = list.head();
+        while (current != null) {
+            OldObject next = current.previous;
+            final WeakReference<?> ref = current.reference;
+            if (effects.isDead(ref)) {
+                remove(current);
+                numDead++;
+            }
+
+            current = next;
+        }
+        return numDead;
+    }
+
+    /**
+     * Remove a given sample from the sampler.
+     */
+    @Uninterruptible(reason = "Access protected by lock.")
+    private void remove(OldObject sample) {
+        final OldObject prev = sample.previous;
+        if (prev != null) {
+            // To keep samples evenly distributed over time,
+            // the weight of a sample that is removed should be redistributed.
+            // Here it gets redistributed to the sample that came just after in time.
+            queue.remove(prev);
+            prev.span += sample.span;
+            queue.push(prev);
+        }
+        queue.remove(sample);
+        list.remove(sample);
+        sample.clear();
+    }
+
+    /**
+     * Evict the sample with the smallest span from the sampler, by removing the head of the queue.
+     */
+    @Uninterruptible(reason = "Access protected by lock.")
+    private void evict() {
+        final OldObject head = queue.poll();
+        list.remove(head);
+        head.clear();
+    }
+
+    @Uninterruptible(reason = "Access protected by lock.")
+    private void store(WeakReference<?> ref, long allocatedSize, long allocatedTime, int arrayLength) {
+        final OldObject sample = push(ref, allocatedSize, allocatedTime, arrayLength);
+        list.prepend(sample);
+    }
+
+    @Uninterruptible(reason = "Access protected by lock.")
+    private OldObject push(WeakReference<?> ref, long allocatedSize, long allocatedTime, int arrayLength) {
+        final Thread thread = Thread.currentThread();
+        final long heapUsedAtLastGC = effects.getHeapUsedAtLastGC();
+
+        // Note: thread can be null during shutdown, don't remove thread null check
+        if (thread == null) {
+            return queue.push(ref, allocatedSize, allocatedTime, 0L, 0L, heapUsedAtLastGC, arrayLength);
+        }
+
+        final long stackTraceId = effects.getStackTraceId();
+        final long threadId = effects.getThreadId(thread);
+        return queue.push(ref, allocatedSize, allocatedTime, threadId, stackTraceId, heapUsedAtLastGC, arrayLength);
+    }
+}

--- a/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/jfr/AbstractJfrTest.java
+++ b/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/jfr/AbstractJfrTest.java
@@ -39,8 +39,10 @@ import java.util.List;
 import java.util.Random;
 import java.util.function.BooleanSupplier;
 
+import jdk.jfr.Unsigned;
 import org.graalvm.nativeimage.ImageInfo;
 import org.graalvm.nativeimage.hosted.Feature;
+import org.graalvm.nativeimage.hosted.RuntimeProxyCreation;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.BeforeClass;
@@ -187,4 +189,15 @@ public abstract class AbstractJfrTest {
 }
 
 class JfrTestFeature implements Feature {
+    @Override
+    public void beforeAnalysis(BeforeAnalysisAccess access) {
+        /*
+         * Register proxies for event data assertion
+         *
+         * Unsigned added to be able to query RecordedObject.getLong() method, and this method
+         * checks if the value returned has the jdk.jfr.Unsigned. The jfr layer in HotSpot creates a
+         * proxy to query this information.
+         */
+        RuntimeProxyCreation.register(Unsigned.class);
+    }
 }

--- a/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/jfr/oldobject/JfrOldObjectTest.java
+++ b/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/jfr/oldobject/JfrOldObjectTest.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2023, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2023, Red Hat Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package com.oracle.svm.test.jfr.oldobject;
+
+import com.oracle.svm.core.jfr.JfrEvent;
+import com.oracle.svm.test.jfr.JfrRecordingTest;
+import jdk.jfr.Recording;
+import jdk.jfr.ValueDescriptor;
+import jdk.jfr.consumer.RecordedEvent;
+import jdk.jfr.consumer.RecordedFrame;
+import jdk.jfr.consumer.RecordedObject;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.rules.TestName;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public abstract class JfrOldObjectTest extends JfrRecordingTest {
+    static Object leak;
+
+    @Rule public TestName name = new TestName();
+
+    @Before
+    public void triggerUpdateOfLastKnownHeapUsage() {
+        // Trigger GC before tests to get a reading of last known heap usage for the first executed
+        // test.
+        System.gc();
+    }
+
+    @After
+    public void garbageCollectLeak() {
+        // Force previous tests objects to be garbage collected.
+        // The scavenge logic in the sampler should clear those from the queue.
+        leak = null;
+        System.gc();
+        System.gc();
+    }
+
+    Recording startRecording() throws Throwable {
+        final String[] events = {JfrEvent.OldObjectSample.getName()};
+        Map<String, String> settings = new HashMap<>();
+        settings.put("old-objects-stack-trace", "true");
+        return startRecording(events, getDefaultConfiguration(), settings);
+    }
+
+    Collection<RecordedEvent> filterEventsByType(Class<?> type, List<RecordedEvent> events) {
+        return filterEventsByTypeName(type.getName(), events);
+    }
+
+    Collection<RecordedEvent> filterEventsByTypeName(String typeName, List<RecordedEvent> events) {
+        final List<RecordedEvent> filteredEvents = events.stream().filter(e -> typeName.equals(e.<RecordedObject> getValue("object").getClass("type").getName())).toList();
+        Assert.assertFalse(filteredEvents.isEmpty());
+        return filteredEvents;
+    }
+
+    void assertOldObjectEvent(RecordedEvent event) {
+        final List<ValueDescriptor> fields = event.getFields();
+        Assert.assertEquals(11, fields.size());
+        Assert.assertEquals(0, event.getDuration().toMillis());
+        Assert.assertTrue(event.getLong("lastKnownHeapUsage") > 0);
+        Assert.assertTrue(event.getLong("objectAge") > 0);
+        Assert.assertNull(event.getValue("root"));
+
+        final List<RecordedFrame> frames = event.getStackTrace().getFrames();
+        Assert.assertTrue(frames.size() > 0);
+        Assert.assertTrue(frames.stream().anyMatch(e -> name.getMethodName().equals(e.getMethod().getName())));
+
+        final long allocationTime = event.getLong("allocationTime");
+        Assert.assertTrue(allocationTime > 0);
+
+        final long objectSize = event.getLong("objectSize");
+        Assert.assertTrue(objectSize > 0);
+
+        final long startTime = event.getLong("startTime");
+        Assert.assertTrue(startTime > 0);
+        Assert.assertTrue(String.format("Allocation time (%d) should be earlier or same time as event start time (%d)", allocationTime, startTime), allocationTime <= startTime);
+
+    }
+}

--- a/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/jfr/oldobject/TestOldObjectProfiler.java
+++ b/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/jfr/oldobject/TestOldObjectProfiler.java
@@ -1,0 +1,482 @@
+/*
+ * Copyright (c) 2023, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2023, Red Hat Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package com.oracle.svm.test.jfr.oldobject;
+
+import com.oracle.svm.core.Uninterruptible;
+import com.oracle.svm.core.heap.ReferenceInternals;
+import com.oracle.svm.core.jfr.oldobject.OldObjectEffects;
+import com.oracle.svm.core.jfr.oldobject.OldObjectEventEmitter;
+import com.oracle.svm.core.jfr.oldobject.OldObjectList;
+import com.oracle.svm.core.jfr.oldobject.OldObjectSampler;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.lang.ref.WeakReference;
+import java.util.Arrays;
+import java.util.stream.IntStream;
+import java.util.stream.LongStream;
+import java.util.stream.Stream;
+
+public class TestOldObjectProfiler {
+    @Test
+    public void testScavenge() {
+        final int size = 10;
+        final MutableBoolean isDead = new MutableBoolean(false);
+        final TestEffects effects = new TestEffects(20L, size) {
+            @Override
+            @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
+            public boolean isDead(WeakReference<?> ref) {
+                final int value = (int) getWeakReferent(ref);
+                if (value < 10) {
+                    return isDead.get();
+                }
+
+                return false;
+            }
+        };
+        final OldObjectList list = new OldObjectList();
+        final OldObjectSampler sampler = new OldObjectSampler(size, list, effects);
+        final OldObjectEventEmitter eventEmitter = new OldObjectEventEmitter(list, effects);
+
+        for (int i = 0; i < size; i++) {
+            sampler.sample(new WeakReference<>(i), (i + 1) * 10_000, -1);
+        }
+
+        // Set is-alive check for samples in first round to be false.
+        // Scavenging should kick in when lower-span objects are sampled.
+        isDead.set(true);
+
+        for (int i = 0; i < size; i++) {
+            sampler.sample(new WeakReference<>(10 + i), (i + 1) * 100, -1);
+        }
+
+        // Make sure that lower-span objects are inserted as a result of scavenging higher-span
+        // objects,
+        // and not as a result of checking that high-span objects are not alive at emit time.
+        isDead.set(false);
+
+        eventEmitter.emit(0);
+        assertStreamEquals(IntStream.rangeClosed(10, 19).boxed(), effects.objects());
+    }
+
+    @Test
+    public void testEvictUponFull() {
+        final int size = 10;
+        final TestEffects effects = new TestEffects(20L, size);
+        final OldObjectList list = new OldObjectList();
+        final OldObjectSampler sampler = new OldObjectSampler(size, list, effects);
+        final OldObjectEventEmitter eventEmitter = new OldObjectEventEmitter(list, effects);
+
+        for (int i = 0; i < size; i++) {
+            sampler.sample(new WeakReference<>(i), (i + 1) * 100, -1);
+        }
+
+        eventEmitter.emit(0);
+        assertStreamEquals(IntStream.rangeClosed(0, 9).boxed(), effects.objects());
+
+        // Clear accumulated samples and see what gets emitted now.
+        effects.clearSamples();
+
+        // Queue is full and objects to sample have bigger span than initial ones.
+        // So sampling these new objects should result in evicting previously sampled ones.
+        for (int i = 0; i < size; i++) {
+            sampler.sample(new WeakReference<>(10 + i), (i + 1) * 10_000, -1);
+        }
+
+        eventEmitter.emit(0);
+        assertStreamEquals(IntStream.rangeClosed(10, 19).boxed(), effects.objects());
+    }
+
+    @Test
+    public void testEmitSkippingMiddle() {
+        final int size = 8;
+        final TestEffects effects = new TestEffects(20L, size) {
+            @Override
+            @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
+            public boolean isDead(WeakReference<?> ref) {
+                final Object value = super.getWeakReferent(ref);
+                return "4".equals(value);
+            }
+        };
+        final OldObjectList list = new OldObjectList();
+        final OldObjectSampler sampler = new OldObjectSampler(size, list, effects);
+        final OldObjectEventEmitter eventEmitter = new OldObjectEventEmitter(list, effects);
+
+        for (int i = 0; i < size; i++) {
+            sampler.sample(new WeakReference<>(String.valueOf(i)), i * 100, -1);
+        }
+
+        eventEmitter.emit(0);
+        assertLongStreamEquals(LongStream.concat(LongStream.rangeClosed(20L, 23L), LongStream.rangeClosed(25L, 27L)), effects.allocationTimes());
+    }
+
+    @Test
+    public void testEmitSkippingYoungest() {
+        final int size = 8;
+        final TestEffects effects = new TestEffects(20L, size) {
+            @Override
+            @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
+            public boolean isDead(WeakReference<?> ref) {
+                final Object value = super.getWeakReferent(ref);
+                return "7".equals(value);
+            }
+        };
+        final OldObjectList list = new OldObjectList();
+        final OldObjectSampler sampler = new OldObjectSampler(size, list, effects);
+        final OldObjectEventEmitter eventEmitter = new OldObjectEventEmitter(list, effects);
+
+        for (int i = 0; i < size; i++) {
+            sampler.sample(new WeakReference<>(String.valueOf(i)), i * 100, -1);
+        }
+
+        eventEmitter.emit(0);
+        assertLongStreamEquals(LongStream.rangeClosed(20L, 26L), effects.allocationTimes());
+    }
+
+    @Test
+    public void testEmitSkippingOldest() {
+        final int size = 8;
+        final TestEffects effects = new TestEffects(20L, size) {
+            @Override
+            @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
+            public boolean isDead(WeakReference<?> ref) {
+                final Object value = super.getWeakReferent(ref);
+                return "0".equals(value);
+            }
+        };
+        final OldObjectList list = new OldObjectList();
+        final OldObjectSampler sampler = new OldObjectSampler(size, list, effects);
+        final OldObjectEventEmitter eventEmitter = new OldObjectEventEmitter(list, effects);
+
+        for (int i = 0; i < size; i++) {
+            sampler.sample(new WeakReference<>(String.valueOf(i)), i * 100, -1);
+        }
+
+        eventEmitter.emit(0);
+        assertLongStreamEquals(LongStream.rangeClosed(21L, 27L), effects.allocationTimes());
+    }
+
+    @Test
+    public void testEmitSkippingAll() {
+        final int size = 8;
+        final TestEffects effects = new TestEffects(20L, size) {
+            @Override
+            @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
+            public boolean isDead(WeakReference<?> ref) {
+                return true;
+            }
+        };
+        final OldObjectList list = new OldObjectList();
+        final OldObjectSampler sampler = new OldObjectSampler(size, list, effects);
+        final OldObjectEventEmitter eventEmitter = new OldObjectEventEmitter(list, effects);
+
+        for (int i = 0; i < size; i++) {
+            sampler.sample(new WeakReference<>(String.valueOf(i)), i * 100, -1);
+        }
+
+        eventEmitter.emit(0);
+        Assert.assertEquals(0, effects.sizeSamples());
+    }
+
+    @Test
+    public void testSampleManyEmitQueueSize() {
+        final int size = 256;
+        final TestEffects effects = new TestEffects(20L, size);
+        final OldObjectList list = new OldObjectList();
+        final OldObjectSampler sampler = new OldObjectSampler(size, list, effects);
+        final OldObjectEventEmitter eventEmitter = new OldObjectEventEmitter(list, effects);
+
+        for (int i = 0; i < 1_000_000; i++) {
+            sampler.sample(new WeakReference<>(String.valueOf(i)), i, -1);
+        }
+
+        eventEmitter.emit(0);
+        Assert.assertEquals(256, effects.sizeSamples());
+    }
+
+    @Test
+    public void testSampleOverflowEvictYoungest() {
+        final int size = 8;
+        final TestEffects effects = new TestEffects(20L, size);
+        final OldObjectList list = new OldObjectList();
+        final OldObjectSampler sampler = new OldObjectSampler(size, list, effects);
+        final OldObjectEventEmitter eventEmitter = new OldObjectEventEmitter(list, effects);
+
+        for (int i = 0; i < size + 1; i++) {
+            // Evict youngest because that's the one with the lowest span.
+            final int allocatedSize = i == (size - 1) ? 100 : 200;
+            sampler.sample(new WeakReference<>(String.valueOf(i)), allocatedSize, -1);
+        }
+
+        eventEmitter.emit(0);
+        assertLongStreamEquals(LongStream.concat(LongStream.rangeClosed(20L, 26L), LongStream.rangeClosed(28L, 28L)), effects.allocationTimes());
+    }
+
+    @Test
+    public void testSampleOverflowEvictMiddle() {
+        final int size = 8;
+        final TestEffects effects = new TestEffects(20L, size);
+        final OldObjectList list = new OldObjectList();
+        final OldObjectSampler sampler = new OldObjectSampler(size, list, effects);
+        final OldObjectEventEmitter eventEmitter = new OldObjectEventEmitter(list, effects);
+
+        for (int i = 0; i < size + 1; i++) {
+            // Evict middle because that's the one with the lowest span.
+            final int allocatedSize = i == (size / 2) ? 100 : 200;
+            sampler.sample(new WeakReference<>(String.valueOf(i)), allocatedSize, -1);
+        }
+
+        eventEmitter.emit(0);
+        assertLongStreamEquals(LongStream.concat(LongStream.rangeClosed(20L, 23L), LongStream.rangeClosed(25L, 28L)), effects.allocationTimes());
+    }
+
+    @Test
+    public void testSampleOverflowEvictOldest() {
+        final int size = 8;
+        final TestEffects effects = new TestEffects(20L, size);
+        final OldObjectList list = new OldObjectList();
+        final OldObjectSampler sampler = new OldObjectSampler(size, list, effects);
+        final OldObjectEventEmitter eventEmitter = new OldObjectEventEmitter(list, effects);
+
+        for (int i = 0; i < size + 1; i++) {
+            // Evict oldest because that's the one with the lowest span.
+            sampler.sample(new WeakReference<>(String.valueOf(i)), i * 100, -1);
+        }
+
+        eventEmitter.emit(0);
+        assertLongStreamEquals(LongStream.rangeClosed(21L, 28L), effects.allocationTimes());
+    }
+
+    @Test
+    public void testSampleFullEmit() {
+        final int size = 8;
+        final TestEffects effects = new TestEffects(20L, size);
+        final OldObjectList list = new OldObjectList();
+        final OldObjectSampler sampler = new OldObjectSampler(size, list, effects);
+        final OldObjectEventEmitter eventEmitter = new OldObjectEventEmitter(list, effects);
+
+        for (int i = 0; i < size; i++) {
+            sampler.sample(new WeakReference<>(String.valueOf(i)), i * 100, -1);
+        }
+
+        eventEmitter.emit(0);
+        assertLongStreamEquals(LongStream.rangeClosed(20L, 27L), effects.allocationTimes());
+    }
+
+    @Test
+    public void testSampleNotFullEmit() {
+        final int size = 8;
+        final TestEffects effects = new TestEffects(20L, size);
+        final OldObjectList list = new OldObjectList();
+        final OldObjectSampler sampler = new OldObjectSampler(size, list, effects);
+        final OldObjectEventEmitter eventEmitter = new OldObjectEventEmitter(list, effects);
+
+        for (int i = 0; i < size - 1; i++) {
+            sampler.sample(new WeakReference<>(String.valueOf(i)), i * 100, -1);
+        }
+
+        eventEmitter.emit(0);
+        assertLongStreamEquals(LongStream.rangeClosed(20L, 26L), effects.allocationTimes());
+    }
+
+    @Test
+    public void testSingleSample() {
+        final int size = 3;
+        final TestEffects effects = new TestEffects(20L, 3);
+        final OldObjectList list = new OldObjectList();
+        final OldObjectSampler sampler = new OldObjectSampler(size, list, effects);
+        final OldObjectEventEmitter eventEmitter = new OldObjectEventEmitter(list, effects);
+
+        sampler.sample(new WeakReference<>("a-sample"), 10, -1);
+        eventEmitter.emit(0);
+        final TestSample testSample = effects.peekLastSample();
+        Assert.assertNotNull(testSample);
+        Assert.assertEquals("a-sample", testSample.obj);
+        Assert.assertEquals(21, testSample.timestamp);
+        Assert.assertEquals(10, testSample.objectSize);
+        Assert.assertEquals(20, testSample.allocationTime);
+        Assert.assertEquals(50, testSample.threadId);
+        Assert.assertEquals(40, testSample.stackTraceId);
+        Assert.assertEquals(60, testSample.heapUsedAtLastGC);
+        Assert.assertEquals(-1, testSample.arrayLength);
+        Assert.assertEquals(1, effects.sizeSamples());
+    }
+
+    static void assertLongStreamEquals(LongStream expected, Stream<?> actual) {
+        assertStreamEquals(expected.boxed(), actual);
+    }
+
+    static void assertStreamEquals(Stream<?> expected, Stream<?> actual) {
+        Assert.assertEquals(expected.toList(), actual.toList());
+    }
+
+    private static class TestEffects implements OldObjectEffects {
+        private final TestSample[] testSamples;
+        private int head = 0;
+        private int tail = 0;
+        private long ticks;
+
+        TestEffects(long initialTicks, int size) {
+            this.ticks = initialTicks;
+            this.testSamples = new TestSample[size];
+            for (int i = 0; i < size; i++) {
+                this.testSamples[i] = new TestSample();
+            }
+        }
+
+        @Override
+        @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
+        public long elapsedTicks() {
+            return ticks++;
+        }
+
+        @Override
+        @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
+        public Object getWeakReferent(WeakReference<?> ref) {
+            try {
+                return ReferenceInternals.getReferent(ref);
+            } catch (ClassCastException e) {
+                // A class cast occurs when running this test as a plain Java unit test.
+                // Fallback to a mechanism that works in that environment.
+                return getWeakReferent0(ref);
+            }
+        }
+
+        @Override
+        @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
+        public boolean isDead(WeakReference<?> ref) {
+            try {
+                return ReferenceInternals.refersTo(ref, null);
+            } catch (NullPointerException e) {
+                // A NPE occurs when running this test as a plain Java unit test.
+                // Fallback to a mechanism that works in that environment.
+                return getWeakReferent0(ref) == null;
+            }
+        }
+
+        @Uninterruptible(reason = "A fallback for when this test is run in JVM mode", calleeMustBe = false)
+        private static Object getWeakReferent0(WeakReference<?> ref) {
+            return ref.get();
+        }
+
+        @Override
+        @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
+        public void emit(Object aliveObject, long timestamp, long allocatedSize, long allocationTime, long threadId, long stackTraceId, long heapUsedAtLastGC, int arrayLength) {
+            testSamples[tail++].set(aliveObject, timestamp, allocatedSize, allocationTime, threadId, stackTraceId, heapUsedAtLastGC, arrayLength);
+        }
+
+        @Override
+        @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
+        public long getStackTraceId() {
+            return 40;
+        }
+
+        @Override
+        @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
+        public long getThreadId(Thread thread) {
+            return 50;
+        }
+
+        @Override
+        @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
+        public long getHeapUsedAtLastGC() {
+            return 60;
+        }
+
+        TestSample peekLastSample() {
+            return testSamples[head];
+        }
+
+        int sizeSamples() {
+            return tail - head;
+        }
+
+        Stream<Long> allocationTimes() {
+            return Arrays.stream(testSamples).filter(s -> s.allocationTime != 0).map(TestSample::getAllocationTime);
+        }
+
+        Stream<Object> objects() {
+            return Arrays.stream(testSamples).filter(s -> s.allocationTime != 0).map(TestSample::getObject);
+        }
+
+        public void clearSamples() {
+            head = 0;
+            tail = 0;
+            for (TestSample testSample : testSamples) {
+                testSample.set(null, 0, 0, 0, 0, 0, 0, 0);
+            }
+        }
+    }
+
+    private static final class TestSample {
+        Object obj;
+        long timestamp;
+        long objectSize;
+        long allocationTime;
+        long threadId;
+        long stackTraceId;
+        long heapUsedAtLastGC;
+        int arrayLength;
+
+        @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
+        void set(Object obj, long timestamp, long allocatedSize, long allocationTime, long threadId, long stackTraceId, long heapUsedAtLastGC, int arrayLength) {
+            this.obj = obj;
+            this.timestamp = timestamp;
+            this.objectSize = allocatedSize;
+            this.allocationTime = allocationTime;
+            this.threadId = threadId;
+            this.stackTraceId = stackTraceId;
+            this.heapUsedAtLastGC = heapUsedAtLastGC;
+            this.arrayLength = arrayLength;
+        }
+
+        long getAllocationTime() {
+            return allocationTime;
+        }
+
+        Object getObject() {
+            return obj;
+        }
+    }
+
+    private static final class MutableBoolean {
+        private boolean value;
+
+        MutableBoolean(boolean value) {
+            this.value = value;
+        }
+
+        void set(boolean newValue) {
+            value = newValue;
+        }
+
+        @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
+        boolean get() {
+            return value;
+        }
+    }
+}

--- a/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/jfr/oldobject/TestRecordingArrayLeak.java
+++ b/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/jfr/oldobject/TestRecordingArrayLeak.java
@@ -47,9 +47,6 @@ public class TestRecordingArrayLeak extends JfrOldObjectTest {
             node[2] = right;
             node = right;
         }
-        // Trigger a GC so that last sweep gets updated,
-        // and the objects above are considered older than last GC sweep time.
-        System.gc();
 
         stopRecording(recording, events -> filterEventsByTypeName("[Ljava.lang.Object;", events).forEach(this::assertRecordedEvent));
     }

--- a/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/jfr/oldobject/TestRecordingArrayLeak.java
+++ b/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/jfr/oldobject/TestRecordingArrayLeak.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2023, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2023, Red Hat Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package com.oracle.svm.test.jfr.oldobject;
+
+import jdk.jfr.Recording;
+import jdk.jfr.consumer.RecordedEvent;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class TestRecordingArrayLeak extends JfrOldObjectTest {
+    @Test
+    public void testArrayLeak() throws Throwable {
+        Recording recording = startRecording();
+
+        Object[] node = new Object[3];
+        leak = node;
+        for (int i = 0; i < 10_000; i++) {
+            Object[] value = new Object[100];
+            node[0] = value;
+            Object[] left = new Object[3];
+            node[1] = left;
+            Object[] right = new Object[3];
+            node[2] = right;
+            node = right;
+        }
+        // Trigger a GC so that last sweep gets updated,
+        // and the objects above are considered older than last GC sweep time.
+        System.gc();
+
+        stopRecording(recording, events -> filterEventsByTypeName("[Ljava.lang.Object;", events).forEach(this::assertRecordedEvent));
+    }
+
+    private void assertRecordedEvent(RecordedEvent event) {
+        assertOldObjectEvent(event);
+        final int arraySize = event.getInt("arrayElements");
+        Assert.assertTrue("Unexpected array size: " + arraySize, arraySize == 100 || arraySize == 3);
+    }
+}

--- a/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/jfr/oldobject/TestRecordingObjectDescription.java
+++ b/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/jfr/oldobject/TestRecordingObjectDescription.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 2023, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2023, Red Hat Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package com.oracle.svm.test.jfr.oldobject;
+
+import com.oracle.svm.core.jfr.SubstrateJVM;
+import jdk.jfr.Recording;
+import jdk.jfr.consumer.RecordedEvent;
+import jdk.jfr.consumer.RecordedObject;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.lang.ref.WeakReference;
+import java.util.concurrent.TimeUnit;
+
+public class TestRecordingObjectDescription extends JfrOldObjectTest {
+    @Test
+    public void testThreadGroupName() throws Throwable {
+        Recording recording = startRecording();
+        sample(new MyThreadGroup("My Thread Group"));
+        stopRecording(recording, events -> filterEventsByType(MyThreadGroup.class, events).forEach(e -> assertDescription("Thread Group: My Thread Group", e)));
+    }
+
+    @Test
+    public void testThreadGroupEllipsis() throws Throwable {
+        final int objectDescriptionMaxSize = 100;
+        final String threadGroupName = "x".repeat(2 * objectDescriptionMaxSize);
+
+        Recording recording = startRecording();
+        sample(new MyThreadGroup(threadGroupName));
+        stopRecording(recording, events -> filterEventsByType(MyThreadGroup.class, events).forEach(e -> assertDescriptionLimit("xxx...", objectDescriptionMaxSize, e)));
+    }
+
+    @Test
+    public void testThreadName() throws Throwable {
+        Recording recording = startRecording();
+        sample(new MyThread("My Thread"));
+        stopRecording(recording, events -> filterEventsByType(MyThread.class, events).forEach(e -> assertDescription("Thread Name: My Thread", e)));
+    }
+
+    @Test
+    public void testClassName() throws Throwable {
+        Recording recording = startRecording();
+        sample(String.class);
+        stopRecording(recording, events -> filterEventsByType(Class.class, events).forEach(e -> assertDescription("Class Name: java.lang.String", e)));
+    }
+
+    private static void sample(Object obj) {
+        // For single-shot sampling attempts, loop until sampling in successful.
+        // This is needed because other internal threads could be trying to sample too,
+        // e.g. JFR Periodic Tasks.
+        long waitTimeSec = 5;
+        long endTime = System.nanoTime() + TimeUnit.SECONDS.toNanos(waitTimeSec);
+        boolean success;
+        long sleepTime;
+        do {
+            success = SubstrateJVM.getJfrOldObjectProfiler().sample(new WeakReference<>(obj), 1_000, Integer.MIN_VALUE);
+            sleepTime = endTime - System.nanoTime();
+        } while (!success && sleepTime > 0);
+
+        if (!success) {
+            throw new AssertionError("Timed out waiting for sampling to complete");
+        }
+    }
+
+    private static void assertDescription(String expected, RecordedEvent event) {
+        final String description = event.<RecordedObject> getValue("object").getValue("description");
+        Assert.assertEquals(expected, description);
+    }
+
+    private static void assertDescriptionLimit(String expected, int expectedSize, RecordedEvent event) {
+        final String description = event.<RecordedObject> getValue("object").getValue("description");
+        Assert.assertEquals(expectedSize, description.length());
+        Assert.assertTrue(description.contains(expected));
+        Assert.assertTrue(description.contains("Thread Group: x"));
+    }
+
+    public static final class MyThreadGroup extends ThreadGroup {
+        public MyThreadGroup(String name) {
+            super(name);
+        }
+    }
+
+    public static final class MyThread extends Thread {
+        public MyThread(String name) {
+            super(name);
+        }
+    }
+}

--- a/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/jfr/oldobject/TestRecordingPlainObjectLeak.java
+++ b/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/jfr/oldobject/TestRecordingPlainObjectLeak.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2023, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2023, Red Hat Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package com.oracle.svm.test.jfr.oldobject;
+
+import jdk.jfr.Recording;
+import jdk.jfr.consumer.RecordedEvent;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class TestRecordingPlainObjectLeak extends JfrOldObjectTest {
+    private static final int DEFAULT_OLD_OBJECT_QUEUE_SIZE = 256;
+
+    @Test
+    public void testObjectLeak() throws Throwable {
+        Recording recording = startRecording();
+
+        Node node = new Node();
+        leak = node;
+        for (int i = 0; i < 10_000; i++) {
+            node.value = new Node();
+            node.left = new Node();
+            node.right = new Node();
+            node = node.right;
+        }
+        // Trigger a GC so that last sweep gets updated,
+        // and the objects above are considered older than last GC sweep time.
+        System.gc();
+
+        stopRecording(recording, events -> {
+            Assert.assertTrue(events.size() < DEFAULT_OLD_OBJECT_QUEUE_SIZE);
+            filterEventsByType(Node.class, events).forEach(this::assertRecordedEvent);
+        });
+    }
+
+    private void assertRecordedEvent(RecordedEvent event) {
+        assertOldObjectEvent(event);
+        Assert.assertEquals(Integer.MIN_VALUE, event.getInt("arrayElements"));
+    }
+
+    static class Node {
+        Node left;
+        Node right;
+        Object value;
+    }
+}

--- a/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/jfr/oldobject/TestRecordingPlainObjectLeak.java
+++ b/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/jfr/oldobject/TestRecordingPlainObjectLeak.java
@@ -46,9 +46,6 @@ public class TestRecordingPlainObjectLeak extends JfrOldObjectTest {
             node.right = new Node();
             node = node.right;
         }
-        // Trigger a GC so that last sweep gets updated,
-        // and the objects above are considered older than last GC sweep time.
-        System.gc();
 
         stopRecording(recording, events -> {
             Assert.assertTrue(events.size() < DEFAULT_OLD_OBJECT_QUEUE_SIZE);

--- a/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/jfr/utils/JfrFileParser.java
+++ b/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/jfr/utils/JfrFileParser.java
@@ -54,6 +54,7 @@ import com.oracle.svm.test.jfr.utils.poolparsers.GCWhenConstantPoolParser;
 import com.oracle.svm.test.jfr.utils.poolparsers.MethodConstantPoolParser;
 import com.oracle.svm.test.jfr.utils.poolparsers.ModuleConstantPoolParser;
 import com.oracle.svm.test.jfr.utils.poolparsers.MonitorInflationCauseConstantPoolParser;
+import com.oracle.svm.test.jfr.utils.poolparsers.OldObjectConstantPoolParser;
 import com.oracle.svm.test.jfr.utils.poolparsers.PackageConstantPoolParser;
 import com.oracle.svm.test.jfr.utils.poolparsers.StacktraceConstantPoolParser;
 import com.oracle.svm.test.jfr.utils.poolparsers.SymbolConstantPoolParser;
@@ -90,6 +91,7 @@ public class JfrFileParser {
         addParser(JfrType.VMOperation, new VMOperationConstantPoolParser(this));
         addParser(JfrType.MonitorInflationCause, new MonitorInflationCauseConstantPoolParser(this));
         addParser(JfrType.GCWhen, new GCWhenConstantPoolParser(this));
+        addParser(JfrType.OldObject, new OldObjectConstantPoolParser(this));
     }
 
     private void addParser(JfrType type, ConstantPoolParser parser) {

--- a/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/jfr/utils/poolparsers/OldObjectConstantPoolParser.java
+++ b/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/jfr/utils/poolparsers/OldObjectConstantPoolParser.java
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2023, Red Hat Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,41 +23,30 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
-package com.oracle.svm.core.jfr;
 
-import com.oracle.svm.core.Uninterruptible;
+package com.oracle.svm.test.jfr.utils.poolparsers;
 
-/**
- * Maps JFR types against their IDs in the JDK.
- */
-public enum JfrType {
-    Class("java.lang.Class"),
-    String("java.lang.String"),
-    Thread("java.lang.Thread"),
-    ThreadState("jdk.types.ThreadState"),
-    ThreadGroup("jdk.types.ThreadGroup"),
-    StackTrace("jdk.types.StackTrace"),
-    ClassLoader("jdk.types.ClassLoader"),
-    Method("jdk.types.Method"),
-    Symbol("jdk.types.Symbol"),
-    Module("jdk.types.Module"),
-    Package("jdk.types.Package"),
-    FrameType("jdk.types.FrameType"),
-    GCCause("jdk.types.GCCause"),
-    GCName("jdk.types.GCName"),
-    GCWhen("jdk.types.GCWhen"),
-    VMOperation("jdk.types.VMOperationType"),
-    MonitorInflationCause("jdk.types.InflateCause"),
-    OldObject("jdk.types.OldObject");
+import com.oracle.svm.core.jfr.JfrType;
+import com.oracle.svm.test.jfr.utils.JfrFileParser;
+import com.oracle.svm.test.jfr.utils.RecordingInput;
+import org.junit.Assert;
 
-    private final long id;
+import java.io.IOException;
 
-    JfrType(String name) {
-        this.id = JfrMetadataTypeLibrary.lookupType(name);
+public final class OldObjectConstantPoolParser extends ConstantPoolParser {
+    public OldObjectConstantPoolParser(JfrFileParser parser) {
+        super(parser);
     }
 
-    @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
-    public long getId() {
-        return id;
+    @Override
+    public void parse(RecordingInput input) throws IOException {
+        final int numOldObjects = input.readInt();
+        for (int i = 0; i < numOldObjects; i++) {
+            addFoundId(input.readLong()); // Id.
+            Assert.assertTrue("Address can't be 0", input.readLong() != 0); // Address
+            addExpectedId(JfrType.Class, input.readLong()); // ClassId.
+            input.readUTF(); // Description
+            input.readLong(); // todo parent address (path-to-gc-roots)
+        }
     }
 }


### PR DESCRIPTION
Implements JFR `jdk.OldObjectSample` event for #5145, without path to GC root functionality. I have a prototype for the path to GC root functionality, but I’ve decided to split this work into a separate PR to make reviewing more manageable.

This PR includes:
* Event emitted for sampled objects and arrays that are possible leaks.
* They are sampled when they’re allocated via the slow path. The slow path happens when an object does not fit in the TLAB and a new one is required. Arrays bigger than the large array threshold are also allocated via the slow path regardless.
* Following the same logic found in HotSpot, the sampler is implemented as a custom priority queue ordered by span, which is based on allocation size. Objects with the smallest span are at the top of the queue.
* The sample queue is initialized with a fixed-size array at runtime. The default size is 256 elements, but this can be configured at runtime using `-XX:FlightRecorderOptions=old-object-queue-size=<size>` option.
* If the queue is full, and the sampled object is bigger than the top, the top is removed and the sampled object is inserted.
* If the queue is full and the sampled object is smaller than the top, the code tries to scavenge the queue which means purging objects that have been garbage collected.
* To scavenge, the underlying array backing the queue is iterated over, removing those sampled objects that have been garbage collected.
* To check if an object has been garbage collected or not, sampled objects are wrapped around WeakReferences.
* Operations on the sampler queue are protected by a new non-reentrant `SpinLock`. This new lock implementation works similarly to a `VMMutex` but extends it to offer a `tryLock()` function. This function is useful for sampling because if another object is already being sampled and the lock cannot be acquired, the sampling is simply skipped. When emitting old object sample events, the sampler waits to acquire the lock.
* Old object sample events emitted with custom descriptions for `Thread`, `ThreadGroup` and `Class`. Ellipsis descriptions are also supported.

Caveats:
* ~Calling `WeakReference.get()` from uninterruptible code fails. Adding `@AnnotateOriginal @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)` to `Target_java_lang_ref_Reference.get()` does not seem to have any impact. Looking at `AnnotationSubstitutionProcessor`, classes that have `@Substitute` don’t seem to get processed for methods with `@AnnotateOriginal`. Worked around by adding `calleeMustBe = false` to the `Uninterruptible` method within which `WeakReference.get()` is called.~ This caveat has been addressed, see latest commits.
* Old object queue size can only be configured at runtime via the startup recorder options flag. I couldn’t find a way to unit test this since all unit tests run as a single binary run, so the queue size is fixed for all the tests.
* Old object sample event descriptions for classes that have a `size` field not implemented since they’re not feasible in a closed world environment. In HotSpot this is achieved by using reflection to lookup a `size` field but that cannot be done in SubstrateVM.
* Old object sample event description tests only added for thread group. Threads not tested because creating many instances of those triggers other intermediary objects to be sampled so couldn’t easily get to the `Thread` instances. Classes not tested since it requires dynamically creating brand new `Class` instances at runtime, something not feasible in closed-world SubstrateVM.

Once this PR is integrated I'll work on adding path to GC root functionality.