### PR TITLE
Remove legacy truffle bits for the non-jlink case

### DIFF
--- a/substratevm/src/com.oracle.svm.driver/src/com/oracle/svm/driver/NativeImage.java
+++ b/substratevm/src/com.oracle.svm.driver/src/com/oracle/svm/driver/NativeImage.java
@@ -573,39 +573,16 @@ public class NativeImage {
         }
 
         private List<Path> createTruffleBuilderModulePath() {
-            Path libTruffleDir = rootDir.resolve(Paths.get("lib", "truffle"));
-            List<Path> jars = getJars(libTruffleDir, "truffle-api", "truffle-runtime", "truffle-enterprise");
-            if (!jars.isEmpty()) {
-                /*
-                 * If Truffle is installed as part of the JDK we always add the builder modules of
-                 * Truffle to the builder module path. This is legacy support and should in the
-                 * future no longer be needed.
-                 */
-                jars.addAll(getJars(libTruffleDir, "truffle-compiler"));
-                Path builderPath = rootDir.resolve(Paths.get("lib", "truffle", "builder"));
-                if (Files.exists(builderPath)) {
-                    List<Path> truffleRuntimeSVMJars = getJars(builderPath, "truffle-runtime-svm", "truffle-enterprise-svm");
-                    jars.addAll(truffleRuntimeSVMJars);
-                    if (libJvmciDir != null && !truffleRuntimeSVMJars.isEmpty()) {
-                        // truffle-runtime-svm depends on polyglot, which is not part of non-jlinked
-                        // JDKs
-                        jars.addAll(getJars(libJvmciDir, "polyglot"));
-                    }
-                }
-                if (libJvmciDir != null) {
-                    // truffle-runtime depends on polyglot, which is not part of non-jlinked JDKs
-                    jars.addAll(getJars(libTruffleDir, "jniutils"));
-                }
-            }
             /*
              * Non-Jlinked JDKs don't have truffle-compiler as part of the JDK, however the native
              * image builder still needs it
              */
             if (libJvmciDir != null) {
-                jars.addAll(getJars(libTruffleDir, "truffle-compiler"));
+                Path libTruffleDir = rootDir.resolve(Paths.get("lib", "truffle"));
+                return getJars(libTruffleDir, "truffle-compiler");
+            } else {
+                return Collections.emptyList();
             }
-
-            return jars;
         }
 
         /**


### PR DESCRIPTION
This is a clean-up patch as discussed in #7205. There should be no need to manually add `truffle-runtime-svm` to the module path on GraalVM >= 23.1.