### PR TITLE
Respect --link-at-build-time in OptionClassFilter for class/package

### DIFF
--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/option/OptionClassFilter.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/option/OptionClassFilter.java
@@ -65,6 +65,10 @@ public class OptionClassFilter {
     }
 
     public Set<OptionOrigin> isPackageOrClassIncluded(String packageName) {
+        if (requireCompleteAll) {
+            return reasonCommandLine;
+        }
+
         return requireCompletePackageOrClass.get(packageName);
     }
 


### PR DESCRIPTION
GraalVM fails to report issues related to missing classes or packages at
link time when checking with
`com.oracle.svm.hosted.LinkAtBuildTimeSupport#packageOrClassAtBuildTime`
despite `--link-at-build-time` being set.
