### PR TITLE
[GR-52025] Use update center for NetBeans 14 in IGV

### DIFF
--- a/visualizer/IdealGraphVisualizer/VisualizerUI/src/org/graalvm/visualizer/ui/Bundle.properties
+++ b/visualizer/IdealGraphVisualizer/VisualizerUI/src/org/graalvm/visualizer/ui/Bundle.properties
@@ -1,5 +1,5 @@
 OpenIDE-Module-Name=Visualizer UI Customizations
 OpenIDE-Module-Display-Category=IGV
-Services/AutoupdateType/distribution-update-provider.instance=NetBeans 12.5 distribution
-URL_NBUpdateCenter=https://netbeans.apache.org/nb/updates/12.5/updates.xml.gz?{$netbeans.hash.code}
-URL_NBPluginPortal=https://netbeans.apache.org/nb/plugins/12.5/catalog.xml.gz
+Services/AutoupdateType/distribution-update-provider.instance=NetBeans 14 distribution
+URL_NBUpdateCenter=https://netbeans.apache.org/nb/updates/14/updates.xml.gz?{$netbeans.hash.code}
+URL_NBPluginPortal=https://netbeans.apache.org/nb/plugins/14/catalog.xml.gz


### PR DESCRIPTION
Looks like IGV has been [updated to use NetBeans-14](https://github.com/oracle/graal/blob/f105a80046c34cc69b35c1e45227e119cfa2ee80/visualizer/IdealGraphVisualizer/nbproject/platform.properties#L343), however the system is still configured to use _update centers_ from NetBeans 12.5 - that's unfortunate as the latest versions of plugins aren't available. This PR aligns the IGV's base NetBeans version with its update centers.

CCing @tkrodriguez, @sdedic, @dbalek, @Ondrej-Douda 