### PR TITLE
Minor JFR update and cleanups

### DIFF
--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/SubstrateJVM.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/SubstrateJVM.java
@@ -186,16 +186,6 @@ public class SubstrateJVM {
         return get().jfrLogging;
     }
 
-    public static Object getHandler(Class<? extends jdk.internal.event.Event> eventClass) {
-        try {
-            Field f = eventClass.getDeclaredField("eventHandler");
-            f.setAccessible(true);
-            return f.get(null);
-        } catch (NoSuchFieldException | IllegalArgumentException | IllegalAccessException e) {
-            throw new InternalError("Could not access event handler");
-        }
-    }
-
     @Uninterruptible(reason = "Prevent races with VM operations that start/stop recording.", callerMustBe = true)
     protected boolean isRecording() {
         return recording;

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/sampler/SamplerSampleWriter.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/sampler/SamplerSampleWriter.java
@@ -189,7 +189,6 @@ public final class SamplerSampleWriter {
         /* Put in the stack with other unprocessed buffers and send a signal to the JFR recorder. */
         SamplerBuffer oldBuffer = data.getSamplerBuffer();
         SubstrateJVM.getSamplerBufferPool().pushFullBuffer(oldBuffer);
-        SubstrateJVM.getRecorderThread().signal();
 
         /* Reinitialize data structure. */
         data.setSamplerBuffer(newBuffer);


### PR DESCRIPTION
### Summary

1. Remove `SubstrateJVM#getHandler` because it is never called. 
2. Remove superfluous double signalling of RecorderThread (it's already signaled in `pushFullBuffer`)