### PR TITLE
[GR-52295] JFR Throttler Sampling Distribution Test Update

### DIFF
--- a/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/jfr/TestThrottler.java
+++ b/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/jfr/TestThrottler.java
@@ -233,7 +233,7 @@ public class TestThrottler extends JfrRecordingTest {
     public void testDistributionHighRate() {
         int maxPopPerWindow = 2000;
         int expectedSamplesPerWindow = 50;
-        testDistribution(() -> maxPopPerWindow, expectedSamplesPerWindow, 0.02);
+        testDistribution(() -> maxPopPerWindow, expectedSamplesPerWindow, 0.05);
     }
 
     @Test
@@ -308,7 +308,7 @@ public class TestThrottler extends JfrRecordingTest {
     }
 
     private static void expectNear(double value1, double value2, double error) {
-        assertTrue(Math.abs(value1 - value2) <= error);
+        assertTrue(value1 + " is not close enough to " + value2 + ". The error tolerance is " + error, Math.abs(value1 - value2) <= error);
     }
 
     private static void assertDistributionProperties(int distributionSlots, int[] population, int[] sample, int populationSize, int sampleSize) {


### PR DESCRIPTION
This PR addresses GH issue: https://github.com/oracle/graal/issues/8401

The test case [`testDistributionHighRate`](https://github.com/oracle/graal/blob/3a131e2f5779742c793d1711cbc04837252ac9d3/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/jfr/TestThrottler.java#L233) fails intermittently due to under-sampling below the allowed error tolerance (2%). This is because the `JfrAdaptiveSampler` [incorporates an element of randomness into the sampling algorithm](https://github.com/oracle/graal/blob/master/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/throttling/JfrAdaptiveSampler.java#L170). All the `testDistribution*` test cases suffer from the same problem because they rely on tolerance values to check the sampling distribution which has some randomness to it. In the corresponding tests in Hotspot (which are actually disabled), it seems like these tolerance values have been picked arbitrarily/empirically, not derived from anything in particular. If, I remove the randomness from the sampler, the test behaves deterministically and always passes. I don't think it makes much sense to remove the randomness here since the purpose of the distribution tests is to test the random sampling. 

This PR bumps up the tolerance for the failing test to 5%. Based on what I have observed, the results are never off by more than 3% (in about 300 runs). This may not be the desired solution since there is still a non-zero chance the RNG causes the test result to be beyond the tolerance. Another solution is to remove the `testDistribution*` test cases from the set throttler tests entirely, [as is done in OpenJDK](https://github.com/openjdk/jdk/blob/b419e9517361ed9d28f8ab2f5beacf5adfe3db91/test/hotspot/gtest/jfr/test_adaptiveSampler.cpp#L243).  If we want to omit those tests, I'll update this PR to do that instead.

