### PR TITLE
Force xml class load order after JDK-8306055

### DIFF
--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/xml/JavaxXmlClassAndResourcesLoaderFeature.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/xml/JavaxXmlClassAndResourcesLoaderFeature.java
@@ -44,10 +44,12 @@ public class JavaxXmlClassAndResourcesLoaderFeature extends JNIRegistrationUtil 
 
     @Override
     public void beforeAnalysis(BeforeAnalysisAccess access) {
-        // Ensure that class loading of xml related classes work
-        // com.sun.org.apache.xerces.internal.impl.XMLDocumentFragmentScannerImpl
-        // implicitly depends on jdk.xml.internal.JdkXmlUtils. So initialization
-        // order needs to happen in the reverse order.
+        /*
+         * Ensure that class loading of xml related classes work.
+         * com.sun.org.apache.xerces.internal.impl.XMLDocumentFragmentScannerImpl
+         * implicitly depends on jdk.xml.internal.JdkXmlUtils. So initialization
+         * order needs to happen in the reverse order.
+         */
         Class<?> jdkUtil = access.findClassByName("jdk.xml.internal.JdkXmlUtils");
         if (jdkUtil != null) {
             ReflectionUtil.newInstance(jdkUtil);

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/xml/JavaxXmlClassAndResourcesLoaderFeature.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/xml/JavaxXmlClassAndResourcesLoaderFeature.java
@@ -36,7 +36,7 @@ import static com.oracle.svm.hosted.xml.XMLParsersRegistration.TransformerClasse
 
 import com.oracle.svm.core.feature.InternalFeature;
 import com.oracle.svm.core.jdk.JNIRegistrationUtil;
-import com.oracle.svm.util.ReflectionUtil;
+import com.oracle.svm.hosted.classinitialization.ClassInitializationSupport;
 import com.oracle.svm.core.feature.AutomaticallyRegisteredFeature;
 
 @AutomaticallyRegisteredFeature
@@ -46,13 +46,13 @@ public class JavaxXmlClassAndResourcesLoaderFeature extends JNIRegistrationUtil 
     public void beforeAnalysis(BeforeAnalysisAccess access) {
         /*
          * Ensure that class loading of xml related classes work.
-         * com.sun.org.apache.xerces.internal.impl.XMLDocumentFragmentScannerImpl
-         * implicitly depends on jdk.xml.internal.JdkXmlUtils. So initialization
-         * order needs to happen in the reverse order.
+         * com.sun.org.apache.xerces.internal.impl.XMLDocumentFragmentScannerImpl implicitly depends
+         * on jdk.xml.internal.JdkXmlUtils. So initialization order needs to happen in the reverse
+         * order.
          */
         Class<?> jdkUtil = access.findClassByName("jdk.xml.internal.JdkXmlUtils");
         if (jdkUtil != null) {
-            ReflectionUtil.newInstance(jdkUtil);
+            ClassInitializationSupport.singleton().forceInitializeHosted(jdkUtil, "break circular class initialization in XML code", false);
         }
         access.registerReachabilityHandler(new SAXParserClasses()::registerConfigs,
                         method(access, "javax.xml.parsers.SAXParserFactory", "newInstance"));


### PR DESCRIPTION
Here is a proposal to fix the issue described in #8075. By eagerly loading the `jdk.xml.internal.JdkXmlUtils` class which only contains static constants, the analysis is then free to scan the class space and (potentially) initialize classes in any order - since we make sure `jdk.xml.internal.JdkXmlUtils` has already been loaded in the host JVM.

Passes the simple reproducer and also seems to fix the issues we've seen in Quarkus CI:

```
$ native-image Test
========================================================================================================================
GraalVM Native Image: Generating 'test' (executable)...
========================================================================================================================
[1/8] Initializing...                                                                                    (6.6s @ 0.17GB)
 Java version: 23-beta+2-ea, vendor version: Mandrel-24.1.0-dev
 Graal compiler: optimization level: 2, target machine: x86-64-v3
 C compiler: gcc (redhat, x86_64, 13.2.1)
 Garbage collector: Serial GC (max heap size: 80% of RAM)
 1 user-specific feature(s):
 - com.oracle.svm.thirdparty.gson.GsonFeature
------------------------------------------------------------------------------------------------------------------------
Build resources:
 - 26.49GB of memory (42.3% of 62.56GB system memory, determined at start)
 - 12 thread(s) (100.0% of 12 available processor(s), determined at start)
[2/8] Performing analysis...  [***]                                                                     (13.3s @ 0.50GB)
    4,217 reachable types   (75.8% of    5,562 total)
    6,392 reachable fields  (47.9% of   13,333 total)
   21,478 reachable methods (49.8% of   43,115 total)
    1,354 types,    87 fields, and   703 methods registered for reflection
       58 types,    58 fields, and    52 methods registered for JNI access
        4 native libraries: dl, pthread, rt, z
[3/8] Building universe...                                                                               (1.9s @ 0.45GB)
[4/8] Parsing methods...      [*]                                                                        (1.5s @ 0.59GB)
[5/8] Inlining methods...     [***]                                                                      (1.0s @ 0.55GB)
[6/8] Compiling methods...    [****]                                                                    (12.6s @ 0.46GB)
[7/8] Laying out methods...   [*]                                                                        (2.0s @ 0.56GB)
[8/8] Creating image...       [*]                                                                        (1.8s @ 0.64GB)
   9.03MB (44.48%) for code area:    12,776 compilation units
  10.94MB (53.90%) for image heap:  121,684 objects and 47 resources
 336.62kB ( 1.62%) for other data
  20.30MB in total
------------------------------------------------------------------------------------------------------------------------
Top 10 origins of code area:                                Top 10 object types in image heap:
   4.49MB java.base                                            2.65MB byte[] for code metadata
   3.15MB java.xml                                             1.63MB byte[] for java.lang.String
 986.68kB svm.jar (Native Image)                               1.19MB java.lang.String
 112.55kB java.logging                                         1.00MB java.lang.Class
  63.88kB org.graalvm.nativeimage.base                       523.07kB heap alignment
  47.59kB jdk.proxy1                                         513.00kB int[][]
  45.84kB jdk.proxy3                                         410.61kB byte[] for general heap data
  26.79kB jdk.internal.vm.ci                                 362.40kB com.oracle.svm.core.hub.DynamicHubCompanion
  21.97kB org.graalvm.collections                            266.02kB java.util.HashMap$Node
  11.42kB jdk.proxy2                                         247.65kB java.lang.Object[]
  16.78kB for 4 more packages                                  2.20MB for 1105 more object types
------------------------------------------------------------------------------------------------------------------------
Recommendations:
 HEAP: Set max heap for improved and more predictable memory usage.
 CPU:  Enable more CPU features with '-march=native' for improved performance.
------------------------------------------------------------------------------------------------------------------------
                        1.9s (4.2% of total time) in 222 GCs | Peak RSS: 1.11GB | CPU load: 8.07
------------------------------------------------------------------------------------------------------------------------
Produced artifacts:
 /home/sgehwolf/Documents/mandrel/bugs/upstream-graal/issue_xml_jdk22/testme/test (executable)
========================================================================================================================
Finished generating 'test' in 42.3s.
$ ./test 2 test.xml 
Child nodes: 1
First child: point
Loaded: class com.sun.org.apache.xerces.internal.impl.XMLDocumentFragmentScannerImpl
```
