### PR TITLE
Clean up off-heap memory usages

### DIFF
--- a/sdk/src/org.graalvm.nativeimage/src/org/graalvm/nativeimage/UnmanagedMemory.java
+++ b/sdk/src/org.graalvm.nativeimage/src/org/graalvm/nativeimage/UnmanagedMemory.java
@@ -146,4 +146,14 @@ public final class UnmanagedMemory {
     public static void free(PointerBase ptr) {
         ImageSingletons.lookup(UnmanagedMemorySupport.class).free(ptr);
     }
+
+    /**
+     * Temporarily the same as {@link UnmanagedMemory#free(PointerBase)}. Will later be different
+     * because it will not attempt to perform any NMT operations. This is crucial for releasing
+     * memory allocated by C libraries which will not have NMT "malloc headers". If
+     * {@link UnmanagedMemory#free(PointerBase)} is used instead, a segfault will occur.
+     */
+    public static void untrackedFree(PointerBase ptr) {
+        ImageSingletons.lookup(UnmanagedMemorySupport.class).free(ptr);
+    }
 }

--- a/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/PosixProcessPropertiesSupport.java
+++ b/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/PosixProcessPropertiesSupport.java
@@ -36,12 +36,12 @@ import java.util.stream.Collectors;
 import org.graalvm.nativeimage.c.type.CCharPointer;
 import org.graalvm.nativeimage.c.type.CTypeConversion;
 import org.graalvm.nativeimage.c.type.CTypeConversion.CCharPointerHolder;
+import org.graalvm.nativeimage.UnmanagedMemory;
 import org.graalvm.word.PointerBase;
 import org.graalvm.word.WordFactory;
 
 import com.oracle.svm.core.BaseProcessPropertiesSupport;
 import com.oracle.svm.core.graal.stackvalue.UnsafeStackValue;
-import com.oracle.svm.core.headers.LibC;
 import com.oracle.svm.core.posix.headers.Dlfcn;
 import com.oracle.svm.core.posix.headers.Signal;
 import com.oracle.svm.core.posix.headers.Stdlib;
@@ -103,7 +103,7 @@ public abstract class PosixProcessPropertiesSupport extends BaseProcessPropertie
         try {
             return CTypeConversion.toJavaString(realpath);
         } finally {
-            LibC.free(realpath);
+            UnmanagedMemory.untrackedFree(realpath);
         }
     }
 
@@ -164,7 +164,7 @@ public abstract class PosixProcessPropertiesSupport extends BaseProcessPropertie
             } else {
                 /* Success */
                 final String result = CTypeConversion.toJavaString(realpathPointer);
-                LibC.free(realpathPointer);
+                UnmanagedMemory.untrackedFree(realpathPointer);
                 return result;
             }
         }

--- a/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/UnmanagedMemorySupportImpl.java
+++ b/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/UnmanagedMemorySupportImpl.java
@@ -24,6 +24,9 @@
  */
 package com.oracle.svm.core.posix;
 
+import jdk.graal.compiler.api.replacements.Fold;
+
+import org.graalvm.nativeimage.ImageSingletons;
 import org.graalvm.nativeimage.impl.UnmanagedMemorySupport;
 import org.graalvm.word.PointerBase;
 import org.graalvm.word.UnsignedWord;
@@ -31,31 +34,36 @@ import org.graalvm.word.WordFactory;
 
 import com.oracle.svm.core.Uninterruptible;
 import com.oracle.svm.core.feature.AutomaticallyRegisteredImageSingleton;
-import com.oracle.svm.core.headers.LibC;
+import com.oracle.svm.core.headers.LibCSupport;
 
 @AutomaticallyRegisteredImageSingleton(UnmanagedMemorySupport.class)
 class UnmanagedMemorySupportImpl implements UnmanagedMemorySupport {
     @Override
     @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
     public <T extends PointerBase> T malloc(UnsignedWord size) {
-        return LibC.malloc(size);
+        return libc().malloc(size);
     }
 
     @Override
     @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
     public <T extends PointerBase> T calloc(UnsignedWord size) {
-        return LibC.calloc(WordFactory.unsigned(1), size);
+        return libc().calloc(WordFactory.unsigned(1), size);
     }
 
     @Override
     @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
     public <T extends PointerBase> T realloc(T ptr, UnsignedWord size) {
-        return LibC.realloc(ptr, size);
+        return libc().realloc(ptr, size);
     }
 
     @Override
     @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
     public void free(PointerBase ptr) {
-        LibC.free(ptr);
+        libc().free(ptr);
+    }
+
+    @Fold
+    static LibCSupport libc() {
+        return ImageSingletons.lookup(LibCSupport.class);
     }
 }

--- a/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/darwin/DarwinSystemPropertiesSupport.java
+++ b/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/darwin/DarwinSystemPropertiesSupport.java
@@ -31,13 +31,13 @@ import org.graalvm.nativeimage.c.type.CCharPointer;
 import org.graalvm.nativeimage.c.type.CTypeConversion;
 import org.graalvm.nativeimage.c.type.CTypeConversion.CCharPointerHolder;
 import org.graalvm.nativeimage.impl.RuntimeSystemPropertiesSupport;
+import org.graalvm.nativeimage.UnmanagedMemory;
 import org.graalvm.word.UnsignedWord;
 import org.graalvm.word.WordFactory;
 
 import com.oracle.svm.core.feature.AutomaticallyRegisteredFeature;
 import com.oracle.svm.core.feature.InternalFeature;
 import com.oracle.svm.core.graal.stackvalue.UnsafeStackValue;
-import com.oracle.svm.core.headers.LibC;
 import com.oracle.svm.core.jdk.SystemPropertiesSupport;
 import com.oracle.svm.core.posix.PosixSystemPropertiesSupport;
 import com.oracle.svm.core.posix.headers.Limits;
@@ -105,7 +105,7 @@ public class DarwinSystemPropertiesSupport extends PosixSystemPropertiesSupport 
                 CCharPointer osVersionStr = Foundation.systemVersionPlatform();
                 if (osVersionStr.isNonNull()) {
                     osVersionValue = CTypeConversion.toJavaString(osVersionStr);
-                    LibC.free(osVersionStr);
+                    UnmanagedMemory.untrackedFree(osVersionStr);
                     return osVersionValue;
                 }
             } else {
@@ -120,7 +120,7 @@ public class DarwinSystemPropertiesSupport extends PosixSystemPropertiesSupport 
         CCharPointer osVersionStr = Foundation.systemVersionPlatformFallback();
         if (osVersionStr.isNonNull()) {
             osVersionValue = CTypeConversion.toJavaString(osVersionStr);
-            LibC.free(osVersionStr);
+            UnmanagedMemory.untrackedFree(osVersionStr);
             return osVersionValue;
         }
         return osVersionValue = "Unknown";

--- a/substratevm/src/com.oracle.svm.core.windows/src/com/oracle/svm/core/windows/WindowsUnmanagedMemorySupportImpl.java
+++ b/substratevm/src/com.oracle.svm.core.windows/src/com/oracle/svm/core/windows/WindowsUnmanagedMemorySupportImpl.java
@@ -24,6 +24,9 @@
  */
 package com.oracle.svm.core.windows;
 
+import jdk.graal.compiler.api.replacements.Fold;
+
+import org.graalvm.nativeimage.ImageSingletons;
 import org.graalvm.nativeimage.impl.UnmanagedMemorySupport;
 import org.graalvm.word.PointerBase;
 import org.graalvm.word.UnsignedWord;
@@ -31,31 +34,36 @@ import org.graalvm.word.WordFactory;
 
 import com.oracle.svm.core.Uninterruptible;
 import com.oracle.svm.core.feature.AutomaticallyRegisteredImageSingleton;
-import com.oracle.svm.core.headers.LibC;
+import com.oracle.svm.core.headers.LibCSupport;
 
 @AutomaticallyRegisteredImageSingleton(UnmanagedMemorySupport.class)
 class WindowsUnmanagedMemorySupportImpl implements UnmanagedMemorySupport {
     @Override
     @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
     public <T extends PointerBase> T malloc(UnsignedWord size) {
-        return LibC.malloc(size);
+        return libc().malloc(size);
     }
 
     @Override
     @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
     public <T extends PointerBase> T calloc(UnsignedWord size) {
-        return LibC.calloc(WordFactory.unsigned(1), size);
+        return libc().calloc(WordFactory.unsigned(1), size);
     }
 
     @Override
     @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
     public <T extends PointerBase> T realloc(T ptr, UnsignedWord size) {
-        return LibC.realloc(ptr, size);
+        return libc().realloc(ptr, size);
     }
 
     @Override
     @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
     public void free(PointerBase ptr) {
-        LibC.free(ptr);
+        libc().free(ptr);
+    }
+
+    @Fold
+    static LibCSupport libc() {
+        return ImageSingletons.lookup(LibCSupport.class);
     }
 }

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/headers/LibC.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/headers/LibC.java
@@ -68,26 +68,6 @@ public class LibC {
     }
 
     @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
-    public static <T extends PointerBase> T malloc(UnsignedWord size) {
-        return libc().malloc(size);
-    }
-
-    @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
-    public static <T extends PointerBase> T calloc(UnsignedWord nmemb, UnsignedWord size) {
-        return libc().calloc(nmemb, size);
-    }
-
-    @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
-    public static <T extends PointerBase> T realloc(PointerBase ptr, UnsignedWord size) {
-        return libc().realloc(ptr, size);
-    }
-
-    @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
-    public static void free(PointerBase ptr) {
-        libc().free(ptr);
-    }
-
-    @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
     public static void exit(int status) {
         libc().exit(status);
     }

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/TimeZoneSubstitutions.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/TimeZoneSubstitutions.java
@@ -100,7 +100,7 @@ final class Target_java_util_TimeZone {
             CCharPointer tzId = LibCHelper.SVM_FindJavaTZmd(tzMappingsPtr, contentLen);
             String result = CTypeConversion.toJavaString(tzId);
             // SVM_FindJavaTZmd returns a newly allocated string
-            UnmanagedMemory.free(tzId);
+            UnmanagedMemory.untrackedFree(tzId);
             return result;
         } finally {
             if (refContent != null) {


### PR DESCRIPTION
### Summary
This PR does a bit of clean up to set the stage for further work on native memory tracking (see issue: https://github.com/oracle/graal/issues/7631).  Specifically, it replaces usages of `LibC` malloc/calloc/realloc/free with calls to`UnmanagedMemory`.  From now on, I suggest that `LibC` not be used directly to manage memory.  This will allow for NMT code to be added to `UnmanagedMemorySupport` implementations. Additionally, this PR specifically marks locations where memory allocated outside Java code must be freed (`UnmanagedMemory#untrackedFree`). 

This refactoring serves a second important purpose. It helps mitigate the following pitfalls associated with "malloc headers" needed for NMT. [In hotspot](https://github.com/openjdk/jdk/blob/master/src/hotspot/share/services/mallocHeader.hpp#L37-L88), the "malloc header" is an extra bit of memory allocated contiguously with the main memory payload. It contains metadata such as size and type used for NMT.  I think a similar approach can be used in SubstrateVM using `@RawStructures` (similar to how the JFR buffers have a header and payload). A pointer to the data payload is returned from malloc and the header is transparent to the caller.  Here are the pitfalls I can see:

1. If `LibC#malloc()` is used to allocate memory instead of `UnmanagedMemorySupport`, we'll miss some data that should be tracked. 
2. If `LibC#free()` is used to free tracked memory, we'll be in trouble because only `UnmanagedMemorySupport` is aware of the extra header data.
3. If `UnmanagedMemory#free()` is called on untracked memory (off-heap memory allocated outside of Java), then we'll segfault when trying to access a header that doesn't exist. 

The clean up in this PR mitigates these pitfalls, but doesn't eliminate them. If the user is determined, they can use `ImageSingletons.lookup(LibCSupport.class)` to use LibC directly, and they can choose to use `UnmanagedMemory#free()` instead of `UnmanagedMemory#untrackedFree()` if they ignore the Javadoc.

