### PR TITLE
[GR-51629] Add support for JFR -XX:FlightRecorderOptions

### DIFF
--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/SubstrateOptions.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/SubstrateOptions.java
@@ -918,6 +918,9 @@ public class SubstrateOptions {
     @Option(help = "file:doc-files/FlightRecorderLoggingHelp.txt")//
     public static final RuntimeOptionKey<String> FlightRecorderLogging = new RuntimeOptionKey<>("all=warning", Immutable);
 
+    @Option(help = "Use additional flight recorder options.")//
+    public static final RuntimeOptionKey<String> FlightRecorderOptions = new RuntimeOptionKey<>("", Immutable);
+
     public static String reportsPath() {
         Path reportsPath = ImageSingletons.lookup(ReportingSupport.class).reportsPath;
         if (reportsPath.isAbsolute()) {

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/SubstrateOptions.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/SubstrateOptions.java
@@ -918,7 +918,7 @@ public class SubstrateOptions {
     @Option(help = "file:doc-files/FlightRecorderLoggingHelp.txt")//
     public static final RuntimeOptionKey<String> FlightRecorderLogging = new RuntimeOptionKey<>("all=warning", Immutable);
 
-    @Option(help = "Use additional flight recorder options.")//
+    @Option(help = "file:doc-files/FlightRecorderOptionsHelp.txt")//
     public static final RuntimeOptionKey<String> FlightRecorderOptions = new RuntimeOptionKey<>("", Immutable);
 
     public static String reportsPath() {

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/doc-files/FlightRecorderOptionsHelp.txt
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/doc-files/FlightRecorderOptionsHelp.txt
@@ -4,7 +4,7 @@ This option expects a comma separated list of key-value pairs. None of the optio
 
 globalbuffercount   (Optional) Number of global buffers. This option is a legacy
                     option: change the memorysize parameter to alter the number of
-                    global buffers. This value cannot be changed once JFR has been"
+                    global buffers. This value cannot be changed once JFR has been
                     initialized. (LONG, default determined by the value for
                     memorysize)
 

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/doc-files/FlightRecorderOptionsHelp.txt
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/doc-files/FlightRecorderOptionsHelp.txt
@@ -1,0 +1,46 @@
+Usage: -XX:FlightRecorderOptions=[option[=value][,...]]
+
+This option expects a comma separated list of key-value pairs. None of the options are mandatory. Possible option keys are as follows:
+
+globalbuffercount   (Optional) Number of global buffers. This option is a legacy
+                    option: change the memorysize parameter to alter the number of
+                    global buffers. This value cannot be changed once JFR has been"
+                    initialized. (LONG, default determined by the value for
+                    memorysize)
+
+globalbuffersize    (Optional) Size of the global buffers, in bytes. This option is a
+                    legacy option: change the memorysize parameter to alter the size
+                    of the global buffers. This value cannot be changed once JFR has
+                    been initialized. (STRING, default determined by the value for
+                    memorysize)
+
+maxchunksize        (Optional) Maximum size of an individual data chunk in bytes if
+                    one of the following suffixes is not used: 'm' or 'M' for
+                    megabytes OR 'g' or 'G' for gigabytes. This value cannot be
+                    changed once JFR has been initialized. (STRING, 12M)
+
+memorysize          (Optional) Overall memory size, in bytes if one of the following
+                    suffixes is not used: 'm' or 'M' for megabytes OR 'g' or 'G' for
+                    gigabytes. This value cannot be changed once JFR has been
+                    initialized. (STRING, 10M)
+
+repositorypath      (Optional) Path to the location where recordings are stored until
+                    they are written to a permanent file. (STRING, The default
+                    location is the temporary directory for the operating system. On
+                    Linux operating systems, the temporary directory is /tmp. On
+                    Windows, the temporary directory is specified by the TMP
+                    environment variable)
+
+stackdepth          (Optional) Stack depth for stack traces. Setting this value
+                    greater than the default of 64 may cause a performance
+                    degradation. This value cannot be changed once JFR has been
+                    initialized. (LONG, 64)
+
+thread_buffer_size  (Optional) Local buffer size for each thread in bytes if one of
+                    the following suffixes is not used: 'k' or 'K' for kilobytes or
+                    'm' or 'M' for megabytes. Overriding this parameter could reduce
+                    performance and is not recommended. This value cannot be changed
+                    once JFR has been initialized. (STRING, 8k)
+
+preserve-repository (Optional) Preserve files stored in the disk repository after the
+                    Java Virtual Machine has exited. (BOOLEAN, false)

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/JfrManager.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/JfrManager.java
@@ -55,9 +55,11 @@ import jdk.jfr.internal.LogLevel;
 import jdk.jfr.internal.LogTag;
 import jdk.jfr.internal.Logger;
 import jdk.jfr.internal.OldObjectSample;
+import jdk.jfr.internal.Options;
 import jdk.jfr.internal.PrivateAccess;
 import jdk.jfr.internal.SecuritySupport;
 import jdk.jfr.internal.jfc.JFC;
+import jdk.jfr.internal.Repository;
 
 /**
  * Called during VM startup and teardown. Also triggers the JFR argument parsing.
@@ -73,7 +75,7 @@ public class JfrManager {
         this.hostedEnabled = hostedEnabled;
     }
 
-    public static boolean isJFREnabled() {
+    public static boolean shouldBeginRecordingAtLaunch() {
         return SubstrateOptions.FlightRecorder.getValue() || !SubstrateOptions.StartFlightRecording.getValue().isEmpty();
     }
 
@@ -86,7 +88,7 @@ public class JfrManager {
         return isFirstIsolate -> {
             parseFlightRecorderLogging(SubstrateOptions.FlightRecorderLogging.getValue());
             periodicEventSetup();
-            if (isJFREnabled()) {
+            if (shouldBeginRecordingAtLaunch()) {
                 initRecording();
             }
         };
@@ -115,17 +117,27 @@ public class JfrManager {
     }
 
     private static void initRecording() {
-        Map<JfrStartArgument, String> args = parseStartFlightRecording();
-        String name = args.get(JfrStartArgument.Name);
-        String[] settings = parseSettings(args);
-        Long delay = parseDuration(args, JfrStartArgument.Delay);
-        Long duration = parseDuration(args, JfrStartArgument.Duration);
-        Boolean disk = parseBoolean(args, JfrStartArgument.Disk);
-        String path = args.get(JfrStartArgument.Filename);
-        Long maxAge = parseDuration(args, JfrStartArgument.MaxAge);
-        Long maxSize = parseMaxSize(args, JfrStartArgument.MaxSize);
-        Boolean dumpOnExit = parseBoolean(args, JfrStartArgument.DumpOnExit);
-        Boolean pathToGcRoots = parseBoolean(args, JfrStartArgument.PathToGCRoots);
+        Map<JfrArgument, String> startArgs = parseJfrOptions(SubstrateOptions.StartFlightRecording.getValue(), JfrStartArgument.values());
+        Map<JfrArgument, String> optionsArgs = parseJfrOptions(SubstrateOptions.FlightRecorderOptions.getValue(), FlightRecorderOptionsArgument.values());
+
+        String name = startArgs.get(JfrStartArgument.Name);
+        String[] settings = parseSettings(startArgs);
+        Long delay = parseDuration(startArgs, JfrStartArgument.Delay);
+        Long duration = parseDuration(startArgs, JfrStartArgument.Duration);
+        Boolean disk = parseBoolean(startArgs, JfrStartArgument.Disk);
+        String path = startArgs.get(JfrStartArgument.Filename);
+        Long maxAge = parseDuration(startArgs, JfrStartArgument.MaxAge);
+        Long maxSize = parseMaxSize(startArgs, JfrStartArgument.MaxSize);
+        Boolean dumpOnExit = parseBoolean(startArgs, JfrStartArgument.DumpOnExit);
+        Boolean pathToGcRoots = parseBoolean(startArgs, JfrStartArgument.PathToGCRoots);
+        String stackDepth = optionsArgs.get(FlightRecorderOptionsArgument.StackDepth);
+        Long maxChunkSize = parseMaxSize(optionsArgs, FlightRecorderOptionsArgument.MaxChunkSize);
+        Long memorySize = parseMaxSize(optionsArgs, FlightRecorderOptionsArgument.MemorySize);
+        Long globalBufferSize = parseMaxSize(optionsArgs, FlightRecorderOptionsArgument.GlobalBufferSize);
+        Long globalBufferCount = parseMaxSize(optionsArgs, FlightRecorderOptionsArgument.GlobalBufferCount);
+        Long threadBufferSize = parseMaxSize(optionsArgs, FlightRecorderOptionsArgument.ThreadBufferSize);
+        Boolean preserveRepo = parseBoolean(optionsArgs, FlightRecorderOptionsArgument.PreserveRepository);
+        String repositoryPath = optionsArgs.get(FlightRecorderOptionsArgument.RepositoryPath);
 
         try {
             if (Logger.shouldLog(LogTag.JFR_DCMD, LogLevel.DEBUG)) {
@@ -180,6 +192,47 @@ public class JfrManager {
                     // to avoid typo, delay shorter than 1s makes no sense.
                     throw new Exception("Could not start recording, delay must be at least 1 second.");
                 }
+            }
+
+            if (stackDepth != null) {
+                try {
+                    Options.setStackDepth(Integer.valueOf(stackDepth));
+                } catch (Throwable e) {
+                    throw new Exception("Could not start recording, stack depth is not an integer.", e);
+                }
+            }
+
+            if (repositoryPath != null) {
+                try {
+                    SecuritySupport.SafePath repositorySafePath = new SecuritySupport.SafePath(repositoryPath);
+                    Repository.getRepository().setBasePath(repositorySafePath);
+                } catch (Throwable e) {
+                    throw new Exception("Could not start recording, repository path is invalid.", e);
+                }
+            }
+
+            if (maxChunkSize != null) {
+                Options.setMaxChunkSize(maxChunkSize);
+            }
+
+            if (preserveRepo != null) {
+                Options.setPreserveRepository(preserveRepo);
+            }
+
+            if (threadBufferSize != null) {
+                Options.setThreadBufferSize(threadBufferSize);
+            }
+
+            if (globalBufferCount != null) {
+                Options.setGlobalBufferCount(globalBufferCount);
+            }
+
+            if (globalBufferSize != null) {
+                Options.setGlobalBufferSize(globalBufferSize);
+            }
+
+            if (memorySize != null) {
+                Options.setMemorySize(memorySize);
             }
 
             Recording recording = new Recording();
@@ -297,15 +350,13 @@ public class JfrManager {
         }
     }
 
-    private static Map<JfrStartArgument, String> parseStartFlightRecording() {
-        Map<JfrStartArgument, String> optionsMap = new HashMap<>();
-        String text = SubstrateOptions.StartFlightRecording.getValue();
-        if (!text.isEmpty()) {
-            JfrStartArgument[] possibleArguments = JfrStartArgument.values();
-            String[] options = text.split(",");
+    private static Map<JfrArgument, String> parseJfrOptions(String userInput, JfrArgument[] possibleArguments) {
+        Map<JfrArgument, String> optionsMap = new HashMap<>();
+        if (!userInput.isEmpty()) {
+            String[] options = userInput.split(",");
             for (String option : options) {
                 String[] keyVal = option.split("=");
-                JfrStartArgument arg = findArgument(possibleArguments, keyVal[0]);
+                JfrArgument arg = findArgument(possibleArguments, keyVal[0]);
                 if (arg == null) {
                     throw VMError.shouldNotReachHere("Unknown argument '" + keyVal[0] + "' in " + SubstrateOptions.StartFlightRecording.getName());
                 }
@@ -315,7 +366,7 @@ public class JfrManager {
         return optionsMap;
     }
 
-    private static String[] parseSettings(Map<JfrStartArgument, String> args) throws UserException {
+    private static String[] parseSettings(Map<JfrArgument, String> args) throws UserException {
         String settings = args.get(JfrStartArgument.Settings);
         if (settings == null) {
             return new String[]{DEFAULT_JFC_NAME};
@@ -327,7 +378,7 @@ public class JfrManager {
     }
 
     @SuppressFBWarnings(value = "NP_BOOLEAN_RETURN_NULL", justification = "null allowed as return value")
-    private static Boolean parseBoolean(Map<JfrStartArgument, String> args, JfrStartArgument key) throws IllegalArgumentException {
+    private static Boolean parseBoolean(Map<JfrArgument, String> args, JfrArgument key) throws IllegalArgumentException {
         String value = args.get(key);
         if (value == null) {
             return null;
@@ -336,11 +387,11 @@ public class JfrManager {
         } else if ("false".equalsIgnoreCase(value)) {
             return false;
         } else {
-            throw VMError.shouldNotReachHere("Could not parse JFR argument '" + key.cmdLineKey + "=" + value + "'. Expected a boolean value.");
+            throw VMError.shouldNotReachHere("Could not parse JFR argument '" + key.getCmdLineKey() + "=" + value + "'. Expected a boolean value.");
         }
     }
 
-    private static Long parseDuration(Map<JfrStartArgument, String> args, JfrStartArgument key) {
+    private static Long parseDuration(Map<JfrArgument, String> args, JfrStartArgument key) {
         String value = args.get(key);
         if (value != null) {
             try {
@@ -384,7 +435,7 @@ public class JfrManager {
         return null;
     }
 
-    private static Long parseMaxSize(Map<JfrStartArgument, String> args, JfrStartArgument key) {
+    private static Long parseMaxSize(Map<JfrArgument, String> args, JfrArgument key) {
         final String value = args.get(key);
         if (value != null) {
             try {
@@ -417,7 +468,7 @@ public class JfrManager {
                         return number;
                 }
             } catch (IllegalArgumentException e) {
-                throw VMError.shouldNotReachHere("Could not parse JFR argument '" + key.cmdLineKey + "=" + value + "'. " + e.getMessage());
+                throw VMError.shouldNotReachHere("Could not parse JFR argument '" + key.getCmdLineKey() + "=" + value + "'. " + e.getMessage());
             }
         }
         return null;
@@ -431,16 +482,20 @@ public class JfrManager {
         return idx;
     }
 
-    private static JfrStartArgument findArgument(JfrStartArgument[] possibleArguments, String value) {
-        for (JfrStartArgument arg : possibleArguments) {
-            if (arg.cmdLineKey.equals(value)) {
+    private static JfrArgument findArgument(JfrArgument[] possibleArguments, String value) {
+        for (JfrArgument arg : possibleArguments) {
+            if (arg.getCmdLineKey().equals(value)) {
                 return arg;
             }
         }
         return null;
     }
 
-    private enum JfrStartArgument {
+    private interface JfrArgument {
+        String getCmdLineKey();
+    }
+
+    private enum JfrStartArgument implements JfrArgument {
         Name("name"),
         Settings("settings"),
         Delay("delay"),
@@ -456,6 +511,33 @@ public class JfrManager {
 
         JfrStartArgument(String key) {
             this.cmdLineKey = key;
+        }
+
+        @Override
+        public String getCmdLineKey() {
+            return cmdLineKey;
+        }
+    }
+
+    private enum FlightRecorderOptionsArgument implements JfrArgument {
+        GlobalBufferCount("globalbuffercount"),
+        GlobalBufferSize("globalbuffersize"),
+        MaxChunkSize("maxchunksize"),
+        MemorySize("memorysize"),
+        RepositoryPath("repositorypath"),
+        StackDepth("stackdepth"),
+        ThreadBufferSize("thread_buffer_size"),
+        PreserveRepository("preserveRepository");
+
+        private final String cmdLineKey;
+
+        FlightRecorderOptionsArgument(String key) {
+            this.cmdLineKey = key;
+        }
+
+        @Override
+        public String getCmdLineKey() {
+            return cmdLineKey;
         }
     }
 }

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/JfrManager.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/JfrManager.java
@@ -527,7 +527,7 @@ public class JfrManager {
         RepositoryPath("repositorypath"),
         StackDepth("stackdepth"),
         ThreadBufferSize("thread_buffer_size"),
-        PreserveRepository("preserveRepository");
+        PreserveRepository("preserve-repository");
 
         private final String cmdLineKey;
 

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/JfrOptionSet.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/JfrOptionSet.java
@@ -35,6 +35,14 @@ import jdk.jfr.internal.Options;
 /**
  * Holds all JFR-related options that can be set by the user. It is also used to validate and adjust
  * the option values as needed.
+ *
+ * Similar to OpenJDK, the options available by -XX:FlightRecorderOptions cannot be set after JFR is
+ * initialized. This means this that after {@link SubstrateJVM#createJFR(boolean)} is called, this
+ * class is no longer needed.
+ *
+ * This class is used to store options set at the OpenJDK Java-level which propagate down to the VM
+ * level via {@link jdk.jfr.internal.JVM}. The option values are stored here until they are
+ * eventually used when first recording is created and JFR is initialized.
  */
 public class JfrOptionSet {
     private static final int MEMORY_SIZE = 1;
@@ -54,6 +62,7 @@ public class JfrOptionSet {
     public final JfrOptionLong globalBufferCount;
     public final JfrOptionLong memorySize;
     public final JfrOptionLong maxChunkSize;
+    public final JfrOptionLong stackDepth;
 
     @Platforms(Platform.HOSTED_ONLY.class)
     public JfrOptionSet() {
@@ -62,6 +71,7 @@ public class JfrOptionSet {
         globalBufferCount = new JfrOptionLong(Options.getGlobalBufferCount());
         memorySize = new JfrOptionLong(Options.getMemorySize());
         maxChunkSize = new JfrOptionLong(Options.getMaxChunkSize());
+        stackDepth = new JfrOptionLong(Options.getStackDepth());
     }
 
     public void validateAndAdjustMemoryOptions() {

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/SubstrateJVM.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/SubstrateJVM.java
@@ -209,6 +209,7 @@ public class SubstrateJVM {
         threadLocal.initialize(options.threadBufferSize.getValue());
         globalMemory.initialize(options.globalBufferSize.getValue(), options.globalBufferCount.getValue());
         unlockedChunkWriter.initialize(options.maxChunkSize.getValue());
+        stackTraceRepo.setStackTraceDepth((int) options.stackDepth.getValue());
 
         recorderThread.start();
 
@@ -444,7 +445,7 @@ public class SubstrateJVM {
      * See {@link JVM#setStackDepth}.
      */
     public void setStackDepth(int depth) {
-        stackTraceRepo.setStackTraceDepth(depth);
+        options.stackDepth.setUserValue(depth);
     }
 
     /**


### PR DESCRIPTION
### Summary
`-XX:FlightRecorderOptions` can be passed on the command line when launching your app. This PR adds support for the following JFR options in native image: 

- `globalbuffercount`
-  `globalbuffersize`
- `maxchunksize`
- `memorysize`
- `repositorypath`
- `stackdepth`
- `thread_buffer_size`
- `preserveRepository`. 

A few of these options are legacy options are are not very important (although the current OpenJDK still supports them). `maxchunksize`, `repositorypath`,  and`stackdepth` are probably the most useful options and advanced JFR users may find them important.  `preserveRepository` is a new option added to JDK22 via https://github.com/openjdk/jdk/pull/13111. 

See issue: https://github.com/oracle/graal/issues/7546 

### Details
In HotSpot, the VM-level JFR options may not be changed after JFR is initialized. This means we expect that `com.oracle.svm.core.jfr.JfrOptionSet` will not be needed after JFR is initialized. Thus the data flow should look something like the diagram below:
**HotSpot:**
<img src=https://github.com/oracle/graal/assets/35396843/521dde86-e778-4cf1-a91c-f10cb47f4974 width="600"/>
**SubstrateVM:**
<img src=https://github.com/oracle/graal/assets/35396843/1dcd30ab-55ac-4dab-b876-2ff8e4b8126e width="600"/>
