### PR TITLE
Break the initialization cycle in NIO/cgroups code

### DIFF
--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/heap/PhysicalMemory.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/heap/PhysicalMemory.java
@@ -107,7 +107,7 @@ public class PhysicalMemory {
                         if (expired) {
                             throw new InternalError("Expired latch!");
                         }
-                        VMError.guarantee(cachedSize != UNSET_SENTINEL, "Expected chached size to be set");
+                        VMError.guarantee(cachedSize != UNSET_SENTINEL, "Expected cached size to be set");
                         return cachedSize;
                     } catch (InterruptedException e) {
                         throw VMError.shouldNotReachHere("Interrupt on countdown latch!");

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/Target_jdk_internal_misc_VM.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/Target_jdk_internal_misc_VM.java
@@ -25,6 +25,7 @@
 package com.oracle.svm.core.jdk;
 
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import com.oracle.svm.core.NeverInline;
 import com.oracle.svm.core.SubstrateOptions;
@@ -35,7 +36,9 @@ import com.oracle.svm.core.annotate.RecomputeFieldValue;
 import com.oracle.svm.core.annotate.RecomputeFieldValue.Kind;
 import com.oracle.svm.core.annotate.Substitute;
 import com.oracle.svm.core.annotate.TargetClass;
+import com.oracle.svm.core.heap.PhysicalMemory;
 import com.oracle.svm.core.snippets.KnownIntrinsics;
+import com.oracle.svm.core.util.VMError;
 
 import jdk.internal.misc.Unsafe;
 
@@ -67,36 +70,44 @@ public final class Target_jdk_internal_misc_VM {
 
     @Alias @InjectAccessors(DirectMemoryAccessors.class) //
     private static long directMemory;
-    @Alias @InjectAccessors(DirectMemoryAccessors.class) //
+    @Alias @InjectAccessors(PageAlignDirectMemoryAccessors.class) //
     private static boolean pageAlignDirectMemory;
+
+    @Alias //
+    public static native void initLevel(int newVal);
+
+    @Alias //
+    public static native int initLevel();
 }
 
 final class DirectMemoryAccessors {
 
     /*
-     * Not volatile to avoid a memory barrier when reading the values. Instead, an explicit barrier
-     * is inserted when writing the values.
+     * Full initialization is two-staged. First, we init directMemory to a static value (25MB) so
+     * that initialization of PhysicalMemory has a chance to finish. At that point isInintialized
+     * will be false, since we need to (potentially) set the value to the actual configured heap
+     * size. That can only be done once PhysicalMemory init completed. We'd introduce a cycle
+     * otherwise.
      */
-    private static boolean initialized;
-
+    private static boolean isInitialized;
+    private static final AtomicInteger INIT_COUNT = new AtomicInteger();
+    private static final long STATIC_DIRECT_MEMORY_AMOUNT = 25 * 1024 * 1024;
     private static long directMemory;
-    private static boolean pageAlignDirectMemory;
 
     static long getDirectMemory() {
-        if (!initialized) {
+        if (!isInitialized) {
             initialize();
         }
         return directMemory;
     }
 
-    static boolean getPageAlignDirectMemory() {
-        if (!initialized) {
-            initialize();
-        }
-        return pageAlignDirectMemory;
-    }
-
     private static void initialize() {
+        if (INIT_COUNT.get() == 2) {
+            /*
+             * Shouldn't really happen, but safeguard for recursive init anyway
+             */
+            return;
+        }
         /*
          * The JDK method VM.saveAndRemoveProperties looks at the system property
          * "sun.nio.MaxDirectMemorySize". However, that property is always set by the Java HotSpot
@@ -107,17 +118,82 @@ final class DirectMemoryAccessors {
         if (newDirectMemory == 0) {
             /*
              * No value explicitly specified. The default in the JDK in this case is the maximum
-             * heap size.
+             * heap size. However, we cannot rely on Runtime.maxMemory() until PhysicalMemory has
+             * fully initialized. Runtime.maxMemory() has a dependency on PhysicalMemory.size()
+             * which in turn depends on container support which might use NIO. To avoid this cycle,
+             * we first initialize the 'directMemory' field to an arbitrary value (25MB), and only
+             * use the Runtime.maxMemory() API once PhysicalMemory has fully initialized.
              */
-            newDirectMemory = Runtime.getRuntime().maxMemory();
+            if (!PhysicalMemory.isInitialized()) {
+                /*
+                 * While initializing physical memory we might end up back here with an INIT_COUNT
+                 * of 1, since we read the directMemory field during container support code
+                 * execution which runs when PhysicalMemory is still initializing.
+                 */
+                VMError.guarantee(INIT_COUNT.get() <= 1, "Initial run needs to have init count 0 or 1");
+                newDirectMemory = STATIC_DIRECT_MEMORY_AMOUNT; // Static value during initialization
+                INIT_COUNT.incrementAndGet();
+            } else {
+                VMError.guarantee(INIT_COUNT.get() <= 1, "Runtime.maxMemory() invariant");
+                /*
+                 * Once we know PhysicalMemory has been properly initialized we can use
+                 * Runtime.maxMemory(). Note that we might end up in this branch for code explicitly
+                 * using the JDK cgroups code. At that point PhysicalMemory has likely been
+                 * initialized.
+                 */
+                INIT_COUNT.incrementAndGet();
+                newDirectMemory = Runtime.getRuntime().maxMemory();
+            }
+        } else {
+            /*
+             * For explicitly set direct memory we are done
+             */
+            Unsafe.getUnsafe().storeFence();
+            directMemory = newDirectMemory;
+            isInitialized = true;
+            if (Target_jdk_internal_misc_VM.initLevel() < 1) {
+                // only the first accessor needs to set this
+                Target_jdk_internal_misc_VM.initLevel(1);
+            }
+            return;
         }
+        VMError.guarantee(newDirectMemory > 0, "New direct memory should be initialized");
 
-        /*
-         * The initialization is not synchronized, so multiple threads can race. Usually this will
-         * lead to the same value, unless the runtime options are modified concurrently - which is
-         * possible but not a case we care about.
-         */
+        Unsafe.getUnsafe().storeFence();
         directMemory = newDirectMemory;
+        if (PhysicalMemory.isInitialized()) {
+            /*
+             * Complete initialization hand-shake once PhysicalMemory is properly initialized. Also
+             * set the VM init level to 1 so as to provoke the NIO code to re-set the internal
+             * MAX_MEMORY field.
+             */
+            isInitialized = true;
+            if (Target_jdk_internal_misc_VM.initLevel() < 1) {
+                // only the first accessor needs to set this
+                Target_jdk_internal_misc_VM.initLevel(1);
+            }
+        }
+    }
+}
+
+final class PageAlignDirectMemoryAccessors {
+
+    /*
+     * Not volatile to avoid a memory barrier when reading the values. Instead, an explicit barrier
+     * is inserted when writing the values.
+     */
+    private static boolean initialized;
+
+    private static boolean pageAlignDirectMemory;
+
+    static boolean getPageAlignDirectMemory() {
+        if (!initialized) {
+            initialize();
+        }
+        return pageAlignDirectMemory;
+    }
+
+    private static void initialize() {
         pageAlignDirectMemory = Boolean.getBoolean("sun.nio.PageAlignDirectMemory");
 
         /* Ensure values are published to other threads before marking fields as initialized. */


### PR DESCRIPTION
When building with an unpatched JDK 21, there is an initialization cycle in the native image code. The details are explained in this issue:
https://github.com/graalvm/mandrel/issues/556

This isn't easily reproducible with a LabsJDK 21 based build. However, I think it would be good to not be dependent on the patch in the base JDK. We have been using this patch in Mandrel as we are using unpatched OpenJDK 21 as a base.

**Details of the patch:**

First, we use a separate accessor for page-alignedness as it doesn't need the more sophisticated initialization of the directMemory field.

Next, ensure PhysicalMemory initialization is serialized and when it is, set directMemory to a static value so that the container code can finish initialization without introducing a cyle. The final directMemory value based on the heap size is then published to JDK code by setting the VM init level to 1. Therefore, application code would use the non-static value as the upper bound.

Closes: https://github.com/graalvm/mandrel/issues/556