### PR TITLE
Omit unnecessary AMD64 TEST instruction

### DIFF
--- a/compiler/src/jdk.graal.compiler/src/jdk/graal/compiler/core/amd64/AMD64NodeLIRBuilder.java
+++ b/compiler/src/jdk.graal.compiler/src/jdk/graal/compiler/core/amd64/AMD64NodeLIRBuilder.java
@@ -31,7 +31,6 @@ import jdk.graal.compiler.core.common.util.CompilationAlarm;
 import jdk.graal.compiler.lir.LIRFrameState;
 import jdk.graal.compiler.lir.amd64.AMD64Call;
 import jdk.graal.compiler.lir.gen.LIRGeneratorTool;
-import jdk.graal.compiler.nodes.DeoptimizingNode;
 import jdk.graal.compiler.nodes.FixedNode;
 import jdk.graal.compiler.nodes.FixedWithNextNode;
 import jdk.graal.compiler.nodes.IfNode;
@@ -62,62 +61,58 @@ public abstract class AMD64NodeLIRBuilder extends NodeLIRBuilder {
 
     @Override
     protected boolean peephole(ValueNode valueNode) {
-        if (valueNode instanceof IntegerDivRemNode) {
-            AMD64ArithmeticLIRGenerator arithmeticGen = (AMD64ArithmeticLIRGenerator) gen.getArithmetic();
-            IntegerDivRemNode divRem = (IntegerDivRemNode) valueNode;
-            FixedNode node = divRem.next();
-            while (true) { // TERMINATION ARGUMENT: iterating next nodes
-                CompilationAlarm.checkProgress(valueNode.graph());
-                if (node instanceof IfNode) {
-                    IfNode ifNode = (IfNode) node;
-                    double probability = ifNode.getTrueSuccessorProbability();
-                    if (probability == 1.0) {
-                        node = ifNode.trueSuccessor();
-                    } else if (probability == 0.0) {
-                        node = ifNode.falseSuccessor();
-                    } else {
-                        break;
-                    }
-                } else if (!(node instanceof FixedWithNextNode)) {
+        if (valueNode instanceof IntegerDivRemNode divRemNode) {
+            return peepholeDivRem(divRemNode);
+        }
+        return false;
+    }
+
+    protected boolean peepholeDivRem(IntegerDivRemNode divRem) {
+        AMD64ArithmeticLIRGenerator arithmeticGen = (AMD64ArithmeticLIRGenerator) gen.getArithmetic();
+        FixedNode node = divRem.next();
+        while (true) { // TERMINATION ARGUMENT: iterating next nodes
+            CompilationAlarm.checkProgress(divRem.graph());
+            if (node instanceof IfNode ifNode) {
+                double probability = ifNode.getTrueSuccessorProbability();
+                if (probability == 1.0) {
+                    node = ifNode.trueSuccessor();
+                } else if (probability == 0.0) {
+                    node = ifNode.falseSuccessor();
+                } else {
                     break;
                 }
+            } else if (!(node instanceof FixedWithNextNode)) {
+                break;
+            }
 
-                FixedWithNextNode fixedWithNextNode = (FixedWithNextNode) node;
-                if (fixedWithNextNode instanceof IntegerDivRemNode) {
-                    IntegerDivRemNode otherDivRem = (IntegerDivRemNode) fixedWithNextNode;
-                    if (divRem.getOp() != otherDivRem.getOp() && divRem.getType() == otherDivRem.getType()) {
-                        if (otherDivRem.getX() == divRem.getX() && otherDivRem.getY() == divRem.getY() && !hasOperand(otherDivRem)) {
-                            Value[] results;
-                            switch (divRem.getType()) {
-                                case SIGNED:
-                                    results = arithmeticGen.emitSignedDivRem(operand(divRem.getX()), operand(divRem.getY()), state((DeoptimizingNode) valueNode));
-                                    break;
-                                case UNSIGNED:
-                                    results = arithmeticGen.emitUnsignedDivRem(operand(divRem.getX()), operand(divRem.getY()), state((DeoptimizingNode) valueNode));
-                                    break;
-                                default:
-                                    throw GraalError.shouldNotReachHereUnexpectedValue(divRem.getType()); // ExcludeFromJacocoGeneratedReport
-                            }
-                            switch (divRem.getOp()) {
-                                case DIV:
-                                    assert otherDivRem.getOp() == Op.REM : Assertions.errorMessage(valueNode, otherDivRem);
-                                    setResult(divRem, results[0]);
-                                    setResult(otherDivRem, results[1]);
-                                    break;
-                                case REM:
-                                    assert otherDivRem.getOp() == Op.DIV : Assertions.errorMessage(valueNode, otherDivRem);
-                                    setResult(divRem, results[1]);
-                                    setResult(otherDivRem, results[0]);
-                                    break;
-                                default:
-                                    throw GraalError.shouldNotReachHereUnexpectedValue(divRem.getOp()); // ExcludeFromJacocoGeneratedReport
-                            }
-                            return true;
+            FixedWithNextNode fixedWithNextNode = (FixedWithNextNode) node;
+            if (fixedWithNextNode instanceof IntegerDivRemNode otherDivRem) {
+                if (divRem.getOp() != otherDivRem.getOp() && divRem.getType() == otherDivRem.getType()) {
+                    if (otherDivRem.getX() == divRem.getX() && otherDivRem.getY() == divRem.getY() && !hasOperand(otherDivRem)) {
+                        Value[] results = switch (divRem.getType()) {
+                            case SIGNED -> arithmeticGen.emitSignedDivRem(operand(divRem.getX()), operand(divRem.getY()), state(divRem));
+                            case UNSIGNED -> arithmeticGen.emitUnsignedDivRem(operand(divRem.getX()), operand(divRem.getY()), state(divRem));
+                            default -> throw GraalError.shouldNotReachHereUnexpectedValue(divRem.getType()); // ExcludeFromJacocoGeneratedReport
+                        };
+                        switch (divRem.getOp()) {
+                            case DIV:
+                                assert otherDivRem.getOp() == Op.REM : Assertions.errorMessage(divRem, otherDivRem);
+                                setResult(divRem, results[0]);
+                                setResult(otherDivRem, results[1]);
+                                break;
+                            case REM:
+                                assert otherDivRem.getOp() == Op.DIV : Assertions.errorMessage(divRem, otherDivRem);
+                                setResult(divRem, results[1]);
+                                setResult(otherDivRem, results[0]);
+                                break;
+                            default:
+                                throw GraalError.shouldNotReachHereUnexpectedValue(divRem.getOp()); // ExcludeFromJacocoGeneratedReport
                         }
+                        return true;
                     }
                 }
-                node = fixedWithNextNode.next();
             }
+            node = fixedWithNextNode.next();
         }
         return false;
     }


### PR DESCRIPTION
This is inspired by similar [change](https://bugs.openjdk.org/browse/JDK-8312213) in JDK. When a TEST instruction immediately follows one of AND/OR/XOR, it may be left out because the necessary flags (SF, ZF) are already set.

This patch might probably be structured better, and extended to support more cases. But first I'd just like to check if the approach taken is sane and overall makes sense, so I'd appreciate comments and criticisms.