### PR TITLE
Check threshold for native JFR events

### DIFF
--- a/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/JfrGCEventSupport.java
+++ b/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/JfrGCEventSupport.java
@@ -67,7 +67,7 @@ class JfrGCEventSupport {
 
     @Uninterruptible(reason = "Accesses a JFR buffer.")
     public void emitGarbageCollectionEvent(UnsignedWord gcEpoch, GCCause cause, long start) {
-        if (JfrEvent.GarbageCollection.shouldEmit()) {
+        if (JfrEvent.GarbageCollection.shouldEmit(start)) {
             long pauseTime = JfrTicks.elapsedTicks() - start;
 
             JfrNativeEventWriterData data = StackValue.get(JfrNativeEventWriterData.class);
@@ -88,7 +88,7 @@ class JfrGCEventSupport {
     @Uninterruptible(reason = "Accesses a JFR buffer.")
     public void emitGCPhasePauseEvent(UnsignedWord gcEpoch, int level, String name, long startTicks) {
         JfrEvent event = getGCPhasePauseEvent(level);
-        if (event.shouldEmit()) {
+        if (event.shouldEmit(startTicks)) {
             long end = JfrTicks.elapsedTicks();
             JfrNativeEventWriterData data = StackValue.get(JfrNativeEventWriterData.class);
             JfrNativeEventWriterDataAccess.initializeThreadLocalNativeBuffer(data);

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/JfrEvent.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/JfrEvent.java
@@ -91,4 +91,9 @@ public final class JfrEvent {
     public boolean shouldEmit() {
         return SubstrateJVM.get().isRecording() && SubstrateJVM.get().isEnabled(this) && !SubstrateJVM.get().isCurrentThreadExcluded();
     }
+
+    @Uninterruptible(reason = "Prevent races with VM operations that start/stop recording.", callerMustBe = true)
+    public boolean shouldEmit(long startTicks) {
+        return shouldEmit() && JfrTicks.elapsedTicks() - startTicks > SubstrateJVM.get().getThreshold(this);
+    }
 }

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/JfrNativeEventSetting.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/JfrNativeEventSetting.java
@@ -44,6 +44,7 @@ public class JfrNativeEventSetting {
     public JfrNativeEventSetting() {
     }
 
+    @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
     public long getThresholdTicks() {
         return thresholdTicks;
     }

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/SubstrateJVM.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/SubstrateJVM.java
@@ -658,6 +658,11 @@ public class SubstrateJVM {
         return true;
     }
 
+    @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
+    long getThreshold(JfrEvent event) {
+        return eventSettings[(int) event.getId()].getThresholdTicks();
+    }
+
     /**
      * See {@link JVM#setCutoff}.
      */

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/events/JavaMonitorEnterEvent.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/events/JavaMonitorEnterEvent.java
@@ -47,7 +47,7 @@ public class JavaMonitorEnterEvent {
 
     @Uninterruptible(reason = "Accesses a JFR buffer.")
     public static void emit0(Object obj, long previousOwnerTid, long startTicks) {
-        if (JfrEvent.JavaMonitorEnter.shouldEmit()) {
+        if (JfrEvent.JavaMonitorEnter.shouldEmit(startTicks)) {
             JfrNativeEventWriterData data = StackValue.get(JfrNativeEventWriterData.class);
             JfrNativeEventWriterDataAccess.initializeThreadLocalNativeBuffer(data);
 

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/events/JavaMonitorInflateEvent.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/events/JavaMonitorInflateEvent.java
@@ -48,7 +48,7 @@ public class JavaMonitorInflateEvent {
 
     @Uninterruptible(reason = "Accesses a JFR buffer.")
     public static void emit0(Object obj, long startTicks, MonitorInflationCause cause) {
-        if (JfrEvent.JavaMonitorInflate.shouldEmit()) {
+        if (JfrEvent.JavaMonitorInflate.shouldEmit(startTicks)) {
             JfrNativeEventWriterData data = StackValue.get(JfrNativeEventWriterData.class);
             JfrNativeEventWriterDataAccess.initializeThreadLocalNativeBuffer(data);
 

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/events/JavaMonitorWaitEvent.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/events/JavaMonitorWaitEvent.java
@@ -46,7 +46,7 @@ public class JavaMonitorWaitEvent {
 
     @Uninterruptible(reason = "Accesses a JFR buffer.")
     private static void emit0(long startTicks, Object obj, long notifier, long timeout, boolean timedOut) {
-        if (JfrEvent.JavaMonitorWait.shouldEmit()) {
+        if (JfrEvent.JavaMonitorWait.shouldEmit(startTicks)) {
             JfrNativeEventWriterData data = org.graalvm.nativeimage.StackValue.get(JfrNativeEventWriterData.class);
             JfrNativeEventWriterDataAccess.initializeThreadLocalNativeBuffer(data);
             JfrNativeEventWriter.beginSmallEvent(data, JfrEvent.JavaMonitorWait);

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/events/SafepointBeginEvent.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/events/SafepointBeginEvent.java
@@ -52,7 +52,7 @@ public class SafepointBeginEvent {
      */
     @Uninterruptible(reason = "Accesses a JFR buffer.")
     private static void emit0(UnsignedWord safepointId, int numJavaThreads, long startTicks) {
-        if (JfrEvent.SafepointBegin.shouldEmit()) {
+        if (JfrEvent.SafepointBegin.shouldEmit(startTicks)) {
             JfrNativeEventWriterData data = StackValue.get(JfrNativeEventWriterData.class);
             JfrNativeEventWriterDataAccess.initializeThreadLocalNativeBuffer(data);
 

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/events/SafepointEndEvent.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/events/SafepointEndEvent.java
@@ -47,7 +47,7 @@ public class SafepointEndEvent {
 
     @Uninterruptible(reason = "Accesses a JFR buffer.")
     private static void emit0(UnsignedWord safepointId, long startTick) {
-        if (JfrEvent.SafepointEnd.shouldEmit()) {
+        if (JfrEvent.SafepointEnd.shouldEmit(startTick)) {
             JfrNativeEventWriterData data = StackValue.get(JfrNativeEventWriterData.class);
             JfrNativeEventWriterDataAccess.initializeThreadLocalNativeBuffer(data);
 

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/events/ThreadParkEvent.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/events/ThreadParkEvent.java
@@ -47,7 +47,7 @@ public class ThreadParkEvent {
 
     @Uninterruptible(reason = "Accesses a JFR buffer.")
     private static void emit0(long startTicks, Object obj, boolean isAbsolute, long time) {
-        if (JfrEvent.ThreadPark.shouldEmit()) {
+        if (JfrEvent.ThreadPark.shouldEmit(startTicks)) {
             Class<?> parkedClass = null;
             if (obj != null) {
                 parkedClass = obj.getClass();

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/events/ThreadSleepEventJDK17.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/events/ThreadSleepEventJDK17.java
@@ -48,7 +48,7 @@ public class ThreadSleepEventJDK17 {
 
     @Uninterruptible(reason = "Accesses a JFR buffer.")
     private static void emit0(long time, long startTicks) {
-        if (ThreadSleep.shouldEmit()) {
+        if (ThreadSleep.shouldEmit(startTicks)) {
             JfrNativeEventWriterData data = StackValue.get(JfrNativeEventWriterData.class);
             JfrNativeEventWriterDataAccess.initializeThreadLocalNativeBuffer(data);
 

--- a/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/jfr/JfrRecordingTest.java
+++ b/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/jfr/JfrRecordingTest.java
@@ -26,7 +26,9 @@
 
 package com.oracle.svm.test.jfr;
 
+import java.io.IOException;
 import java.nio.file.Path;
+import java.time.Duration;
 import java.util.Collections;
 import java.util.IdentityHashMap;
 import java.util.Map;
@@ -60,6 +62,12 @@ public abstract class JfrRecordingTest extends AbstractJfrTest {
     }
 
     protected Recording startRecording(String[] events, Configuration config, Map<String, String> settings, Path path) throws Throwable {
+        Recording recording = prepareRecording(events, config, settings, path);
+        recording.start();
+        return recording;
+    }
+
+    protected Recording prepareRecording(String[] events, Configuration config, Map<String, String> settings, Path path) throws IOException {
         Recording recording = createRecording(config);
         recordingStates.put(recording, new JfrRecordingState(events));
 
@@ -67,9 +75,7 @@ public abstract class JfrRecordingTest extends AbstractJfrTest {
         if (settings != null) {
             recording.setSettings(settings);
         }
-
         enableEvents(recording, events);
-        recording.start();
         return recording;
     }
 
@@ -84,7 +90,7 @@ public abstract class JfrRecordingTest extends AbstractJfrTest {
     private static void enableEvents(Recording recording, String[] events) {
         /* Additionally, enable all events that the test case wants to test explicitly. */
         for (String event : events) {
-            recording.enable(event);
+            recording.enable(event).withThreshold(Duration.ZERO);
         }
     }
 

--- a/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/jfr/JfrStreamingTest.java
+++ b/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/jfr/JfrStreamingTest.java
@@ -111,7 +111,7 @@ public abstract class JfrStreamingTest extends AbstractJfrTest {
     private static void enableEvents(RecordingStream stream, String[] events) {
         /* Additionally, enable all events that the test case wants to test explicitly. */
         for (String event : events) {
-            stream.enable(event);
+            stream.enable(event).withThreshold(Duration.ZERO);
         }
     }
 

--- a/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/jfr/TestThreshold.java
+++ b/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/jfr/TestThreshold.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2023, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2023, Red Hat Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package com.oracle.svm.test.jfr;
+
+import static com.oracle.svm.test.jfr.AbstractJfrTest.getDefaultConfiguration;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.locks.LockSupport;
+
+import com.oracle.svm.test.jfr.events.StringEvent;
+import org.junit.Test;
+
+import com.oracle.svm.core.jfr.JfrEvent;
+
+import jdk.jfr.Recording;
+import jdk.jfr.consumer.RecordedClass;
+import jdk.jfr.consumer.RecordedEvent;
+import jdk.jfr.consumer.RecordedThread;
+
+public class TestThreshold extends JfrRecordingTest {
+
+    private static final long SHORT_MILLIS = 10;
+    private static final long THRESHOLD = 20;
+    private static final long LONG_MILLIS = 30;
+
+    private final Helper helper = new Helper();
+
+    @Test
+    public void test() throws Throwable {
+        String[] events = new String[]{JfrEvent.JavaMonitorWait.getName(), JfrEvent.ThreadPark.getName(), "com.jfr.String", "jdk.ThreadSleep"};
+        // Cannot start recording until thresholds are set
+        Recording recording = prepareRecording(events, getDefaultConfiguration(), null, createTempJfrFile());
+        recording.enable(JfrEvent.JavaMonitorWait.getName()).withThreshold(Duration.ofMillis(THRESHOLD));
+        recording.enable(JfrEvent.ThreadPark.getName()).withThreshold(Duration.ofMillis(THRESHOLD));
+        recording.enable("jdk.ThreadSleep").withThreshold(Duration.ofMillis(THRESHOLD));
+        recording.enable("com.jfr.String").withThreshold(Duration.ofMillis(THRESHOLD));
+        recording.start();
+
+        StringEvent shortStringEvent = new StringEvent();
+        shortStringEvent.begin();
+        shortStringEvent.commit();
+        StringEvent longStringEvent = new StringEvent();
+        longStringEvent.begin();
+        Thread.sleep(SHORT_MILLIS);
+        Thread.sleep(LONG_MILLIS);
+        longStringEvent.commit();
+
+        LockSupport.parkNanos(helper, SHORT_MILLIS * 1000000);
+        LockSupport.parkNanos(helper, LONG_MILLIS * 1000000);
+
+        helper.simpleWait(SHORT_MILLIS);
+        helper.simpleWait(LONG_MILLIS);
+
+        stopRecording(recording, this::validateEvents);
+    }
+
+    private void validateEvents(List<RecordedEvent> events) {
+        boolean foundWaitEvent = false;
+        boolean foundJavaEvent = false;
+        boolean foundParkEvent = false;
+        boolean foundSleepEvent = false;
+        for (RecordedEvent event : events) {
+            String eventThread = event.<RecordedThread> getValue("eventThread").getJavaName();
+            assertNotNull("No event thread", eventThread);
+
+            // Even unintentional events emitted by SVM should not have durations over the
+            // threshold.
+            assertTrue(event.getDuration().toMillis() >= LONG_MILLIS);
+
+            if (event.getEventType().getName().equals("com.jfr.String")) {
+                foundJavaEvent = true;
+            } else if (event.getEventType().getName().equals(JfrEvent.JavaMonitorWait.getName()) && event.<RecordedClass> getValue("monitorClass").getName().equals(Helper.class.getName())) {
+                foundWaitEvent = true;
+            } else if (event.getEventType().getName().equals(JfrEvent.ThreadPark.getName()) && event.<RecordedClass> getValue("parkedClass").getName().equals(Helper.class.getName())) {
+                foundParkEvent = true;
+            } else if (event.getEventType().getName().equals("jdk.ThreadSleep")) {
+                foundSleepEvent = true;
+            }
+        }
+        assertTrue(foundJavaEvent && foundWaitEvent && foundParkEvent && foundSleepEvent);
+    }
+
+    private static class Helper {
+        public synchronized void simpleWait(long millis) throws InterruptedException {
+            wait(millis);
+        }
+    }
+}

--- a/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/jfr/TestThreshold.java
+++ b/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/jfr/TestThreshold.java
@@ -26,7 +26,6 @@
 
 package com.oracle.svm.test.jfr;
 
-import static com.oracle.svm.test.jfr.AbstractJfrTest.getDefaultConfiguration;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 


### PR DESCRIPTION
fixes: https://github.com/oracle/graal/issues/6944 

**Description**
Adds checking that duration threshold is exceeded before emitting native events. Java level events are not affected because their threshold values are maintained by `jdk.jfr.internal.PlatformEventType`

This issue is present in previous versions of Native Image JFR and might be worth backporting to 23.0 because the changes are minimal.  