### PR TITLE
[GR-52484] Partial support for physical memory usage (fixes JFR bug) and JFR tests for periodic native events

### DIFF
--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/heap/PhysicalMemory.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/heap/PhysicalMemory.java
@@ -24,9 +24,15 @@
  */
 package com.oracle.svm.core.heap;
 
+import java.io.IOException;
+import java.lang.management.ManagementFactory;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.List;
 import java.util.concurrent.locks.ReentrantLock;
 
 import org.graalvm.nativeimage.ImageSingletons;
+import org.graalvm.nativeimage.Platform;
 import org.graalvm.word.UnsignedWord;
 import org.graalvm.word.WordFactory;
 
@@ -39,6 +45,8 @@ import com.oracle.svm.core.thread.VMOperation;
 import com.oracle.svm.core.util.UnsignedUtils;
 import com.oracle.svm.core.util.VMError;
 
+import com.sun.management.OperatingSystemMXBean;
+
 /**
  * Contains static methods to get configuration of physical memory.
  */
@@ -49,6 +57,8 @@ public class PhysicalMemory {
         /** Get the size of physical memory from the OS. */
         UnsignedWord size();
     }
+
+    private static final long K = 1024;
 
     private static final ReentrantLock LOCK = new ReentrantLock();
     private static final UnsignedWord UNSET_SENTINEL = UnsignedUtils.MAX_VALUE;
@@ -105,6 +115,36 @@ public class PhysicalMemory {
         }
 
         return cachedSize;
+    }
+
+    /**
+     * Returns the amount of used physical memory in bytes, or -1 if not supported yet.
+     */
+    public static long usedSize() {
+        // Containerized Linux, Windows and Mac OS X use the OS bean
+        if ((Containers.isContainerized() && Containers.memoryLimitInBytes() > 0) ||
+                        Platform.includedIn(Platform.WINDOWS.class) ||
+                        Platform.includedIn(Platform.MACOS.class)) {
+            OperatingSystemMXBean osBean = (com.sun.management.OperatingSystemMXBean) ManagementFactory.getOperatingSystemMXBean();
+            return osBean.getTotalMemorySize() - osBean.getFreeMemorySize();
+        }
+        // Non-containerized Linux uses MemAvailable from /proc/meminfo
+        if (Platform.includedIn(Platform.LINUX.class)) {
+            try {
+                List<String> lines = Files.readAllLines(Paths.get("/proc/meminfo"));
+                for (String line : lines) {
+                    if (!line.contains("MemAvailable")) {
+                        continue;
+                    }
+                    String memAvailable = line.replaceAll("\\D", "");
+                    if (!memAvailable.isEmpty()) {
+                        return size().rawValue() - Long.parseLong(memAvailable) * K;
+                    }
+                }
+            } catch (IOException e) {
+            }
+        }
+        return -1;
     }
 
     /**

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/events/EveryChunkNativePeriodicEvents.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/events/EveryChunkNativePeriodicEvents.java
@@ -51,7 +51,7 @@ public class EveryChunkNativePeriodicEvents extends Event {
 
     public static void emit() {
         emitJavaThreadStats();
-        emitPhysicalMemory();
+        emitPhysicalMemory(PhysicalMemory.usedSize());
         emitClassLoadingStatistics();
         emitPerThreadEvents();
     }
@@ -75,7 +75,7 @@ public class EveryChunkNativePeriodicEvents extends Event {
     }
 
     @Uninterruptible(reason = "Accesses a JFR buffer.")
-    private static void emitPhysicalMemory() {
+    private static void emitPhysicalMemory(long usedSize) {
         if (JfrEvent.PhysicalMemory.shouldEmit()) {
             JfrNativeEventWriterData data = StackValue.get(JfrNativeEventWriterData.class);
             JfrNativeEventWriterDataAccess.initializeThreadLocalNativeBuffer(data);
@@ -83,7 +83,7 @@ public class EveryChunkNativePeriodicEvents extends Event {
             JfrNativeEventWriter.beginSmallEvent(data, JfrEvent.PhysicalMemory);
             JfrNativeEventWriter.putLong(data, JfrTicks.elapsedTicks());
             JfrNativeEventWriter.putLong(data, PhysicalMemory.getCachedSize().rawValue());
-            JfrNativeEventWriter.putLong(data, 0); /* used size */
+            JfrNativeEventWriter.putLong(data, usedSize); /* used size */
             JfrNativeEventWriter.endSmallEvent(data);
         }
     }

--- a/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/jfr/TestEveryChunkNativePeriodicEvents.java
+++ b/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/jfr/TestEveryChunkNativePeriodicEvents.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2024, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, 2024, Red Hat Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package com.oracle.svm.test.jfr;
+
+import static org.junit.Assert.assertTrue;
+
+import com.oracle.svm.core.jfr.JfrEvent;
+
+import java.util.List;
+
+import jdk.jfr.Recording;
+import jdk.jfr.consumer.RecordedEvent;
+import org.junit.Test;
+
+/**
+ * This tests built in native JFR events that are sent periodically upon every chunk. The events
+ * ThreadCPULoad and ThreadAllocationStatistics are not tested here since they already have their
+ * own individual tests.
+ */
+public class TestEveryChunkNativePeriodicEvents extends JfrRecordingTest {
+
+    @Test
+    public void test() throws Throwable {
+        String[] events = new String[]{
+                        JfrEvent.JavaThreadStatistics.getName(),
+                        JfrEvent.PhysicalMemory.getName(),
+                        JfrEvent.ClassLoadingStatistics.getName(),
+        };
+        Recording recording = startRecording(events);
+
+        stopRecording(recording, this::validateEvents);
+    }
+
+    private void validateEvents(List<RecordedEvent> events) {
+        boolean foundJavaThreadStatistics = false;
+        boolean foundPhysicalMemory = false;
+        boolean foundClassLoadingStatistics = false;
+        for (RecordedEvent e : events) {
+            if (e.getEventType().getName().equals(JfrEvent.JavaThreadStatistics.getName())) {
+                foundJavaThreadStatistics = true;
+                assertTrue(e.getLong("activeCount") > 1);
+                assertTrue(e.getLong("daemonCount") > 0);
+                assertTrue(e.getLong("accumulatedCount") > 1);
+                assertTrue(e.getLong("peakCount") > 1);
+            } else if (e.getEventType().getName().equals(JfrEvent.PhysicalMemory.getName())) {
+                foundPhysicalMemory = true;
+                assertTrue(e.getLong("totalSize") > 0);
+                assertTrue(e.getLong("usedSize") > 0 || e.getLong("usedSize") == -1);
+
+            } else if (e.getEventType().getName().equals(JfrEvent.ClassLoadingStatistics.getName())) {
+                foundClassLoadingStatistics = true;
+                assertTrue(e.getLong("loadedClassCount") > 0);
+            }
+        }
+        assertTrue(foundJavaThreadStatistics && foundPhysicalMemory && foundClassLoadingStatistics);
+    }
+
+}


### PR DESCRIPTION
### Summary

- Add partial support for physical memory usage (if container usage is enabled and linux). 
- Fix bug when reporting physical memory usage in `jdk.PhysicalMemory` JFR event. It will now be set to a valid value or -1 (instead of 0).
- Add tests for `jdk.PhysicalMemory` and other periodic native JFR events.

Note: Eventually, it may be worth adding support in for the case `Containers.isContainerized()` is false. This will require different implementations for different OS. In hotspot, the implmentation for Linux attempts to read `/proc/meminfo `, and if that fails, it tries to read the struct returned from the sysinfo() call.

Related issue: https://github.com/oracle/graal/issues/8486

```
$ mx native-image --install-exit-handlers --enable-monitoring=jfr -m jdk.httpserver

$ ./jdk.httpserver -XX:StartFlightRecording=filename=rec.jfr 

$ $JAVA_HOME/bin/jfr print --events jdk.PhysicalMemory rec.jfr 
jdk.PhysicalMemory {
  startTime = 13:14:55.953 (2024-03-04)
  totalSize = 62.4 GB
  usedSize = 35.3 GB
}

jdk.PhysicalMemory {
  startTime = 13:14:57.352 (2024-03-04)
  totalSize = 62.4 GB
  usedSize = 35.3 GB
}


```