### PR TITLE
Update JFR EventWriter substitutions to support java-level virtual thread events

### DIFF
--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/JfrThreadLocal.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/JfrThreadLocal.java
@@ -257,7 +257,14 @@ public class JfrThreadLocal implements ThreadListener {
     }
 
     public Target_jdk_jfr_internal_EventWriter getEventWriter() {
-        return javaEventWriter.get();
+        Target_jdk_jfr_internal_EventWriter eventWriter = javaEventWriter.get();
+        // Handling for virtual threads that don't have their own fast thread locals.
+        if (eventWriter != null && eventWriter.threadID != SubstrateJVM.getCurrentThreadId()) {
+            eventWriter.threadID = SubstrateJVM.getCurrentThreadId();
+            Target_java_lang_Thread tjlt = SubstrateUtil.cast(Thread.currentThread(), Target_java_lang_Thread.class);
+            eventWriter.excluded = tjlt.jfrExcluded;
+        }
+        return eventWriter;
     }
 
     /**

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/Target_jdk_jfr_internal_EventWriter.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/Target_jdk_jfr_internal_EventWriter.java
@@ -38,6 +38,9 @@ public final class Target_jdk_jfr_internal_EventWriter {
     @Alias //
     @TargetElement(onlyWith = JDK19OrLater.class) boolean excluded;
 
+    @Alias //
+    @TargetElement(onlyWith = JDK19OrLater.class) long threadID;
+
     @Alias
     @SuppressWarnings("unused")
     @TargetElement(onlyWith = JDK17OrEarlier.class)

--- a/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/jfr/TestJavaLevelVirtualThreadEvents.java
+++ b/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/jfr/TestJavaLevelVirtualThreadEvents.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2023, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2023, Red Hat Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package com.oracle.svm.test.jfr;
+
+import static org.junit.Assert.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import com.oracle.svm.test.jfr.events.StringEvent;
+import org.junit.Test;
+
+import jdk.jfr.Recording;
+import jdk.jfr.consumer.RecordedEvent;
+import jdk.jfr.consumer.RecordedThread;
+import com.oracle.svm.core.thread.VirtualThreads;
+
+/**
+ * This test ensures that java level events emittred by virtual threads have the correct java thread
+ * ID information, associated with them. In particular this should help catch out of date
+ * substitutions related to the Java level JFR EventWriter.
+ */
+
+public class TestJavaLevelVirtualThreadEvents extends JfrRecordingTest {
+    private static final int MILLIS = 50;
+    private static final int THREADS = 5;
+    private static final String[] TESTED_EVENTS = new String[]{"jdk.ThreadSleep", "jdk.VirtualThreadStart", "jdk.VirtualThreadEnd", "jdk.VirtualThreadPinned", "com.jfr.String"};
+    private static final Map<Long, List<String>> seenThreads = Collections.synchronizedMap(new HashMap<>());
+
+    @Test
+    public void test() throws Throwable {
+        Recording recording = startRecording(TESTED_EVENTS);
+        Runnable r = () -> {
+            try {
+                seenThreads.put(Thread.currentThread().threadId(), new ArrayList<>(List.of(TESTED_EVENTS)));
+                /*
+                 * Pinning the current thread here will result in a VirtualThreadPinned event
+                 * emitted when it attempts to yield at the subsequent Thread.sleep() call
+                 */
+                VirtualThreads.singleton().pinCurrent();
+                Thread.sleep(MILLIS);
+                com.oracle.svm.test.jfr.events.StringEvent stringEvent = new StringEvent();
+                stringEvent.begin();
+                stringEvent.message = "some message body";
+                stringEvent.commit();
+            } catch (InterruptedException e) {
+                throw new RuntimeException(e);
+            }
+        };
+        VirtualStressor.execute(THREADS, r);
+
+        stopRecording(recording, this::validateEvents);
+    }
+
+    private void validateEvents(List<RecordedEvent> events) {
+        for (RecordedEvent event : events) {
+            String eventName = event.getEventType().getName();
+            RecordedThread eventThread = event.getThread("eventThread");
+            if (eventThread == null) {
+                continue;
+            }
+            long tid = eventThread.getJavaThreadId();
+            List<String> remainingEvents = seenThreads.get(tid);
+            if (remainingEvents == null) {
+                continue;
+            }
+            remainingEvents.remove(eventName);
+            if (remainingEvents.isEmpty()) {
+                seenThreads.remove(tid);
+            }
+
+        }
+        assertTrue(seenThreads.isEmpty());
+    }
+}

--- a/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/jfr/TestThreadParkEvents.java
+++ b/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/jfr/TestThreadParkEvents.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2023, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2023, Red Hat Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package com.oracle.svm.test.jfr;
+
+import static org.junit.Assert.assertTrue;
+
+import java.util.List;
+import java.util.concurrent.locks.LockSupport;
+
+import com.oracle.svm.core.jfr.JfrEvent;
+import jdk.jfr.consumer.RecordedClass;
+import org.junit.Test;
+
+import jdk.jfr.Recording;
+import jdk.jfr.consumer.RecordedEvent;
+
+public class TestThreadParkEvents extends JfrRecordingTest {
+    private static final long MILLIS = 500;
+    private static final long NANOS = MILLIS * 1000000;
+    static volatile boolean passedCheckpoint = false;
+    final Blocker blocker = new Blocker();
+
+    @Test
+    public void test() throws Throwable {
+        String[] events = new String[]{JfrEvent.ThreadPark.getName()};
+
+        Recording recording = startRecording(events);
+
+        LockSupport.parkNanos(NANOS);
+        LockSupport.parkNanos(blocker, NANOS);
+        LockSupport.parkUntil(System.currentTimeMillis() + MILLIS);
+
+        Runnable waiter = () -> {
+            passedCheckpoint = true;
+            LockSupport.park();
+        };
+
+        Thread waiterThread = new Thread(waiter);
+        waiterThread.start();
+        while (!waiterThread.getState().equals(Thread.State.WAITING) || !passedCheckpoint) {
+            Thread.sleep(10);
+        }
+        LockSupport.unpark(waiterThread);
+        waiterThread.join();
+
+        stopRecording(recording, this::validateEvents);
+    }
+
+    private void validateEvents(List<RecordedEvent> events) {
+        boolean parkNanosFound = false;
+        boolean parkNanosFoundBlocker = false;
+        boolean parkUntilFound = false;
+        boolean parkUnparkFound = false;
+        for (RecordedEvent event : events) {
+            if (event.<Long> getValue("timeout") < 0 && event.<Long> getValue("until") < 0) {
+                parkUnparkFound = true;
+            } else {
+                if ((event.<Long> getValue("timeout").longValue() == (NANOS))) {
+                    if (event.getValue("parkedClass") == null) {
+                        parkNanosFound = true;
+                    } else if (event.<RecordedClass> getValue("parkedClass").getName().equals(Blocker.class.getName())) {
+                        parkNanosFoundBlocker = true;
+                    }
+                } else if (event.<Long> getValue("timeout") < 0 && event.<Long> getValue("until") > 0) {
+                    parkUntilFound = true;
+                }
+            }
+
+        }
+        assertTrue(parkNanosFound && parkNanosFoundBlocker && parkUntilFound && parkUnparkFound);
+    }
+
+    class Blocker {
+    }
+}


### PR DESCRIPTION
**Summary of Changes**

The java-level JFR EventWriter substitution code has been out-of-date since Java 11 and so does not properly support virtual threads. As a result, incorrect thread data was attached to events emitted by virtual threads. 

Each carrier thread has it's own java-level EventWriter which is shared among all the vthreads that get mounted on it. This means that when a vthread uses the java-level EventWriter, it must update the appropriate members with its own specific data. This is the same situation as in hotspot: https://github.com/openjdk/jdk/blob/master/src/hotspot/share/jfr/writers/jfrJavaEventWriter.cpp#L250

Added a test to catch this problem in the future. 

Added a test for `jdk.ThreadPark` because I noticed this event was missing a test (not related to the EventWriter issue).