### PR TITLE
[GR-52453] Implement jdk.ContainerConfiguration.hostTotalMemory()

### DIFF
--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/Target_jdk_jfr_internal_JVM.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/Target_jdk_jfr_internal_JVM.java
@@ -27,6 +27,7 @@ package com.oracle.svm.core.jfr;
 import java.util.List;
 import java.util.function.BooleanSupplier;
 
+import org.graalvm.nativeimage.ImageSingletons;
 import org.graalvm.nativeimage.Platform;
 import org.graalvm.nativeimage.Platforms;
 import org.graalvm.nativeimage.ProcessProperties;
@@ -38,6 +39,7 @@ import com.oracle.svm.core.annotate.RecomputeFieldValue;
 import com.oracle.svm.core.annotate.Substitute;
 import com.oracle.svm.core.annotate.TargetClass;
 import com.oracle.svm.core.annotate.TargetElement;
+import com.oracle.svm.core.heap.PhysicalMemory.PhysicalMemorySupport;
 import com.oracle.svm.core.jdk.JDK22OrLater;
 import com.oracle.svm.core.jdk.JDK23OrLater;
 import com.oracle.svm.core.jfr.traceid.JfrTraceId;
@@ -527,15 +529,16 @@ public final class Target_jdk_jfr_internal_JVM {
     @Substitute
     @TargetElement(onlyWith = JDK22OrLater.class) //
     public static long hostTotalMemory() {
-        /* Not implemented at the moment. */
-        return 0;
+        // This is intentionally using PhysicalMemorySupport since we are
+        // interested in the host values (and not the containerized values).
+        return ImageSingletons.lookup(PhysicalMemorySupport.class).size().rawValue();
     }
 
     @Substitute
     @TargetElement(onlyWith = JDK23OrLater.class) //
     public static long hostTotalSwapMemory() {
         /* Not implemented at the moment. */
-        return 0;
+        return -1;
     }
 }
 

--- a/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/jfr/TestContainerEvent.java
+++ b/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/jfr/TestContainerEvent.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2024, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package com.oracle.svm.test.jfr;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.List;
+
+import org.junit.Test;
+
+import com.oracle.svm.test.jfr.events.ThreadEvent;
+
+import jdk.jfr.Recording;
+import jdk.jfr.consumer.RecordedEvent;
+
+/**
+ * Test if event jdk.ContainerConfiguration is working.
+ */
+public class TestContainerEvent extends JfrRecordingTest {
+    @Test
+    public void test() throws Throwable {
+        String[] events = new String[]{"jdk.ContainerConfiguration"};
+        Recording recording = startRecording(events);
+
+        // Do something; doesn't matter what
+        ThreadEvent event = new ThreadEvent();
+        event.thread = Thread.currentThread();
+        event.commit();
+
+        stopRecording(recording, TestContainerEvent::validateEvents);
+    }
+
+    private static void validateEvents(List<RecordedEvent> events) {
+        assertEquals(1, events.size());
+        assertEquals(events.getFirst().getEventType().getName(), "jdk.ContainerConfiguration");
+        RecordedEvent re = events.getFirst();
+        long hostTotalMem = (long) re.getValue("hostTotalMemory");
+        long hostTotalSwap = (long) re.getValue("hostTotalSwapMemory");
+
+        assertTrue(hostTotalMem > 0);
+        assertTrue("Host swap not implemented", hostTotalSwap < 0);
+    }
+}


### PR DESCRIPTION
Use `PhysicalMemorySupport` to retrieve the total host value. The `PhysicalMemory` class would return the container values.

Closes: #8485

**Testing**

- [x] Reproducer from #8485 passes after this patch. Tested inside and outside a container with a memory limit.

Inside a container with a memory limit of 500MB:
```
jdk.ContainerConfiguration {
  startTime = 13:10:55.301
  containerType = "cgroupv1"
  cpuSlicePeriod = 100 ms
  cpuQuota = 300 ms
  cpuShares = -1
  effectiveCpuCount = 3
  memorySoftLimit = -1 byte
  memoryLimit = 500.0 MB
  swapMemoryLimit = 600.0 MB
  hostTotalMemory = 62.6 GB
  hostTotalSwapMemory = -1 byte
}
```

On the physical host:
```
jdk.ContainerConfiguration {
  startTime = 14:06:32.742
  containerType = "cgroupv1"
  cpuSlicePeriod = 100 ms
  cpuQuota = -0.00100 ms
  cpuShares = -1
  effectiveCpuCount = 12
  memorySoftLimit = -1 byte
  memoryLimit = -1 byte
  swapMemoryLimit = -1 byte
  hostTotalMemory = 62.6 GB
  hostTotalSwapMemory = -1 byte
}
``` 