### PR TITLE
Add a `Pause` prefix to the serial GC log entries

### DIFF
--- a/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/GCImpl.java
+++ b/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/GCImpl.java
@@ -412,7 +412,7 @@ public final class GCImpl implements GC {
 
         if (SubstrateGCOptions.PrintGC.getValue() || SubstrateGCOptions.VerboseGC.getValue()) {
             String collectionType = completeCollection ? "Full GC" : "Incremental GC";
-            printGCPrefixAndTime().string(collectionType).string(" (").string(cause.getName()).string(") ")
+            printGCPrefixAndTime().string("Pause ").string(collectionType).string(" (").string(cause.getName()).string(") ")
                             .rational(beforeGc.totalUsed(), M, 2).string("M->").rational(heapAccounting.getUsedBytes(), M, 2).string("M ")
                             .rational(timers.collection.getMeasuredNanos(), TimeUtils.nanosPerMilli, 3).string("ms").newline();
         }


### PR DESCRIPTION
Brings the formatting of GC logs more in line with the implementations in HotSpot. Implementations in HotSpot differentiate between log messsages that provide details about pauses versus log messages that are auxiliary. This change will make it easier to integrate with existing tools that already parse HotSpot GC logs.

Before this change, the output would look like this:
```
[658.653s] GC(11) Incremental GC (Collect on allocation) 54.50M->9.50M 3.346ms
[658.793s] GC(12) Full GC (Collect on allocation) 53.50M->9.00M 23.244ms
```

After this change, it looks like:
```
[94.035s] GC(2257) Pause Incremental GC (Collect on allocation) 8.00M->4.00M 0.301ms
[94.046s] GC(2258) Pause Full GC (Collect on allocation) 8.00M->4.00M 1.863ms
```

And here's a HotSpot G1 log message for comparison:
```
[51.336s][info][gc          ] GC(18) Pause Young (Normal) (G1 Evacuation Pause) 5115M->275M(8192M) 9.727ms
```