### PR TITLE
Fix constant pool JFR ID bug

### DIFF
--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/JfrStackTraceRepository.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/JfrStackTraceRepository.java
@@ -301,7 +301,7 @@ public class JfrStackTraceRepository implements JfrRepository {
     }
 
     public static final class JfrStackTraceTable extends AbstractUninterruptibleHashtable {
-        private long nextId;
+        private static long nextId;
 
         @Override
         @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/JfrSymbolRepository.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/JfrSymbolRepository.java
@@ -177,7 +177,7 @@ public class JfrSymbolRepository implements JfrRepository {
     }
 
     private static class JfrSymbolHashtable extends AbstractUninterruptibleHashtable {
-        private long nextId;
+        private static long nextId;
 
         @Override
         @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)

--- a/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/jfr/TestSymbolTraceIdUniqueness.java
+++ b/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/jfr/TestSymbolTraceIdUniqueness.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2023, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2023, Red Hat Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package com.oracle.svm.test.jfr;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeTrue;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.locks.LockSupport;
+
+import org.graalvm.compiler.serviceprovider.JavaVersionUtil;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.oracle.svm.core.jfr.JfrEvent;
+
+import jdk.jfr.Recording;
+import jdk.jfr.consumer.RecordedClass;
+import jdk.jfr.consumer.RecordedEvent;
+
+/**
+ * This test checks if symbol table JFR trace IDs get reused across successive epochs. If they are
+ * reused/duplicated, the validation step will fail because the trace ID key associated with
+ * com.oracle.svm.test.jfr.AbstractJfrTest$MonitorWaitHelper will also be associated with another
+ * value that was serialized during a prior epoch.
+ */
+public class TestSymbolTraceIdUniqueness extends JfrRecordingTest {
+    private final MonitorWaitHelper helper = new MonitorWaitHelper();
+
+    @Before
+    public void checkJavaVersion() {
+        assumeTrue("skipping JFR virtual thread tests", JavaVersionUtil.JAVA_SPEC >= 19);
+    }
+
+    @Test
+    public void test() throws Throwable {
+        String[] events = new String[]{JfrEvent.JavaMonitorWait.getName(), JfrEvent.ThreadPark.getName()};
+
+        // Turn off flushing to simplify testing
+        Map<String, String> settings = new HashMap<>();
+        settings.put("flush-interval", "0");
+        Recording recording = startRecording(events, getDefaultConfiguration(), settings);
+
+        // Generate some symbol table entries and trace IDs.
+        for (Class<?> clazz : com.oracle.svm.core.heap.Heap.getHeap().getLoadedClasses()) {
+            LockSupport.parkNanos(clazz, 1);
+        }
+
+        // Invoke chunk rotation.
+        recording.dump(createTempJfrFile());
+
+        // Emit event that will insert a new symbol table entry who's ID is under test.
+        helper.doEvent();
+
+        stopRecording(recording, this::validateEvents);
+    }
+
+    private void validateEvents(List<RecordedEvent> events) {
+        boolean found = false;
+        for (RecordedEvent event : events) {
+            if (event.getEventType().getName().equals(JfrEvent.JavaMonitorWait.getName())) {
+                System.out.println("------ Wait: " + event.<RecordedClass> getValue("monitorClass").getName() + "| Thread: " + event.getThread().getJavaName());
+                if (event.getClass("monitorClass").getName().equals(MonitorWaitHelper.class.getName())) {
+                    found = true;
+                    break;
+                }
+
+            }
+        }
+        assertTrue("Class " + MonitorWaitHelper.class.getName() + " has shared duplicate trace ID with another symbol constant pool entry.", found);
+    }
+}

--- a/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/jfr/TestSymbolTraceIdUniqueness.java
+++ b/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/jfr/TestSymbolTraceIdUniqueness.java
@@ -85,7 +85,6 @@ public class TestSymbolTraceIdUniqueness extends JfrRecordingTest {
         boolean found = false;
         for (RecordedEvent event : events) {
             if (event.getEventType().getName().equals(JfrEvent.JavaMonitorWait.getName())) {
-                System.out.println("------ Wait: " + event.<RecordedClass> getValue("monitorClass").getName() + "| Thread: " + event.getThread().getJavaName());
                 if (event.getClass("monitorClass").getName().equals(MonitorWaitHelper.class.getName())) {
                     found = true;
                     break;

--- a/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/jfr/TestSymbolTraceIdUniqueness.java
+++ b/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/jfr/TestSymbolTraceIdUniqueness.java
@@ -27,21 +27,17 @@
 package com.oracle.svm.test.jfr;
 
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assume.assumeTrue;
 
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.locks.LockSupport;
 
-import org.graalvm.compiler.serviceprovider.JavaVersionUtil;
-import org.junit.Before;
 import org.junit.Test;
 
 import com.oracle.svm.core.jfr.JfrEvent;
 
 import jdk.jfr.Recording;
-import jdk.jfr.consumer.RecordedClass;
 import jdk.jfr.consumer.RecordedEvent;
 
 /**
@@ -52,11 +48,6 @@ import jdk.jfr.consumer.RecordedEvent;
  */
 public class TestSymbolTraceIdUniqueness extends JfrRecordingTest {
     private final MonitorWaitHelper helper = new MonitorWaitHelper();
-
-    @Before
-    public void checkJavaVersion() {
-        assumeTrue("skipping JFR virtual thread tests", JavaVersionUtil.JAVA_SPEC >= 19);
-    }
 
     @Test
     public void test() throws Throwable {

--- a/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/jfr/TestSymbolTraceIdUniqueness.java
+++ b/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/jfr/TestSymbolTraceIdUniqueness.java
@@ -36,6 +36,7 @@ import java.util.concurrent.locks.LockSupport;
 import org.junit.Test;
 
 import com.oracle.svm.core.jfr.JfrEvent;
+import com.oracle.svm.core.heap.Heap;
 
 import jdk.jfr.Recording;
 import jdk.jfr.consumer.RecordedEvent;
@@ -59,7 +60,7 @@ public class TestSymbolTraceIdUniqueness extends JfrRecordingTest {
         Recording recording = startRecording(events, getDefaultConfiguration(), settings);
 
         // Generate some symbol table entries and trace IDs.
-        for (Class<?> clazz : com.oracle.svm.core.heap.Heap.getHeap().getLoadedClasses()) {
+        for (Class<?> clazz : Heap.getHeap().getLoadedClasses()) {
             LockSupport.parkNanos(clazz, 1);
         }
 

--- a/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/jfr/TestVirtualThreadsChunkRotation.java
+++ b/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/jfr/TestVirtualThreadsChunkRotation.java
@@ -69,7 +69,6 @@ public class TestVirtualThreadsChunkRotation extends JfrRecordingTest {
         assumeTrue("skipping JFR virtual thread tests", JavaVersionUtil.JAVA_SPEC >= 19);
     }
 
-    @Ignore("GR-46117")
     @Test
     public void test() throws Throwable {
         String[] events = new String[]{JfrEvent.JavaMonitorWait.getName()};

--- a/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/jfr/TestVirtualThreadsChunkRotation.java
+++ b/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/jfr/TestVirtualThreadsChunkRotation.java
@@ -39,7 +39,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import org.graalvm.compiler.serviceprovider.JavaVersionUtil;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import com.oracle.svm.core.jfr.JfrEvent;


### PR DESCRIPTION
**Description of Bug**

The `JfrSymbolRepository` was allowing for JFR IDs to be duplicated across epochs. This results in incorrect symbol constant pool data. Consumer code that reads the JFR data on disk will confuse the values that share the same IDs. VisualVm also interprets the wrong symbol values due to the ID duplication.
 
Although `JfrSymbolHashtable.nextId` monotonically increases and is never reset, there were separate `JfrSymbolHashtable`s for each epoch, resulting in two `nextId` counts. This effectively results in allowing the same ID key to be used twice. 

The[ hotspot code that handles symbol IDs forces them to be unique.](https://github.com/openjdk/jdk/blob/master/src/hotspot/share/jfr/support/jfrSymbolTable.cpp#L37-L39) 

The stacktrace repo suffers from the same problem. The other repositories do not have the same problem because they don't create the IDs themselves (thread repo uses already available TIDs and method repo uses method IDs etc).

**Fix**

Make `JfrSymbolHashtable.nextId` and `JfrStackTraceTable.nextId` static. This way the count is shared across the two different `epochData`s.
This fix also allows `TestVirtualThreadsChunkRotation` to reliably pass. I have removed the `@Ignore` annotation. 

