### PR TITLE
Small JFR clean-up

### DIFF
--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/JfrFeature.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/JfrFeature.java
@@ -149,8 +149,6 @@ public class JfrFeature implements InternalFeature {
 
     @Override
     public void afterRegistration(AfterRegistrationAccess access) {
-        ModuleSupport.accessPackagesToClass(ModuleSupport.Access.OPEN, null, false, "jdk.jfr");
-        ModuleSupport.accessPackagesToClass(ModuleSupport.Access.OPEN, null, false, "java.base");
 
         // Initialize some parts of JFR/JFC at image build time.
         List<Configuration> knownConfigurations = JFC.getConfigurations();

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/JfrFeature.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/JfrFeature.java
@@ -47,7 +47,6 @@ import com.oracle.svm.core.thread.ThreadListenerSupportFeature;
 import com.oracle.svm.core.util.UserError;
 import com.oracle.svm.core.util.VMError;
 import com.oracle.svm.util.LogUtils;
-import com.oracle.svm.util.ModuleSupport;
 import com.oracle.svm.util.ReflectionUtil;
 import com.sun.management.HotSpotDiagnosticMXBean;
 import com.sun.management.internal.PlatformMBeanProviderImpl;

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/Target_jdk_jfr_internal_JVM.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/Target_jdk_jfr_internal_JVM.java
@@ -27,6 +27,7 @@ package com.oracle.svm.core.jfr;
 import java.util.List;
 import java.util.function.BooleanSupplier;
 
+import jdk.jfr.internal.LogLevel;
 import org.graalvm.nativeimage.Platform;
 import org.graalvm.nativeimage.Platforms;
 import org.graalvm.nativeimage.ProcessProperties;
@@ -46,6 +47,7 @@ import com.oracle.svm.util.ReflectionUtil;
 import jdk.graal.compiler.api.replacements.Fold;
 import jdk.jfr.internal.JVM;
 import jdk.jfr.internal.LogTag;
+import jdk.jfr.internal.Logger;
 
 @SuppressWarnings({"static-method", "unused"})
 @TargetClass(value = jdk.jfr.internal.JVM.class, onlyWith = HasJfrSupport.class)
@@ -168,10 +170,16 @@ public final class Target_jdk_jfr_internal_JVM {
         throw VMError.unimplemented("JFR StackFilters are not yet supported.");
     }
 
+    /**
+     * As of 22+27, This method is both used to set cutoff tick values for leak profiling and
+     * for @Deprecated events.
+     */
     @Substitute
     @TargetElement(onlyWith = JDK22OrLater.class)
     public static void setMiscellaneous(long eventTypeId, long value) {
-        throw VMError.unimplemented("@Deprecated JFR events are not yet supported.");
+        // Add logging here since JDK code obfuscates root exception message.
+        Logger.log(LogTag.JFR_SETTING, LogLevel.WARN, "@Deprecated JFR events, and leak profiling are not yet supported.");
+        throw VMError.unimplemented("@Deprecated JFR events, and leak profiling are not yet supported.");
     }
 
     /** See {@link JVM#getThreadId}. */

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/jfr/JfrEventFeature.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/jfr/JfrEventFeature.java
@@ -68,14 +68,6 @@ public class JfrEventFeature implements InternalFeature {
     }
 
     @Override
-    public void afterRegistration(AfterRegistrationAccess access) {
-        ModuleSupport.accessPackagesToClass(ModuleSupport.Access.OPEN, JfrEventFeature.class, false, "jdk.jfr", "jdk.jfr.events");
-        ModuleSupport.accessPackagesToClass(ModuleSupport.Access.OPEN, JfrFeature.class, false, "jdk.jfr", "jdk.jfr.events");
-        ModuleSupport.accessPackagesToClass(ModuleSupport.Access.OPEN, JfrEventSubstitution.class, false, "jdk.internal.vm.ci", "jdk.vm.ci.hotspot");
-        ModuleSupport.accessPackagesToClass(ModuleSupport.Access.OPEN, JfrEventFeature.class, false, "java.base", "jdk.internal.event");
-    }
-
-    @Override
     public void duringSetup(DuringSetupAccess c) {
         FeatureImpl.DuringSetupAccessImpl config = (FeatureImpl.DuringSetupAccessImpl) c;
         MetaAccessProvider metaAccess = config.getMetaAccess().getWrapped();

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/jfr/JfrEventFeature.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/jfr/JfrEventFeature.java
@@ -45,7 +45,6 @@ import com.oracle.svm.core.jfr.traceid.JfrTraceIdMap;
 import com.oracle.svm.core.meta.SharedType;
 import com.oracle.svm.core.util.VMError;
 import com.oracle.svm.hosted.FeatureImpl;
-import com.oracle.svm.util.ModuleSupport;
 
 import jdk.internal.event.Event;
 import jdk.jfr.internal.JVM;

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/jfr/JfrEventSubstitution.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/jfr/JfrEventSubstitution.java
@@ -44,7 +44,6 @@ import com.oracle.svm.core.util.VMError;
 import com.oracle.svm.util.ReflectionUtil;
 
 import jdk.graal.compiler.serviceprovider.JavaVersionUtil;
-import jdk.internal.misc.Unsafe;
 import jdk.jfr.internal.JVM;
 import jdk.jfr.internal.SecuritySupport;
 import jdk.jfr.internal.event.EventWriter;
@@ -72,7 +71,6 @@ public class JfrEventSubstitution extends SubstitutionProcessor {
     JfrEventSubstitution(MetaAccessProvider metaAccess) {
         baseEventType = metaAccess.lookupJavaType(jdk.internal.event.Event.class);
         ResolvedJavaType jdkJfrEventWriter = metaAccess.lookupJavaType(EventWriter.class);
-        changeWriterResetMethod(jdkJfrEventWriter);
         typeSubstitution = new ConcurrentHashMap<>();
         methodSubstitutions = new ConcurrentHashMap<>();
         fieldSubstitutions = new ConcurrentHashMap<>();
@@ -184,54 +182,6 @@ public class JfrEventSubstitution extends SubstitutionProcessor {
 
     private boolean needsClassRedefinition(ResolvedJavaType type) {
         return !type.isAbstract() && baseEventType.isAssignableFrom(type) && !baseEventType.equals(type);
-    }
-
-    /**
-     * The method EventWriter.reset() is private but it is called by the EventHandler classes, which
-     * are generated automatically. To prevent bytecode parsing issues, we patch the visibility of
-     * that method using the hacky way below.
-     */
-    private static void changeWriterResetMethod(ResolvedJavaType eventWriterType) {
-        for (ResolvedJavaMethod m : eventWriterType.getDeclaredMethods(false)) {
-            if (m.getName().equals("reset")) {
-                setPublicModifier(m);
-            }
-        }
-    }
-
-    private static void setPublicModifier(ResolvedJavaMethod m) {
-        try {
-            Class<?> hotspotMethodClass = m.getClass();
-            Method metaspaceMethodM = getMethodToFetchMetaspaceMethod(hotspotMethodClass);
-            metaspaceMethodM.setAccessible(true);
-            long metaspaceMethod = (Long) metaspaceMethodM.invoke(m);
-            VMError.guarantee(metaspaceMethod != 0);
-            Class<?> hotSpotVMConfigC = Class.forName("jdk.vm.ci.hotspot.HotSpotVMConfig");
-            Method configM = hotSpotVMConfigC.getDeclaredMethod("config");
-            configM.setAccessible(true);
-            Field methodAccessFlagsOffsetF = hotSpotVMConfigC.getDeclaredField("methodAccessFlagsOffset");
-            methodAccessFlagsOffsetF.setAccessible(true);
-            Object hotSpotVMConfig = configM.invoke(null);
-            int methodAccessFlagsOffset = methodAccessFlagsOffsetF.getInt(hotSpotVMConfig);
-            int modifiers = Unsafe.getUnsafe().getInt(metaspaceMethod + methodAccessFlagsOffset);
-            int newModifiers = modifiers & ~Modifier.PRIVATE | Modifier.PUBLIC;
-            Unsafe.getUnsafe().putInt(metaspaceMethod + methodAccessFlagsOffset, newModifiers);
-        } catch (Exception ex) {
-            throw VMError.shouldNotReachHere(ex);
-        }
-    }
-
-    private static Method getMethodToFetchMetaspaceMethod(Class<?> method) throws NoSuchMethodException {
-        // The exact method depends on the JVMCI version.
-        try {
-            return method.getDeclaredMethod("getMethodPointer");
-        } catch (NoSuchMethodException e) {
-            try {
-                return method.getDeclaredMethod("getMetaspaceMethod");
-            } catch (NoSuchMethodException e2) {
-                return method.getDeclaredMethod("getMetaspacePointer");
-            }
-        }
     }
 
     /*

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/jfr/JfrEventSubstitution.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/jfr/JfrEventSubstitution.java
@@ -25,9 +25,7 @@
 package com.oracle.svm.hosted.jfr;
 
 import java.lang.annotation.Annotation;
-import java.lang.reflect.Field;
 import java.lang.reflect.Method;
-import java.lang.reflect.Modifier;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 


### PR DESCRIPTION
### Summary
Some minor house cleaning in 3 areas:
1. Remove the "hack" in JfrEventSubstitution.java. It's no longer needed because JDK code has changed to make `EventWriter.reset()` public.
2. Added javadoc and logging in `Target_jdk_jfr_internal_JVM.java`. Currently, whenever a new JFR @Deprecated event is used an unclear error message is logged:
```
 [warn][jfr,setting] Exception occurred when setting value "forRemoval" for class jdk.jfr.internal.Control
Passed
```
One issue is that there may be too much useless logger output that drowns out meaningful logs. A possible solution is to simply log that a feature is unimplemented only once. Instead of logging every time an attempt to use it is made.  What do you think about this?
3. Avoid unnecessary module opening. [This caused issues with Quarkus](https://github.com/oracle/graal/issues/8020). I think this might simply be outdated code and is safe to remove now. 

