### PR TITLE
Fix bug in JFR periodic chunk events and fix thread data in ThreadCPULoad events

### DIFF
--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/JfrManager.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/JfrManager.java
@@ -86,8 +86,8 @@ public class JfrManager {
     public RuntimeSupport.Hook startupHook() {
         return isFirstIsolate -> {
             parseFlightRecorderLogging(SubstrateOptions.FlightRecorderLogging.getValue());
+            periodicEventSetup();
             if (isJFREnabled()) {
-                periodicEventSetup();
                 initRecording();
             }
         };

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/events/ThreadCPULoadEvent.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/events/ThreadCPULoadEvent.java
@@ -44,6 +44,8 @@ import com.oracle.svm.core.threadlocal.FastThreadLocalFactory;
 import com.oracle.svm.core.threadlocal.FastThreadLocalLong;
 import com.oracle.svm.core.util.TimeUtils;
 
+import static com.oracle.svm.core.thread.PlatformThreads.fromVMThread;
+
 public class ThreadCPULoadEvent {
     private static final FastThreadLocalLong cpuTimeTL = FastThreadLocalFactory.createLong("ThreadCPULoadEvent.cpuTimeTL");
     private static final FastThreadLocalLong userTimeTL = FastThreadLocalFactory.createLong("ThreadCPULoadEvent.userTimeTL");
@@ -119,7 +121,7 @@ public class ThreadCPULoadEvent {
 
         JfrNativeEventWriter.beginSmallEvent(data, JfrEvent.ThreadCPULoad);
         JfrNativeEventWriter.putLong(data, JfrTicks.elapsedTicks());
-        JfrNativeEventWriter.putEventThread(data);
+        JfrNativeEventWriter.putThread(data, fromVMThread(isolateThread));
         JfrNativeEventWriter.putFloat(data, userTime / totalAvailableTime);
         JfrNativeEventWriter.putFloat(data, systemTime / totalAvailableTime);
         JfrNativeEventWriter.endSmallEvent(data);


### PR DESCRIPTION
### Summary
This PR fixes two native image JFR problems. 

1. Problem: Periodic end/begin chunk events do not get emitted when the JFR API is used. This is because the appropriate periodic events were previously only registered when JFR is started from the command line. However, this is a problem if recordings are instead started using the JFR API (which is what the unit tests use).
 
This part of the PR should be backported to previous GraalVM versions because it affects every version the JFR custom event API is supported. 

2. Problem: ThreadCPULoad events attach thread data of the thread that is emitting the event instead of the thread that the data belongs to. This problem only manifests when the event is emitted at the end of a chunk (one thread will emit events on behalf of all running threads). The existing test for ThreadCPULoad event only accounts for the case where the event is emitted as a result of a thread exiting, so the bug does not manifest. 

This part of the PR does not need to be backported because ThreadCPULoad was only recently added after the 23.0 release. 