### PR TITLE
Set MaxRAM and MaxRAMPercentage in launcher for native-image driver

### DIFF
--- a/sdk/mx.sdk/vm/launcher_template.cmd
+++ b/sdk/mx.sdk/vm/launcher_template.cmd
@@ -51,7 +51,7 @@ for /f "delims=" %%i in ("%relcp:;=!newline!%") do (
     )
 )
 
-set "jvm_args=-Dorg.graalvm.launcher.shell=true "-Dorg.graalvm.launcher.executablename=%executablename%""
+set "jvm_args=-Dorg.graalvm.launcher.shell=true -XX:MaxRAM=256m -XX:MaxRAMPercentage=80 "-Dorg.graalvm.launcher.executablename=%executablename%""
 set "launcher_args=<launcher_args>"
 
 :: Check option-holding variables.

--- a/sdk/mx.sdk/vm/launcher_template.sh
+++ b/sdk/mx.sdk/vm/launcher_template.sh
@@ -42,7 +42,7 @@ for e in "${relative_cp[@]}"; do
     absolute_cp+=("${location}/${e}")
 done
 
-jvm_args=("-Dorg.graalvm.launcher.shell=true" "-Dorg.graalvm.launcher.executablename=$0")
+jvm_args=("-Dorg.graalvm.launcher.shell=true" "-XX:MaxRAM=256m" "-XX:MaxRAMPercentage=80" "-Dorg.graalvm.launcher.executablename=$0")
 launcher_args=(<launcher_args>)
 
 # Unfortunately, parsing of `--vm.*` arguments has to be done blind:


### PR DESCRIPTION
See https://github.com/oracle/graal/pull/7277#discussion_r1311314465 for motivation.

We have been using this as the default in Mandrel since the 23.1 release.