### PR TITLE
Update committing of java level events

### DIFF
--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/JDK19To20.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/JDK19To20.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2023, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package com.oracle.svm.core.jdk;
+
+import java.util.function.BooleanSupplier;
+
+import org.graalvm.compiler.serviceprovider.JavaVersionUtil;
+
+public class JDK19To20 implements BooleanSupplier {
+    @Override
+    public boolean getAsBoolean() {
+        return JavaVersionUtil.JAVA_SPEC >= 19 && JavaVersionUtil.JAVA_SPEC < 21;
+    }
+}

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/JfrEventWriterAccess.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/JfrEventWriterAccess.java
@@ -46,10 +46,17 @@ public final class JfrEventWriterAccess {
      * the committed position and not to the start of the buffer.
      */
     private static final Field COMMITTED_POSITION_FIELD = ReflectionUtil.lookupField(getEventWriterClass(), "startPosition");
-    private static final Field COMMITTED_POSITION_ADDRESS_FIELD = ReflectionUtil.lookupField(getEventWriterClass(), "startPositionAddress");
+    private static final Field COMMITTED_POSITION_ADDRESS_FIELD;
     private static final Field CURRENT_POSITION_FIELD = ReflectionUtil.lookupField(getEventWriterClass(), "currentPosition");
     private static final Field MAX_POSITION_FIELD = ReflectionUtil.lookupField(getEventWriterClass(), "maxPosition");
     private static final Field VALID_FIELD = ReflectionUtil.lookupField(getEventWriterClass(), "valid");
+    static {
+        if (JavaVersionUtil.JAVA_SPEC < 21) {
+            COMMITTED_POSITION_ADDRESS_FIELD = ReflectionUtil.lookupField(getEventWriterClass(), "startPositionAddress");
+        } else {
+            COMMITTED_POSITION_ADDRESS_FIELD = null;
+        }
+    }
 
     @Platforms(Platform.HOSTED_ONLY.class)
     private JfrEventWriterAccess() {
@@ -73,8 +80,10 @@ public final class JfrEventWriterAccess {
         long maxPos = JfrBufferAccess.getDataEnd(buffer).rawValue();
         long addressOfCommittedPos = JfrBufferAccess.getAddressOfCommittedPos(buffer).rawValue();
         long jfrThreadId = SubstrateJVM.getCurrentThreadId();
-        if (JavaVersionUtil.JAVA_SPEC >= 19) {
+        if (JavaVersionUtil.JAVA_SPEC >= 19 && JavaVersionUtil.JAVA_SPEC < 21) {
             return new Target_jdk_jfr_internal_EventWriter(committedPos, maxPos, addressOfCommittedPos, jfrThreadId, true, isCurrentThreadExcluded);
+        } else if (JavaVersionUtil.JAVA_SPEC >= 21) {
+            return new Target_jdk_jfr_internal_EventWriter(committedPos, maxPos, jfrThreadId, true, isCurrentThreadExcluded);
         } else {
             return new Target_jdk_jfr_internal_EventWriter(committedPos, maxPos, addressOfCommittedPos, jfrThreadId, true);
         }
@@ -92,7 +101,9 @@ public final class JfrEventWriterAccess {
         Pointer maxPos = JfrBufferAccess.getDataEnd(buffer);
 
         U.putLong(writer, U.objectFieldOffset(COMMITTED_POSITION_FIELD), committedPos.rawValue());
-        U.putLong(writer, U.objectFieldOffset(COMMITTED_POSITION_ADDRESS_FIELD), addressOfCommittedPos.rawValue());
+        if (JavaVersionUtil.JAVA_SPEC < 21) {
+            U.putLong(writer, U.objectFieldOffset(COMMITTED_POSITION_ADDRESS_FIELD), addressOfCommittedPos.rawValue());
+        }
         U.putLong(writer, U.objectFieldOffset(CURRENT_POSITION_FIELD), currentPos.rawValue());
         U.putLong(writer, U.objectFieldOffset(MAX_POSITION_FIELD), maxPos.rawValue());
         if (!valid) {

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/SubstrateJVM.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/SubstrateJVM.java
@@ -506,6 +506,13 @@ public class SubstrateJVM {
         return false;
     }
 
+    /** Commit the event to the java buffer (by advancing the pointer). */
+    @Uninterruptible(reason = "Must not allow safepointing to interrupt event commit.")
+    public long commit(long nextPosition) {
+        return JfrThreadLocal.commitJavaEvent(nextPosition);
+
+    }
+
     public void flush() {
         JfrChunkWriter chunkWriter = unlockedChunkWriter.lock();
         try {

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/Target_jdk_jfr_internal_EventWriter.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/Target_jdk_jfr_internal_EventWriter.java
@@ -29,11 +29,14 @@ import com.oracle.svm.core.annotate.TargetClass;
 import com.oracle.svm.core.annotate.TargetElement;
 import com.oracle.svm.core.jdk.JDK17OrEarlier;
 import com.oracle.svm.core.jdk.JDK19OrLater;
+import com.oracle.svm.core.jdk.JDK19To20;
+import com.oracle.svm.core.jdk.JDK21OrLater;
+import com.oracle.svm.core.jdk.JDK20OrEarlier;
 
 @TargetClass(className = "EventWriter", classNameProvider = Package_jdk_jfr_internal_event_helper.class, onlyWith = HasJfrSupport.class)
 public final class Target_jdk_jfr_internal_EventWriter {
     @Alias //
-    @SuppressWarnings("unused") boolean notified;
+    @TargetElement(onlyWith = JDK20OrEarlier.class) @SuppressWarnings("unused") boolean notified;
 
     @Alias //
     @TargetElement(onlyWith = JDK19OrLater.class) boolean excluded;
@@ -46,7 +49,13 @@ public final class Target_jdk_jfr_internal_EventWriter {
 
     @Alias
     @SuppressWarnings("unused")
-    @TargetElement(onlyWith = JDK19OrLater.class)
+    @TargetElement(onlyWith = JDK19To20.class)
     Target_jdk_jfr_internal_EventWriter(long committedPos, long maxPos, long committedPosAddress, long threadID, boolean valid, boolean excluded) {
+    }
+
+    @Alias
+    @SuppressWarnings("unused")
+    @TargetElement(onlyWith = JDK21OrLater.class)
+    Target_jdk_jfr_internal_EventWriter(long committedPos, long maxPos, long threadID, boolean valid, boolean excluded) {
     }
 }

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/Target_jdk_jfr_internal_JVM.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/Target_jdk_jfr_internal_JVM.java
@@ -361,7 +361,7 @@ public final class Target_jdk_jfr_internal_JVM {
 
     /** See {@link JVM#commit}. */
     @Substitute
-    @TargetElement(onlyWith = com.oracle.svm.core.jdk.JDK21OrLater.class)
+    @TargetElement(onlyWith = JDK21OrLater.class)
     @Uninterruptible(reason = "Must not allow safepointing to interrupt event commit.")
     public static long commit(long nextPosition) {
         return SubstrateJVM.get().commit(nextPosition);


### PR DESCRIPTION
Resolves related issues: https://github.com/oracle/graal/issues/7052 and https://github.com/graalvm/mandrel/issues/546

Draft because I'm waiting for LabsJDK to be updated with the changes in OpenJDK21+32 that caused the breakage so I can test. For now, I have tested with mandrel and Temurin build of openjdk21+32.

**Summary**
This change https://github.com/openjdk/jdk21/pull/129 caused some substitutions to become out of date. Additionally, the way Java-level events are committed by the JavaEventWriter has also changed. In openjdk, committing is now done in  native Hotspot code in order to avoid safepointing potentially interrupting the commit operation. This PR achieves the same behaviour by subsituting the new `JVM#commit` method and making it `uninterruptible`.