### PR TITLE
[GR-51626] Update main CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,4 +3,5 @@ platform. There have been significant contributions from both industry
 and academia so far and we thank you for considering to contribute your changes!
 
 - Learn [how to become a GraalVM contributor](https://www.graalvm.org/community/contributors/).
+  - Check individual README.md and CONTRIBUTING.md files in the subprojects to learn how to build and import them into your IDE (for example, [the compiler README.md](compiler/README.md))
 - Subscribe and post to [graalvm-dev@oss.oracle.com](https://oss.oracle.com/mailman/listinfo/graalvm-dev) for questions related to working with the sources or extending the GraalVM ecosystem by creating new languages, tools, or embeddings.


### PR DESCRIPTION
When trying to find the info about how-to contribute the first time, it is a long way from CONTRIBUTING.md to graalvm website then to the youtube video, which will lead you to the compiler/README.md. I think with this change the way to your first contribution becomes much straighter and shorter