### PR TITLE
Use -1 as max value for eden and survivor spaces

### DIFF
--- a/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/AbstractMemoryPoolMXBean.java
+++ b/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/AbstractMemoryPoolMXBean.java
@@ -45,12 +45,14 @@ import sun.management.Util;
 
 public abstract class AbstractMemoryPoolMXBean extends AbstractMXBean implements MemoryPoolMXBean {
 
+    protected static final UnsignedWord UNDEFINED = WordFactory.signed(UNDEFINED_MEMORY_USAGE);
+    private static final UnsignedWord UNINITIALIZED = WordFactory.zero();
+
     private final String name;
     private final String[] managerNames;
     protected final UninterruptibleUtils.AtomicUnsigned peakUsage = new UninterruptibleUtils.AtomicUnsigned();
 
-    private static final UnsignedWord UNDEFINED = WordFactory.zero();
-    protected UnsignedWord initialValue = UNDEFINED;
+    protected UnsignedWord initialValue = UNINITIALIZED;
 
     @Platforms(Platform.HOSTED_ONLY.class)
     protected AbstractMemoryPoolMXBean(String name, String... managerNames) {
@@ -59,7 +61,7 @@ public abstract class AbstractMemoryPoolMXBean extends AbstractMXBean implements
     }
 
     UnsignedWord getInitialValue() {
-        if (initialValue.equal(UNDEFINED)) {
+        if (initialValue.equal(UNINITIALIZED)) {
             initialValue = computeInitialValue();
         }
         return initialValue;

--- a/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/GenScavengeMemoryPoolMXBeans.java
+++ b/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/GenScavengeMemoryPoolMXBeans.java
@@ -162,7 +162,7 @@ public class GenScavengeMemoryPoolMXBeans {
 
         @Override
         UnsignedWord getMaximumValue() {
-            return GCImpl.getPolicy().getMaximumOldSize();
+            return UNDEFINED;
         }
 
         @Override
@@ -200,7 +200,7 @@ public class GenScavengeMemoryPoolMXBeans {
 
         @Override
         UnsignedWord getMaximumValue() {
-            return GCImpl.getPolicy().getMaximumHeapSize();
+            return UNDEFINED;
         }
 
         @Override

--- a/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/GenScavengeMemoryPoolMXBeans.java
+++ b/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/GenScavengeMemoryPoolMXBeans.java
@@ -81,7 +81,7 @@ public class GenScavengeMemoryPoolMXBeans {
 
         @Override
         UnsignedWord getMaximumValue() {
-            return GCImpl.getPolicy().getMaximumEdenSize();
+            return UNDEFINED;
         }
 
         @Override
@@ -124,7 +124,7 @@ public class GenScavengeMemoryPoolMXBeans {
 
         @Override
         UnsignedWord getMaximumValue() {
-            return GCImpl.getPolicy().getMaximumSurvivorSize();
+            return UNDEFINED;
         }
 
         @Override


### PR DESCRIPTION
This PR addresses #6814.

It turns out max eden size is enforced post factum, i.e. if 'memory used' >= 'max size' then GC is started (see [`AbstractCollectionPolicy::shouldCollectOnAllocation`](https://github.com/oracle/graal/blob/8b81a03fee458013b8b703e234e77edc4836be43/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/AbstractCollectionPolicy.java#L90)). This applies also to young generation as a whole -- see [`BasicPolicy::shouldCollectOnAllocation`](https://github.com/oracle/graal/blob/8b81a03fee458013b8b703e234e77edc4836be43/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/BasicCollectionPolicies.java#L60). So we cannot assume that maximum size, as reported by collection policy, will never be exceeded. It seems there is no meaningful estimation for the maximum size of young generation spaces, other than `MaxHeapSize`.

The solution proposed here is to return -1 for young gen (eden and survivor) spaces. This is also how Hotspot behaves in JDKs 17 and 19.