### PR TITLE
svm: fix for JDK 21.0.4 after the downport of "8315373: Change VirtualThread to unmount after freezing, re-mount before thawing" and dependnet changes

### DIFF
--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/JDK21u3OrEarlier.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/JDK21u3OrEarlier.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package com.oracle.svm.core.jdk;
+
+import java.util.function.BooleanSupplier;
+
+import org.graalvm.compiler.serviceprovider.JavaVersionUtil;
+
+public class JDK21u3OrEarlier implements BooleanSupplier {
+
+    public static final boolean jdk21u3OrEarlier = JavaVersionUtil.JAVA_SPEC < 21 ||
+        (JavaVersionUtil.JAVA_SPEC == 21 && Runtime.version().update() <= 3);
+
+    @Override
+    public boolean getAsBoolean() {
+        return jdk21u3OrEarlier;
+    }
+}

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/JDK21u4OrLater.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/JDK21u4OrLater.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package com.oracle.svm.core.jdk;
+
+import java.util.function.BooleanSupplier;
+
+import org.graalvm.compiler.serviceprovider.JavaVersionUtil;
+
+public class JDK21u4OrLater implements BooleanSupplier {
+
+    public static final boolean jdk21u4OrLater = JavaVersionUtil.JAVA_SPEC > 21 ||
+        (JavaVersionUtil.JAVA_SPEC == 21 && Runtime.version().update() >= 4);
+
+    @Override
+    public boolean getAsBoolean() {
+        return jdk21u4OrLater;
+    }
+}

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/thread/Target_java_lang_VirtualThread.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/thread/Target_java_lang_VirtualThread.java
@@ -30,6 +30,8 @@ import static com.oracle.svm.core.thread.VirtualThreadHelper.asThread;
 import java.util.Locale;
 import java.util.concurrent.Executor;
 
+import org.graalvm.compiler.serviceprovider.JavaVersionUtil;
+
 import com.oracle.svm.core.SubstrateUtil;
 import com.oracle.svm.core.Uninterruptible;
 import com.oracle.svm.core.annotate.Alias;
@@ -43,6 +45,7 @@ import com.oracle.svm.core.jdk.JDK19OrLater;
 import com.oracle.svm.core.jdk.JDK20OrEarlier;
 import com.oracle.svm.core.jdk.JDK20OrLater;
 import com.oracle.svm.core.jdk.JDK21OrLater;
+import com.oracle.svm.core.jdk.JDK21OrEarlier;
 import com.oracle.svm.core.jdk.LoomJDK;
 import com.oracle.svm.core.jfr.HasJfrSupport;
 import com.oracle.svm.core.jfr.SubstrateJVM;
@@ -62,8 +65,12 @@ public final class Target_java_lang_VirtualThread {
     @Alias static int PINNED;
     @Alias static int YIELDING;
     @Alias static int TERMINATED;
-    @Alias static int RUNNABLE_SUSPENDED;
-    @Alias static int PARKED_SUSPENDED;
+    @Alias //
+    @TargetElement(onlyWith = JDK21OrEarlier.class) //
+    static int RUNNABLE_SUSPENDED;
+    @Alias //
+    @TargetElement(onlyWith = JDK21OrEarlier.class) //
+    static int PARKED_SUSPENDED;
     @Alias static Target_jdk_internal_vm_ContinuationScope VTHREAD_SCOPE;
     // Checkstyle: resume
 
@@ -164,7 +171,7 @@ public final class Target_java_lang_VirtualThread {
             } else {
                 return Thread.State.RUNNABLE;
             }
-        } else if (state == RUNNABLE || state == RUNNABLE_SUSPENDED) {
+        } else if (state == RUNNABLE || (JavaVersionUtil.JAVA_SPEC <= 21 && state == RUNNABLE_SUSPENDED)) {
             return Thread.State.RUNNABLE;
         } else if (state == RUNNING) {
             Object token = VirtualThreadHelper.acquireInterruptLockMaybeSwitch(this);
@@ -179,7 +186,7 @@ public final class Target_java_lang_VirtualThread {
             return Thread.State.RUNNABLE;
         } else if (state == PARKING || state == YIELDING) {
             return Thread.State.RUNNABLE;
-        } else if (state == PARKED || state == PARKED_SUSPENDED || state == PINNED) {
+        } else if (state == PARKED || (JavaVersionUtil.JAVA_SPEC <= 21 && state == PARKED_SUSPENDED) || state == PINNED) {
             int parkedThreadStatus = MonitorSupport.singleton().getParkedThreadStatus(asThread(this), false);
             switch (parkedThreadStatus) {
                 case ThreadStatus.BLOCKED_ON_MONITOR_ENTER:

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/thread/Target_java_lang_VirtualThread.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/thread/Target_java_lang_VirtualThread.java
@@ -59,17 +59,20 @@ public final class Target_java_lang_VirtualThread {
     // Checkstyle: stop
     @Alias static int NEW;
     @Alias static int STARTED;
-    @Alias static int RUNNABLE;
+    @Alias //
+    @TargetElement(onlyWith = JDK21OrEarlier.class) static int RUNNABLE;
     @Alias static int RUNNING;
     @Alias static int PARKING;
     @Alias static int PARKED;
     @Alias static int PINNED;
     @Alias static int YIELDING;
+    @TargetElement(onlyWith = JDK22OrLater.class) @Alias static int YIELDED;
     @Alias static int TERMINATED;
     @Alias static int SUSPENDED;
     @TargetElement(onlyWith = JDK22OrLater.class) @Alias static int TIMED_PARKING;
     @TargetElement(onlyWith = JDK22OrLater.class) @Alias static int TIMED_PARKED;
     @TargetElement(onlyWith = JDK22OrLater.class) @Alias static int TIMED_PINNED;
+    @TargetElement(onlyWith = JDK22OrLater.class) @Alias static int UNPARKED;
     @Alias static Target_jdk_internal_vm_ContinuationScope VTHREAD_SCOPE;
     // Checkstyle: resume
 
@@ -170,7 +173,9 @@ public final class Target_java_lang_VirtualThread {
             } else {
                 return Thread.State.RUNNABLE;
             }
-        } else if (state == RUNNABLE) {
+        } else if (JavaVersionUtil.JAVA_SPEC < 22 && state == RUNNABLE) {
+            return Thread.State.RUNNABLE;
+        } else if (JavaVersionUtil.JAVA_SPEC >= 22 && (state == UNPARKED || state == YIELDED)) {
             return Thread.State.RUNNABLE;
         } else if (state == RUNNING) {
             Object token = VirtualThreadHelper.acquireInterruptLockMaybeSwitch(this);

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/thread/Target_java_lang_VirtualThread.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/thread/Target_java_lang_VirtualThread.java
@@ -45,8 +45,8 @@ import com.oracle.svm.core.jdk.JDK19OrLater;
 import com.oracle.svm.core.jdk.JDK20OrEarlier;
 import com.oracle.svm.core.jdk.JDK20OrLater;
 import com.oracle.svm.core.jdk.JDK21OrLater;
-import com.oracle.svm.core.jdk.JDK21OrEarlier;
-import com.oracle.svm.core.jdk.JDK22OrLater;
+import com.oracle.svm.core.jdk.JDK21u3OrEarlier;
+import com.oracle.svm.core.jdk.JDK21u4OrLater;
 import com.oracle.svm.core.jdk.LoomJDK;
 import com.oracle.svm.core.jfr.HasJfrSupport;
 import com.oracle.svm.core.jfr.SubstrateJVM;
@@ -60,19 +60,19 @@ public final class Target_java_lang_VirtualThread {
     @Alias static int NEW;
     @Alias static int STARTED;
     @Alias //
-    @TargetElement(onlyWith = JDK21OrEarlier.class) static int RUNNABLE;
+    @TargetElement(onlyWith = JDK21u3OrEarlier.class) static int RUNNABLE;
     @Alias static int RUNNING;
     @Alias static int PARKING;
     @Alias static int PARKED;
     @Alias static int PINNED;
     @Alias static int YIELDING;
-    @TargetElement(onlyWith = JDK22OrLater.class) @Alias static int YIELDED;
+    @TargetElement(onlyWith = JDK21u4OrLater.class) @Alias static int YIELDED;
     @Alias static int TERMINATED;
     @Alias static int SUSPENDED;
-    @TargetElement(onlyWith = JDK22OrLater.class) @Alias static int TIMED_PARKING;
-    @TargetElement(onlyWith = JDK22OrLater.class) @Alias static int TIMED_PARKED;
-    @TargetElement(onlyWith = JDK22OrLater.class) @Alias static int TIMED_PINNED;
-    @TargetElement(onlyWith = JDK22OrLater.class) @Alias static int UNPARKED;
+    @TargetElement(onlyWith = JDK21u4OrLater.class) @Alias static int TIMED_PARKING;
+    @TargetElement(onlyWith = JDK21u4OrLater.class) @Alias static int TIMED_PARKED;
+    @TargetElement(onlyWith = JDK21u4OrLater.class) @Alias static int TIMED_PINNED;
+    @TargetElement(onlyWith = JDK21u4OrLater.class) @Alias static int UNPARKED;
     @Alias static Target_jdk_internal_vm_ContinuationScope VTHREAD_SCOPE;
     // Checkstyle: resume
 
@@ -173,9 +173,9 @@ public final class Target_java_lang_VirtualThread {
             } else {
                 return Thread.State.RUNNABLE;
             }
-        } else if (JavaVersionUtil.JAVA_SPEC < 22 && state == RUNNABLE) {
+        } else if (JDK21u3OrEarlier.jdk21u3OrEarlier && state == RUNNABLE) {
             return Thread.State.RUNNABLE;
-        } else if (JavaVersionUtil.JAVA_SPEC >= 22 && (state == UNPARKED || state == YIELDED)) {
+        } else if (JDK21u4OrLater.jdk21u4OrLater && (state == UNPARKED || state == YIELDED)) {
             return Thread.State.RUNNABLE;
         } else if (state == RUNNING) {
             Object token = VirtualThreadHelper.acquireInterruptLockMaybeSwitch(this);
@@ -203,7 +203,7 @@ public final class Target_java_lang_VirtualThread {
             }
         } else if (state == TERMINATED) {
             return Thread.State.TERMINATED;
-        } else if (JavaVersionUtil.JAVA_SPEC >= 22) {
+        } else if (JDK21u4OrLater.jdk21u4OrLater) {
             if (state == TIMED_PARKING) {
                 return Thread.State.RUNNABLE;
             } else if (state == TIMED_PARKED || state == TIMED_PINNED) {


### PR DESCRIPTION
This change fixes svm after the downport of [JDK-8315373](https://bugs.openjdk.org/browse/JDK-8315373) (which included [JDK-8312498](https://bugs.openjdk.org/browse/JDK-8312498), [JDK-8312777](https://bugs.openjdk.org/browse/JDK-8312777), [JDK-8321270](https://bugs.openjdk.org/browse/JDK-8321270), [JDK-8322818](https://bugs.openjdk.org/browse/JDK-8322818), [JDK-8323002](https://bugs.openjdk.org/browse/JDK-8323002), [JDK-8323296](https://bugs.openjdk.org/browse/JDK-8323296), [JDK-8316924](https://bugs.openjdk.org/browse/JDK-8316924)) to OpenJDK 21.0.4. It does this by downporting 
- [[svm: adopt "JDK-8312498 Thread::getState and JVM TI GetThreadState sh…](https://github.com/graalvm/graalvm-for-jdk21-community-backports/commit/a65b9e93f9792b15808789104b8c084f6f23e1f9)
- [[GR-48899] Support TIMED_WAITING for virtual threads](https://github.com/graalvm/graalvm-for-jdk21-community-backports/commit/142c5f49593c79a87bf150adfbb37b825166ecd4)
- [svm: adopt "JDK-8321270: Virtual Thread.yield consumes parking permit…](https://github.com/graalvm/graalvm-for-jdk21-community-backports/commit/aa1c4a9e9502736e60efc5401c944971701238c6)

and adopting them to work on JDK 21.

I'm not sure if this fix should be done in this repository or in the [master](https://github.com/graalvm/graalvm-for-jdk21-community-backports) branch of the [graalvm/graalvm-for-jdk21-community-backports](https://github.com/graalvm/graalvm-for-jdk21-community-backports) repository which currently matches the [release/graal-vm/23.1](https://github.com/oracle/graal/tree/release/graal-vm/23.1) branch of this repository. I don't understand how these two branches/repositories are related, if one is synced into the other automatically or if one of them is abandoned. For any case I've also submitted this PR to  [graalvm/graalvm-for-jdk21-community-backports](https://github.com/graalvm/graalvm-for-jdk21-community-backports) as well ([see PR](https://github.com/graalvm/graalvm-for-jdk21-community-backports/pull/1)). Feel free to close one of them but please be so kind and explain the relationship of the two branches/repositories :)
