### PR TITLE
Fix NPE at shutdown when accessing current thread

### DIFF
--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/thread/Target_java_lang_Thread.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/thread/Target_java_lang_Thread.java
@@ -220,6 +220,9 @@ public final class Target_java_lang_Thread {
     @TargetElement(name = "currentThread", onlyWith = ContinuationsSupported.class)
     static Thread currentVThread() {
         Thread thread = PlatformThreads.currentThread.get();
+        if (thread == null) {
+            return null;
+        }
         Target_java_lang_Thread tjlt = SubstrateUtil.cast(thread, Target_java_lang_Thread.class);
         return (tjlt.vthread != null) ? tjlt.vthread : thread;
     }


### PR DESCRIPTION
### Summary
This fixes an NPE at VM shutdown when Thread.currentThread() may attempt to be used, but current thread is not yet assigned. 

This bug is very similar to : https://github.com/oracle/graal/pull/6559 

See the this example GDB backtrace:
```
(gdb) bt
#0  java.lang.Thread::currentThread() () at com/oracle/svm/core/thread/Target_java_lang_Thread.java:222
#1  0x000000000049486d in com.oracle.svm.core.jfr.JfrEvent::shouldEmit() (this=0x7ffff6eb1288) at com/oracle/svm/core/jfr/JfrEvent.java:98
#2  0x00000000004adf35 in com.oracle.svm.core.jfr.events.ObjectAllocationInNewTLABEvent::emit0(long, java.lang.Class*, org.graalvm.word.UnsignedWord, org.graalvm.word.UnsignedWord) (startTicks=12379031078, hub=0x7ffff6aad760, allocationSize=0xc8, tlabSize=0x80000) at com/oracle/svm/core/jfr/events/ObjectAllocationInNewTLABEvent.java:50
#3  0x00000000004626d5 in com.oracle.svm.core.jfr.events.ObjectAllocationInNewTLABEvent::emit(long, java.lang.Class*, org.graalvm.word.UnsignedWord, org.graalvm.word.UnsignedWord) (startTicks=12379031078, hub=0x7ffff6aad760, allocationSize=0xc8, tlabSize=0x80000) at com/oracle/svm/core/jfr/events/ObjectAllocationInNewTLABEvent.java:44
#4  com.oracle.svm.core.genscavenge.ThreadLocalAllocation::slowPathNewInstanceWithoutAllocating(java.lang.Class*) (hub=0x7ffff6aad760) at com/oracle/svm/core/genscavenge/ThreadLocalAllocation.java:241
#5  0x0000000000462569 in com.oracle.svm.core.genscavenge.ThreadLocalAllocation::slowPathNewInstance(org.graalvm.compiler.word.Word) (objectHeader=0x4ad760 <com.oracle.svm.core.jfr.events.JVMInformation::getJvmName()+16>) at com/oracle/svm/core/genscavenge/ThreadLocalAllocation.java:221
#6  0x00000000005259f6 in com.oracle.svm.core.thread.PlatformThreads::ensureCurrentAssigned(java.lang.String*, java.lang.ThreadGroup*, bool) (name=0x7ffff6911c70, group=0x7ffff6600000, asDaemon=false) at com/oracle/svm/core/thread/PlatformThreads.java:445
#7  0x0000000000416a7b in com.oracle.svm.core.JavaMainWrapper::runShutdown0() () at com/oracle/svm/core/JavaMainWrapper.java:254
#8  0x0000000000416831 in com.oracle.svm.core.JavaMainWrapper::runShutdown() () at com/oracle/svm/core/JavaMainWrapper.java:250
#9  com.oracle.svm.core.JavaMainWrapper::doRun(int, org.graalvm.nativeimage.c.type.CCharPointerPointer) (argc=2, argv=0x7fffffffe448) at com/oracle/svm/core/JavaMainWrapper.java:294
#10 0x000000000044548e in com.oracle.svm.core.JavaMainWrapper::run(int, org.graalvm.nativeimage.c.type.CCharPointerPointer) (argc=2, argv=0x7fffffffe448) at com/oracle/svm/core/JavaMainWrapper.java:275
#11 com.oracle.svm.core.code.IsolateEnterStub::JavaMainWrapper_run_5087f5482cc9a6abc971913ece43acb471d2631b(int, org.graalvm.nativeimage.c.type.CCharPointerPointer) (::(void)=<optimized out>, __1=<optimized out>) at com/oracle/svm/core/code/IsolateEnterStub.java:1
```