### PR TITLE
[GR-49402] Correct mangling of primitive types in BFD name mangler

### DIFF
--- a/substratevm/mx.substratevm/testhello.py
+++ b/substratevm/mx.substratevm/testhello.py
@@ -478,7 +478,7 @@ def test():
             r"%sprivate:"%spaces_pattern,
             r"%sstatic void noInlineFoo\(void\);"%spaces_pattern,
             r"%sstatic void noInlineHere\(int\);"%spaces_pattern,
-            r"%sstatic void noInlineManyArgs\(int, int, int, int, boolean, int, int, long, int, long, float, float, float, float, double, float, float, float, float, double, boolean, float\);"%spaces_pattern,
+            r"%sstatic void noInlineManyArgs\(int, byte, short, char, boolean, int, int, long, int, long, float, float, float, float, double, float, float, float, float, double, boolean, float\);"%spaces_pattern,
             r"%sstatic void noInlinePassConstants\(void\);"%spaces_pattern,
             r"%sstatic void noInlineTest\(void\);"%spaces_pattern,
             r"%sstatic void noInlineThis\(void\);"%spaces_pattern,
@@ -673,9 +673,9 @@ def test():
     execute("continue")
     exec_string = execute("info args")
     rexp =[r"i0 = 0",
-           r"i1 = 1",
-           r"i2 = 2",
-           r"i3 = 3",
+           r"b1 = 1 '\\001'",
+           r"s2 = 2",
+           r"c3 = 51",
            r"b4 = true",
            r"i5 = 5",
            r"i6 = 6",
@@ -725,9 +725,9 @@ def test():
 
     exec_string = execute("info args")
     rexp =[r"i0 = 0",
-           r"i1 = 1",
-           r"i2 = 2",
-           r"i3 = 3",
+           r"b1 = 1 '\\001'",
+           r"s2 = 2",
+           r"c3 = 51",
            r"b4 = true",
            r"i5 = 5",
            r"i6 = 6",

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/image/NativeImageBFDNameProvider.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/image/NativeImageBFDNameProvider.java
@@ -279,16 +279,35 @@ class NativeImageBFDNameProvider implements UniqueShortNameProvider {
          *
          * Primitive Parameter Types
          *
-         * Primitive parameter types (or return types) are encoded using a single letter as follows:
+         * Primitive parameter types (or return types) may be encoded using a single letter cases
+         * where the symbol encodes a C++ primitive type with the same name and bit layout and
+         * interpretation as the Java type:
          *
-         *   bool -> b
-         *   byte -> a
          *   short -> s
-         *   char -> t
          *   int -> i
          *   long -> l
          *   float -> f
          *   double -> d
+         *   void -> v
+         *
+         * Other primitive types need to be encoded as symbols
+         *
+         *   boolean -> 7boolean
+         *   byte -> 4byte
+         *   char -> 4char
+         *
+         * In these latter cases the single letter encodings that identifies a C++ type with the
+         * same bit layout and interpretation (respectively, b, c and t) encode for differently
+         * named C++ type (respectively "bool", "char", and unsigned short). Their use would cause
+         * method signatures to be printed with a wrong and potentially misleading name e.g. if
+         * method void Foo::foo(boolean, byte, char) were encoded as _ZN3Foo3fooEJvbct it would
+         * then demangle as Foo::foo(bool, char, unsigned short).
+         *
+         * It would be possible to encode the name "char" using symbol c. However, that would
+         * suggest that the type is a signed 8 bit value rather than a 16 bit unsigned value.
+         * Note that the info section includes appropriate definitions of these three primitive
+         * types with the appropriate names so tools which attempt to resolve the symbol names to
+         * type info should work correctly.
          *
          * Object parameter types (which includes interfaces and enums) are encoded using the class
          * name encoding described above preceded by  prefix 'P'.
@@ -328,28 +347,46 @@ class NativeImageBFDNameProvider implements UniqueShortNameProvider {
          *
          * Substitutions:
          *
-         * Namespace prefix elements (i.e. the leading elements of an N...E encoding) are indexed and
-         * can be referenced using a shorthand index, saving space in the symbol encoding. In the
-         * standard Java encoding this means that common package and class name prefixes can be
-         * independently substituted (also template prefixes).
+         * Symbol elements are indexed and can be referenced using a shorthand index, saving
+         * space in the symbol encoding.
          *
-         * For example, when encoding the first parameter type, the standard Java encoding of method
-         * startsWith of class java.lang.String can refer to the common prefixes java, lang and String
-         * established by the namespace encoding of the method name:
+         * For example, consider C++ equivalent of String.compareTo and its corresponding encoding
          *
-         *   boolean startsWith(java.lang.String, int) -> _ZN4java4lang6String10startsWithEJbPN4java4lang6StringEi
-         *      -> _ZN4java4lang6String10startsWithEJbPN$_$0_$1_Ei
+         *   int java::lang::String::compareTo(java::lang::String)
+         *      -> _ZN4java4lang6String9compareToEJiPS1_
          *
-         * The namespace prefixes 4java, 4lang and 6String establish successive bindings for the
-         * indexed substitution variables $_, $0_ and $1_.
+         * The symbol encodings 4java, 4lang and 6String and 9compareTo establish
+         * successive bindings for the indexed substitution variables S_, S0_, S1_ and S2_ to
+         * the respective names java, java::lang, java::lang::String and java::lang::String::compareTo
+         * (note that bindings accumulate preceding elements when symbols occur inside a namespace).
+         * The encoding of the argument list uses S1_ references the 3rd binding i.e. the class
+         * name. The problem with this, as seen before when using namespaces is that the demangler
+         * accumulates names using a '::' separator between the namespace components rather than the
+         * desired  '.' separator.
          *
-         * The Graal encoding makes much more limited use of namespace prefixes but it can still profit
-         * from them to produce more concise encodings:
+         * The Graal encoding can work around the namespace separator as shown earlier and still employ
+         * symbols as prefixes in order to produce more concise encodings. The full encoding for the
          *
-         *   boolean startsWith(java.lang.String, int) -> _ZN16java.lang.String10startsWithEJbP16java.lang.Stringi
-         *      -> _ZN16java.lang.String10startsWithEJbP$_i
+         *   int String.compareTo(java.lang.String)
+         *      -> _ZN16java.lang.String9compareToEJiP16java.lang.String
          *
-         * Indexed prefix references are encoded as "S_", "S0_", ... "S9_", "SA_", ... "SZ_", "S10_", ...
+         * However, it is also possible to encode this more concisely as
+         *
+         *   int String.compareTo(java.lang.String)
+         *      -> _ZN16java.lang.String9compareToEJiPS_
+         *
+         * S_ translates to the first symbol introduced in the namespace i.e. java.lang.String.
+         *
+         * Substitutions can also occur when parameter types are repeated e.g.
+         *
+         * int Arrays.NaturalOrder.compare(Object first, Object second)
+         *      -> _ZN19Arrays$NaturalOrder7compareEJiPP16java.lang.ObjectPS_2
+         * 
+         * In this case the class name symbol 19Arrays$NaturalOrde binds $_ to Arrays$NaturalOrder,
+         * the method name symbol 7compare binds $1_ to Arrays$NaturalOrder::compareTo and the
+         * first parameter type name symbol 16java.lang.Object binds $2_ to java.lang.Object.
+         *
+         * Indexed symbol references are encoded as "S_", "S0_", ... "S9_", "SA_", ... "SZ_", "S10_", ...
          * i.e. after "$_" for index 0, successive encodings for index i embded the base 36 digits for
          * (i - 1) between "S" and "_".
          */
@@ -383,14 +420,166 @@ class NativeImageBFDNameProvider implements UniqueShortNameProvider {
     }
 
     private static class BFDMangler {
+
+        /*
+         * The mangler tracks certain elements as they are inserted into the mangled name and bind
+         * short symbol name to use as substitutions. If the same element needs to be re-inserted
+         * the mangler can embed the short symbol instead of generating the previously mangled full
+         * text. Short symbol names are bound in a well-defined sequence at well-defined points
+         * during mangling. This allows the demangler to identify exactly which text in the previous
+         * input must be used to replace a short symbol name.
+         *
+         * A binding occurs whenever a simple name is mangled outside of a namespace. For example, a
+         * top level class name mangled as 3Hello will bind the next available short name with the
+         * result that it will demangle to Hello and can be used to replace later occurrences of the
+         * string Hello.
+         *
+         * When a sequence of simple names is mangled inside a namespace substitution bindings are
+         * recorded for each successive composite namespace prefix but not for the final symbol
+         * itself. For example, when method name Hello::main is mangled to N5Hello4main4 a single
+         * binding is recorded which demangles to Hello. If a class has been loaded by an
+         * application loader and, hence, has a name which includes a loader namespace prefix (to
+         * avoid the possibility of the same named class being loaded by two different loaders) then
+         * the method name, say AppCL504::Hello::main, would mangle to a namespace encoding with 3
+         * elements N8AppCL5045Hello4mainE which would introduce two bindings, the first demangling
+         * to AppCL504 and the second to AppCL504::Hello.
+         *
+         * A binding is also recorded whenever a pointer type is mangled. The bound symbol demangles
+         * to whatever the text decoded from the scope of the P followed by a '*' to translate it to
+         * a pointer type. For example, when the type in parameter list (Foo*) is encoded as P3Foo a
+         * binding is recorded for the pointer as well as for the type Foo. The first binding
+         * demangles to Foo. The second binding demangles to Foo*.
+         *
+         * n.b. repeated use of the pointer operator results in repeated bindings. So, if a
+         * parameter with type Foo** were to be encoded as PP3Foo three bindings would recorded
+         * which demangle to Foo, Foo* and Foo**. However, multiple indirections do not occur in
+         * Java signatures.
+         *
+         * n.b.b. repeated mentions of the same symbol would redundantly record a binding. For
+         * example if int Hello::compareTo(Hello*) were mangled to _ZN5Hello9compareToEJiP5Hello the
+         * resulting bindings would be S_ ==> Hello, S0_ ==> Hello::compareTo, S1_ ==> Hello and S2_
+         * ==> Hello* i.e. both S_ and S1_ would demangle to Hello. This situation should never
+         * arise. A name can always be correctly encoded without repeats. In the above example that
+         * woudl be _ZN5Hello9compareToEJiPS_.
+         */
         final NativeImageBFDNameProvider nameProvider;
         final StringBuilder sb;
-        final List<String> prefixes;
+
+        // A list of lookup names identifying substituted elements. A prospective name for an
+        // element that is about to be encoded can be looked up in this list. If a match is found
+        // the list index can be used to identify the relevant short symbol. If it is not found
+        // then inserting the name serves to allocate the short name associated with the inserted
+        // element's result index.
+        List<LookupName> bindings;
+
+        /**
+         * A lookup name is used as a key to record and subsequently lookup a short symbol that can
+         * replace one or more elements of a mangled name. A lookup name is usually just a simple
+         * string, i.e. some text that is to be mangled and to which the corresponding short symbol
+         * should decode. However, substitutions for namespace prefixes (e.g. AppLoader506::Foo)
+         * require a composite lookup name that composes a namespace prefix (AppLoader506) with a
+         * trailing simple name (Foo). The corresponding short symbol will demangle to the string
+         * produced by composing the prefix and simple name with a :: separator (i.e. restoring
+         * AppLoader506::Foo). Short symbols for pointer types (e.g. Foo* or AppLoader506::Foo*)
+         * require a pointer lookup name that identifies the substituted text as a pointer to some
+         * underlying type (e.g. Foo or AppLoader506::Foo). The corresponding short symbol will
+         * demangle to the string produced by demangling the underlying type with a * suffix. In
+         * theory the prefix for a pointer type lookup name might be defined by another pointer type
+         * lookup name (if, say, we needed to encode type Foo**). In practice, that case should not
+         * arise with Java method signatures.
+         */
+        private abstract class LookupName {
+            String value;
+
+            protected LookupName(String value) {
+                assert value != null;
+                this.value = value;
+            }
+
+            @Override
+            public abstract String toString();
+        }
+
+        private class SimpleLookupName extends LookupName {
+            SimpleLookupName(String value) {
+                super(value);
+            }
+
+            @Override
+            public boolean equals(Object other) {
+                if (other != null && other instanceof SimpleLookupName) {
+                    return this.value.equals(((SimpleLookupName) other).value);
+                }
+                return false;
+            }
+
+            @Override
+            public int hashCode() {
+                return value.hashCode() + 29;
+            }
+
+            @Override
+            public String toString() {
+                return value;
+            }
+        }
+
+        private abstract class CompositeLookupName extends LookupName {
+            LookupName tail;
+
+            CompositeLookupName(String value, LookupName tail) {
+                super(value);
+                assert tail != null;
+                // it makes sense to concatenate Foo with Bar or Foo::Bar with Baz and
+                // Foo* with * but we not Foo* with Bar or Foo::Bar* with Baz
+                // assert !(tail instanceof PointerLookupName) || this instanceof PointerLookupName;
+                this.tail = tail;
+            }
+
+            public boolean equals(Object other) {
+                if (other != null && other instanceof NamespaceLookupName) {
+                    CompositeLookupName otherCompositeLookupName = (CompositeLookupName) other;
+                    assert tail != null && otherCompositeLookupName.tail != null;
+                    return value.equals(otherCompositeLookupName.value) && tail.equals(otherCompositeLookupName.tail);
+                }
+                return false;
+            }
+
+            @Override
+            public int hashCode() {
+                return value.hashCode() ^ tail.hashCode() + 37;
+            }
+        }
+
+        private class NamespaceLookupName extends CompositeLookupName {
+            NamespaceLookupName(String value, LookupName tail) {
+                super(value, tail);
+            }
+
+            @Override
+            public String toString() {
+                return value + "::" + tail.toString();
+            }
+        }
+
+        private class PointerLookupName extends NamespaceLookupName {
+            PointerLookupName(LookupName prefix) {
+                // use * as the value to compose with the prefix because it cannot
+                // arise as a simple name
+                super("*", prefix);
+            }
+
+            @Override
+            public String toString() {
+                // don't insert a '::' separator when composing
+                return tail.toString() + value;
+            }
+        }
 
         BFDMangler(NativeImageBFDNameProvider provider) {
             nameProvider = provider;
             sb = new StringBuilder("_Z");
-            prefixes = new ArrayList<>();
+            bindings = new ArrayList<>();
         }
 
         public String mangle(String loaderName, ResolvedJavaType declaringClass, String memberName, Signature methodSignature, boolean isConstructor) {
@@ -441,30 +630,70 @@ class NativeImageBFDNameProvider implements UniqueShortNameProvider {
             return sb.toString();
         }
 
-        private void mangleSimpleName(String s) {
+        private void mangleWriteSimpleName(String s) {
             // a simple name starting with a digit would invalidate the C++ mangled encoding scheme
             assert !s.startsWith("[0-9]");
             sb.append(s.length());
             sb.append(s);
         }
 
-        private void mangleRecordPrefix(String prefix) {
-            if (!substitutePrefix(prefix)) {
-                mangleSimpleName(prefix);
-                recordPrefix(prefix);
+        private void mangleWriteSubstitutableNameRecord(String name) {
+            LookupName lookupName = new SimpleLookupName(name);
+            if (!substituteName(new SimpleLookupName(name))) {
+                // failed so mangle the name and create a binding to track it
+                mangleWriteSimpleName(name);
+                recordName(lookupName);
             }
         }
 
-        private void manglePrefix(String prefix) {
-            if (!substitutePrefix(prefix)) {
-                mangleSimpleName(prefix);
+        private void mangleWriteSubstitutableNameNoRecord(String name) {
+            LookupName lookupName = new SimpleLookupName(name);
+            if (!substituteName(lookupName)) {
+                // failed so mangle the name
+                mangleWriteSimpleName(name);
             }
         }
 
-        private boolean substitutePrefix(String prefix) {
-            int index = prefixIdx(prefix);
+        private void mangleWriteSubstitutablePrefixedName(String prefix, String name) {
+            // this should only be called when inserting a sequence into a namespace
+            assert sb.charAt(sb.length() - 1) == 'N';
+            // we can substitute both symbols
+            mangleWriteSubstitutableNameRecord(prefix);
+            // in theory the trailing simple name may be substitutable but cannot
+            // have an associated binding. in practice gdb will not translate
+            // a substitution in this position even though the demangler will
+
+            // mangleWriteSubstitutableNameNoRecord(name);
+            mangleWriteSimpleName(name);
+        }
+
+        private void mangleWriteSubstitutablePrefixedName(String prefix1, String prefix2, String name) {
+            // this should only be called when inserting a sequence into a namespace
+            assert sb.charAt(sb.length() - 1) == 'N';
+            // we can substitute the composed prefix followed by the name
+            // or we can substitute all three individual symbols
+            LookupName lookup2 = new SimpleLookupName(prefix2);
+            LookupName lookup = new NamespaceLookupName(prefix1, lookup2);
+            // try substituting the combined prefix
+            if (!substituteName(lookup)) {
+                // we may still be able to establish a binding for the first prefix
+                mangleWriteSubstitutableNameRecord(prefix1);
+                // we cannot establish a binding for the trailing prefix
+                mangleWriteSubstitutableNameNoRecord(prefix2);
+                recordName(lookup);
+            }
+            // in theory the trailing simple name may be substitutable but cannot
+            // have an associated binding. in practice gdb will not translate
+            // a substitution in this position even though the demangler will
+
+            // mangleWriteSubstitutableNameNoRecord(name);
+            mangleWriteSimpleName(name);
+        }
+
+        private boolean substituteName(LookupName name) {
+            int index = bindings.indexOf(name);
             if (index >= 0) {
-                writePrefix(index);
+                writeSubstitution(index);
                 return true;
             }
             return false;
@@ -476,12 +705,11 @@ class NativeImageBFDNameProvider implements UniqueShortNameProvider {
 
         private void mangleClassAndMemberName(String loaderName, String className, String methodName) {
             sb.append('N');
-            // only leading elements of namespace encoding may be recorded as substitutions
             if (encodeLoaderName(loaderName)) {
-                mangleRecordPrefix(loaderName);
+                mangleWriteSubstitutablePrefixedName(loaderName, className, methodName);
+            } else {
+                mangleWriteSubstitutablePrefixedName(className, methodName);
             }
-            mangleRecordPrefix(className);
-            mangleSimpleName(methodName);
             sb.append('E');
         }
 
@@ -490,11 +718,31 @@ class NativeImageBFDNameProvider implements UniqueShortNameProvider {
             if (encodeLoaderName) {
                 sb.append('N');
                 // only leading elements of namespace encoding may be recorded as substitutions
-                mangleRecordPrefix(loaderName);
-            }
-            manglePrefix(className);
-            if (encodeLoaderName) {
+                mangleWriteSubstitutablePrefixedName(loaderName, className);
                 sb.append('E');
+            } else {
+                mangleWriteSubstitutableNameRecord(className);
+            }
+        }
+
+        private void mangleClassPointer(String loaderName, String className) {
+            boolean encodeLoaderName = encodeLoaderName(loaderName);
+            LookupName classLookup = new SimpleLookupName(className);
+            LookupName lookup = classLookup;
+            if (encodeLoaderName) {
+                lookup = new NamespaceLookupName(loaderName, classLookup);
+            }
+            PointerLookupName pointerLookup = new PointerLookupName(lookup);
+            // see if we can use a short name for the pointer
+            if (!substituteName(pointerLookup)) {
+                // failed - so we need to mark this as a pointer,
+                // encode the class name and (only) then record a
+                // binding for the pointer, ensuring that bindings
+                // for the pointer type and its referent appear in
+                // the expected order
+                sb.append("P");
+                mangleClassName(loaderName, className);
+                recordName(pointerLookup);
             }
         }
 
@@ -543,23 +791,23 @@ class NativeImageBFDNameProvider implements UniqueShortNameProvider {
             if (type.isPrimitive()) {
                 manglePrimitiveType(type);
             } else if (type.isArray()) {
-                sb.append('P');
                 mangleArrayType(type);
             } else {
+                String loaderName = nameProvider.classLoaderNameAndId(type);
+                String className = type.toJavaName();
                 if (nameProvider.needsPointerPrefix(type)) {
-                    sb.append('P');
+                    mangleClassPointer(loaderName, className);
+                } else {
+                    mangleClassName(loaderName, className);
                 }
-                mangleClassName(nameProvider.classLoaderNameAndId(type), type.toJavaName());
             }
         }
 
         private void mangleType(UnresolvedJavaType type) {
             if (type.isArray()) {
-                sb.append('P');
                 mangleArrayType(type);
             } else {
-                sb.append('P');
-                mangleClassName("", type.toJavaName());
+                mangleClassPointer("", type.toJavaName());
             }
         }
 
@@ -567,11 +815,9 @@ class NativeImageBFDNameProvider implements UniqueShortNameProvider {
             if (type.isPrimitive()) {
                 manglePrimitiveType(type);
             } else if (type.isArray()) {
-                sb.append('P');
                 mangleArrayType(type);
             } else {
-                sb.append('P');
-                mangleClassName(nameProvider.uniqueShortLoaderName(type.getClassLoader()), type.getName());
+                mangleClassPointer(nameProvider.uniqueShortLoaderName(type.getClassLoader()), type.getName());
             }
         }
 
@@ -589,7 +835,7 @@ class NativeImageBFDNameProvider implements UniqueShortNameProvider {
                 baseType = baseType.getComponentType();
             }
             String loaderName = nameProvider.classLoaderNameAndId(baseType);
-            mangleArrayName(loaderName, baseType.toJavaName(), count);
+            mangleArrayPointer(loaderName, baseType.toJavaName(), count);
         }
 
         private void mangleArrayType(UnresolvedJavaType arrayType) {
@@ -599,7 +845,7 @@ class NativeImageBFDNameProvider implements UniqueShortNameProvider {
                 count++;
                 baseType = baseType.getComponentType();
             }
-            mangleArrayName("", baseType.toJavaName(), count);
+            mangleArrayPointer("", baseType.toJavaName(), count);
         }
 
         private void mangleArrayType(Class<?> arrayType) {
@@ -610,30 +856,21 @@ class NativeImageBFDNameProvider implements UniqueShortNameProvider {
                 baseType = baseType.getComponentType();
             }
             String loaderName = nameProvider.uniqueShortLoaderName(baseType.getClassLoader());
-            mangleArrayName(loaderName, baseType.getName(), count);
+            mangleArrayPointer(loaderName, baseType.getName(), count);
         }
 
-        private void mangleArrayName(String loaderName, String baseName, int dims) {
-            /*
-             * This code mangles the array name as a symbol using the array base type and required
-             * number of '[]' pairs.
-             */
-            int len = baseName.length() + (dims * 2);
-            boolean encodeLoaderName = encodeLoaderName(loaderName);
+        private void mangleArrayPointer(String loaderName, String baseName, int dims) {
+            // an array is just a class with a name that includes trailing [] pairs
+            mangleClassPointer(loaderName, makeArrayName(baseName, dims));
+        }
 
-            if (encodeLoaderName) {
-                sb.append("N");
-                // only leading elements of namespace encoding may be recorded as substitutions
-                mangleRecordPrefix(loaderName);
-            }
-            sb.append(len);
-            sb.append(baseName);
+        private String makeArrayName(String baseName, int dims) {
+            StringBuilder sb1 = new StringBuilder();
+            sb1.append(baseName);
             for (int i = 0; i < dims; i++) {
-                sb.append("[]");
+                sb1.append("[]");
             }
-            if (encodeLoaderName) {
-                sb.append("E");
-            }
+            return sb1.toString();
         }
 
         private void manglePrimitiveType(ResolvedJavaType type) {
@@ -647,33 +884,35 @@ class NativeImageBFDNameProvider implements UniqueShortNameProvider {
         }
 
         private void mangleTypeChar(char c) {
+            // we can use single char encodings for most primitive types
+            // but we need to encode boolean, byte and char specially
             switch (c) {
                 case 'Z':
-                    sb.append('b');
+                    mangleWriteSubstitutableNameRecord("boolean");
                     return;
                 case 'B':
-                    sb.append('a');
+                    mangleWriteSubstitutableNameRecord("byte");
                     return;
                 case 'S':
-                    sb.append('s');
+                    sb.append("s");
                     return;
                 case 'C':
-                    sb.append('t');
+                    mangleWriteSubstitutableNameRecord("char");
                     return;
                 case 'I':
-                    sb.append('i');
+                    sb.append("i");
                     return;
                 case 'J':
-                    sb.append('l');
+                    sb.append("l");
                     return;
                 case 'F':
-                    sb.append('f');
+                    sb.append("f");
                     return;
                 case 'D':
-                    sb.append('d');
+                    sb.append("d");
                     return;
                 case 'V':
-                    sb.append('v');
+                    sb.append("v");
                     return;
                 default:
                     // should never reach here
@@ -681,7 +920,7 @@ class NativeImageBFDNameProvider implements UniqueShortNameProvider {
             }
         }
 
-        private void writePrefix(int i) {
+        private void writeSubstitution(int i) {
             sb.append('S');
             // i = 0 has no digits, i = 1 -> 0, ... i = 10 -> 9, i = 11 -> A, ... i = 36 -> Z, i =
             // 37 -> 10, ...
@@ -703,12 +942,8 @@ class NativeImageBFDNameProvider implements UniqueShortNameProvider {
             }
         }
 
-        private void recordPrefix(String prefix) {
-            prefixes.add(prefix);
-        }
-
-        private int prefixIdx(String prefix) {
-            return prefixes.indexOf(prefix);
+        private void recordName(LookupName name) {
+            bindings.add(name);
         }
     }
 

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/image/NativeImageBFDNameProvider.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/image/NativeImageBFDNameProvider.java
@@ -35,13 +35,13 @@ import jdk.vm.ci.meta.JavaType;
 import jdk.vm.ci.meta.ResolvedJavaType;
 import jdk.vm.ci.meta.Signature;
 import jdk.vm.ci.meta.UnresolvedJavaType;
+import org.graalvm.collections.EconomicMap;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Executable;
 import java.lang.reflect.Member;
 import java.lang.reflect.Method;
 import java.lang.reflect.Parameter;
-import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -470,7 +470,14 @@ class NativeImageBFDNameProvider implements UniqueShortNameProvider {
         // the list index can be used to identify the relevant short symbol. If it is not found
         // then inserting the name serves to allocate the short name associated with the inserted
         // element's result index.
-        List<LookupName> bindings;
+        /**
+         * A map relating lookup names to the index for the corresponding short name with which it
+         * can be substituted. A prospective name for an element that is about to be encoded can be
+         * looked up in this list. If a match is found the list index can be used to identify the
+         * relevant short symbol. If it is not found then it can be inserted to allocate the next
+         * short name, using the current size of the map to identify the next available index.
+         */
+        EconomicMap<LookupName, Integer> bindings;
 
         /**
          * A lookup name is used as a key to record and subsequently lookup a short symbol that can
@@ -488,10 +495,10 @@ class NativeImageBFDNameProvider implements UniqueShortNameProvider {
          * lookup name (if, say, we needed to encode type Foo**). In practice, that case should not
          * arise with Java method signatures.
          */
-        private interface LookupName {
+        private sealed interface LookupName permits SimpleLookupName, CompositeLookupName {
         }
 
-        private interface CompositeLookupName extends LookupName {
+        private sealed interface CompositeLookupName extends LookupName permits NamespaceLookupName, PointerLookupName {
         }
 
         private record SimpleLookupName(String value) implements LookupName {
@@ -518,7 +525,7 @@ class NativeImageBFDNameProvider implements UniqueShortNameProvider {
         BFDMangler(NativeImageBFDNameProvider provider) {
             nameProvider = provider;
             sb = new StringBuilder("_Z");
-            bindings = new ArrayList<>();
+            bindings = EconomicMap.create();
         }
 
         public String mangle(String loaderName, ResolvedJavaType declaringClass, String memberName, Signature methodSignature, boolean isConstructor) {
@@ -619,15 +626,15 @@ class NativeImageBFDNameProvider implements UniqueShortNameProvider {
             assert sb.charAt(sb.length() - 1) == 'N';
             // we can substitute the composed prefix followed by the name
             // or we can substitute all three individual symbols
-            LookupName lookup2 = new SimpleLookupName(prefix2);
-            LookupName lookup = new NamespaceLookupName(prefix1, lookup2);
+            LookupName simpleLookupName = new SimpleLookupName(prefix2);
+            LookupName namespaceLookupName = new NamespaceLookupName(prefix1, simpleLookupName);
             // try substituting the combined prefix
-            if (!substituteName(lookup)) {
+            if (!substituteName(namespaceLookupName)) {
                 // we may still be able to establish a binding for the first prefix
                 mangleWriteSubstitutableNameRecord(prefix1);
                 // we cannot establish a binding for the trailing prefix
                 mangleWriteSubstitutableNameNoRecord(prefix2);
-                recordName(lookup);
+                recordName(namespaceLookupName);
             }
             // see comment in previous method as to why we call mangleWriteSimpleName
             // instead of mangleWriteSubstitutableNameNoRecord(name)
@@ -635,9 +642,9 @@ class NativeImageBFDNameProvider implements UniqueShortNameProvider {
         }
 
         private boolean substituteName(LookupName name) {
-            int index = bindings.indexOf(name);
-            if (index >= 0) {
-                writeSubstitution(index);
+            Integer index = bindings.get(name);
+            if (index != null) {
+                writeSubstitution(index.intValue());
                 return true;
             }
             return false;
@@ -887,7 +894,7 @@ class NativeImageBFDNameProvider implements UniqueShortNameProvider {
         }
 
         private void recordName(LookupName name) {
-            bindings.add(name);
+            bindings.put(name, bindings.size());
         }
     }
 

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/image/NativeImageBFDNameProvider.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/image/NativeImageBFDNameProvider.java
@@ -279,7 +279,7 @@ class NativeImageBFDNameProvider implements UniqueShortNameProvider {
          *
          * Primitive Parameter Types
          *
-         * Primitive parameter types (or return types) may be encoded using a single letter cases
+         * Primitive parameter types (or return types) may be encoded using a single letter
          * where the symbol encodes a C++ primitive type with the same name and bit layout and
          * interpretation as the Java type:
          *
@@ -507,8 +507,8 @@ class NativeImageBFDNameProvider implements UniqueShortNameProvider {
 
             @Override
             public boolean equals(Object other) {
-                if (other instanceof SimpleLookupName) {
-                    return this.value.equals(((SimpleLookupName) other).value);
+                if (other instanceof SimpleLookupName otherSimpleLookupName) {
+                    return this.value.equals(otherSimpleLookupName.value);
                 }
                 return false;
             }
@@ -534,8 +534,7 @@ class NativeImageBFDNameProvider implements UniqueShortNameProvider {
             }
 
             public boolean equals(Object other) {
-                if (other instanceof NamespaceLookupName) {
-                    CompositeLookupName otherCompositeLookupName = (CompositeLookupName) other;
+                if (other instanceof CompositeLookupName otherCompositeLookupName) {
                     assert tail != null && otherCompositeLookupName.tail != null;
                     return value.equals(otherCompositeLookupName.value) && tail.equals(otherCompositeLookupName.tail);
                 }

--- a/substratevm/src/com.oracle.svm.test/src/hello/Hello.java
+++ b/substratevm/src/com.oracle.svm.test/src/hello/Hello.java
@@ -158,12 +158,12 @@ public class Hello {
     }
 
     @NeverInline("For testing purposes")
-    private static void noInlineManyArgs(int i0, int i1, int i2, int i3, boolean b4, int i5, int i6, long l7, int i8, long l9,
+    private static void noInlineManyArgs(int i0, byte b1, short s2, char c3, boolean b4, int i5, int i6, long l7, int i8, long l9,
                     float f0, float f1, float f2, float f3, double d4, float f5, float f6, float f7, float f8, double d9, boolean b10, float f11) {
         System.out.println("i0 = " + i0);
-        System.out.println("i1 = " + i1);
-        System.out.println("i2 = " + i2);
-        System.out.println("i3 = " + i3);
+        System.out.println("b1 = " + b1);
+        System.out.println("s2 = " + s2);
+        System.out.println("c3 = " + c3);
         System.out.println("b4 = " + b4);
         System.out.println("i5 = " + i5);
         System.out.println("i6 = " + i6);
@@ -232,7 +232,7 @@ public class Hello {
         inlineCallChain();
         noInlineThis();
         inlineFrom();
-        noInlineManyArgs(0, 1, 2, 3, true, 5, 6, 7, 8, 9,
+        noInlineManyArgs(0, (byte) 1, (short) 2, '3', true, 5, 6, 7, 8, 9,
                         0.0F, 1.125F, 2.25F, 3.375F, 4.5F, 5.625F, 6.75F, 7.875F, 9.0F, 10.125D, false, 12.375F);
         noInlinePassConstants();
         System.out.println(lambda.get());


### PR DESCRIPTION
This PR fixes issue #7421 (q.v.)

The issue is susceptible to a simple fix and a more sophisticated fix as outlined below. The current patch implements the more sophisticated patch in order to minimize symbol footprint

## Basic fix

The simplest solution to the problem is to encode primitive type name using embedded symbol names. So, given the two examples cited in the issue

```
void java.util.Arrays::fill(byte[]*, int, int, byte)
java.lang.String[]* java.lang.String::split(java.lang.String*, int, boolean)
```

the encodings would be

```
_ZN16java.util.Arrays4fillEJvP6byte[]ii4byte
_ZN16java.lang.String5splitEJP18java.lang.String[]PS_i7boolean
```

which successfully decode as desired

```
$ c++filt _ZN16java.util.Arrays4fillEJvP6byte[]ii4byte
void java.util.Arrays::fill(byte[]*, int, int, byte)
$ c++filt _ZN16java.lang.String5splitEJP18java.lang.String[]PS_i7boolean
java.lang.String[]* java.lang.String::split(java.lang.String*, int, boolean)
```

Note that the names `4byte`, `7boolean` and `4char` refer to typedefs for primitive types defined in the debug info section so analysis tools which process these names will still be able to resolve them to appropriate machine layouts.

## Better fix

The problem with the basic fix is that it significantly enlarges symbol names when signatures include repeat occurrences of the same primitive type:

```
int jdk.internal.misc.Unsafe::makeInt(byte, byte, byte, byte)
  --> _ZN24jdk.internal.misc.Unsafe7makeIntEJi4byte4byte4byte4byte

$ c++filt _ZN24jdk.internal.misc.Unsafe7makeIntEJi4byte4byte4byte4byte
int jdk.internal.misc.Unsafe::makeInt(byte, byte, byte, byte)
````

A better solution profits from the use of short names to refer to elements that have already been encoded.

In the above case the encoding of the class name(space) as part of the method name introduces the short name `S_` for `jdk.internal.misc.Unsafe`. Likewise, encoding of the first parameter type introduces short name `S0_` for type name `byte`. The latter binding meant that repeated occurrences of `4byte` can be replaced with `S0_`.

```
int jdk.internal.misc.Unsafe::makeInt(byte, byte, byte, byte)
  --> _ZN24jdk.internal.misc.Unsafe7makeIntEJi4byteS0_S0_S0_

$ c++filt _ZN24jdk.internal.misc.Unsafe7makeIntEJi4byteS0_S0_S0_
int jdk.internal.misc.Unsafe::makeInt(byte, byte, byte, byte)
````

Implementing short name substitution only provides a small gain in footprint when encoding primitive symbol names (2 bytes per `char` or `byte` parameter, 5 per `boolean` parameter). However, it can shorten symbols much more significantly when object type names are repeated. For example without short name substitution the following encoding arises for method `Arrays::deepEquals`:

```
boolean java.util.Arrays::deepEquals(java.lang.Object[]*, java.lang.Object[]*)
  --> _ZN16java.util.Arrays10deepEqualsEJ7booleanP18java.lang.Object[]P18java.lang.Object[]

$ c++filt _ZN16java.util.Arrays10deepEqualsEJ7booleanP18java.lang.Object[]P18java.lang.Object[]
boolean java.util.Arrays::deepEquals(java.lang.Object[]*, java.lang.Object[]*)
```

The repeated `Object[]*` argument can be encoded using a short name as follows:

```
boolean java.util.Arrays::deepEquals(java.lang.Object[]*, java.lang.Object[]*)
  --> _ZN16java.util.Arrays10deepEqualsEJ7booleanP18java.lang.Object[]S2_

$ c++filt _ZN16java.util.Arrays10deepEqualsEJ7booleanP18java.lang.Object[]S2_
boolean java.util.Arrays::deepEquals(java.lang.Object[]*, java.lang.Object[]*)
```

providing a much greater saving in footprint (18 bytes).
