### PR TITLE
[GR-52940] Fix reported values in GCHeapSummary JFR event.

### DIFF
--- a/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/JfrGCHeapSummaryEvent.java
+++ b/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/JfrGCHeapSummaryEvent.java
@@ -55,11 +55,12 @@ class JfrGCHeapSummaryEvent {
             JfrNativeEventWriter.putLong(data, gcWhen.getId());
 
             // VirtualSpace
-            JfrNativeEventWriter.putLong(data, 0L); // start
-            JfrNativeEventWriter.putLong(data, 0L); // committedEnd
+            JfrNativeEventWriter.putLong(data, -1); // start
+            JfrNativeEventWriter.putLong(data, -1); // committedEnd
             JfrNativeEventWriter.putLong(data, committedSize.rawValue());
-            JfrNativeEventWriter.putLong(data, 0L); // reservedEnd
-            JfrNativeEventWriter.putLong(data, 0L); // reservedSize
+            JfrNativeEventWriter.putLong(data, -1); // reservedEnd
+            // Reserved heap size matches committed size
+            JfrNativeEventWriter.putLong(data, committedSize.rawValue()); // reservedSize
 
             JfrNativeEventWriter.putLong(data, heapUsed.rawValue());
             JfrNativeEventWriter.endSmallEvent(data);

--- a/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/jfr/TestGCHeapSummaryEvent.java
+++ b/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/jfr/TestGCHeapSummaryEvent.java
@@ -29,6 +29,7 @@ import static org.junit.Assert.assertTrue;
 
 import java.util.List;
 
+import jdk.jfr.consumer.RecordedObject;
 import org.junit.Test;
 
 import com.oracle.svm.core.jfr.JfrEvent;
@@ -49,5 +50,16 @@ public class TestGCHeapSummaryEvent extends JfrRecordingTest {
 
     private static void validateEvents(List<RecordedEvent> events) {
         assertTrue(events.size() > 0);
+        for (RecordedEvent event : events) {
+            RecordedObject heapSpace = event.getValue("heapSpace");
+            assertTrue(heapSpace.getLong("start") == -1);
+            assertTrue(heapSpace.getLong("committedEnd") == -1);
+            assertTrue(heapSpace.getLong("reservedEnd") == -1);
+            assertTrue(heapSpace.getLong("committedSize") > 0);
+            assertTrue(heapSpace.getLong("reservedSize") >= heapSpace.getLong("committedSize"));
+            assertTrue(event.getLong("gcId") >= 0);
+            assertTrue(event.getString("when").equals("Before GC") || event.getString("when").equals("After GC"));
+            assertTrue(event.getLong("heapUsed") > 0);
+        }
     }
 }


### PR DESCRIPTION
Previously, the `jdk.GCHeapSummary` event erroneously reported all the following fields as 0:

1. reservedEnd
2. committedEnd
3. start
4. reservedSize
```
jdk.GCHeapSummary {
  startTime = 19:06:03.003 (2024-03-25)
  gcId = 0
  when = "Before GC"
  heapSpace = {
    start = 0x00000000
    committedEnd = 0x00000000
    committedSize = 28.8 MB
    reservedEnd = 0x00000000
    reservedSize = 0 bytes
  }
  heapUsed = 28.8 MB
}


```
**Fields 1-3** contain information about the boundaries of the Java heap. These fields make sense in Hotspot because the heap is one contiguous region from which sub-regions are utilized. Fields 1-3  are not applicable in SubstrateVM since heap space is allocated on a chunk-by-chunk basis when it's needed at runtime. These chunks are not a single contiguous region because each chunk corresponds to a different`mmap` call, and there is no guarantee that chunks are adjacent. To avoid confusion, this PR sets those fields to -1 (instead of 0) to indicate they are not applicable.

**Field 4**, contains information about the amount of virtual memory reserved for the Java heap.  In Hotspot, committed and reserved sizes are different since a large region is initially reserved, and committed regions are later carved out of it.  However, In SubstrateVM, the amount of memory reserved and committed for heap usage is the same, since memory is reserved lazily on an as-needed basis. Field 4 has been changed from 0 to match the reported committed size. 

After the changes: 
```
jdk.GCHeapSummary {
  startTime = 16:07:06.376 (2024-03-25)
  gcId = 0
  when = "Before GC"
  heapSpace = {
    start = 0xFFFFFFFFFFFFFFFF
    committedEnd = 0xFFFFFFFFFFFFFFFF
    committedSize = 28.8 MB
    reservedEnd = 0xFFFFFFFFFFFFFFFF
    reservedSize = 28.8 MB
  }
  heapUsed = 28.8 MB
}

```
----
**Note:**
The reserved and committed sizes are not actually identical in SubstrateVM because the `VirtualMemoryProvider` may  request extra space to accommodate address alignment. So reserved size may be a little bit larger than committed size in reality. Using NMT I find:
```
Total committed memory: 29597312 bytes
Total reserved memory: 30122640 bytes
```
So it's not a huge difference. In the future, if NMT is enabled, we can choose source the memory usage from NMT. And if NMT is disabled, then we can fallback to matching committed and reserved sizes. I think it would be redundant to add a separate tracking system independent of NMT to more accurately report reserved size.  