### PR TITLE
Fix typo in Shape.newBuilder().layout()

### DIFF
--- a/truffle/docs/DynamicObjectModel.md
+++ b/truffle/docs/DynamicObjectModel.md
@@ -122,7 +122,7 @@ public final class MyLanguage extends TruffleLanguage<MyContext> {
     private final Shape initialArrayShape;
 
     public MyLanguage() {
-        this.initialObjectShape = Shape.newBuilder(ExtendedObject.class).build();
+        this.initialObjectShape = Shape.newBuilder().layout(ExtendedObject.class).build();
         this.initialArrayShape = Shape.newBuilder().build();
     }
 


### PR DESCRIPTION
The other reference to the method is correct, but the call to `layout` was missing here.