### PR TITLE
Use calling convention to derive incoming param register and stack slot locations

### DIFF
--- a/substratevm/mx.substratevm/testhello.py
+++ b/substratevm/mx.substratevm/testhello.py
@@ -104,14 +104,83 @@ def test():
     checker = Checker("ptype 'hello.Hello$DefaultGreeter'", rexp)
     checker.check(exec_string)
 
+    # run to main so the program image is loaded
+    exec_string = execute("break main")
+    print(exec_string)
+    exec_string = execute("run")
+    print(exec_string)
+    exec_string = execute("delete breakpoints")
+    print(exec_string)
+
+    # First thing to check is the arguments passed to the CEntryPoint
+    # routine that enters Java
+    # Find a method whose name starts with JavaMainWrapper_run_
+    # It should belong to class IsolateEnterStub
+    exec_string = execute("info func JavaMainWrapper_run_")
+    rexp = r"%s:%sint com.oracle.svm.core.code.IsolateEnterStub::(JavaMainWrapper_run_%s)\(%s\);"%(digits_pattern, spaces_pattern, wildcard_pattern, wildcard_pattern)
+    checker = Checker('info func JavaMainWrapper_run_', rexp)
+    matches = checker.check(exec_string)
+    # n.b can ony get here with one match
+    match = matches[0]
+    method_name = match.group(1)
+    print("method_name = %s"%(method_name))
+
+    ## Now find the method start addess and break it
+    command = "x/i 'com.oracle.svm.core.code.IsolateEnterStub'::%s"%(method_name)
+    exec_string = execute(command)
+    rexp = r"%s0x(%s)%scom.oracle.svm.core.code.IsolateEnterStub::JavaMainWrapper_run_%s"%(wildcard_pattern, hex_digits_pattern, wildcard_pattern, wildcard_pattern)
+    checker = Checker('x/i IsolateEnterStub::%s'%(method_name), rexp)
+    matches = checker.check(exec_string)
+    # n.b can ony get here with one match
+    match = matches[0]
+    
+    bp_address = int(match.group(1), 16)
+    print("bp = %s %x"%(match.group(1), bp_address))
+    exec_string = execute("x/i 0x%x"%bp_address)
+    print(exec_string)
+
+    # exec_string = execute("break hello.Hello::noInlineManyArgs")
+    exec_string = execute("break *0x%x"%bp_address)
+    rexp = r"Breakpoint %s at %s: file com/oracle/svm/core/code/IsolateEnterStub.java, line 1\."%(digits_pattern, address_pattern)
+    checker = Checker(r"break *0x%x"%bp_address, rexp)
+    checker.check(exec_string)
+
+    # run to breakpoint then delete it
+    execute("run")
+    execute("delete breakpoints")
+
+    # check incoming parameters are bound to sensible values
+    exec_string = execute("info args")
+    rexp = [r"__0 = %s"%(digits_pattern),
+            r"__1 = 0x%s"%(hex_digits_pattern)]
+    checker = Checker("info args : %s"%(method_name), rexp)
+    checker.check(exec_string)
+
+    exec_string = execute("p __0")
+    rexp = [r"\$%s = 1"%(digits_pattern)]
+    checker = Checker("p __0", rexp)
+    checker.check(exec_string)
+
+    
+    exec_string = execute("p __1")
+    rexp = [r"\$%s = \(org\.graalvm\.nativeimage\.c\.type\.CCharPointerPointer\) 0x%s"%(digits_pattern, hex_digits_pattern)]
+    checker = Checker("p __1", rexp)
+    checker.check(exec_string)
+
+    exec_string = execute("p __1[0]")
+    rexp = [r'\$%s = \(org\.graalvm\.nativeimage\.c\.type\.CCharPointer\) 0x%s "%s/hello_image"'%(digits_pattern, hex_digits_pattern, wildcard_pattern)]
+    checker = Checker("p __1[0]", rexp)
+    checker.check(exec_string)
+
+    
     # set a break point at hello.Hello::main
-    # expect "Breakpoint 1 at 0x[0-9a-f]+: file hello.Hello.java, line %d."
+    # expect "Breakpoint <n> at 0x[0-9a-f]+: file hello.Hello.java, line %d."
     exec_string = execute("break hello.Hello::main")
-    rexp = r"Breakpoint 1 at %s: file hello/Hello\.java, line %d\."%(address_pattern, main_start)
+    rexp = r"Breakpoint %s at %s: file hello/Hello\.java, line %d\."%(digits_pattern, address_pattern, main_start)
     checker = Checker('break main', rexp)
     checker.check(exec_string)
 
-    # run the program till the breakpoint
+    # continue the program until the breakpoint
     execute("run")
     execute("delete breakpoints")
 
@@ -403,7 +472,7 @@ def test():
         sys.exit(1)
 
     # set breakpoint at substituted method hello.Hello$DefaultGreeter::greet
-    # expect "Breakpoint 2 at 0x[0-9a-f]+: file hello/Target_Hello_DefaultGreeter.java, line [0-9]+."
+    # expect "Breakpoint <n> at 0x[0-9a-f]+: file hello/Target_Hello_DefaultGreeter.java, line [0-9]+."
     exec_string = execute("break hello.Hello$DefaultGreeter::greet")
     rexp = r"Breakpoint %s at %s: file hello/Target_hello_Hello_DefaultGreeter\.java, line %s\."%(digits_pattern, address_pattern, digits_pattern)
     checker = Checker("break on substituted method", rexp)
@@ -429,7 +498,7 @@ def test():
     # however in Java 17 and GraalVM >21.3.0 this method ends up getting inlined and we can't (yet?!) set a breakpoint
     # only to a specific override of a method by specifying the parameter types when that method gets inlined.
     # As a result the breakpoint will be set at all println overrides.
-    # expect "Breakpoint 1 at 0x[0-9a-f]+: java.io.PrintStream::println. ([0-9]+ locations)""
+    # expect "Breakpoint <n> at 0x[0-9a-f]+: java.io.PrintStream::println. ([0-9]+ locations)""
     exec_string = execute("break java.io.PrintStream::println")
     # we cannot be sure how much inlining will happen so we
     # specify a pattern for the number of locations
@@ -564,8 +633,8 @@ def test():
     checker = Checker('break inlineFrom', rexp)
     checker.check(exec_string, skip_fails=False)
 
-    exec_string = execute("info break 6")
-    rexp = [r"6%sbreakpoint%skeep%sy%s%s in hello\.Hello::inlineFrom\(\) at hello/Hello\.java:119"%(spaces_pattern, spaces_pattern, spaces_pattern, spaces_pattern, address_pattern)]
+    exec_string = execute("info break")
+    rexp = [r"%s%sbreakpoint%skeep%sy%s%s in hello\.Hello::inlineFrom\(\) at hello/Hello\.java:119"%(digits_pattern, spaces_pattern, spaces_pattern, spaces_pattern, spaces_pattern, address_pattern)]
     checker = Checker('info break inlineFrom', rexp)
     checker.check(exec_string)
 

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/image/NativeImageDebugInfoFeature.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/image/NativeImageDebugInfoFeature.java
@@ -29,7 +29,7 @@ import java.util.function.Function;
 
 import jdk.graal.compiler.debug.DebugContext;
 import jdk.graal.compiler.printer.GraalDebugHandlersFactory;
-import jdk.vm.ci.code.RegisterConfig;
+import com.oracle.svm.core.graal.meta.RuntimeConfiguration;
 import org.graalvm.nativeimage.ImageSingletons;
 import org.graalvm.nativeimage.Platform;
 
@@ -44,7 +44,6 @@ import com.oracle.svm.core.UniqueShortNameProvider;
 import com.oracle.svm.core.UniqueShortNameProviderDefaultImpl;
 import com.oracle.svm.core.feature.AutomaticallyRegisteredFeature;
 import com.oracle.svm.core.feature.InternalFeature;
-import com.oracle.svm.core.graal.meta.SubstrateRegisterConfig;
 import com.oracle.svm.core.option.HostedOptionValues;
 import com.oracle.svm.hosted.FeatureImpl;
 import com.oracle.svm.hosted.ProgressReporter;
@@ -109,10 +108,9 @@ class NativeImageDebugInfoFeature implements InternalFeature {
             var accessImpl = (FeatureImpl.BeforeImageWriteAccessImpl) access;
             var image = accessImpl.getImage();
             var debugContext = new DebugContext.Builder(HostedOptionValues.singleton(), new GraalDebugHandlersFactory(GraalAccess.getOriginalSnippetReflection())).build();
-            RegisterConfig registerConfig = ((FeatureImpl.BeforeImageWriteAccessImpl) access).getRuntimeConfiguration().getBackendForNormalMethod().getCodeCache().getRegisterConfig();
-            assert registerConfig instanceof SubstrateRegisterConfig : "unexpected register configuration!";
+            RuntimeConfiguration runtimeConfiguration = ((FeatureImpl.BeforeImageWriteAccessImpl) access).getRuntimeConfiguration();
             DebugInfoProvider provider = new NativeImageDebugInfoProvider(debugContext, image.getCodeCache(), image.getHeap(), image.getNativeLibs(), accessImpl.getHostedMetaAccess(),
-                    (SubstrateRegisterConfig) registerConfig);
+                            runtimeConfiguration);
             var objectFile = image.getObjectFile();
             objectFile.installDebugInfo(provider);
 

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/image/NativeImageDebugInfoProvider.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/image/NativeImageDebugInfoProvider.java
@@ -2457,7 +2457,12 @@ class NativeImageDebugInfoProvider extends NativeImageDebugInfoProviderBase impl
         }
 
         static NativeImageDebugStackValue create(StackSlot value, int framesize) {
-            return memoizedCreate(value.getOffset(framesize));
+            // Work around a problem on AArch64 where StackSlot asserts if it is
+            // passed a zero frame size, even though this is what is expected
+            // for stack slot offsets provided at the point of entry (because,
+            // unlike x86, lr has not been pushed).
+            int offset = (framesize == 0 ? value.getRawOffset() : value.getOffset(framesize));
+            return memoizedCreate(offset);
         }
 
         static NativeImageDebugStackValue create(DebugLocalValueInfo previous, int adjustment) {

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/image/NativeImageDebugInfoProvider.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/image/NativeImageDebugInfoProvider.java
@@ -42,12 +42,13 @@ import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import com.oracle.svm.hosted.DeadlockWatchdog;
-import org.graalvm.collections.EconomicMap;
 import jdk.graal.compiler.code.CompilationResult;
 import jdk.graal.compiler.debug.DebugContext;
 import jdk.graal.compiler.graph.NodeSourcePosition;
 import jdk.graal.compiler.java.StableMethodNameFormatter;
+import jdk.vm.ci.code.CallingConvention;
+import jdk.vm.ci.meta.AllocatableValue;
+import org.graalvm.collections.EconomicMap;
 import org.graalvm.nativeimage.ImageSingletons;
 import org.graalvm.nativeimage.c.struct.CPointerTo;
 import org.graalvm.nativeimage.c.struct.RawPointerTo;
@@ -66,7 +67,9 @@ import com.oracle.svm.core.code.CompilationResultFrameTree.FrameNode;
 import com.oracle.svm.core.code.CompilationResultFrameTree.Visitor;
 import com.oracle.svm.core.config.ConfigurationValues;
 import com.oracle.svm.core.graal.code.SubstrateBackend.SubstrateMarkId;
+import com.oracle.svm.core.graal.meta.SubstrateRegisterConfig;
 import com.oracle.svm.core.image.ImageHeapPartition;
+import com.oracle.svm.hosted.DeadlockWatchdog;
 import com.oracle.svm.hosted.c.NativeLibraries;
 import com.oracle.svm.hosted.c.info.AccessorInfo;
 import com.oracle.svm.hosted.c.info.ElementInfo;
@@ -121,8 +124,9 @@ class NativeImageDebugInfoProvider extends NativeImageDebugInfoProviderBase impl
     private final DebugContext debugContext;
     private final Set<HostedMethod> allOverrides;
 
-    NativeImageDebugInfoProvider(DebugContext debugContext, NativeImageCodeCache codeCache, NativeImageHeap heap, NativeLibraries nativeLibs, HostedMetaAccess metaAccess) {
-        super(codeCache, heap, nativeLibs, metaAccess);
+    NativeImageDebugInfoProvider(DebugContext debugContext, NativeImageCodeCache codeCache, NativeImageHeap heap, NativeLibraries nativeLibs, HostedMetaAccess metaAccess,
+                            SubstrateRegisterConfig registerConfig) {
+        super(codeCache, heap, nativeLibs, metaAccess, registerConfig);
         this.debugContext = debugContext;
         /* Calculate the set of all HostedMethods that are overrides. */
         allOverrides = heap.hUniverse.getMethods().stream()
@@ -1452,15 +1456,14 @@ class NativeImageDebugInfoProvider extends NativeImageDebugInfoProviderBase impl
                 return;
             }
             // create a synthetic location record including details of passed arguments
-            ParamLocationProducer locProducer = new ParamLocationProducer(method);
+            ParamLocationProducer locProducer = new ParamLocationProducer(hostedMethod);
             debugContext.log(DebugContext.DETAILED_LEVEL, "Add synthetic Location Info : %s (0, %d)", method.getName(), firstLocationOffset - 1);
             NativeImageDebugLocationInfo locationInfo = new NativeImageDebugLocationInfo(method, firstLocationOffset, locProducer);
             // if the prologue extends beyond the stack extend and uses the stack then the info
             // needs
             // splitting at the extend point with the stack offsets adjusted in the new info
             if (locProducer.usesStack() && firstLocationOffset > stackDecrement) {
-                int adjustment = adjustFrameSize(getFrameSize());
-                NativeImageDebugLocationInfo splitLocationInfo = locationInfo.split(stackDecrement, adjustment);
+                NativeImageDebugLocationInfo splitLocationInfo = locationInfo.split(stackDecrement, getFrameSize());
                 debugContext.log(DebugContext.DETAILED_LEVEL, "Split synthetic Location Info : %s (%d, %d) (%d, %d)", locationInfo.name(), 0,
                                 locationInfo.addressLo() - 1, locationInfo.addressLo(), locationInfo.addressHi() - 1);
                 locationInfos.add(0, splitLocationInfo);
@@ -1872,7 +1875,7 @@ class NativeImageDebugInfoProvider extends NativeImageDebugInfoProviderBase impl
         }
 
         // special constructor for synthetic location info which splits off the initial segment
-        // of the first range to accommodate a stack access prior to the stack push
+        // of the first range to accommodate a stack access prior to the stack extend
         NativeImageDebugLocationInfo(NativeImageDebugLocationInfo toSplit, int stackDecrement, int frameSize) {
             super(toSplit.method);
             this.lo = stackDecrement;
@@ -1885,8 +1888,12 @@ class NativeImageDebugInfoProvider extends NativeImageDebugInfoProviderBase impl
             this.localInfoList = new ArrayList<>(toSplit.localInfoList.size());
             for (DebugLocalValueInfo localInfo : toSplit.localInfoList) {
                 if (localInfo.localKind() == DebugLocalValueInfo.LocalKind.STACKSLOT) {
-                    int newSlot = localInfo.stackSlot() + frameSize;
-                    NativeImageDebugLocalValue value = NativeImageDebugStackValue.create(newSlot);
+                    // need to redefine the value for this param using a stack slot value
+                    // that allows for the stack being extended by framesize. however we
+                    // also need to remove any adjustment that was made to allow for the
+                    // difference between the caller SP and the pre-extend callee SP.
+                    int adjustment = frameSize - PRE_EXTEND_FRAME_ADJUSTMENT;
+                    NativeImageDebugLocalValue value = NativeImageDebugStackValue.create(localInfo, adjustment);
                     NativeImageDebugLocalValueInfo nativeLocalInfo = (NativeImageDebugLocalValueInfo) localInfo;
                     NativeImageDebugLocalValueInfo newLocalinfo = new NativeImageDebugLocalValueInfo(nativeLocalInfo.name,
                                     value,
@@ -1963,7 +1970,8 @@ class NativeImageDebugInfoProvider extends NativeImageDebugInfoProviderBase impl
                 JavaKind kind = ownerType.getJavaKind();
                 JavaKind storageKind = isForeignWordType(ownerType, ownerType) ? JavaKind.Long : kind;
                 assert kind == JavaKind.Object : "must be an object";
-                NativeImageDebugLocalValue value = locProducer.nextLocation(kind);
+                // NativeImageDebugLocalValue value = locProducer.nextLocation(kind);
+                NativeImageDebugLocalValue value = locProducer.thisLocation();
                 debugContext.log(DebugContext.DETAILED_LEVEL, "locals[%d] %s type %s slot %d", localIdx, name, ownerType.getName(), slot);
                 debugContext.log(DebugContext.DETAILED_LEVEL, "  =>  %s kind %s", value, storageKind);
                 localInfos.add(new NativeImageDebugLocalValueInfo(name, value, storageKind, ownerType, slot, firstLine));
@@ -1976,7 +1984,8 @@ class NativeImageDebugInfoProvider extends NativeImageDebugInfoProviderBase impl
                 ResolvedJavaType paramType = (ResolvedJavaType) signature.getParameterType(i, ownerType);
                 JavaKind kind = paramType.getJavaKind();
                 JavaKind storageKind = isForeignWordType(paramType, ownerType) ? JavaKind.Long : kind;
-                NativeImageDebugLocalValue value = locProducer.nextLocation(kind);
+                // NativeImageDebugLocalValue value = locProducer.nextLocation(kind);
+                NativeImageDebugLocalValue value = locProducer.paramLocation(i);
                 debugContext.log(DebugContext.DETAILED_LEVEL, "locals[%d] %s type %s slot %d", localIdx, name, ownerType.getName(), slot);
                 debugContext.log(DebugContext.DETAILED_LEVEL, "  =>  %s kind %s", value, storageKind);
                 localInfos.add(new NativeImageDebugLocalValueInfo(name, value, storageKind, paramType, slot, firstLine));
@@ -2095,10 +2104,10 @@ class NativeImageDebugInfoProvider extends NativeImageDebugInfoProviderBase impl
             return this;
         }
 
-        public NativeImageDebugLocationInfo split(int stackDecrement, int adjustment) {
+        public NativeImageDebugLocationInfo split(int stackDecrement, int frameSize) {
             // this should be for an initial range extending beyond the stack decrement
             assert lo == 0 && lo < stackDecrement && stackDecrement < hi : "invalid split request";
-            return new NativeImageDebugLocationInfo(this, stackDecrement, adjustment);
+            return new NativeImageDebugLocationInfo(this, stackDecrement, frameSize);
         }
 
     }
@@ -2159,164 +2168,102 @@ class NativeImageDebugInfoProvider extends NativeImageDebugInfoProviderBase impl
     };
 
     /**
-     * adjustment in bytes added to offset for stack passed parameters on AMD64
-     *
-     * the value allows for a word offset from the unadjusted sp to allow for the stacked return
-     * address and a second word offset to address the first stack passed parameter with index 0.
+     * Adjustment in bytes that needs to be added to incoming parameter raw offsets to derive the
+     * parameter offset relative to the unadjusted callee stack pointer.
      */
-    static final int AMD64_STACK_OFFSET = 16;
+    static final int PRE_EXTEND_FRAME_ADJUSTMENT;
 
     /**
-     * adjustment in bytes added to offset for stack passed parameters on AARCH64
+     * Adjustment in bytes added to raw offset for stack passed parameters on AMD64.
      *
-     * the value allows for a word offset from the unadjusted sp to address the first stack passed
-     * parameter with index 0.
+     * The value includes a word offset from the unadjusted (pre-extend) sp to allow for the stacked
+     * return address.
      */
-    static final int AARCH64_STACK_OFFSET = 8;
+    static final int AMD64_PRE_EXTEND_FRAME_ADJUSTMENT = 8;
 
     /**
-     * Adjustment in bytes added to frame size when recomputing parameter stack offsets after stack
-     * adjustment on AMD64.
+     * Adjustment in bytes added to raw offset for stack passed parameters on AARCH64.
      *
-     * The value allows for the fact that the reported framesize includes the stacked return address
-     * which has already been rolled into the offsets derived for the unadjusted sp.
+     * The value is zero because nothing is pushed until the stack extend occurs.
      */
-    static final int AMD64_FRAMESIZE_ADJUSTMENT = -8;
+    static final int AARCH64_PRE_EXTEND_FRAME_ADJUSTMENT = 0;
 
-    /**
-     * Adjustment in bytes added to frame size when recomputing parameter stack offsets after stack
-     * adjustment on AARCH64.
-     *
-     * The value in this case is zero. Although the reported framesize for AArch64 includes the
-     * pushed lr and fp registers these have not been rolled into the offsets derived for the
-     * unadjusted sp.
-     */
-    static final int AARCH64_FRAMESIZE_ADJUSTMENT = 0;
-
-    static int adjustFrameSize(int frameSize) {
-        // make sure this is the right arch and os
+    static {
         Architecture arch = ConfigurationValues.getTarget().arch;
         assert arch instanceof AMD64 || arch instanceof AArch64 : "unexpected architecture";
         OS os = OS.getCurrent();
         assert os == OS.LINUX || os == OS.WINDOWS : "unexpected os";
-        int adjustment = frameSize;
         if (arch instanceof AMD64) {
             // reported amd64 frame size includes an extra 8 bytes for the stacked return address
-            adjustment += AMD64_FRAMESIZE_ADJUSTMENT;
+            PRE_EXTEND_FRAME_ADJUSTMENT = AMD64_PRE_EXTEND_FRAME_ADJUSTMENT;
         } else {
-            adjustment += AARCH64_FRAMESIZE_ADJUSTMENT;
+            PRE_EXTEND_FRAME_ADJUSTMENT = AARCH64_PRE_EXTEND_FRAME_ADJUSTMENT;
         }
-        return adjustment;
     }
 
     class ParamLocationProducer {
-        Register[] gpregs;
-        Register[] fregs;
-        int nextGPRegIdx;
-        int nextFPregIdx;
-        int nextStackIdx;
-        int stackParamCount;
-        int stackOffset;
+        private final HostedMethod hostedMethod;
+        private final CallingConvention callingConvention;
+        private boolean usesStack;
 
-        ParamLocationProducer(ResolvedJavaMethod method) {
-            Architecture arch = ConfigurationValues.getTarget().arch;
+        private static final int adjustment;
+
+        static {
+            final Architecture arch = ConfigurationValues.getTarget().arch;
+            // make sure this is the right arch and os
             assert arch instanceof AMD64 || arch instanceof AArch64 : "unexpected architecture";
             OS os = OS.getCurrent();
             assert os == OS.LINUX || os == OS.WINDOWS : "unexpected os";
-            if (arch instanceof AArch64) {
-                assert os == OS.LINUX : "unexpected os/architecture";
-                gpregs = AARCH64_GPREG;
-                fregs = AARCH64_FREG;
-                stackOffset = AARCH64_STACK_OFFSET;
+            if (arch instanceof AMD64) {
+                // on x86 the position of incoming stack arguments relative to the
+                // unadjusted stack pointer needs adjusting to allow for a pushed
+                // return address
+                adjustment = AMD64_PRE_EXTEND_FRAME_ADJUSTMENT;
             } else {
-                if (os == OS.LINUX) {
-                    gpregs = AMD64_GPREG_LINUX;
-                    fregs = AMD64_FREG_LINUX;
-                } else {
-                    gpregs = AMD64_GPREG_WINDOWS;
-                    fregs = AMD64_FREG_WINDOWS;
-                }
-                stackOffset = AMD64_STACK_OFFSET;
-            }
-            nextGPRegIdx = 0;
-            nextFPregIdx = 0;
-            nextStackIdx = 0;
-            stackParamCount = computeStackCount(method);
-        }
-
-        public NativeImageDebugLocalValue nextLocation(JavaKind kind) {
-            switch (kind) {
-                case Float:
-                case Double:
-                    return nextFloatingLocation();
-                case Void:
-                case Illegal:
-                    assert false : "unexpected parameter kind in next location request";
-                    return null;
-                default:
-                    return nextIntegerLocation();
+                // on aarch64 the position of incoming stack arguments relative to the
+                // unadjusted stack pointer is just the raw offset
+                adjustment = AARCH64_PRE_EXTEND_FRAME_ADJUSTMENT;
             }
         }
 
-        public NativeImageDebugLocalValue nextFloatingLocation() {
-            if (nextFPregIdx < fregs.length) {
-                return NativeImageDebugRegisterValue.create(fregs[nextFPregIdx++].number);
+        ParamLocationProducer(HostedMethod method) {
+            this.hostedMethod = method;
+            this.callingConvention = getCallingConvention(hostedMethod);
+            // assume no stack slots until we find out otherwise
+            this.usesStack = false;
+        }
+
+        NativeImageDebugLocalValue thisLocation() {
+            assert !hostedMethod.isStatic();
+            return unpack(callingConvention.getArgument(0));
+        }
+
+        NativeImageDebugLocalValue paramLocation(int paramIdx) {
+            assert paramIdx < hostedMethod.getSignature().getParameterCount(false);
+            int idx = paramIdx;
+            if (!hostedMethod.isStatic()) {
+                idx++;
+            }
+            return unpack(callingConvention.getArgument(idx));
+        }
+
+        private NativeImageDebugLocalValue unpack(AllocatableValue value) {
+            if (value instanceof RegisterValue) {
+                RegisterValue registerValue = (RegisterValue) value;
+                return NativeImageDebugRegisterValue.create(registerValue);
             } else {
-                return nextStackLocation();
+                // call argument must be a stack slot if it is not a register
+                StackSlot stackSlot = (StackSlot) value;
+                this.usesStack = true;
+                // the calling convention provides raw offsets from the SP at point
+                // of call but these need adjusting to allow for a stacked return
+                // address and/or frame pointer according to the architecture
+                return new NativeImageDebugStackValue(stackSlot.getRawOffset() + adjustment);
             }
-        }
-
-        public NativeImageDebugLocalValue nextIntegerLocation() {
-            if (nextGPRegIdx < gpregs.length) {
-                return NativeImageDebugRegisterValue.create(gpregs[nextGPRegIdx++].number);
-            } else {
-                return nextStackLocation();
-            }
-        }
-
-        public NativeImageDebugLocalValue nextStackLocation() {
-            // offset is computed relative to the undecremented stack pointer and includes an extra
-            // offset to adjust for any intervening return address and frame pointer
-            assert nextStackIdx < stackParamCount : "encountered too many stack params";
-            int stackIdx = nextStackIdx++;
-            return NativeImageDebugStackValue.create((stackIdx * 8) + stackOffset);
         }
 
         public boolean usesStack() {
-            return stackParamCount > 0;
-        }
-
-        private int computeStackCount(ResolvedJavaMethod method) {
-            int numIntegerParams = 0;
-            int numFloatingParams = 0;
-            Signature signature = method.getSignature();
-            int parameterCount = signature.getParameterCount(false);
-            if (!method.isStatic()) {
-                numIntegerParams++;
-            }
-            for (int i = 0; i < parameterCount; i++) {
-                switch (signature.getParameterKind(i)) {
-                    case Float:
-                    case Double:
-                        numFloatingParams++;
-                        break;
-                    case Void:
-                    case Illegal:
-                        assert false : "unexpected parameter kind in method sig";
-                        break;
-                    default:
-                        numIntegerParams++;
-                        break;
-                }
-            }
-            int excessParams = 0;
-            if (numIntegerParams > gpregs.length) {
-                excessParams += (numIntegerParams - gpregs.length);
-            }
-            if (numFloatingParams > fregs.length) {
-                excessParams += (numFloatingParams - fregs.length);
-            }
-            return excessParams;
+            return usesStack;
         }
     }
 
@@ -2504,26 +2451,35 @@ class NativeImageDebugInfoProvider extends NativeImageDebugInfoProviderBase impl
     public static final class NativeImageDebugRegisterValue extends NativeImageDebugLocalValue {
         private static EconomicMap<Integer, NativeImageDebugRegisterValue> registerValues = EconomicMap.create();
         private int number;
+        private String name;
 
-        private NativeImageDebugRegisterValue(int number) {
+        private NativeImageDebugRegisterValue(int number, String name) {
             this.number = number;
+            this.name = "reg:" + name;
         }
 
         static NativeImageDebugRegisterValue create(RegisterValue value) {
-            return create(value.getRegister().number);
+            int number = value.getRegister().number;
+            String name = value.getRegister().name;
+            return memoizedCreate(number, name);
         }
 
-        static NativeImageDebugRegisterValue create(int number) {
-            NativeImageDebugRegisterValue value = registerValues.get(number);
-            if (value == null) {
-                value = new NativeImageDebugRegisterValue(number);
-                registerValues.put(number, value);
+        static NativeImageDebugRegisterValue memoizedCreate(int number, String name) {
+            NativeImageDebugRegisterValue reg = registerValues.get(number);
+            if (reg == null) {
+                reg = new NativeImageDebugRegisterValue(number, name);
+                registerValues.put(number, reg);
             }
-            return value;
+            return reg;
         }
 
         public int getNumber() {
             return number;
+        }
+
+        @Override
+        public String toString() {
+            return name;
         }
 
         @Override
@@ -2544,16 +2500,23 @@ class NativeImageDebugInfoProvider extends NativeImageDebugInfoProviderBase impl
     public static final class NativeImageDebugStackValue extends NativeImageDebugLocalValue {
         private static EconomicMap<Integer, NativeImageDebugStackValue> stackValues = EconomicMap.create();
         private int offset;
+        private String name;
 
         private NativeImageDebugStackValue(int offset) {
             this.offset = offset;
+            this.name = "stack:" + offset;
         }
 
-        private static NativeImageDebugStackValue create(StackSlot value, int framesize) {
-            return create(value.getOffset(framesize));
+        static NativeImageDebugStackValue create(StackSlot value, int framesize) {
+            return memoizedCreate(value.getOffset(framesize));
         }
 
-        private static NativeImageDebugStackValue create(int offset) {
+        static NativeImageDebugStackValue create(DebugLocalValueInfo previous, int adjustment) {
+            assert previous.localKind() == DebugLocalValueInfo.LocalKind.STACKSLOT;
+            return memoizedCreate(previous.stackSlot() + adjustment);
+        }
+
+        private static NativeImageDebugStackValue memoizedCreate(int offset) {
             NativeImageDebugStackValue value = stackValues.get(offset);
             if (value == null) {
                 value = new NativeImageDebugStackValue(offset);
@@ -2564,6 +2527,11 @@ class NativeImageDebugInfoProvider extends NativeImageDebugInfoProviderBase impl
 
         public int getOffset() {
             return offset;
+        }
+
+        @Override
+        public String toString() {
+            return name;
         }
 
         @Override
@@ -2611,6 +2579,11 @@ class NativeImageDebugInfoProvider extends NativeImageDebugInfoProviderBase impl
 
         public long getHeapOffset() {
             return heapoffset;
+        }
+
+        @Override
+        public String toString() {
+            return "constant:" + value.toString();
         }
 
         @Override

--- a/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/debug/CStructTests.java
+++ b/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/debug/CStructTests.java
@@ -217,6 +217,27 @@ public class CStructTests {
         free(cs);
     }
 
+    public void mixedArguments() {
+        SimpleStruct ss1 = UnmanagedMemory.malloc(SizeOf.get(SimpleStruct.class));
+        SimpleStruct2 ss2 = UnmanagedMemory.malloc(SizeOf.get(SimpleStruct2.class));
+        String m1 = "a message in a bottle";
+        String m2 = "a ship in a bottle";
+        String m3 = "courage in a bottle";
+        ss1.setFirst(1);
+        ss1.setSecond(2);
+        ss2.setAlpha((byte) 99);
+        ss2.setBeta(100L);
+        testMixedArguments(m1, (short) 1, ss1, 123456789L, m2, ss2, m3);
+        free(ss1);
+        free(ss2);
+    }
+
+    public void testMixedArguments(String m1, short s, SimpleStruct ss1, long l, String m2, SimpleStruct2 ss2, String m3) {
+        System.out.println("You find " + m1);
+        System.out.println("You find " + m2);
+        System.out.println("You find " + m3);
+    }
+
     public static void main(String[] args) {
         CStructTests tests = new CStructTests();
         tests.composite();

--- a/substratevm/src/com.oracle.svm.test/src/hello/Hello.java
+++ b/substratevm/src/com.oracle.svm.test/src/hello/Hello.java
@@ -240,6 +240,7 @@ public class Hello {
         CStructTests tests = new CStructTests();
         tests.composite();
         tests.weird();
+        tests.mixedArguments();
         System.exit(0);
     }
     /*


### PR DESCRIPTION
This PR modifies the debug info provider to use the compiler calling convention when generating locations for incoming parameters. This ensures that the correct locations are used appropriate to the current operating system, target CPU and incoming call API type (Java or Native).
