### PR TITLE
Add support for -XX:+HeapDumpOnOutOfMemoryError

### DIFF
--- a/docs/reference-manual/native-image/guides/create-heap-dump-from-native-executable.md
+++ b/docs/reference-manual/native-image/guides/create-heap-dump-from-native-executable.md
@@ -9,12 +9,13 @@ permalink: /reference-manual/native-image/guides/create-heap-dump/
 
 You can create a heap dump of a running executable to monitor its execution. Just like any other Java heap dump, it can be opened with the [VisualVM](../../../tools/visualvm.md) tool.
 
-To enable heap dump support, native executables must be built with the `--enable-monitoring=heapdump` option. Heap dumps can then be created in three different ways:
+To enable heap dump support, native executables must be built with the `--enable-monitoring=heapdump` option. Heap dumps can then be created in different ways:
 
 1. Create heap dumps with VisualVM.
 2. Dump the initial heap of a native executable using the `-XX:+DumpHeapAndExit` command-line option.
 3. Create heap dumps sending a `SIGUSR1` signal at run time.
 4. Create heap dumps programmatically using the [`org.graalvm.nativeimage.VMRuntime#dumpHeap`](https://github.com/oracle/graal/blob/master/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/VMInspectionOptions.java) API.
+5. If `-XX:+HeapDumpOnOutOfMemoryError` is passed in at runtime and an `OutOfMemoryError` is encountered, a heap dump will be produced.
 
 All approaches are described below.
 
@@ -274,6 +275,18 @@ The condition to create a heap dump is provided as an option on the command line
     The resulting heap dump can be then opened with the [VisualVM](../../../tools/visualvm.md) tool like any other Java heap dump, as illustrated below.
 
     ![Native Image Heap Dump View in VisualVM](img/heap-dump-api.png)
+
+## Create a Heap Dump on `OutOfMemoryError`
+
+Start the application with `-XX:+HeapDumpOnOutOfMemoryError` option to get a heap dump when an `OutOfMemoryError` occurs.
+The generated heap dump file name will have the `svm-heapdump-<PID>.hprof` naming format.
+For example:
+
+```shell
+./example -XX:+HeapDumpOnOutOfMemoryError
+Dumping heap to svm-heapdump-67799.hprof ...
+Exception in thread "main" java.lang.OutOfMemoryError: Garbage-collected heap size exceeded.
+```
 
 ### Related Documentation
 

--- a/sdk/src/org.graalvm.nativeimage/src/org/graalvm/nativeimage/VMRuntime.java
+++ b/sdk/src/org.graalvm.nativeimage/src/org/graalvm/nativeimage/VMRuntime.java
@@ -92,6 +92,20 @@ public final class VMRuntime {
         ImageSingletons.lookup(HeapDumpSupport.class).dumpHeap(outputFile, live);
     }
 
+    /**
+     * Dumps the heap to a predetermined file in case of an @{@link OutOfMemoryError}, in the same format as the hprof heap dump.
+     *
+     * @throws UnsupportedOperationException if this operation is not supported.
+     *
+     * @since 23.1
+     */
+    public static void dumpHeapOnOutOfMemoryError() {
+        if (!ImageSingletons.contains(HeapDumpSupport.class)) {
+            throw new UnsupportedOperationException();
+        }
+        ImageSingletons.lookup(HeapDumpSupport.class).dumpHeapOnOutOfMemoryError();
+    }
+
     private VMRuntime() {
     }
 }

--- a/sdk/src/org.graalvm.nativeimage/src/org/graalvm/nativeimage/impl/HeapDumpSupport.java
+++ b/sdk/src/org.graalvm.nativeimage/src/org/graalvm/nativeimage/impl/HeapDumpSupport.java
@@ -44,4 +44,7 @@ public interface HeapDumpSupport {
 
     void dumpHeap(String outputFile, boolean live) throws java.io.IOException;
 
+    void dumpHeapOnOutOfMemoryError();
+
+    void initHeapDumpOnOutOfMemoryErrorPath();
 }

--- a/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/GCImpl.java
+++ b/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/GCImpl.java
@@ -35,6 +35,7 @@ import org.graalvm.nativeimage.IsolateThread;
 import org.graalvm.nativeimage.Platform;
 import org.graalvm.nativeimage.Platforms;
 import org.graalvm.nativeimage.StackValue;
+import org.graalvm.nativeimage.VMRuntime;
 import org.graalvm.nativeimage.c.function.CodePointer;
 import org.graalvm.nativeimage.c.struct.RawField;
 import org.graalvm.nativeimage.c.struct.RawStructure;
@@ -150,8 +151,15 @@ public final class GCImpl implements GC {
             outOfMemory = collectWithoutAllocating(GenScavengeGCCause.OnAllocation, false);
         }
         if (outOfMemory) {
-            throw OutOfMemoryUtil.heapSizeExceeded();
+            heapSizeExceeded();
         }
+    }
+
+    private static void heapSizeExceeded() {
+        if (SubstrateOptions.isHeapDumpOnOutOfMemoryError()) {
+            VMRuntime.dumpHeapOnOutOfMemoryError();
+        }
+        throw OutOfMemoryUtil.heapSizeExceeded();
     }
 
     @Override
@@ -165,7 +173,7 @@ public final class GCImpl implements GC {
         if (!hasNeverCollectPolicy()) {
             boolean outOfMemory = collectWithoutAllocating(cause, forceFullGC);
             if (outOfMemory) {
-                throw OutOfMemoryUtil.heapSizeExceeded();
+                heapSizeExceeded();
             }
         }
     }

--- a/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/PosixRawFileOperationSupport.java
+++ b/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/PosixRawFileOperationSupport.java
@@ -30,6 +30,7 @@ import java.nio.ByteOrder;
 import org.graalvm.nativeimage.ImageSingletons;
 import org.graalvm.nativeimage.Platform;
 import org.graalvm.nativeimage.Platforms;
+import org.graalvm.nativeimage.c.type.CCharPointer;
 import org.graalvm.nativeimage.c.type.CTypeConversion;
 import org.graalvm.word.Pointer;
 import org.graalvm.word.SignedWord;
@@ -61,10 +62,27 @@ public class PosixRawFileOperationSupport extends AbstractRawFileOperationSuppor
     }
 
     @Override
+    public RawFileDescriptor create(CCharPointer cPath, FileCreationMode creationMode, FileAccessMode accessMode) {
+        int flags = parseMode(creationMode) | parseMode(accessMode);
+        return open0(cPath, flags);
+    }
+
+    private static RawFileDescriptor open0(CCharPointer cPath, int flags) {
+        int permissions = PosixStat.S_IRUSR() | PosixStat.S_IWUSR();
+        return WordFactory.signed(Fcntl.NoTransitions.open(cPath, flags, permissions));
+    }
+
+    @Override
     public RawFileDescriptor open(File file, FileAccessMode mode) {
         String path = file.getPath();
         int flags = parseMode(mode);
         return open0(path, flags);
+    }
+
+    @Override
+    public RawFileDescriptor open(CCharPointer cPath, FileAccessMode mode) {
+        int flags = parseMode(mode);
+        return open0(cPath, flags);
     }
 
     private static RawFileDescriptor open0(String path, int flags) {

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/DumpHeapOnSignalFeature.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/DumpHeapOnSignalFeature.java
@@ -30,6 +30,7 @@ import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.TimeZone;
 
+import org.graalvm.nativeimage.ImageSingletons;
 import org.graalvm.nativeimage.ProcessProperties;
 import org.graalvm.nativeimage.VMRuntime;
 
@@ -39,6 +40,7 @@ import com.oracle.svm.core.jdk.RuntimeSupport;
 import com.oracle.svm.core.log.Log;
 
 import jdk.internal.misc.Signal;
+import org.graalvm.nativeimage.impl.HeapDumpSupport;
 
 @AutomaticallyRegisteredFeature
 public class DumpHeapOnSignalFeature implements InternalFeature {
@@ -59,6 +61,9 @@ final class DumpHeapStartupHook implements RuntimeSupport.Hook {
     public void execute(boolean isFirstIsolate) {
         if (isFirstIsolate && SubstrateOptions.EnableSignalHandling.getValue()) {
             DumpHeapReport.install();
+            if (SubstrateOptions.isHeapDumpOnOutOfMemoryError()) {
+                ImageSingletons.lookup(HeapDumpSupport.class).initHeapDumpOnOutOfMemoryErrorPath();
+            }
         }
     }
 }

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/SubstrateOptions.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/SubstrateOptions.java
@@ -825,6 +825,13 @@ public class SubstrateOptions {
         }
     };
 
+    @Option(help = "Dump heap to file when java.lang.OutOfMemoryError is thrown.")//
+    public static final RuntimeOptionKey<Boolean> HeapDumpOnOutOfMemoryError = new RuntimeOptionKey<>(false, Immutable);
+
+    public static boolean isHeapDumpOnOutOfMemoryError() {
+        return VMInspectionOptions.hasHeapDumpSupport() && SubstrateOptions.HeapDumpOnOutOfMemoryError.getValue();
+    }
+
     @Option(help = "The path (filename or directory) where heap dumps are created (defaults to the working directory).")//
     public static final RuntimeOptionKey<String> HeapDumpPath = new RuntimeOptionKey<>("", Immutable);
 

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/heap/dump/HeapDumpSupportImpl.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/heap/dump/HeapDumpSupportImpl.java
@@ -88,15 +88,19 @@ public class HeapDumpSupportImpl implements HeapDumpSupport {
     @Override
     @RestrictHeapAccess(access = NO_ALLOCATION, reason = "Heap dumping on OutOfMemoryError must not allocate.")
     public void dumpHeapOnOutOfMemoryError() {
+        final Log log = Log.log();
+
         final RawFileDescriptor fd = getFileSupport().create(heapOnErrorDumpPath, FileCreationMode.CREATE_OR_REPLACE, RawFileOperationSupport.FileAccessMode.READ_WRITE);
         if (!getFileSupport().isValid(fd)) {
-            Log.log().string("Invalid file descriptor opening heap dump on OutOfMemoryError.").newline();
+            log.string("Invalid file descriptor opening heap dump on OutOfMemoryError.").newline();
             return;
         }
 
         int size = SizeOf.get(HeapDumpVMOperationData.class);
         HeapDumpVMOperationData data = StackValue.get(size);
         UnmanagedMemoryUtil.fill((Pointer) data, WordFactory.unsigned(size), (byte) 0);
+
+        log.string("Dumping heap to ").string(heapOnErrorDumpPath).string(" ...").newline();
 
         data.setGCBefore(false);
         data.setRawFileDescriptor(fd);

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/heapdump/HeapDumpSupportImpl.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/heapdump/HeapDumpSupportImpl.java
@@ -36,4 +36,14 @@ public class HeapDumpSupportImpl implements HeapDumpSupport {
             com.oracle.svm.core.heapdump.HeapDumpWriter.singleton().writeHeapTo(fileOutputStream, live);
         }
     }
+
+    @Override
+    public void dumpHeapOnOutOfMemoryError() {
+        // No-op
+    }
+
+    @Override
+    public void initHeapDumpOnOutOfMemoryErrorPath() {
+        // No-op
+    }
 }

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/os/RawFileOperationSupport.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/os/RawFileOperationSupport.java
@@ -28,6 +28,7 @@ import java.io.File;
 
 import org.graalvm.compiler.api.replacements.Fold;
 import org.graalvm.nativeimage.ImageSingletons;
+import org.graalvm.nativeimage.c.type.CCharPointer;
 import org.graalvm.word.Pointer;
 import org.graalvm.word.UnsignedWord;
 import org.graalvm.word.WordBase;
@@ -89,6 +90,15 @@ public interface RawFileOperationSupport {
     RawFileDescriptor create(File file, FileCreationMode creationMode, FileAccessMode accessMode);
 
     /**
+     * Creates a file with the specified {@link FileCreationMode creation} and {@link FileAccessMode
+     * access modes}.
+     *
+     * @return If the operation is successful, it returns the file descriptor. Otherwise, it returns
+     *         a value where {@link #isValid} will return false.
+     */
+    RawFileDescriptor create(CCharPointer path, FileCreationMode creationMode, FileAccessMode accessMode);
+
+    /**
      * Opens a file with the specified {@link FileAccessMode access mode}.
      *
      * @return If the operation is successful, it returns the file descriptor. Otherwise, it returns
@@ -103,6 +113,14 @@ public interface RawFileOperationSupport {
      *         a value where {@link #isValid} will return false.
      */
     RawFileDescriptor open(File file, FileAccessMode accessMode);
+
+    /**
+     * Opens a file with the specified {@link FileAccessMode access mode}.
+     *
+     * @return If the operation is successful, it returns the file descriptor. Otherwise, it returns
+     *         a value where {@link #isValid} will return false.
+     */
+    RawFileDescriptor open(CCharPointer path, FileAccessMode accessMode);
 
     /**
      * Checks if a file descriptor is valid or if it represents an error value.


### PR DESCRIPTION
Closes #4641.

Implements support for `-XX:+HeapDumpOnOutOfMemoryError` flag.

I've made some small changes to the `HeapDumpOperation` to be able to use it for this use case. The key thing is that all code in the operation has to be allocation free, which meant tweaking the error reporting method to not allocate. After discussing with @christianhaeubl, a new set of `open` and `create` methods have been added that take a `CCharPointer`. On startup, if `-XX:+HeapDumpOnOutOfMemoryError` is passed, the filename is pre-calculated and stored temporarily in case it's needed. Then, when OOME hits, the `CCharPointer` is used to create the file descriptor and pass it to the native VM operation.

To use `-XX:+HeapDumpOnOutOfMemoryError`, native image has to be built with `--enable-monitoring=heapdump`.

I will push the documentation updates shortly.