### PR TITLE
Do not expose canonicalized names for mapped relative directories in `fd_prestat_dir_name` so WASI SDK can resolve relative file names correctly.

### DIFF
--- a/wasm/src/org.graalvm.wasm/src/org/graalvm/wasm/predefined/wasi/fd/FdManager.java
+++ b/wasm/src/org.graalvm.wasm/src/org/graalvm/wasm/predefined/wasi/fd/FdManager.java
@@ -96,7 +96,7 @@ public final class FdManager implements Closeable {
                 throw WasmException.create(Failure.INVALID_WASI_DIRECTORIES_MAPPING);
             }
 
-            put(fd, new PreopenedDirectoryFd(this, hostDir, virtualDir));
+            put(fd, new PreopenedDirectoryFd(this, hostDir, virtualDir, virtualDirPath));
             ++fd;
         }
     }

--- a/wasm/src/org.graalvm.wasm/src/org/graalvm/wasm/predefined/wasi/fd/PreopenedDirectoryFd.java
+++ b/wasm/src/org.graalvm.wasm/src/org/graalvm/wasm/predefined/wasi/fd/PreopenedDirectoryFd.java
@@ -63,9 +63,9 @@ final class PreopenedDirectoryFd extends DirectoryFd {
 
     private final String virtualPath;
 
-    PreopenedDirectoryFd(FdManager fdManager, TruffleFile hostFile, TruffleFile virtualFile) {
+    PreopenedDirectoryFd(FdManager fdManager, TruffleFile hostFile, TruffleFile virtualFile, String virtualPath) {
         super(fdManager, virtualFile, new PreopenedDirectory(hostFile, virtualFile), FS_RIGHTS_BASE, FS_RIGHTS_INHERITING, FS_FLAGS);
-        virtualPath = virtualFile.getPath();
+        this.virtualPath = virtualPath;
     }
 
     @Override


### PR DESCRIPTION
Exposing the canonicalized names creates problems with `__wasilibc_find_abspath` in WASI SDK 20. That implementation has differing behavior based on whether a fully-qualified or a relative path is supplied. Canonicalization bypasses the relative path handling causing other relative paths to fail to resolve correctly.

Additionally, GraalWasm does various path prefix checks when opening files. The prefix check fails when opening a relative file path because the canonicalized directory name does not appear in the relative path name. Retaining the directory's originally mapped relative path name allows the prefix check to pass.