### PR TITLE
[GR-51017] Use JDK 17 for building Quarkus

### DIFF
--- a/.github/workflows/quarkus.yml
+++ b/.github/workflows/quarkus.yml
@@ -128,6 +128,11 @@ jobs:
       with:
         name: graalvm
         path: graalvm.tgz
+    # Use Java 17 to build Quarkus as that's the lowest supported JDK version currently
+    - uses: actions/setup-java@v4
+      with:
+        distribution: 'temurin'
+        java-version: '17'
     - name: Build Quarkus
       run: |
         cd ${QUARKUS_PATH}
@@ -189,11 +194,10 @@ jobs:
         if: startsWith(matrix.os-name, 'ubuntu')
         shell: bash
         run: tar -xzf maven-repo.tgz -C ~
-      - uses: graalvm/setup-graalvm@v1
+      - uses: actions/setup-java@v4
         with:
-          version: 'latest'
+          distribution: 'temurin'
           java-version: '17'
-          github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Build with Maven
         if: startsWith(matrix.os-name, 'ubuntu')
         env:


### PR DESCRIPTION
Quarkus no longer supports JDK 11

See https://github.com/oracle/graal/actions/runs/7162366442/job/19499236553#step:12:2328
