### PR TITLE
The Graal compiler component depends on Graal SDK as well

### DIFF
--- a/compiler/mx.compiler/mx_compiler.py
+++ b/compiler/mx.compiler/mx_compiler.py
@@ -1337,7 +1337,7 @@ cmp_ce_components = [
         dir_name='graal',
         license_files=[],
         third_party_license_files=[],
-        dependencies=['Truffle Compiler'],
+        dependencies=['Graal SDK', 'Truffle Compiler'],
         jar_distributions=[  # Dev jars (annotation processors)
             'compiler:GRAAL_PROCESSOR',
         ],


### PR DESCRIPTION
See the `distDependencies` of the GRAAL distribution in mx.compiler/suite.py

Closes https://github.com/oracle/graal/issues/7146