### PR TITLE
Espresso: Fix parsing of LocalVariableTable and adapt JDWP implementation

### DIFF
--- a/espresso/src/com.oracle.truffle.espresso.jdwp/src/com/oracle/truffle/espresso/jdwp/impl/JDWP.java
+++ b/espresso/src/com.oracle.truffle.espresso.jdwp/src/com/oracle/truffle/espresso/jdwp/impl/JDWP.java
@@ -1505,7 +1505,7 @@ public final class JDWP {
                     reply.writeLong(local.getStartBCI());
                     reply.writeString(local.getNameAsString());
                     reply.writeString(local.getTypeAsString());
-                    reply.writeInt(local.getEndBCI() - local.getStartBCI());
+                    reply.writeInt(local.getEndBCI() - local.getStartBCI() + 1);
                     reply.writeInt(local.getSlot());
                 }
                 return new CommandResult(reply);
@@ -1618,7 +1618,7 @@ public final class JDWP {
                         }
                     }
                     reply.writeString(genericSignature);
-                    reply.writeInt(local.getEndBCI() - local.getStartBCI());
+                    reply.writeInt(local.getEndBCI() - local.getStartBCI() + 1);
                     reply.writeInt(local.getSlot());
                 }
                 return new CommandResult(reply);

--- a/espresso/src/com.oracle.truffle.espresso/src/com/oracle/truffle/espresso/classfile/ClassfileParser.java
+++ b/espresso/src/com.oracle.truffle.espresso/src/com/oracle/truffle/espresso/classfile/ClassfileParser.java
@@ -1126,7 +1126,7 @@ public final class ClassfileParser {
                 throw ConstantPool.classFormatError("Invalid local variable table attribute entry: index points to an invalid frame slot: " + slot);
             }
 
-            locals[i] = new Local(poolName, typeName, bci, bci + length, slot);
+            locals[i] = new Local(poolName, typeName, bci, bci + length - 1, slot);
 
         }
         return new LocalVariableTable(name, locals);


### PR DESCRIPTION
# Why this change is needed
During the parsing of local variable tables in class files, the start byte code index (BCI) and the end BCI between which a local variable is visible are set for each local variable. Local variables are represented with the class `Local` which implements `LocalRef`. The documentation of `LocalRef` implies that local variables are visible from the start BCI (inclusive) to the end BCI (inclusive).

When parsing the class file, the `ClassFileParser` sets the end BCI to the start BCI plus the length for which the variable is visible. According to the [JVM Specification](https://docs.oracle.com/javase/specs/jvms/se14/html/jvms-4.html#jvms-4.7.13), this index (start BCI + length) is exclusive, which contradicts the documentation of `LocalRef`.

# How the change is implemented
This PR aligns the class file parser to the documentation of `LocalRef`, by setting the end BCI to the last index a variable is visible (start BCI + length - 1) while parsing and thus following the documentation of `LocalRef`. Since the JDWP implementation assumes the end BCI to be exclusive as well, it has been adapted to the change.