### PR TITLE
Handle unspecified module name in nameToResourceInputStream

### DIFF
--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/ResourcesHelper.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/ResourcesHelper.java
@@ -109,7 +109,7 @@ public class ResourcesHelper {
 
     public static InputStream nameToResourceInputStream(String mn, String resourceName) throws IOException {
         VMError.guarantee(ImageInfo.inImageRuntimeCode(), "ResourcesHelper code should only be used at runtime");
-        Module module = ModuleLayer.boot().findModule(mn).orElse(null);
+        Module module = mn == null ? null : ModuleLayer.boot().findModule(mn).orElse(null);
         URL url = nameToResourceURL(module, resourceName);
         return url != null ? url.openStream() : null;
     }


### PR DESCRIPTION
Resolves `NullPointerException` introduced with https://github.com/oracle/graal/commit/5103185f98ab0b96295814f95df0ff6d83e979f2 (https://github.com/oracle/graal/pull/7827) as reported in https://github.com/quarkusio/quarkus/issues/37212

Closes https://github.com/quarkusio/quarkus/issues/37212 