### PR TITLE
Ensure that `DefaultStackTraceElementObject` satisfies the contract of `InteropLibrary`

### DIFF
--- a/truffle/src/com.oracle.truffle.api.exception/src/com/oracle/truffle/api/exception/DefaultStackTraceElementObject.java
+++ b/truffle/src/com.oracle.truffle.api.exception/src/com/oracle/truffle/api/exception/DefaultStackTraceElementObject.java
@@ -69,8 +69,12 @@ final class DefaultStackTraceElementObject implements TruffleObject {
 
     @ExportMessage
     @TruffleBoundary
-    Object getExecutableName() {
-        return rootNode.getName();
+    Object getExecutableName() throws UnsupportedMessageException {
+        String name = rootNode.getName();
+        if (name == null) {
+            throw UnsupportedMessageException.create();
+        }
+        return name;
     }
 
     @ExportMessage


### PR DESCRIPTION
Proposing a fix to #7359 