### PR TITLE
[GR-50675] Fix class-path order when Manifests include "Class-Path" attributes

### DIFF
--- a/substratevm/src/com.oracle.svm.driver/src/com/oracle/svm/driver/NativeImage.java
+++ b/substratevm/src/com.oracle.svm.driver/src/com/oracle/svm/driver/NativeImage.java
@@ -2110,12 +2110,13 @@ public class NativeImage {
 
         Path classpathEntryFinal = useBundle() ? bundleSupport.substituteClassPath(classpathEntry) : classpathEntry;
         if (!imageClasspath.contains(classpathEntryFinal) && !customImageClasspath.contains(classpathEntryFinal)) {
+            boolean added = destination.add(classpathEntryFinal);
             if (ClasspathUtils.isJar(classpathEntryFinal)) {
                 processJarManifestMainAttributes(classpathEntryFinal, (jarFilePath, attributes) -> handleClassPathAttribute(destination, jarFilePath, attributes));
             }
             boolean ignore = processClasspathNativeImageMetaInf(classpathEntryFinal);
-            if (!ignore) {
-                destination.add(classpathEntryFinal);
+            if (added && ignore) {
+                destination.remove(classpathEntryFinal);
             }
         }
     }


### PR DESCRIPTION
`destination` is the classpath GraalVM creates from parsing the jar files passed to it. The ordering of the entries in the classpath is important. Jar files themselves should be added before the entries of their corresponding "Class-Path" attributes.

At the same time we want to process the contents of `META-INF/native-image` of the entries in the "Class-Path" before processing the contents of `META-INF/native-image` of the jar itself. This is required to ensure that the jar `META-INF/native-image` contents can override those of the entries in its "Class-Path".

As a result I chose to optimistically add the path to the classpath (aka `destination`) and remove it afterwards if deemed necessary.

Fixes https://github.com/oracle/graal/issues/7677

The fix should be backported to 23.1 as well