### PR TITLE
Ignore permitted languages that aren't present in sandbox check

### DIFF
--- a/truffle/src/com.oracle.truffle.polyglot/src/com/oracle/truffle/polyglot/PolyglotEngineImpl.java
+++ b/truffle/src/com.oracle.truffle.polyglot/src/com/oracle/truffle/polyglot/PolyglotEngineImpl.java
@@ -2264,7 +2264,11 @@ final class PolyglotEngineImpl implements com.oracle.truffle.polyglot.PolyglotIm
             return;
         }
         for (String permittedLanguage : permittedLanguages) {
-            idToLanguage.get(permittedLanguage).validateSandbox(sandboxPolicy);
+            PolyglotLanguage language = idToLanguage.get(permittedLanguage);
+            if (language != null) {
+                language.validateSandbox(sandboxPolicy);
+            }
+            // otherwise, the language cannot be used anyway
         }
     }
 


### PR DESCRIPTION
Consider following method:

```
    private static void createContext(SandboxPolicy policy) {
        Context.newBuilder("myMissingLang") // myMissingLang is not present
                .sandbox(policy)
                .in(InputStream.nullInputStream())
                .out(OutputStream.nullOutputStream())
                .err(OutputStream.nullOutputStream())
                .build();
    }
```
Running `createContext(SandboxPolicy.TRUSTED)` will run without exceptions, while `createContext(SandboxPolicy.CONSTRAINED)` currently throws the following exception:
```
Exception in thread "main" org.graalvm.polyglot.PolyglotException: java.lang.NullPointerException: Cannot invoke "com.oracle.truffle.polyglot.PolyglotLanguage.validateSandbox(org.graalvm.polyglot.SandboxPolicy)" because the return value of "java.util.Map.get(Object)" is null
	at org.graalvm.truffle/com.oracle.truffle.polyglot.PolyglotEngineImpl.validateSandbox(PolyglotEngineImpl.java:2209)
	at org.graalvm.truffle/com.oracle.truffle.polyglot.PolyglotEngineImpl.<init>(PolyglotEngineImpl.java:339)
	at org.graalvm.truffle/com.oracle.truffle.polyglot.PolyglotImpl.buildEngine(PolyglotImpl.java:283)
	at com.oracle.graal.graal_enterprise/com.oracle.truffle.polyglot.enterprise.EnterprisePolyglotImpl.buildEngine(stripped:136)
	at org.graalvm.sdk/org.graalvm.polyglot.Engine$Builder.build(Engine.java:681)
	at org.graalvm.sdk/org.graalvm.polyglot.Context$Builder.build(Context.java:1926)
```

This PR avoids the NPE by ignoring entries in the permittedLanguages array that don't have a matching language installed. This way, the behavior is the same for all sandbox policies.