### PR TITLE
Omit internal jdk.JavaMonitorWait JFR events

### DIFF
--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/Target_jdk_jfr_internal_JVM_ChunkRotationMonitor.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/Target_jdk_jfr_internal_JVM_ChunkRotationMonitor.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2023, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2023, Red Hat Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package com.oracle.svm.core.jfr;
+
+import com.oracle.svm.core.annotate.TargetClass;
+
+@TargetClass(className = "jdk.jfr.internal.JVM$ChunkRotationMonitor", onlyWith = HasJfrSupport.class)
+public final class Target_jdk_jfr_internal_JVM_ChunkRotationMonitor {
+}

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/events/JavaMonitorWaitEvent.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/events/JavaMonitorWaitEvent.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2022, 2022, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2022, 2022, Red Hat Inc. All rights reserved.
+ * Copyright (c) 2022, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2023, Red Hat Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,10 +36,11 @@ import com.oracle.svm.core.jfr.JfrNativeEventWriterData;
 import com.oracle.svm.core.jfr.JfrNativeEventWriterDataAccess;
 import com.oracle.svm.core.jfr.JfrTicks;
 import com.oracle.svm.core.jfr.SubstrateJVM;
+import com.oracle.svm.core.jfr.Target_jdk_jfr_internal_JVM_ChunkRotationMonitor;
 
 public class JavaMonitorWaitEvent {
     public static void emit(long startTicks, Object obj, long notifier, long timeout, boolean timedOut) {
-        if (HasJfrSupport.get() && !"jdk.jfr.internal.JVM$ChunkRotationMonitor".equals(obj.getClass().getName())) {
+        if (HasJfrSupport.get() && obj != null && !Target_jdk_jfr_internal_JVM_ChunkRotationMonitor.class.equals(obj.getClass())) {
             emit0(startTicks, obj, notifier, timeout, timedOut);
         }
     }

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/events/JavaMonitorWaitEvent.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/events/JavaMonitorWaitEvent.java
@@ -39,7 +39,7 @@ import com.oracle.svm.core.jfr.SubstrateJVM;
 
 public class JavaMonitorWaitEvent {
     public static void emit(long startTicks, Object obj, long notifier, long timeout, boolean timedOut) {
-        if (HasJfrSupport.get() && !obj.getClass().getName().equals("jdk.jfr.internal.JVM$ChunkRotationMonitor")) {
+        if (HasJfrSupport.get() && !"jdk.jfr.internal.JVM$ChunkRotationMonitor".equals(obj.getClass().getName())) {
             emit0(startTicks, obj, notifier, timeout, timedOut);
         }
     }

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/events/JavaMonitorWaitEvent.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/events/JavaMonitorWaitEvent.java
@@ -39,7 +39,7 @@ import com.oracle.svm.core.jfr.SubstrateJVM;
 
 public class JavaMonitorWaitEvent {
     public static void emit(long startTicks, Object obj, long notifier, long timeout, boolean timedOut) {
-        if (HasJfrSupport.get()) {
+        if (HasJfrSupport.get() && !obj.getClass().getName().equals("jdk.jfr.internal.JVM$ChunkRotationMonitor")) {
             emit0(startTicks, obj, notifier, timeout, timedOut);
         }
     }


### PR DESCRIPTION
### Summary
This is a very minor change to replicate the behavior in OpenJDK by omitting internal `jdk.JavaMonitorWait` events emitted by the JFR periodic task.  This basically just reduces some noise, especially when the application is idle.

Bugzilla: https://bugs.openjdk.org/browse/JDK-8286707?jql=text%20~%20%22jfr%22
OpenJDK PR: https://github.com/openjdk/jdk/pull/8883

See before (sorted by thread name):
![image](https://github.com/oracle/graal/assets/35396843/9029ada6-2a3e-4806-bce9-4d20410d0529)

And after:
![image](https://github.com/oracle/graal/assets/35396843/59fbdf02-237a-4955-8f4c-a2dc7b5d4f62)

