### PR TITLE
[GR-52942] Add JFR events and track peak usage for native memory tracking.

### DIFF
--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/JfrEvent.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/JfrEvent.java
@@ -71,6 +71,8 @@ public final class JfrEvent {
     public static final JfrEvent AllocationRequiringGC = create("jdk.AllocationRequiringGC");
     public static final JfrEvent OldObjectSample = create("jdk.OldObjectSample");
     public static final JfrEvent ObjectAllocationSample = create("jdk.ObjectAllocationSample", JfrEventFlags.SupportsThrottling);
+    public static final JfrEvent NativeMemoryUsage = create("jdk.NativeMemoryUsage");
+    public static final JfrEvent NativeMemoryUsageTotal = create("jdk.NativeMemoryUsageTotal");
 
     private final long id;
     private final String name;

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/JfrFeature.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/JfrFeature.java
@@ -172,7 +172,9 @@ public class JfrFeature implements InternalFeature {
         JfrSerializerSupport.get().register(new JfrGCNameSerializer());
         JfrSerializerSupport.get().register(new JfrVMOperationNameSerializer());
         JfrSerializerSupport.get().register(new JfrGCWhenSerializer());
-
+        if (VMInspectionOptions.hasNativeMemoryTrackingSupport()) {
+            JfrSerializerSupport.get().register(new JfrNmtCategorySerializer());
+        }
         ThreadListenerSupport.get().register(SubstrateJVM.getThreadLocal());
 
         RuntimeClassInitializationSupport rci = ImageSingletons.lookup(RuntimeClassInitializationSupport.class);

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/JfrNmtCategorySerializer.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/JfrNmtCategorySerializer.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2024, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, 2024, Red Hat Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package com.oracle.svm.core.jfr;
+
+import com.oracle.svm.core.nmt.NmtCategory;
+import org.graalvm.nativeimage.Platform;
+import org.graalvm.nativeimage.Platforms;
+
+public class JfrNmtCategorySerializer implements JfrSerializer {
+    @Platforms(Platform.HOSTED_ONLY.class)
+    public JfrNmtCategorySerializer() {
+    }
+
+    @Override
+    public void write(JfrChunkWriter writer) {
+        writer.writeCompressedLong(JfrType.NMTType.getId());
+
+        NmtCategory[] nmtCategories = NmtCategory.values();
+        writer.writeCompressedLong(nmtCategories.length);
+        for (int i = 0; i < nmtCategories.length; i++) {
+            writer.writeCompressedInt(i);
+            writer.writeString(nmtCategories[i].getName());
+        }
+    }
+}

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/JfrType.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/JfrType.java
@@ -47,7 +47,8 @@ public enum JfrType {
     GCWhen("jdk.types.GCWhen"),
     VMOperation("jdk.types.VMOperationType"),
     MonitorInflationCause("jdk.types.InflateCause"),
-    OldObject("jdk.types.OldObject");
+    OldObject("jdk.types.OldObject"),
+    NMTType("jdk.types.NMTType");
 
     private final long id;
 

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/events/NativeMemoryUsagePeakEvent.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/events/NativeMemoryUsagePeakEvent.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2024, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, 2024, Red Hat Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package com.oracle.svm.core.jfr.events;
+
+import jdk.jfr.Category;
+import jdk.jfr.Description;
+import jdk.jfr.Event;
+import jdk.jfr.Label;
+import jdk.jfr.Name;
+import jdk.jfr.StackTrace;
+
+@Name("svm.NativeMemoryUsagePeak")
+@Label("Native Memory Usage Peak")
+@Description("Information about native memory peak usage of committed virtual memory and malloc.")
+@Category("Native Image")
+@StackTrace(false)
+public class NativeMemoryUsagePeakEvent extends Event {
+    @Label("Memory Type") public String type;
+    @Label("Peak Usage") public long peakUsage;
+    @Label("Count At Peak") public long countAtPeak;
+}

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/events/NativeMemoryUsageTotalPeakEvent.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/events/NativeMemoryUsageTotalPeakEvent.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2024, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, 2024, Red Hat Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package com.oracle.svm.core.jfr.events;
+
+import jdk.jfr.Category;
+import jdk.jfr.Description;
+import jdk.jfr.Event;
+import jdk.jfr.Label;
+import jdk.jfr.Name;
+import jdk.jfr.StackTrace;
+
+@Name("svm.NativeMemoryUsageTotalPeak")
+@Label("Native Memory Usage Total Peak")
+@Description("Information about native memory peak usage of committed virtual memory and malloc.")
+@Category("Native Image")
+@StackTrace(false)
+public class NativeMemoryUsageTotalPeakEvent extends Event {
+    @Label("Peak Usage") public long peakUsage;
+    @Label("Count At Peak") public long countAtPeak;
+}

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/nmt/NativeMemoryTracking.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/nmt/NativeMemoryTracking.java
@@ -144,8 +144,39 @@ public class NativeMemoryTracking {
         return ((Pointer) mallocHeader).add(sizeOfNmtHeader());
     }
 
+    @Uninterruptible(reason = CALLED_FROM_UNINTERRUPTIBLE_CODE, mayBeInlined = true)
     public long getUsedMemory(NmtCategory category) {
         return mallocMemorySnapshot.getInfoByCategory(category).getUsed();
+    }
+
+    @Uninterruptible(reason = CALLED_FROM_UNINTERRUPTIBLE_CODE, mayBeInlined = true)
+    public long getPeakUsedMemory(NmtCategory category) {
+        return mallocMemorySnapshot.getInfoByCategory(category).getPeakUsed();
+    }
+
+    @Uninterruptible(reason = CALLED_FROM_UNINTERRUPTIBLE_CODE, mayBeInlined = true)
+    public long getCountAtPeakUsage(NmtCategory category) {
+        return mallocMemorySnapshot.getInfoByCategory(category).getCountAtPeakUsage();
+    }
+
+    @Uninterruptible(reason = CALLED_FROM_UNINTERRUPTIBLE_CODE, mayBeInlined = true)
+    public long getTotalCount() {
+        return mallocMemorySnapshot.getTotalInfo().getCount();
+    }
+
+    @Uninterruptible(reason = CALLED_FROM_UNINTERRUPTIBLE_CODE, mayBeInlined = true)
+    public long getTotalUsedMemory() {
+        return mallocMemorySnapshot.getTotalInfo().getUsed();
+    }
+
+    @Uninterruptible(reason = CALLED_FROM_UNINTERRUPTIBLE_CODE, mayBeInlined = true)
+    public long getPeakTotalUsedMemory() {
+        return mallocMemorySnapshot.getTotalInfo().getPeakUsed();
+    }
+
+    @Uninterruptible(reason = CALLED_FROM_UNINTERRUPTIBLE_CODE, mayBeInlined = true)
+    public long getCountAtTotalPeakUsage() {
+        return mallocMemorySnapshot.getTotalInfo().getCountAtPeakUsage();
     }
 
     public static RuntimeSupport.Hook shutdownHook() {
@@ -156,13 +187,17 @@ public class NativeMemoryTracking {
         if (VMInspectionOptions.PrintNMTStatistics.getValue()) {
             System.out.println();
             System.out.println("Native memory tracking");
-            System.out.println("  Total used memory: " + mallocMemorySnapshot.getTotalInfo().getUsed() + " bytes");
-            System.out.println("  Total alive allocations: " + mallocMemorySnapshot.getTotalInfo().getCount());
+            System.out.println("  Peak total used memory: " + getPeakTotalUsedMemory() + " bytes");
+            System.out.println("  Total alive allocations at peak usage: " + getCountAtTotalPeakUsage());
+            System.out.println("  Total used memory: " + getTotalUsedMemory() + " bytes");
+            System.out.println("  Total alive allocations: " + getTotalCount());
 
             for (int i = 0; i < NmtCategory.values().length; i++) {
                 String name = NmtCategory.values()[i].getName();
                 NmtMallocMemoryInfo info = mallocMemorySnapshot.getInfoByCategory(i);
 
+                System.out.println("  " + name + " peak used memory: " + info.getPeakUsed() + " bytes");
+                System.out.println("  " + name + " alive allocations at peak: " + info.getCountAtPeakUsage());
                 System.out.println("  " + name + " used memory: " + info.getUsed() + " bytes");
                 System.out.println("  " + name + " alive allocations: " + info.getCount());
             }

--- a/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/jfr/TestNmtEvents.java
+++ b/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/jfr/TestNmtEvents.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2024, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, 2024, Red Hat Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package com.oracle.svm.test.jfr;
+
+import static org.junit.Assert.assertTrue;
+
+import com.oracle.svm.core.jfr.JfrEvent;
+import com.oracle.svm.core.memory.NativeMemory;
+import com.oracle.svm.core.nmt.NmtCategory;
+
+import java.util.List;
+
+import jdk.jfr.Recording;
+import jdk.jfr.consumer.RecordedEvent;
+import org.junit.Test;
+
+import org.graalvm.word.Pointer;
+import org.graalvm.word.WordFactory;
+
+public class TestNmtEvents extends JfrRecordingTest {
+    private static final int ALLOCATION_SIZE = 1024 * 16;
+
+    @Test
+    public void test() throws Throwable {
+        String[] events = new String[]{
+                        JfrEvent.NativeMemoryUsage.getName(),
+                        JfrEvent.NativeMemoryUsageTotal.getName(),
+                        "svm.NativeMemoryUsageTotalPeak",
+                        "svm.NativeMemoryUsagePeak"
+        };
+
+        Recording recording = startRecording(events);
+
+        Pointer ptr = NativeMemory.malloc(WordFactory.unsigned(ALLOCATION_SIZE), NmtCategory.Code);
+
+        /* Force a chunk rotation to trigger periodic event emission. */
+        recording.dump(createTempJfrFile());
+
+        NativeMemory.free(ptr);
+
+        stopRecording(recording, TestNmtEvents::validateEvents);
+    }
+
+    private static void validateEvents(List<RecordedEvent> events) {
+        boolean foundNativeMemoryUsage = false;
+        boolean foundNativeMemoryUsageTotal = false;
+        boolean foundNativeMemoryUsageTotalPeak = false;
+        boolean foundNativeMemoryUsagePeak = false;
+
+        assertTrue(events.size() >= 4);
+        for (RecordedEvent e : events) {
+            if (e.getEventType().getName().equals(JfrEvent.NativeMemoryUsage.getName()) &&
+                            e.getString("type").equals(NmtCategory.Code.getName())) {
+                foundNativeMemoryUsage = true;
+
+            }
+            if (e.getEventType().getName().equals("svm.NativeMemoryUsageTotalPeak")) {
+                foundNativeMemoryUsageTotalPeak = true;
+            }
+            if (e.getEventType().getName().equals("svm.NativeMemoryUsagePeak") &&
+                            e.getString("type").equals(NmtCategory.Code.getName())) {
+                foundNativeMemoryUsagePeak = true;
+            }
+            if (e.getEventType().getName().equals(JfrEvent.NativeMemoryUsageTotal.getName())) {
+                foundNativeMemoryUsageTotal = true;
+            }
+        }
+        assertTrue(foundNativeMemoryUsage);
+        assertTrue(foundNativeMemoryUsageTotal);
+        assertTrue(foundNativeMemoryUsagePeak);
+        assertTrue(foundNativeMemoryUsageTotalPeak);
+    }
+}

--- a/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/jfr/utils/JfrFileParser.java
+++ b/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/jfr/utils/JfrFileParser.java
@@ -54,6 +54,7 @@ import com.oracle.svm.test.jfr.utils.poolparsers.GCWhenConstantPoolParser;
 import com.oracle.svm.test.jfr.utils.poolparsers.MethodConstantPoolParser;
 import com.oracle.svm.test.jfr.utils.poolparsers.ModuleConstantPoolParser;
 import com.oracle.svm.test.jfr.utils.poolparsers.MonitorInflationCauseConstantPoolParser;
+import com.oracle.svm.test.jfr.utils.poolparsers.NmtCategoryConstantPoolParser;
 import com.oracle.svm.test.jfr.utils.poolparsers.OldObjectConstantPoolParser;
 import com.oracle.svm.test.jfr.utils.poolparsers.PackageConstantPoolParser;
 import com.oracle.svm.test.jfr.utils.poolparsers.StacktraceConstantPoolParser;
@@ -92,6 +93,7 @@ public class JfrFileParser {
         addParser(JfrType.MonitorInflationCause, new MonitorInflationCauseConstantPoolParser(this));
         addParser(JfrType.GCWhen, new GCWhenConstantPoolParser(this));
         addParser(JfrType.OldObject, new OldObjectConstantPoolParser(this));
+        addParser(JfrType.NMTType, new NmtCategoryConstantPoolParser(this));
     }
 
     private void addParser(JfrType type, ConstantPoolParser parser) {

--- a/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/jfr/utils/poolparsers/NmtCategoryConstantPoolParser.java
+++ b/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/jfr/utils/poolparsers/NmtCategoryConstantPoolParser.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2024, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, 2024, Red Hat Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package com.oracle.svm.test.jfr.utils.poolparsers;
+
+import com.oracle.svm.test.jfr.utils.JfrFileParser;
+import com.oracle.svm.test.jfr.utils.RecordingInput;
+import org.junit.Assert;
+
+import java.io.IOException;
+
+public class NmtCategoryConstantPoolParser extends AbstractSerializerParser {
+    public NmtCategoryConstantPoolParser(JfrFileParser parser) {
+        super(parser);
+    }
+
+    @Override
+    public void parse(RecordingInput input) throws IOException {
+        int count = input.readInt();
+        Assert.assertTrue(count > 0);
+        for (int i = 0; i < count; i++) {
+            addFoundId(input.readInt());
+            Assert.assertFalse("NMT category name is empty!", input.readUTF().isEmpty());
+        }
+    }
+}

--- a/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/nmt/NativeMemoryTrackingTests.java
+++ b/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/nmt/NativeMemoryTrackingTests.java
@@ -83,6 +83,24 @@ public class NativeMemoryTrackingTests {
         assertEquals(0, getUsedMemory());
     }
 
+    @Test
+    public void testPeakTracking() {
+        assertEquals(0, getUsedMemory());
+
+        Pointer ptr1 = NativeMemory.malloc(WordFactory.unsigned(ALLOCATION_SIZE), NmtCategory.Code);
+        long initialPeak = NativeMemoryTracking.singleton().getPeakUsedMemory(NmtCategory.Code);
+        assertTrue(initialPeak > 0);
+
+        Pointer ptr2 = NativeMemory.malloc(WordFactory.unsigned(initialPeak * 2), NmtCategory.Code);
+        long newPeak = NativeMemoryTracking.singleton().getPeakUsedMemory(NmtCategory.Code);
+        assertTrue(newPeak >= initialPeak * 2);
+
+        NativeMemory.free(ptr1);
+        NativeMemory.free(ptr2);
+        assertTrue(NativeMemoryTracking.singleton().getPeakUsedMemory(NmtCategory.Code) == newPeak);
+        assertEquals(0, getUsedMemory());
+    }
+
     private static long getUsedMemory() {
         return NativeMemoryTracking.singleton().getUsedMemory(NmtCategory.Code);
     }


### PR DESCRIPTION
This pull request adds JFR events for recently added native memory tracking. 

It also adds tracking of peak malloc usage. Unfortunately, the stock NMT JFR events from the openJDK do not contain peak usage data. So the only way to view the peak usage data is by specifying `-XX:+PrintNMTStatistics` at runtime.  Another possibility is to add Native Image specific `NativeMemoryUsagePeak` events.

See issue: https://github.com/oracle/graal/issues/8452