### PR TITLE
[GR-44559] Finish ThreadMXBean implementation for Native Image.

### DIFF
--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/Target_java_lang_management_ThreadInfo.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/Target_java_lang_management_ThreadInfo.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package com.oracle.svm.core.jdk;
+
+import com.oracle.svm.core.annotate.Alias;
+import com.oracle.svm.core.annotate.TargetClass;
+
+@SuppressWarnings({"unused"})
+@TargetClass(java.lang.management.ThreadInfo.class)
+final class Target_java_lang_management_ThreadInfo {
+
+    @Alias
+    Target_java_lang_management_ThreadInfo(Thread t, int state, Object lockObj, Thread lockOwner,
+                    long blockedCount, long blockedTime,
+                    long waitedCount, long waitedTime,
+                    StackTraceElement[] stackTrace,
+                    Object[] monitors,
+                    int[] stackDepths,
+                    Object[] synchronizers) {
+    }
+}

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/ThreadMXUtils.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/ThreadMXUtils.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package com.oracle.svm.core.jdk;
+
+import com.oracle.svm.core.SubstrateUtil;
+import com.oracle.svm.core.jdk.management.SubstrateThreadMXBean;
+import com.oracle.svm.core.locks.Target_java_util_concurrent_locks_AbstractOwnableSynchronizer;
+import com.oracle.svm.core.monitor.JavaMonitor;
+import com.oracle.svm.core.thread.JavaThreads.JMXMonitoring;
+import com.oracle.svm.core.thread.PlatformThreads;
+
+import java.lang.management.ThreadInfo;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.concurrent.locks.AbstractOwnableSynchronizer;
+import java.util.concurrent.locks.LockSupport;
+
+/**
+ * Utils to support {@link SubstrateThreadMXBean} for providing threading information for JMX
+ * support. Include the {@link ThreadInfo} constructing utils, and deadlock detection utils.
+ */
+public class ThreadMXUtils {
+
+    public static class ThreadInfoConstructionUtils {
+
+        private static StackTraceElement[] getStackTrace(Thread thread, int maxDepth) {
+            StackTraceElement[] stackTrace = thread.getStackTrace();
+            return maxDepth == -1 || maxDepth >= stackTrace.length ? stackTrace : Arrays.copyOfRange(stackTrace, 0, maxDepth);
+        }
+
+        private record Blocker(Object blockObject, Thread ownerThread) {
+        }
+
+        private static Blocker getBlockerInfo(Thread thread) {
+            Object blocker = LockSupport.getBlocker(thread);
+
+            if (blocker instanceof JavaMonitor javaMonitor) {
+                return new Blocker(
+                                javaMonitor.getBlockedObject(),
+                                SubstrateThreadMXBean.getThreadById(javaMonitor.getOwnerThreadId()));
+            } else if (blocker instanceof AbstractOwnableSynchronizer synchronizer) {
+                return new Blocker(synchronizer,
+                                SubstrateUtil.cast(synchronizer, Target_java_util_concurrent_locks_AbstractOwnableSynchronizer.class)
+                                                .getExclusiveOwnerThread());
+            }
+            return new Blocker(blocker, null);
+        }
+
+        private static Object[] getLockedSynchronizers(Thread thread) {
+            return JMXMonitoring.getThreadLocks(thread);
+        }
+
+        private record LockedMonitors(Object[] monitorObjects, int[] monitorDepths) {
+        }
+
+        private static LockedMonitors getLockedMonitors(Thread thread, int stacktraceLength) {
+            List<JMXMonitoring.MonitorInfo> monitors = JMXMonitoring.getThreadMonitors(thread);
+            Object[] monitorObjects = monitors.stream().map(JMXMonitoring.MonitorInfo::originalObject).toArray();
+            int[] monitorDepths = monitors.stream().mapToInt(monitorInfo -> stacktraceLength < 0 ? -1 : stacktraceLength - monitorInfo.stacksize()).toArray();
+            return new LockedMonitors(monitorObjects, monitorDepths);
+        }
+
+        private static int getThreadState(Thread thread, boolean inNative) {
+            int state = PlatformThreads.getThreadStatus(thread);
+            if (inNative) {
+                // set the JMM thread state native flag to true:
+                state |= 0x00400000;
+            }
+            return state;
+        }
+
+        public static ThreadInfo getThreadInfo(Thread thread, int maxDepth,
+                        boolean withLockedMonitors, boolean withLockedSynchronizers) {
+            Blocker blocker = getBlockerInfo(thread);
+            StackTraceElement[] stackTrace = getStackTrace(thread, maxDepth);
+            LockedMonitors lockedMonitors = getLockedMonitors(thread, stackTrace.length);
+            boolean inNative = stackTrace.length > 0 && stackTrace[0].isNativeMethod();
+            Target_java_lang_management_ThreadInfo targetThreadInfo = new Target_java_lang_management_ThreadInfo(
+                            thread,
+                            getThreadState(thread, inNative),
+                            blocker.blockObject,
+                            blocker.ownerThread,
+                            JMXMonitoring.getThreadTotalBlockedCount(thread),
+                            JMXMonitoring.getThreadTotalBlockedTime(thread),
+                            JMXMonitoring.getThreadTotalWaitedCount(thread),
+                            JMXMonitoring.getThreadTotalWaitedTime(thread),
+                            stackTrace,
+                            withLockedMonitors ? lockedMonitors.monitorObjects : new Object[0],
+                            withLockedMonitors ? lockedMonitors.monitorDepths : new int[0],
+                            withLockedSynchronizers ? getLockedSynchronizers(thread) : new Object[0]);
+            return SubstrateUtil.cast(targetThreadInfo, ThreadInfo.class);
+        }
+    }
+
+    public static class DeadlockDetectionUtils {
+        /**
+         * Returns an array of thread ids of blocked threads within some given array of ThreadInfo.
+         *
+         * @param threadInfos array of ThreadInfo for the threads among which the deadlocks should
+         *            be detected
+         * @param byMonitorOnly true if we are interested only in the deadlocks blocked exclusively
+         *            on monitors
+         * @return array containing thread ids of deadlocked threads
+         */
+        public static long[] findDeadlockedThreads(ThreadInfo[] threadInfos, boolean byMonitorOnly) {
+            HashSet<Long> deadlocked = new HashSet<>();
+            for (ThreadInfo threadInfo : threadInfos) {
+                HashSet<Long> chain = new HashSet<>();
+                ThreadInfo current = threadInfo;
+                while (current != null && current.getLockInfo() != null && !deadlocked.contains(current.getThreadId())) {
+                    if (!chain.add(current.getThreadId())) {
+                        if (!byMonitorOnly || chain.stream().allMatch(DeadlockDetectionUtils::isBlockedByMonitor)) {
+                            deadlocked.addAll(chain);
+                        }
+                        chain.clear();
+                        break;
+                    }
+                    long currentLockOwnerId = current.getLockOwnerId();
+                    current = Arrays.stream(threadInfos).filter(ti -> ti.getThreadId() == currentLockOwnerId).findAny().orElse(null);
+                }
+            }
+            return deadlocked.stream().mapToLong(threadId -> threadId).toArray();
+        }
+
+        /**
+         * Anything that is deadlocked can be blocked either by monitor (the object related to
+         * JavaMonitor), or a lock (anything under AbstractOwnableSynchronizer).
+         *
+         * @return true if provided thread is blocked by a monitor
+         */
+        private static boolean isBlockedByMonitor(long threadId) {
+            return LockSupport.getBlocker(SubstrateThreadMXBean.getThreadById(threadId)) instanceof JavaMonitor;
+        }
+    }
+}

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/management/SubstrateThreadMXBean.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/management/SubstrateThreadMXBean.java
@@ -31,6 +31,8 @@ import java.util.Objects;
 
 import javax.management.ObjectName;
 
+import com.oracle.svm.core.jdk.ThreadMXUtils;
+import com.oracle.svm.core.thread.ThreadCpuTimeSupport;
 import org.graalvm.nativeimage.ImageSingletons;
 import org.graalvm.nativeimage.Platform;
 import org.graalvm.nativeimage.Platforms;
@@ -38,10 +40,12 @@ import org.graalvm.nativeimage.Platforms;
 import com.oracle.svm.core.Uninterruptible;
 import com.oracle.svm.core.jdk.UninterruptibleUtils.AtomicInteger;
 import com.oracle.svm.core.jdk.UninterruptibleUtils.AtomicLong;
+import com.oracle.svm.core.jdk.ThreadMXUtils.ThreadInfoConstructionUtils;
 import com.oracle.svm.core.thread.PlatformThreads;
-import com.oracle.svm.core.thread.ThreadCpuTimeSupport;
 
 import sun.management.Util;
+
+import static com.oracle.svm.core.Uninterruptible.CALLED_FROM_UNINTERRUPTIBLE_CODE;
 
 /**
  * This class provides a partial implementation of {@link com.sun.management.ThreadMXBean} for SVM.
@@ -55,9 +59,9 @@ public final class SubstrateThreadMXBean implements com.sun.management.ThreadMXB
     private final AtomicInteger peakThreadCount = new AtomicInteger(0);
     private final AtomicInteger threadCount = new AtomicInteger(0);
     private final AtomicInteger daemonThreadCount = new AtomicInteger(0);
-
     private boolean allocatedMemoryEnabled;
     private boolean cpuTimeEnabled;
+    private boolean contentionMonitoringEnabled;
 
     @Platforms(Platform.HOSTED_ONLY.class)
     SubstrateThreadMXBean() {
@@ -150,45 +154,62 @@ public final class SubstrateThreadMXBean implements com.sun.management.ThreadMXB
         return daemonThreadCount.get();
     }
 
-    /* All remaining methods are unsupported on Substrate VM. */
-
     @Override
     public long[] getAllThreadIds() {
-        return new long[0];
+        return Arrays.stream(PlatformThreads.getAllThreads())
+                        .mapToLong(Thread::threadId)
+                        .toArray();
+    }
+
+    public static Thread getThreadById(long id) {
+        return Arrays.stream(PlatformThreads.getAllThreads())
+                        .filter(thread -> thread.threadId() == id)
+                        .findAny().orElse(null);
     }
 
     @Override
     public ThreadInfo getThreadInfo(long id) {
-        return null;
+        return getThreadInfo(id, -1);
     }
 
     @Override
     public ThreadInfo[] getThreadInfo(long[] ids) {
-        return new ThreadInfo[0];
+        return getThreadInfo(ids, -1);
     }
 
     @Override
     public ThreadInfo getThreadInfo(long id, int maxDepth) {
-        return null;
+        return getThreadInfo(id, maxDepth, false, false);
+    }
+
+    private ThreadInfo getThreadInfo(long id, int maxDepth, boolean lockedMonitors, boolean lockedSynchronizers) {
+        Thread thread = getThreadById(id);
+        return getThreadInfo(thread, maxDepth, lockedMonitors, lockedSynchronizers);
+    }
+
+    private ThreadInfo getThreadInfo(Thread thread, int maxDepth, boolean lockedMonitors, boolean lockedSynchronizers) {
+        return thread == null ? null : ThreadInfoConstructionUtils.getThreadInfo(thread, maxDepth, lockedMonitors, lockedSynchronizers);
     }
 
     @Override
     public ThreadInfo[] getThreadInfo(long[] ids, int maxDepth) {
-        return new ThreadInfo[0];
+        return (ThreadInfo[]) Arrays.stream(ids).mapToObj(id -> getThreadInfo(id, maxDepth)).toArray();
     }
 
     @Override
     public boolean isThreadContentionMonitoringSupported() {
-        return false;
+        return true;
     }
 
     @Override
+    @Uninterruptible(reason = CALLED_FROM_UNINTERRUPTIBLE_CODE, mayBeInlined = true)
     public boolean isThreadContentionMonitoringEnabled() {
-        return false;
+        return contentionMonitoringEnabled;
     }
 
     @Override
-    public void setThreadContentionMonitoringEnabled(boolean enable) {
+    public void setThreadContentionMonitoringEnabled(boolean value) {
+        contentionMonitoringEnabled = value;
     }
 
     @Override
@@ -256,32 +277,36 @@ public final class SubstrateThreadMXBean implements com.sun.management.ThreadMXB
 
     @Override
     public long[] findMonitorDeadlockedThreads() {
-        return new long[0];
+        ThreadInfo[] threadInfos = dumpAllThreads(true, false);
+        return ThreadMXUtils.DeadlockDetectionUtils.findDeadlockedThreads(threadInfos, true);
     }
 
     @Override
     public long[] findDeadlockedThreads() {
-        return new long[0];
+        ThreadInfo[] threadInfos = dumpAllThreads(true, true);
+        return ThreadMXUtils.DeadlockDetectionUtils.findDeadlockedThreads(threadInfos, false);
     }
 
     @Override
     public boolean isObjectMonitorUsageSupported() {
-        return false;
+        return true;
     }
 
     @Override
     public boolean isSynchronizerUsageSupported() {
-        return false;
+        return true;
     }
 
     @Override
     public ThreadInfo[] getThreadInfo(long[] ids, boolean lockedMonitors, boolean lockedSynchronizers) {
-        return new ThreadInfo[0];
+        return Arrays.stream(ids).mapToObj(id -> getThreadInfo(id, -1, lockedMonitors, lockedSynchronizers))
+                        .toArray(ThreadInfo[]::new);
     }
 
     @Override
     public ThreadInfo[] dumpAllThreads(boolean lockedMonitors, boolean lockedSynchronizers) {
-        return new ThreadInfo[0];
+        return Arrays.stream(PlatformThreads.getAllThreads()).map(thread -> getThreadInfo(thread, -1, lockedMonitors, lockedSynchronizers))
+                        .toArray(ThreadInfo[]::new);
     }
 
     @Override
@@ -290,7 +315,6 @@ public final class SubstrateThreadMXBean implements com.sun.management.ThreadMXB
         if (!valid) {
             return -1;
         }
-
         return PlatformThreads.getThreadAllocatedBytes(id);
     }
 
@@ -324,8 +348,8 @@ public final class SubstrateThreadMXBean implements com.sun.management.ThreadMXB
     }
 
     private static void verifyThreadIds(long[] ids) {
-        for (int i = 0; i < ids.length; i++) {
-            verifyThreadId(ids[i]);
+        for (long id : ids) {
+            verifyThreadId(id);
         }
     }
 

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/locks/Target_java_util_concurrent_locks_AbstractOwnableSynchronizer.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/locks/Target_java_util_concurrent_locks_AbstractOwnableSynchronizer.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package com.oracle.svm.core.locks;
+
+import com.oracle.svm.core.SubstrateUtil;
+import com.oracle.svm.core.annotate.Alias;
+import com.oracle.svm.core.annotate.Substitute;
+import com.oracle.svm.core.annotate.TargetClass;
+import com.oracle.svm.core.thread.JavaThreads;
+
+import java.util.concurrent.locks.AbstractOwnableSynchronizer;
+
+/**
+ * {@link java.util.concurrent.locks.AbstractOwnableSynchronizer} is substituted in order to track
+ * the locks per thread when JMX support is enabled.
+ */
+@SuppressWarnings({"unused"})
+@TargetClass(value = java.util.concurrent.locks.AbstractOwnableSynchronizer.class)
+public final class Target_java_util_concurrent_locks_AbstractOwnableSynchronizer {
+
+    /**
+     * The current owner of exclusive mode synchronization.
+     */
+    @Alias //
+    private transient Thread exclusiveOwnerThread;
+
+    /**
+     * Sets the thread that currently owns exclusive access. A {@code null} argument indicates that
+     * no thread owns access. This method does not otherwise impose any synchronization or
+     * {@code volatile} field accesses.
+     * 
+     * @param thread the owner thread
+     */
+    @Substitute()
+    protected void setExclusiveOwnerThread(Thread thread) {
+        if (thread == null && exclusiveOwnerThread != null) {
+            JavaThreads.JMXMonitoring.removeThreadLock(exclusiveOwnerThread,
+                            SubstrateUtil.cast(this, AbstractOwnableSynchronizer.class));
+        } else {
+            JavaThreads.JMXMonitoring.addThreadLock(thread,
+                            SubstrateUtil.cast(this, AbstractOwnableSynchronizer.class));
+        }
+        exclusiveOwnerThread = thread;
+    }
+
+    /**
+     * Returns the thread last set by {@code setExclusiveOwnerThread}, or {@code null} if never set.
+     * This method does not otherwise impose any synchronization or {@code volatile} field accesses.
+     * 
+     * @return the owner thread
+     */
+    @Alias
+    public Thread getExclusiveOwnerThread() {
+        return exclusiveOwnerThread;
+    }
+}

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/monitor/JavaMonitor.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/monitor/JavaMonitor.java
@@ -73,8 +73,11 @@ public class JavaMonitor extends JavaMonitorQueuedSynchronizer {
             acquire(1);
             JavaMonitorEnterEvent.emit(obj, latestJfrTid, startTicks);
         }
-
         latestJfrTid = SubstrateJVM.getCurrentThreadId();
+    }
+
+    public Object getBlockedObject() {
+        return blockedObject;
     }
 
     public void monitorExit() {
@@ -216,6 +219,10 @@ public class JavaMonitor extends JavaMonitorQueuedSynchronizer {
     // see ReentrantLock.Sync.isLocked()
     boolean isLocked() {
         return getState() != 0;
+    }
+
+    public long getOwnerThreadId() {
+        return getState();
     }
 
     /**

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/monitor/JavaMonitorQueuedSynchronizer.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/monitor/JavaMonitorQueuedSynchronizer.java
@@ -145,6 +145,7 @@ abstract class JavaMonitorQueuedSynchronizer {
     private transient volatile Node head;
     private transient volatile Node tail;
     private volatile long state;
+    protected Object blockedObject;
 
     // see AbstractQueuedLongSynchronizer.getState()
     @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/thread/PlatformThreads.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/thread/PlatformThreads.java
@@ -907,7 +907,7 @@ public abstract class PlatformThreads {
         return vmOp.result;
     }
 
-    static Thread[] getAllThreads() {
+    public static Thread[] getAllThreads() {
         GetAllThreadsOperation vmOp = new GetAllThreadsOperation();
         vmOp.enqueue();
         return vmOp.result.toArray(new Thread[0]);
@@ -1075,8 +1075,10 @@ public abstract class PlatformThreads {
     @Uninterruptible(reason = CALLED_FROM_UNINTERRUPTIBLE_CODE, mayBeInlined = true)
     public static void setThreadStatus(Thread thread, int threadStatus) {
         assert !isVirtual(thread);
-        assert toTarget(thread).holder.threadStatus != ThreadStatus.TERMINATED : "once a thread is marked as terminated, its status must not change";
-        toTarget(thread).holder.threadStatus = threadStatus;
+        Target_java_lang_Thread targetThread = toTarget(thread);
+        assert targetThread.holder.threadStatus != ThreadStatus.TERMINATED : "once a thread is marked as terminated, its status must not change";
+        JavaThreads.JMXMonitoring.handleContentionMonitoring(targetThread, threadStatus);
+        targetThread.holder.threadStatus = threadStatus;
     }
 
     static boolean compareAndSetThreadStatus(Thread thread, int expectedStatus, int newStatus) {

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/thread/Target_java_lang_Thread.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/thread/Target_java_lang_Thread.java
@@ -31,6 +31,9 @@ import java.security.AccessControlContext;
 import java.util.Map;
 import java.util.Objects;
 
+import java.util.concurrent.ConcurrentLinkedDeque;
+import java.util.concurrent.locks.AbstractOwnableSynchronizer;
+import org.graalvm.collections.EconomicSet;
 import org.graalvm.nativeimage.IsolateThread;
 import org.graalvm.nativeimage.Platforms;
 import org.graalvm.nativeimage.impl.InternalPlatform;
@@ -90,6 +93,42 @@ public final class Target_java_lang_Thread {
     @Inject //
     @RecomputeFieldValue(kind = RecomputeFieldValue.Kind.NewInstance, declClass = ThreadData.class)//
     UnacquiredThreadData threadData;
+
+    @Inject //
+    @RecomputeFieldValue(kind = RecomputeFieldValue.Kind.Reset) //
+    long lastStartedWaiting = -1;
+
+    @Inject //
+    @RecomputeFieldValue(kind = RecomputeFieldValue.Kind.Reset) //
+    long lastStartedBlocked = -1;
+
+    @Inject //
+    @RecomputeFieldValue(kind = RecomputeFieldValue.Kind.Reset) //
+    long timeWaited = 0;
+
+    @Inject //
+    @RecomputeFieldValue(kind = RecomputeFieldValue.Kind.Reset) //
+    long timeBlocked = 0;
+
+    @Inject //
+    @RecomputeFieldValue(kind = RecomputeFieldValue.Kind.Reset) //
+    long blockedCount = 0;
+
+    @Inject //
+    @RecomputeFieldValue(kind = RecomputeFieldValue.Kind.Reset) //
+    long waitedCount = 0;
+
+    /**
+     * If the thread owns a lock or a monitor, it can't be updated by any other thread before the
+     * owner of that lock resets itself.
+     */
+    @Inject //
+    @RecomputeFieldValue(kind = RecomputeFieldValue.Kind.Reset) //
+    EconomicSet<AbstractOwnableSynchronizer> locks;
+
+    @Inject //
+    @RecomputeFieldValue(kind = RecomputeFieldValue.Kind.Reset) //
+    ConcurrentLinkedDeque<JavaThreads.JMXMonitoring.MonitorInfo> monitors;
 
     @Alias//
     ClassLoader contextClassLoader;


### PR DESCRIPTION
The functionality of `ThreadMXBean` is implemented and working within native image [GR-44559](https://github.com/oracle/graal/issues/6101)

### Testing
Build native image with: `--enable-monitoring=jmxserver,jvmstat` 
Run it with:
`-Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.port=9996 -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.enableThreadContentionMonitoring=true`

Tools like VisualVM show the Thread monitoring info:

<img width="989" alt="Screenshot 2023-12-04 at 11 15 56" src="https://github.com/oracle/graal/assets/14926811/4cabc678-a1df-42b7-8b7f-ede9ff2625c2">

Example result of `dumpAllThreads` method call:

<img width="553" alt="Screenshot 2023-12-04 at 11 19 58" src="https://github.com/oracle/graal/assets/14926811/80573df5-36aa-4569-a778-6ff12aee624e">

Result of `getThreadInfo` by Thread id (the locks and monitors shouldn't be included):
<img width="525" alt="Screenshot 2023-12-04 at 11 24 57" src="https://github.com/oracle/graal/assets/14926811/9618d68b-2e7c-4403-b855-36fc3c39a923">

Deadlock detection returns an array of ids of deadlocked threads:
<img width="284" alt="Screenshot 2023-12-04 at 11 28 51" src="https://github.com/oracle/graal/assets/14926811/20ee82cf-11fc-4cb4-b0fa-3be67eecf071">

Closes #6101