### PR TITLE
Less indented (but full) stacktrace in IGV

### DIFF
--- a/visualizer/IdealGraphVisualizer/SourceRepository/src/org/graalvm/visualizer/source/impl/ui/StackViewTopComponent.java
+++ b/visualizer/IdealGraphVisualizer/SourceRepository/src/org/graalvm/visualizer/source/impl/ui/StackViewTopComponent.java
@@ -642,7 +642,7 @@ public final class StackViewTopComponent extends TopComponent
                     return s;
                 }
             };
-            node.setDisplayName(provider.getProperties().getString(PROPNAME_NAME, "")); // NOI18N 
+            node.setDisplayName(provider.getProperties().getString(PROPNAME_NAME, "")); // NOI18N
             setActivatedNodes(new Node[]{node});
         }
     }
@@ -702,10 +702,17 @@ public final class StackViewTopComponent extends TopComponent
                 }
             }
         }
-        NodeStack.Frame head = locs.bottom();
-        ChainNode node = new ChainNode(head, head.getLookup().lookup(Node.class),
-                                       head.getNested() == null ? Children.LEAF : new ChainChildren(head));
+        final int indentLevel = 24;
         Children.Array arr = new Children.Array();
+        for (int i = locs.size() - 1; i > indentLevel; i--) {
+            NodeStack.Frame frame = locs.get(i);
+            ChainNode node = new ChainNode(frame, frame.getLookup().lookup(Node.class),Children.LEAF);
+            arr.add(new Node[]{node});
+        }
+
+        NodeStack.Frame head = locs.size() > indentLevel ? locs.get(indentLevel) : locs.bottom();
+        Children children = head.getNested() == null ? Children.LEAF : new ChainChildren(head);
+        ChainNode node = new ChainNode(head, head.getLookup().lookup(Node.class), children);
         arr.add(new Node[]{node});
         manager.setRootContext(new AbstractNode(arr));
         Node toSelect = findNode(locs.top());


### PR DESCRIPTION
Truffle stack traces are huge and long. I've noticed the current IGV implementation truncates them at depth 50 cutting out the most interesting parts. While investigating how to fix that I realized the problem is in indentation. While the indentation of the stack frames is nice, it is far less important than **ability to see the whole stack**.

![Less Indentation](https://github.com/oracle/graal/assets/26887752/b762c691-0b3b-4d91-ad64-fbd7d80fdcdd)

This PR inserts `org.openide.nodes.Node` instances for all frames in, but **indents only last 24**. As a result all the frames are available and the most important ones are nicely indented. CCing @sdedic, @tkrodriguez 