### PR TITLE
 [GR-50985] Set alignment to 1 for Java DWARF debug info sections

### DIFF
--- a/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/ELFObjectFile.java
+++ b/substratevm/src/com.oracle.objectfile/src/com/oracle/objectfile/elf/ELFObjectFile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1184,14 +1184,14 @@ public class ELFObjectFile extends ObjectFile {
         DwarfRangesSectionImpl elfRangesSectionImpl = dwarfSections.getRangesSectionImpl();
         DwarfLineSectionImpl elfLineSectionImpl = dwarfSections.getLineSectionImpl();
         /* Now we can create the section elements with empty content. */
-        newUserDefinedSection(elfStrSectionImpl.getSectionName(), elfStrSectionImpl);
-        newUserDefinedSection(elfAbbrevSectionImpl.getSectionName(), elfAbbrevSectionImpl);
-        newUserDefinedSection(frameSectionImpl.getSectionName(), frameSectionImpl);
-        newUserDefinedSection(elfLocSectionImpl.getSectionName(), elfLocSectionImpl);
-        newUserDefinedSection(elfInfoSectionImpl.getSectionName(), elfInfoSectionImpl);
-        newUserDefinedSection(elfARangesSectionImpl.getSectionName(), elfARangesSectionImpl);
-        newUserDefinedSection(elfRangesSectionImpl.getSectionName(), elfRangesSectionImpl);
-        newUserDefinedSection(elfLineSectionImpl.getSectionName(), elfLineSectionImpl);
+        newDebugSection(elfStrSectionImpl.getSectionName(), elfStrSectionImpl);
+        newDebugSection(elfAbbrevSectionImpl.getSectionName(), elfAbbrevSectionImpl);
+        newDebugSection(frameSectionImpl.getSectionName(), frameSectionImpl);
+        newDebugSection(elfLocSectionImpl.getSectionName(), elfLocSectionImpl);
+        newDebugSection(elfInfoSectionImpl.getSectionName(), elfInfoSectionImpl);
+        newDebugSection(elfARangesSectionImpl.getSectionName(), elfARangesSectionImpl);
+        newDebugSection(elfRangesSectionImpl.getSectionName(), elfRangesSectionImpl);
+        newDebugSection(elfLineSectionImpl.getSectionName(), elfLineSectionImpl);
         /*
          * Add symbols for the base of all DWARF sections whose content may need to be referenced
          * using a section global offset. These need to be written using a base relative reloc so


### PR DESCRIPTION
This PR addresses cases when GraalVM sometimes generates corrupted debug info by ensuring that  debug sections have alignment set to 1.

Current we mistakenly generate debug info sections with alignment of 8 (for 64-bit OS) and this causes linker to generate corrupt debug info when it has several object files with debug info with different alignment. For example on Alpine Linux crt1.o and crti.o libraries have debug information section with alignment of 1. Linker writes those sections first and then pads to alignment of 8 before processing Graal-generated debug info section because it has alignment of 8.

Evidently calling `newUserDefinedSection` was an oversight as `newDebugSection` method already has a comment on this exact issue:
```
                                 // debugging information is mostly unaligned; padding can result in
                                 // corrupted data when the linker merges multiple debugging
                                 // sections from different inputs
```

See #https://github.com/oracle/graal/issues/4574 for more insight.