### PR TITLE
[GR-52454] Include signal exit handlers in the image build if JFR or NMT is also included

### DIFF
--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/SubstrateExitHandlerFeature.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/SubstrateExitHandlerFeature.java
@@ -34,7 +34,7 @@ import com.oracle.svm.core.feature.AutomaticallyRegisteredFeature;
 public class SubstrateExitHandlerFeature implements InternalFeature {
     @Override
     public void beforeAnalysis(BeforeAnalysisAccess access) {
-        if (SubstrateOptions.InstallExitHandlers.getValue()) {
+        if (SubstrateOptions.InstallExitHandlers.getValue() || VMInspectionOptions.hasJfrSupport() || VMInspectionOptions.hasNativeMemoryTrackingSupport()) {
             RuntimeSupport.getRuntimeSupport().addStartupHook(new SubstrateExitHandlerStartupHook());
         }
     }


### PR DESCRIPTION
Currently, Native Image shutdown hooks don't run upon SIGINT unless the hosted option`--install-exit-handlers` is set to true at build time. This is a problem for JFR and NMT that do important work such as dumping stats/recordings on exit.

See issue: https://github.com/oracle/graal/issues/8482