### PR TITLE
Avoid printing "Alternative API option(s):" when non are present

### DIFF
--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/ProgressReporter.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/ProgressReporter.java
@@ -334,7 +334,7 @@ public class ProgressReporter {
             l().a(" ").a(optionToOriginEntry.getKey()).println();
             ExperimentalOptionDetails details = optionToOriginEntry.getValue();
             l().a("   Origin: ").a(details.origin).println();
-            if (details.alternatives != null) {
+            if (details.alternatives != null && !details.alternatives.isEmpty()) {
                 l().a("   Alternative API option(s): " + details.alternatives).println();
             }
         }


### PR DESCRIPTION
Avoids output like the following:

```
[libjvmcicompiler:100878]  -H:ReportAnalysisForbiddenType
[libjvmcicompiler:100878]    Origin: macro option 'jvmcicompiler-library@file:///home/zakkak/code/graal/sdk/mxbuild/linux-amd64/GRAALVM_9777A156F1_JAVA21_STAGE1/graalvm-9777a156f1-java21-23.1.0-dev/lib/svm/macros/jvmcicompiler-library/@user'
[libjvmcicompiler:100878]    Alternative API option(s): 
[libjvmcicompiler:100878]  -H:Path
[libjvmcicompiler:100878]    Origin: command line
```