### PR TITLE
[GR-50220] Allow resources inclusion from jar files in paths containing spaces

### DIFF
--- a/substratevm/mx.substratevm/suite.py
+++ b/substratevm/mx.substratevm/suite.py
@@ -946,6 +946,24 @@ suite = {
             "jacoco" : "exclude",
         },
 
+        "com.oracle.svm.with.space.test": {
+            "subDir": "src",
+            "sourceDirs": ["src"],
+            "dependencies": [
+                "mx:JUNIT_TOOL",
+                "sdk:NATIVEIMAGE",
+            ],
+            "checkstyle": "com.oracle.svm.test",
+            "workingSets": "SVM",
+            "annotationProcessors": [
+                "compiler:GRAAL_PROCESSOR",
+                "SVM_PROCESSOR",
+            ],
+            "javaCompliance" : "21+",
+            "spotbugs": "false",
+            "jacoco" : "exclude",
+        },
+
         "com.oracle.svm.configure.test": {
             "subDir": "src",
             "sourceDirs": ["src"],
@@ -1990,6 +2008,21 @@ suite = {
             "SVM_CONFIGURE",
           ],
           "testDistribution" : True,
+        },
+
+        # Special test distribution used for testing inclusion of resources from jar files with a space in their name.
+        # The space in the distribution name is intentional.
+        "SVM_TESTS WITH SPACE" : {
+            "subDir": "src",
+            "relpath" : True,
+            "dependencies" : [
+                "com.oracle.svm.with.space.test",
+            ],
+            "distDependencies": [
+                "sdk:NATIVEIMAGE",
+                "mx:JUNIT_TOOL",
+            ],
+            "testDistribution" : True,
         },
 
         "POLYGLOT_NATIVE_API" : {

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/ResourcesFeature.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/ResourcesFeature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -281,12 +281,12 @@ public final class ResourcesFeature implements InternalFeature {
                     }
                 }
 
-                InputStream is = module.getResourceAsStream(resourcePath);
                 boolean isDirectory = Files.isDirectory(Path.of(resourcePath));
                 if (isDirectory) {
                     String content = getDirectoryContent(resourcePath, false);
                     Resources.singleton().registerDirectoryResource(module, resourcePath, content, false);
                 } else {
+                    InputStream is = module.getResourceAsStream(resourcePath);
                     registerResource(module, resourcePath, false, is);
                 }
             } catch (IOException e) {
@@ -310,13 +310,13 @@ public final class ResourcesFeature implements InternalFeature {
             while (urls.hasMoreElements()) {
                 URL url = urls.nextElement();
                 try {
-                    InputStream is = url.openStream();
                     boolean fromJar = url.getProtocol().equalsIgnoreCase("jar");
                     boolean isDirectory = resourceIsDirectory(url, fromJar, resourcePath);
                     if (isDirectory) {
                         String content = getDirectoryContent(fromJar ? url.toString() : Paths.get(url.toURI()).toString(), fromJar);
                         Resources.singleton().registerDirectoryResource(null, resourcePath, content, fromJar);
                     } else {
+                        InputStream is = url.openStream();
                         registerResource(null, resourcePath, fromJar, is);
                     }
                 } catch (IOException e) {
@@ -345,8 +345,8 @@ public final class ResourcesFeature implements InternalFeature {
         /* Util functions for resource attributes calculations */
         private String urlToJarPath(URL url) {
             try {
-                return ((JarURLConnection) url.openConnection()).getJarFileURL().getFile();
-            } catch (IOException e) {
+                return ((JarURLConnection) url.openConnection()).getJarFileURL().toURI().getPath();
+            } catch (IOException | URISyntaxException e) {
                 throw new RuntimeException(e);
             }
         }

--- a/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/NativeImageResourceFileSystemProviderTest.java
+++ b/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/NativeImageResourceFileSystemProviderTest.java
@@ -26,6 +26,7 @@
 package com.oracle.svm.test;
 
 import static com.oracle.svm.test.NativeImageResourceUtils.RESOURCE_DIR;
+import static com.oracle.svm.test.NativeImageResourceUtils.RESOURCE_DIR_WITH_SPACE;
 import static com.oracle.svm.test.NativeImageResourceUtils.RESOURCE_EMPTY_DIR;
 import static com.oracle.svm.test.NativeImageResourceUtils.RESOURCE_FILE_1;
 import static com.oracle.svm.test.NativeImageResourceUtils.RESOURCE_FILE_2;
@@ -227,6 +228,20 @@ public class NativeImageResourceFileSystemProviderTest {
         try (Stream<Path> stream = Files.walk(emptyDirPath)) {
             Assert.assertEquals(1, stream.count());
         } catch (IOException e) {
+            Assert.fail("IOException occurred during file system walk, starting from the root.");
+        }
+    }
+
+    /**
+     * Query a directory with spaces in its name.
+     */
+    @Test
+    public void queryDirWithSpaces() {
+        Path dirWithSpaces = fileSystem.getPath(RESOURCE_DIR_WITH_SPACE);
+        try (Stream<Path> stream = Files.walk(dirWithSpaces)) {
+            Assert.assertEquals(1, stream.count());
+        } catch (IOException e) {
+            e.printStackTrace();
             Assert.fail("IOException occurred during file system walk, starting from the root.");
         }
     }

--- a/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/NativeImageResourceTest.java
+++ b/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/NativeImageResourceTest.java
@@ -26,6 +26,7 @@
 package com.oracle.svm.test;
 
 import static com.oracle.svm.test.NativeImageResourceUtils.RESOURCE_DIR;
+import static com.oracle.svm.test.NativeImageResourceUtils.RESOURCE_DIR_WITH_SPACE;
 import static com.oracle.svm.test.NativeImageResourceUtils.RESOURCE_FILE_1;
 import static com.oracle.svm.test.NativeImageResourceUtils.RESOURCE_FILE_2;
 import static com.oracle.svm.test.NativeImageResourceUtils.RESOURCE_FILE_3;
@@ -128,6 +129,19 @@ public class NativeImageResourceTest {
         Assert.assertTrue("Two URLs must be the same!", compareTwoURLs(url1, url2));
 
         String nonCanonicalResourceDirectoryName = RESOURCE_DIR + "/./";
+        resourceNameToURL(nonCanonicalResourceDirectoryName, false);
+    }
+
+    @Test
+    public void classGetDirectoryWithSpaceResource() {
+        URL url1 = resourceNameToURL(RESOURCE_DIR_WITH_SPACE + "/", true);
+        Assert.assertTrue("The URL should end with slash!", url1.toString().endsWith("/"));
+
+        URL url2 = resourceNameToURL(RESOURCE_DIR_WITH_SPACE, true);
+        Assert.assertFalse("The URL should not end with slash!", url2.toString().endsWith("/"));
+        Assert.assertTrue("Two URLs must be the same!", compareTwoURLs(url1, url2));
+
+        String nonCanonicalResourceDirectoryName = RESOURCE_DIR_WITH_SPACE + "/./";
         resourceNameToURL(nonCanonicalResourceDirectoryName, false);
     }
 

--- a/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/NativeImageResourceUtils.java
+++ b/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/NativeImageResourceUtils.java
@@ -44,6 +44,7 @@ public class NativeImageResourceUtils {
     public static final String RESOURCE_DIR = "/resources";
     public static final String SIMPLE_RESOURCE_DIR = "/simpleDir";
     public static final String RESOURCE_EMPTY_DIR = RESOURCE_DIR + "/empty";
+    public static final String RESOURCE_DIR_WITH_SPACE = RESOURCE_DIR + "/dir with space";
     public static final String RESOURCE_FILE_1 = RESOURCE_DIR + "/resource-test1.txt";
     public static final String RESOURCE_FILE_2 = RESOURCE_DIR + "/resource-test2.txt";
     public static final String RESOURCE_FILE_3 = RESOURCE_DIR + "/resource-test3.html";
@@ -58,6 +59,7 @@ public class NativeImageResourceUtils {
             RuntimeResourceAccess.addResource(resourceModule, RESOURCE_DIR.substring(1));
             RuntimeResourceAccess.addResource(resourceModule, SIMPLE_RESOURCE_DIR.substring(1));
             RuntimeResourceAccess.addResource(resourceModule, RESOURCE_EMPTY_DIR.substring(1));
+            RuntimeResourceAccess.addResource(resourceModule, RESOURCE_DIR_WITH_SPACE.substring(1));
             RuntimeResourceAccess.addResource(resourceModule, RESOURCE_FILE_1.substring(1));
             RuntimeResourceAccess.addResource(resourceModule, RESOURCE_FILE_2.substring(1));
             RuntimeResourceAccess.addResource(resourceModule, RESOURCE_FILE_3.substring(1));

--- a/substratevm/src/com.oracle.svm.test/src/resources/dir with space/.mxkeep
+++ b/substratevm/src/com.oracle.svm.test/src/resources/dir with space/.mxkeep
@@ -1,0 +1,1 @@
+This file instructs mx to create a jar entry for the parent directory

--- a/substratevm/src/com.oracle.svm.with.space.test/src/META-INF/native-image/com.oracle.svm.with.space.test/native-image.properties
+++ b/substratevm/src/com.oracle.svm.with.space.test/src/META-INF/native-image/com.oracle.svm.with.space.test/native-image.properties
@@ -1,0 +1,3 @@
+Args= \
+  --initialize-at-run-time=com.oracle.svm.with.space.test \
+  --features=com.oracle.svm.with.space.test.NativeImageResourceUtils$TestFeature

--- a/substratevm/src/com.oracle.svm.with.space.test/src/com/oracle/svm/with/space/test/NativeImageResourceTest.java
+++ b/substratevm/src/com.oracle.svm.with.space.test/src/com/oracle/svm/with/space/test/NativeImageResourceTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2022, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package com.oracle.svm.with.space.test;
+
+import java.net.URL;
+import java.nio.file.Path;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class NativeImageResourceTest {
+
+    @Test
+    @SuppressWarnings("deprecation")
+    public void accessFileFromJarWithSpaceInName() {
+        URL url = NativeImageResourceUtils.resourceNameToURL(NativeImageResourceUtils.RESOURCE_FILE_IN_JAR_WITH_SPACE, true);
+        Assert.assertNotNull("URL is null!", url);
+        Path path = NativeImageResourceUtils.resourceNameToPath(NativeImageResourceUtils.RESOURCE_FILE_IN_JAR_WITH_SPACE, true);
+        Assert.assertNotNull("Path is null!", path);
+    }
+}

--- a/substratevm/src/com.oracle.svm.with.space.test/src/com/oracle/svm/with/space/test/NativeImageResourceUtils.java
+++ b/substratevm/src/com.oracle.svm.with.space.test/src/com/oracle/svm/with/space/test/NativeImageResourceUtils.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2022, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package com.oracle.svm.with.space.test;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import org.graalvm.nativeimage.hosted.Feature;
+import org.graalvm.nativeimage.hosted.RuntimeResourceAccess;
+import org.junit.Assert;
+
+public class NativeImageResourceUtils {
+
+    public static final String ROOT_DIRECTORY = "/";
+    public static final String RESOURCE_DIR = "/resources";
+    public static final String RESOURCE_FILE_IN_JAR_WITH_SPACE = RESOURCE_DIR + "/resource-in-jar-with-space.txt";
+
+    // Register resources.
+    public static final class TestFeature implements Feature {
+        @Override
+        public void beforeAnalysis(BeforeAnalysisAccess access) {
+            // Remove leading / for the resource patterns
+            Module resourceModule = TestFeature.class.getModule();
+            RuntimeResourceAccess.addResource(resourceModule, RESOURCE_DIR.substring(1));
+            RuntimeResourceAccess.addResource(resourceModule, RESOURCE_FILE_IN_JAR_WITH_SPACE.substring(1));
+        }
+    }
+
+    public static URL resourceNameToURL(String resourceName, boolean failIfNotExists) {
+        URL resource = NativeImageResourceUtils.class.getResource(resourceName);
+        Assert.assertFalse("Resource " + resourceName + " is not found!", resource == null && failIfNotExists);
+        return resource;
+    }
+
+    public static URI resourceNameToURI(String resourceName, boolean failIfNotExists) {
+        try {
+            URL url = resourceNameToURL(resourceName, failIfNotExists);
+            return url != null ? url.toURI() : null;
+        } catch (URISyntaxException e) {
+            Assert.fail("Bad URI syntax!");
+        }
+        return null;
+    }
+
+    public static Path resourceNameToPath(String resourceName, boolean failIfNotExists) {
+        URI uri = resourceNameToURI(resourceName, failIfNotExists);
+        return uri != null ? Paths.get(uri) : null;
+    }
+}

--- a/substratevm/src/com.oracle.svm.with.space.test/src/resources/resource-in-jar-with-space.txt
+++ b/substratevm/src/com.oracle.svm.with.space.test/src/resources/resource-in-jar-with-space.txt
@@ -1,0 +1,1 @@
+I am in a jar with spaces in its name!


### PR DESCRIPTION
Since https://github.com/oracle/graal/pull/7670 it is no longer possible to build projects that include resources from paths with spaces.

How to reproduce:

1. Build graal `master` from source
2. `export GRAALVM_HOME=/path/to/graal/master/build`
3. `git clone https://github.com/quarkusio/quarkus`
4. `cd quarkus`
5. `./mvnw -Dquickly`
6. `./mvnw -Dnative -pl integration-tests/simple\ with\ space -Dnative.surefire.skip -Dformat.skip -Dno-descriptor-tests clean verify -Dquarkus.native.container-build=false`

This PR resolves this issue and adds a set of tests for resource names with spaces (which don't catch the issue at hand, but are still good to test against).

Closes https://github.com/quarkusio/quarkus/issues/36998