### PR TITLE
Add support for jdk.ThreadAllocationStatistics event and fix thread exclusion for chunk periodic events

### DIFF
--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/JfrEvent.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/JfrEvent.java
@@ -93,7 +93,7 @@ public final class JfrEvent {
     @Uninterruptible(reason = "Prevent races with VM operations that start/stop recording.", callerMustBe = true)
     public boolean shouldEmit() {
         assert !hasDuration;
-        return shouldEmit0(null);
+        return shouldEmit0() && !SubstrateJVM.get().isCurrentThreadExcluded();
     }
 
     /**
@@ -103,17 +103,17 @@ public final class JfrEvent {
     @Uninterruptible(reason = "Prevent races with VM operations that start/stop recording.", callerMustBe = true)
     public boolean shouldEmit(Thread thread) {
         assert !hasDuration;
-        return shouldEmit0(thread);
+        return shouldEmit0() && !SubstrateJVM.get().isExcluded(thread);
     }
 
     @Uninterruptible(reason = "Prevent races with VM operations that start/stop recording.", callerMustBe = true)
     public boolean shouldEmit(long durationTicks) {
         assert hasDuration;
-        return shouldEmit0(null) && durationTicks >= SubstrateJVM.get().getThresholdTicks(this);
+        return shouldEmit0() && durationTicks >= SubstrateJVM.get().getThresholdTicks(this) && !SubstrateJVM.get().isCurrentThreadExcluded();
     }
 
     @Uninterruptible(reason = "Prevent races with VM operations that start/stop recording.", callerMustBe = true)
-    private boolean shouldEmit0(Thread thread) {
-        return SubstrateJVM.get().isRecording() && SubstrateJVM.get().isEnabled(this) && !SubstrateJVM.get().isExcluded(thread);
+    private boolean shouldEmit0() {
+        return SubstrateJVM.get().isRecording() && SubstrateJVM.get().isEnabled(this);
     }
 }

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/JfrEvent.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/JfrEvent.java
@@ -93,7 +93,7 @@ public final class JfrEvent {
     @Uninterruptible(reason = "Prevent races with VM operations that start/stop recording.", callerMustBe = true)
     public boolean shouldEmit() {
         assert !hasDuration;
-        return shouldEmit0(Thread.currentThread());
+        return shouldEmit0(null);
     }
 
     /**
@@ -109,7 +109,7 @@ public final class JfrEvent {
     @Uninterruptible(reason = "Prevent races with VM operations that start/stop recording.", callerMustBe = true)
     public boolean shouldEmit(long durationTicks) {
         assert hasDuration;
-        return shouldEmit0(Thread.currentThread()) && durationTicks >= SubstrateJVM.get().getThresholdTicks(this);
+        return shouldEmit0(null) && durationTicks >= SubstrateJVM.get().getThresholdTicks(this);
     }
 
     @Uninterruptible(reason = "Prevent races with VM operations that start/stop recording.", callerMustBe = true)

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/JfrEvent.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/JfrEvent.java
@@ -62,6 +62,7 @@ public final class JfrEvent {
     public static final JfrEvent JavaMonitorInflate = create("jdk.JavaMonitorInflate", true);
     public static final JfrEvent ObjectAllocationInNewTLAB = create("jdk.ObjectAllocationInNewTLAB", false);
     public static final JfrEvent GCHeapSummary = create("jdk.GCHeapSummary", false);
+    public static final JfrEvent ThreadAllocationStatistics = create("jdk.ThreadAllocationStatistics", false);
 
     private final long id;
     private final String name;

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/JfrManager.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/JfrManager.java
@@ -86,8 +86,8 @@ public class JfrManager {
     public RuntimeSupport.Hook startupHook() {
         return isFirstIsolate -> {
             parseFlightRecorderLogging(SubstrateOptions.FlightRecorderLogging.getValue());
+            periodicEventSetup();
             if (isJFREnabled()) {
-                periodicEventSetup();
                 initRecording();
             }
         };

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/JfrThreadLocal.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/JfrThreadLocal.java
@@ -251,19 +251,23 @@ public class JfrThreadLocal implements ThreadListener {
      */
     @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
     public static boolean isThreadExcluded(Thread thread) {
-        Thread targetThread = thread;
         if (thread == null) {
-            if (Thread.currentThread() == null) {
-                return true;
-            }
-            targetThread = Thread.currentThread();
+            return true;
         }
-        if (targetThread != Thread.currentThread() && !VMOperation.isInProgressAtSafepoint()) {
+        if (thread != Thread.currentThread() && !VMOperation.isInProgressAtSafepoint()) {
             return false;
         }
 
-        Target_java_lang_Thread tjlt = SubstrateUtil.cast(targetThread, Target_java_lang_Thread.class);
+        Target_java_lang_Thread tjlt = SubstrateUtil.cast(thread, Target_java_lang_Thread.class);
         return tjlt.jfrExcluded;
+    }
+
+    @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
+    public static boolean isCurrentThreadExcluded() {
+        if (Thread.currentThread() == null) {
+            return true;
+        }
+        return isThreadExcluded(Thread.currentThread());
     }
 
     public static Target_jdk_jfr_internal_EventWriter getEventWriter() {

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/JfrThreadLocal.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/JfrThreadLocal.java
@@ -251,7 +251,12 @@ public class JfrThreadLocal implements ThreadListener {
      */
     @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
     public static boolean isThreadExcluded(Thread thread) {
-        if (thread == null || (thread != Thread.currentThread() && !VMOperation.isInProgressAtSafepoint())) {
+        if (thread == null && Thread.currentThread() == null) {
+            return true;
+        } else if (thread == null) {
+            thread = Thread.currentThread();
+        }
+        if (thread != Thread.currentThread() && !VMOperation.isInProgressAtSafepoint()) {
             return false;
         }
         Target_java_lang_Thread tjlt = SubstrateUtil.cast(thread, Target_java_lang_Thread.class);

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/JfrThreadLocal.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/JfrThreadLocal.java
@@ -251,15 +251,18 @@ public class JfrThreadLocal implements ThreadListener {
      */
     @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
     public static boolean isThreadExcluded(Thread thread) {
-        if (thread == null && Thread.currentThread() == null) {
-            return true;
-        } else if (thread == null) {
-            thread = Thread.currentThread();
+        Thread targetThread = thread;
+        if (thread == null) {
+            if (Thread.currentThread() == null) {
+                return true;
+            }
+            targetThread = Thread.currentThread();
         }
-        if (thread != Thread.currentThread() && !VMOperation.isInProgressAtSafepoint()) {
+        if (targetThread != Thread.currentThread() && !VMOperation.isInProgressAtSafepoint()) {
             return false;
         }
-        Target_java_lang_Thread tjlt = SubstrateUtil.cast(thread, Target_java_lang_Thread.class);
+
+        Target_java_lang_Thread tjlt = SubstrateUtil.cast(targetThread, Target_java_lang_Thread.class);
         return tjlt.jfrExcluded;
     }
 

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/SubstrateJVM.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/SubstrateJVM.java
@@ -701,20 +701,14 @@ public class SubstrateJVM {
         JfrThreadLocal.setExcluded(thread, excluded);
     }
 
+    @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
     public boolean isExcluded(Thread thread) {
         /*
          * Only the current thread is passed to this method in JDK 17, 19, and 20. Eventually, we
-         * will need to implement that in a more general way though, see GR-44616.
+         * will need to implement that in a more general way though, see GR-44616. It can also be
+         * called from internal SVM JFR code upon event emission.
          */
-        if (!thread.equals(Thread.currentThread())) {
-            return false;
-        }
-        return isCurrentThreadExcluded();
-    }
-
-    @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
-    public boolean isCurrentThreadExcluded() {
-        return JfrThreadLocal.isCurrentThreadExcluded();
+        return JfrThreadLocal.isThreadExcluded(thread);
     }
 
     private static class JfrBeginRecordingOperation extends JavaVMOperation {

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/SubstrateJVM.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/SubstrateJVM.java
@@ -711,6 +711,11 @@ public class SubstrateJVM {
         return JfrThreadLocal.isThreadExcluded(thread);
     }
 
+    @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
+    public boolean isCurrentThreadExcluded() {
+        return JfrThreadLocal.isCurrentThreadExcluded();
+    }
+
     private static class JfrBeginRecordingOperation extends JavaVMOperation {
         JfrBeginRecordingOperation() {
             super(VMOperationInfos.get(JfrBeginRecordingOperation.class, "JFR begin recording", SystemEffect.SAFEPOINT));

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/events/EndChunkNativePeriodicEvents.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/events/EndChunkNativePeriodicEvents.java
@@ -27,6 +27,7 @@ package com.oracle.svm.core.jfr.events;
 import java.util.Map;
 import java.util.Properties;
 
+import jdk.jfr.Enabled;
 import org.graalvm.nativeimage.StackValue;
 
 import com.oracle.svm.core.Uninterruptible;
@@ -38,6 +39,8 @@ import com.oracle.svm.core.jfr.JfrNativeEventWriterData;
 import com.oracle.svm.core.jfr.JfrNativeEventWriterDataAccess;
 import com.oracle.svm.core.jfr.JfrTicks;
 import com.oracle.svm.core.jfr.SubstrateJVM;
+import com.oracle.svm.core.thread.VMThreads;
+import com.oracle.svm.core.thread.JavaThreads;
 
 import jdk.jfr.Event;
 import jdk.jfr.Name;
@@ -61,6 +64,7 @@ public class EndChunkNativePeriodicEvents extends Event {
         emitInitialEnvironmentVariables(getEnvironmentVariables());
         emitInitialSystemProperties(getSystemProperties());
         emitThreadCPULoad();
+//        emitThreadAllocationStatistics();
     }
 
     @Uninterruptible(reason = "Accesses a JFR buffer.")
@@ -180,6 +184,32 @@ public class EndChunkNativePeriodicEvents extends Event {
     private static void emitThreadCPULoad() {
         ThreadCPULoadEvent.emitEvents();
     }
+
+//    @Uninterruptible(reason = "Thread locks/holds the THREAD_MUTEX.")
+//    private static void emitThreadAllocationStatistics() {
+//        if (JfrEvent.ThreadAllocationStatistics.shouldEmit()) {
+//            JfrNativeEventWriterData data = StackValue.get(JfrNativeEventWriterData.class);
+//            JfrNativeEventWriterDataAccess.initializeThreadLocalNativeBuffer(data);
+//
+//            VMThreads.lockThreadMutexInNativeCode();
+//            try {
+//                org.graalvm.nativeimage.IsolateThread isolateThread = VMThreads.firstThread();
+//                while (isolateThread.isNonNull()) {
+//                    Thread javaThread = com.oracle.svm.core.thread.PlatformThreads.currentThread.get(isolateThread);
+//                    if (javaThread != null) {
+//                        JfrNativeEventWriter.beginSmallEvent(data, JfrEvent.ThreadAllocationStatistics);
+//                        JfrNativeEventWriter.putLong(data, JfrTicks.elapsedTicks());
+//                        JfrNativeEventWriter.putThread(data, JavaThreads.getThreadId(javaThread));
+//                        JfrNativeEventWriter.putLong(data,Heap.getHeap().getThreadAllocatedMemory(isolateThread));
+//                        JfrNativeEventWriter.endSmallEvent(data);
+//                    }
+//                    isolateThread = VMThreads.nextThread(isolateThread);
+//                }
+//            } finally {
+//                VMThreads.THREAD_MUTEX.unlock();
+//            }
+//        }
+//    }
 
     private static StringEntry[] getEnvironmentVariables() {
         Map<String, String> env = System.getenv();

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/events/EveryChunkNativePeriodicEvents.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/events/EveryChunkNativePeriodicEvents.java
@@ -28,13 +28,19 @@ import java.lang.management.ManagementFactory;
 import java.lang.management.ThreadMXBean;
 
 import org.graalvm.nativeimage.StackValue;
+import org.graalvm.nativeimage.IsolateThread;
 
 import com.oracle.svm.core.Uninterruptible;
+import com.oracle.svm.core.heap.Heap;
+import com.oracle.svm.core.heap.PhysicalMemory;
+import com.oracle.svm.core.heap.VMOperationInfos;
 import com.oracle.svm.core.jfr.JfrEvent;
 import com.oracle.svm.core.jfr.JfrNativeEventWriter;
 import com.oracle.svm.core.jfr.JfrNativeEventWriterData;
 import com.oracle.svm.core.jfr.JfrNativeEventWriterDataAccess;
 import com.oracle.svm.core.jfr.JfrTicks;
+import com.oracle.svm.core.thread.VMThreads;
+import com.oracle.svm.core.thread.JavaVMOperation;
 
 import jdk.jfr.Event;
 import jdk.jfr.Name;
@@ -49,7 +55,9 @@ public class EveryChunkNativePeriodicEvents extends Event {
         emitJavaThreadStats(threadMXBean.getThreadCount(), threadMXBean.getDaemonThreadCount(),
                         threadMXBean.getTotalStartedThreadCount(), threadMXBean.getPeakThreadCount());
 
-        emitPhysicalMemory(com.oracle.svm.core.heap.PhysicalMemory.size().rawValue(), 0);
+        emitPhysicalMemory(PhysicalMemory.size().rawValue(), 0);
+        emitClassLoadingStatistics(Heap.getHeap().getClassCount());
+        emitPerThreadEveryChunkEvents();
     }
 
     @Uninterruptible(reason = "Accesses a JFR buffer.")
@@ -79,6 +87,51 @@ public class EveryChunkNativePeriodicEvents extends Event {
             JfrNativeEventWriter.putLong(data, totalSize);
             JfrNativeEventWriter.putLong(data, usedSize);
             JfrNativeEventWriter.endSmallEvent(data);
+        }
+    }
+
+    @Uninterruptible(reason = "Accesses a JFR buffer.")
+    private static void emitClassLoadingStatistics(long loadedClassCount) {
+        if (JfrEvent.ClassLoadingStatistics.shouldEmit()) {
+            JfrNativeEventWriterData data = StackValue.get(JfrNativeEventWriterData.class);
+            JfrNativeEventWriterDataAccess.initializeThreadLocalNativeBuffer(data);
+
+            JfrNativeEventWriter.beginSmallEvent(data, JfrEvent.ClassLoadingStatistics);
+            JfrNativeEventWriter.putLong(data, JfrTicks.elapsedTicks());
+            JfrNativeEventWriter.putLong(data, loadedClassCount);
+            JfrNativeEventWriter.putLong(data, 0); /* unloadedClassCount */
+            JfrNativeEventWriter.endSmallEvent(data);
+        }
+    }
+
+    /**
+     * This is responsible for handling the emission of all per thread events. This allows for a
+     * single VM operation to iterate the running threads.
+     */
+    private static void emitPerThreadEveryChunkEvents() {
+        if (shouldEmitUnsafe()) {
+            EmitPerThreadEveryChunkEventsOperation vmOp = new EmitPerThreadEveryChunkEventsOperation();
+            vmOp.enqueue();
+        }
+    }
+
+    @Uninterruptible(reason = "Used to avoid the VM operation if it is not absolutely needed.")
+    private static boolean shouldEmitUnsafe() {
+        /* The returned value is racy. */
+        return JfrEvent.ThreadCPULoad.shouldEmit() || JfrEvent.ThreadAllocationStatistics.shouldEmit();
+    }
+
+    private static final class EmitPerThreadEveryChunkEventsOperation extends JavaVMOperation {
+        EmitPerThreadEveryChunkEventsOperation() {
+            super(VMOperationInfos.get(EmitPerThreadEveryChunkEventsOperation.class, "Emit per thread every chunk events", SystemEffect.SAFEPOINT));
+        }
+
+        @Override
+        protected void operate() {
+            for (IsolateThread isolateThread = VMThreads.firstThread(); isolateThread.isNonNull(); isolateThread = VMThreads.nextThread(isolateThread)) {
+                ThreadCPULoadEvent.emit(isolateThread);
+                ThreadAllocationStatisticsEvent.emit(isolateThread);
+            }
         }
     }
 }

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/events/ThreadAllocationStatisticsEvent.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/events/ThreadAllocationStatisticsEvent.java
@@ -48,7 +48,7 @@ public class ThreadAllocationStatisticsEvent {
             JfrNativeEventWriterDataAccess.initializeThreadLocalNativeBuffer(data);
             JfrNativeEventWriter.beginSmallEvent(data, JfrEvent.ThreadAllocationStatistics);
             JfrNativeEventWriter.putLong(data, JfrTicks.elapsedTicks());
-            JfrNativeEventWriter.putLong(data, Heap.getHeap().getThreadAllocatedMemory(isolateThread)); // Allocation
+            JfrNativeEventWriter.putLong(data, Heap.getHeap().getThreadAllocatedMemory(isolateThread));
             JfrNativeEventWriter.putThread(data, javaThread);
             JfrNativeEventWriter.endSmallEvent(data);
 

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/events/ThreadAllocationStatisticsEvent.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/events/ThreadAllocationStatisticsEvent.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2022, 2022, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2022, 2022, Red Hat Inc. All rights reserved.
+ * Copyright (c) 2023, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2023, Red Hat Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/events/ThreadAllocationStatisticsEvent.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/events/ThreadAllocationStatisticsEvent.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2022, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2022, Red Hat Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package com.oracle.svm.core.jfr.events;
+
+import org.graalvm.nativeimage.StackValue;
+import org.graalvm.nativeimage.IsolateThread;
+
+import com.oracle.svm.core.Uninterruptible;
+import com.oracle.svm.core.jfr.JfrEvent;
+import com.oracle.svm.core.jfr.JfrNativeEventWriter;
+import com.oracle.svm.core.jfr.JfrNativeEventWriterData;
+import com.oracle.svm.core.jfr.JfrNativeEventWriterDataAccess;
+import com.oracle.svm.core.jfr.JfrTicks;
+import com.oracle.svm.core.heap.Heap;
+import com.oracle.svm.core.thread.PlatformThreads;
+
+public class ThreadAllocationStatisticsEvent {
+
+    @Uninterruptible(reason = "Accesses a JFR buffer.")
+    public static void emit(IsolateThread isolateThread) {
+        Thread javaThread = PlatformThreads.fromVMThread(isolateThread);
+        if (JfrEvent.ThreadAllocationStatistics.shouldEmit(javaThread)) {
+            JfrNativeEventWriterData data = StackValue.get(JfrNativeEventWriterData.class);
+            JfrNativeEventWriterDataAccess.initializeThreadLocalNativeBuffer(data);
+
+            if (javaThread != null) {
+                JfrNativeEventWriter.beginSmallEvent(data, JfrEvent.ThreadAllocationStatistics);
+                JfrNativeEventWriter.putLong(data, JfrTicks.elapsedTicks());
+                JfrNativeEventWriter.putLong(data, Heap.getHeap().getThreadAllocatedMemory(isolateThread)); // Allocation
+                JfrNativeEventWriter.putThread(data, javaThread);
+                JfrNativeEventWriter.endSmallEvent(data);
+            }
+        }
+    }
+}

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/events/ThreadCPULoadEvent.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/events/ThreadCPULoadEvent.java
@@ -29,7 +29,6 @@ import org.graalvm.nativeimage.IsolateThread;
 import org.graalvm.nativeimage.StackValue;
 
 import com.oracle.svm.core.Uninterruptible;
-import com.oracle.svm.core.heap.VMOperationInfos;
 import com.oracle.svm.core.jdk.Jvm;
 import com.oracle.svm.core.jdk.UninterruptibleUtils;
 import com.oracle.svm.core.jfr.JfrEvent;
@@ -37,9 +36,7 @@ import com.oracle.svm.core.jfr.JfrNativeEventWriter;
 import com.oracle.svm.core.jfr.JfrNativeEventWriterData;
 import com.oracle.svm.core.jfr.JfrNativeEventWriterDataAccess;
 import com.oracle.svm.core.jfr.JfrTicks;
-import com.oracle.svm.core.thread.JavaVMOperation;
 import com.oracle.svm.core.thread.ThreadCpuTimeSupport;
-import com.oracle.svm.core.thread.VMThreads;
 import com.oracle.svm.core.threadlocal.FastThreadLocalFactory;
 import com.oracle.svm.core.threadlocal.FastThreadLocalLong;
 import com.oracle.svm.core.util.TimeUtils;
@@ -125,14 +122,6 @@ public class ThreadCPULoadEvent {
         JfrNativeEventWriter.endSmallEvent(data);
     }
 
-    public static void emitEvents() {
-        /* This is safe because the VM operation rechecks if the event should be emitted. */
-        if (shouldEmitUnsafe()) {
-            EmitThreadCPULoadEventsOperation vmOp = new EmitThreadCPULoadEventsOperation();
-            vmOp.enqueue();
-        }
-    }
-
     @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
     private static int getProcessorCount() {
         /*
@@ -160,24 +149,5 @@ public class ThreadCPULoadEvent {
     @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
     private static long getCurrentTime() {
         return System.nanoTime();
-    }
-
-    @Uninterruptible(reason = "Used to avoid the VM operation if it is not absolutely needed.")
-    private static boolean shouldEmitUnsafe() {
-        /* The returned value is racy. */
-        return JfrEvent.ThreadCPULoad.shouldEmit();
-    }
-
-    private static final class EmitThreadCPULoadEventsOperation extends JavaVMOperation {
-        EmitThreadCPULoadEventsOperation() {
-            super(VMOperationInfos.get(EmitThreadCPULoadEventsOperation.class, "Emit ThreadCPULoad events", SystemEffect.SAFEPOINT));
-        }
-
-        @Override
-        protected void operate() {
-            for (IsolateThread isolateThread = VMThreads.firstThread(); isolateThread.isNonNull(); isolateThread = VMThreads.nextThread(isolateThread)) {
-                emit(isolateThread);
-            }
-        }
     }
 }

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/thread/PlatformThreads.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/thread/PlatformThreads.java
@@ -278,6 +278,25 @@ public abstract class PlatformThreads {
         }
     }
 
+//    @Uninterruptible(reason = "Thread locks/holds the THREAD_MUTEX.")
+//    public static Map<Long, Long> getAllThreadAllocatedBytes() {
+//        Map<Long,Long> threadAllocations = new HashMap<>();
+//        VMThreads.lockThreadMutexInNativeCode();
+//        try {
+//            IsolateThread isolateThread = VMThreads.firstThread();
+//            while (isolateThread.isNonNull()) {
+//                Thread javaThread = PlatformThreads.currentThread.get(isolateThread);
+//                if (javaThread != null) {
+//                    threadAllocations.put(JavaThreads.getThreadId(javaThread), Heap.getHeap().getThreadAllocatedMemory(isolateThread));
+//                }
+//                isolateThread = VMThreads.nextThread(isolateThread);
+//            }
+//        } finally {
+//            VMThreads.THREAD_MUTEX.unlock();
+//        }
+//        return threadAllocations;
+//    }
+
     /* End of accessor functions. */
 
     @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/thread/PlatformThreads.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/thread/PlatformThreads.java
@@ -278,25 +278,6 @@ public abstract class PlatformThreads {
         }
     }
 
-//    @Uninterruptible(reason = "Thread locks/holds the THREAD_MUTEX.")
-//    public static Map<Long, Long> getAllThreadAllocatedBytes() {
-//        Map<Long,Long> threadAllocations = new HashMap<>();
-//        VMThreads.lockThreadMutexInNativeCode();
-//        try {
-//            IsolateThread isolateThread = VMThreads.firstThread();
-//            while (isolateThread.isNonNull()) {
-//                Thread javaThread = PlatformThreads.currentThread.get(isolateThread);
-//                if (javaThread != null) {
-//                    threadAllocations.put(JavaThreads.getThreadId(javaThread), Heap.getHeap().getThreadAllocatedMemory(isolateThread));
-//                }
-//                isolateThread = VMThreads.nextThread(isolateThread);
-//            }
-//        } finally {
-//            VMThreads.THREAD_MUTEX.unlock();
-//        }
-//        return threadAllocations;
-//    }
-
     /* End of accessor functions. */
 
     @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)

--- a/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/jfr/TestThreadAllocationStatisticsEvent.java
+++ b/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/jfr/TestThreadAllocationStatisticsEvent.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2023, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2023, Red Hat Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package com.oracle.svm.test.jfr;
+
+import jdk.jfr.Recording;
+import jdk.jfr.consumer.RecordedEvent;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.assertTrue;
+
+public class TestThreadAllocationStatisticsEvent extends JfrRecordingTest {
+    private Thread thread = null;
+    private static final String THREAD_NAME = "Thread-Name";
+    private List<byte[]> dummyList = new ArrayList<>();
+
+    private volatile boolean finished = false;
+
+    @Test
+    public void test() throws Throwable {
+        String[] events = new String[]{"jdk.ThreadAllocationStatistics"};
+        Recording recording = startRecording(events);
+
+        thread = createAndStartLongLived(THREAD_NAME);
+        stopRecording(recording, TestThreadAllocationStatisticsEvent::validateEvents);
+        assertTrue(thread.isAlive());
+        finished = true;
+    }
+
+    private static void validateEvents(List<RecordedEvent> events) {
+        boolean found = false;
+        for (RecordedEvent e : events) {
+            if (e.getThread("thread").getJavaName().equals(THREAD_NAME) && e.<Long> getValue("allocated") >= 1024L) {
+                found = true;
+                break;
+            }
+        }
+        assertTrue(found);
+    }
+
+    private Thread createAndStartLongLived(String name) {
+        Thread thread = new Thread(() -> {
+            while (!finished) {
+                try {
+                    dummyList.add(new byte[1024]);
+                    Thread.sleep(100);
+                } catch (InterruptedException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+        });
+        thread.setName(name);
+        thread.start();
+        return thread;
+    }
+}

--- a/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/jfr/TestThreadAllocationStatisticsEvent.java
+++ b/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/jfr/TestThreadAllocationStatisticsEvent.java
@@ -47,10 +47,10 @@ public class TestThreadAllocationStatisticsEvent extends JfrRecordingTest {
         String[] events = new String[]{"jdk.ThreadAllocationStatistics"};
         Recording recording = startRecording(events);
 
-        thread = createAndStartLongLived(THREAD_NAME);
-        stopRecording(recording, TestThreadAllocationStatisticsEvent::validateEvents);
-        assertTrue(thread.isAlive());
+        createAndStartLongLived(THREAD_NAME);
+        recording.dump(createTempJfrFile());
         finished = true;
+        stopRecording(recording, TestThreadAllocationStatisticsEvent::validateEvents);
     }
 
     private static void validateEvents(List<RecordedEvent> events) {
@@ -64,8 +64,8 @@ public class TestThreadAllocationStatisticsEvent extends JfrRecordingTest {
         assertTrue(found);
     }
 
-    private Thread createAndStartLongLived(String name) {
-        Thread thread = new Thread(() -> {
+    private void createAndStartLongLived(String name) {
+        thread = new Thread(() -> {
             while (!finished) {
                 try {
                     dummyList.add(new byte[1024]);
@@ -77,6 +77,5 @@ public class TestThreadAllocationStatisticsEvent extends JfrRecordingTest {
         });
         thread.setName(name);
         thread.start();
-        return thread;
     }
 }

--- a/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/jfr/TestThreadCPULoadEvent.java
+++ b/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/jfr/TestThreadCPULoadEvent.java
@@ -26,7 +26,6 @@
 
 package com.oracle.svm.test.jfr;
 
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import java.lang.management.ManagementFactory;
@@ -63,7 +62,6 @@ public class TestThreadCPULoadEvent extends JfrRecordingTest {
     }
 
     private static void validateEvents(List<RecordedEvent> events) {
-        assertEquals(2, events.size());
         Map<String, Float> userTimes = new HashMap<>();
         Map<String, Float> cpuTimes = new HashMap<>();
 


### PR DESCRIPTION
This pull request does: 
1. Add support for the ThreadAllocationStatistics event and does some refactoring to emit all periodic chunk events in a single VM operation. 

2. Modifies the checking of thread exclusion to account for the case where a single thread (during a VM operation) is emitting events on behalf of multiple other threads. It should be checking the other thread's exclusion state, not it's own. This is important for periodic chunk events like ThreadCPULoad and ThreadAllocationStatistics.

3. Moves ClassLoadingStatistics and ThreadCPULoad event code to `EveryChunkNativePeriodicEvents` class.  This is so that they will match the period specified in Hotspot https://github.com/openjdk/jdk/blob/master/src/hotspot/share/jfr/metadata/metadata.xml#L842 


