### PR TITLE
Proof of concept for preserving more linkage errors

### DIFF
--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/ClassLoaderSupport.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/ClassLoaderSupport.java
@@ -63,4 +63,6 @@ public abstract class ClassLoaderSupport {
     public abstract List<ResourceBundle> getResourceBundle(String bundleName, Locale locale);
 
     public abstract LinkageError getLinkageError(String className);
+
+    public abstract LinkageError addLinkageError(String className, LinkageError error);
 }

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/ClassLoaderSupportImpl.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/ClassLoaderSupportImpl.java
@@ -308,4 +308,9 @@ public class ClassLoaderSupportImpl extends ClassLoaderSupport {
     public LinkageError getLinkageError(String className) {
         return classLoaderSupport.getLinkageError(className);
     }
+
+    @Override
+    public LinkageError addLinkageError(String className, LinkageError error) {
+        return classLoaderSupport.addLinkageError(className, error);
+    }
 }

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/LinkAtBuildTimeSupport.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/LinkAtBuildTimeSupport.java
@@ -114,6 +114,10 @@ public final class LinkAtBuildTimeSupport {
         return classLoaderSupport.getLinkageError(className);
     }
 
+    public LinkageError addLinkageError(String className, LinkageError error) {
+        return classLoaderSupport.addLinkageError(className, error);
+    }
+
     @SuppressWarnings("unchecked")
     private String linkAtBuildTimeReason(Class<?> clazz) {
         Object reason = isIncluded(clazz);

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/NativeImageClassLoaderSupport.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/NativeImageClassLoaderSupport.java
@@ -222,6 +222,12 @@ public class NativeImageClassLoaderSupport {
         return linkageErrors.get(className);
     }
 
+    public LinkageError addLinkageError(String className, LinkageError error) {
+        synchronized (linkageErrors) {
+            return linkageErrors.put(className, error);
+        }
+    }
+
     public boolean noEntryForURI(EconomicSet<String> set) {
         return set == emptySet;
     }

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/phases/SharedGraphBuilderPhase.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/phases/SharedGraphBuilderPhase.java
@@ -242,7 +242,11 @@ public abstract class SharedGraphBuilderPhase extends GraphBuilderPhase.Instance
             try {
                 super.maybeEagerlyResolve(cpi, bytecode);
             } catch (UnresolvedElementException e) {
-                if (e.getCause() instanceof LinkageError || e.getCause() instanceof IllegalAccessError) {
+                Throwable cause = e.getCause();
+                if (cause instanceof LinkageError) {
+                    if (cause instanceof NoClassDefFoundError) {
+                        LinkAtBuildTimeSupport.singleton().addLinkageError(cause.getMessage().replace("/", "."), (LinkageError) cause);
+                    }
                     /*
                      * Ignore LinkageError if thrown from eager resolution attempt. This is usually
                      * followed by a call to ConstantPool.lookupType() which should return an


### PR DESCRIPTION
@fniephaus this (unpolished) PR demonstrates how you could extend https://github.com/oracle/graal/pull/6753 to preserve even more linkage errors and further improve error reporting. However, as mentioned in https://github.com/oracle/graal/pull/6507#issuecomment-1568702628 we will still need some JVMCI changes to handle these properly.

It looks like not every class loading goes through https://github.com/oracle/graal/pull/6753/files#diff-05fc37f93d8c3289b812fb9f571b8236a3c18cf5310ca34303bcbba16ba3f0eaL823