### PR TITLE
Fixes issue-7652 for epsilon gc [23.1]

### DIFF
--- a/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/HeapImpl.java
+++ b/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/HeapImpl.java
@@ -683,7 +683,7 @@ public final class HeapImpl extends Heap {
     @Override
     @Uninterruptible(reason = "Ensure that no GC can occur between modification of the object and this call.", callerMustBe = true)
     public void dirtyAllReferencesOf(Object obj) {
-        if (obj != null) {
+        if (SubstrateOptions.useRememberedSet() && obj != null) {
             ForcedSerialPostWriteBarrier.force(OffsetAddressNode.address(obj, 0), false);
         }
     }


### PR DESCRIPTION
This is a clean backport of https://github.com/oracle/graal/pull/7671

As per @peter-hofer 's [suggestion](https://github.com/oracle/graal/issues/7652#issuecomment-1777610982), this patch fixes #7652 

I can confirm it works on the platforms available to me:

* Linux aarch64 ✔️
* Linux amd64 ✔️
* Windows amd64 ✔️

