### PR TITLE
Use callTarget.id instead of hashCode in OptimizedTruffleRuntime and TraceSplittingListener

### DIFF
--- a/truffle/src/com.oracle.truffle.runtime/src/com/oracle/truffle/runtime/OptimizedTruffleRuntime.java
+++ b/truffle/src/com.oracle.truffle.runtime/src/com/oracle/truffle/runtime/OptimizedTruffleRuntime.java
@@ -1295,7 +1295,7 @@ public abstract class OptimizedTruffleRuntime implements TruffleRuntime, Truffle
                 if (target instanceof OptimizedCallTarget) {
                     OptimizedCallTarget callTarget = ((OptimizedCallTarget) target);
                     if (callTarget.isSplit()) {
-                        builder.append(" <split-").append(Integer.toHexString(callTarget.hashCode())).append(">");
+                        builder.append(" <split-").append(callTarget.id).append(">");
                     }
                 }
 

--- a/truffle/src/com.oracle.truffle.runtime/src/com/oracle/truffle/runtime/debug/TraceSplittingListener.java
+++ b/truffle/src/com.oracle.truffle.runtime/src/com/oracle/truffle/runtime/debug/TraceSplittingListener.java
@@ -66,7 +66,7 @@ public final class TraceSplittingListener implements OptimizedTruffleRuntimeList
     public void onCompilationSplit(OptimizedDirectCallNode callNode) {
         OptimizedCallTarget callTarget = callNode.getCallTarget();
         if (callTarget.getOptionValue(OptimizedRuntimeOptions.TraceSplitting)) {
-            String label = String.format("split %3s-%08x-%-4s ", splitCount++, 0xFFFF_FFFFL & callNode.getCurrentCallTarget().hashCode(), callNode.getCallCount());
+            String label = String.format("split %3s-%s-%-4s ", splitCount++, callNode.getCurrentCallTarget().id, callNode.getCallCount());
             final Map<String, Object> debugProperties = callTarget.getDebugProperties();
             debugProperties.put("SourceSection", extractSourceSection(callNode));
             OptimizedTruffleRuntime.getRuntime().logEvent(callTarget, 0, label, debugProperties);


### PR DESCRIPTION
This format is consistent with the format for splits present in the
"[engine] opt" lines when tracing compilation.

Using `--engine.TraceCompilation --engine.TraceSplitting --engine.TraceTransferToInterpreter`
the output changes from
```
[engine] split 297-493b01ef-1     Truffle::RegexpOperations.match_in_region                   |AST   99|Tier 1|Calls/Thres       5/    1|CallsAndLoop/Thres      17/  400|SourceSection /Users/rwstauner/src/truffle-ws/truffleruby/src/main/ruby/truffleruby/core/truffle/regexp_operations.rb~29:881-943
[engine] opt done   id=1722  Truffle::RegexpOperations.match_in_region <split-1722> |Tier 2|Time    90(  42+48  )ms|AST   99|Inlined   2Y   0N|IR    326/   956|CodeSize    3804|Addr 0x11743dcc0|Timestamp 6753643229750|Src regexp_operations.rb:76
[engine] transferToInterpreter at
  Truffle::RegexpOperations.match_in_region(../../../truffle-ws/truffleruby/src/main/ruby/truffleruby/core/truffle/regexp_operations.rb:76) <split-493b01ef>
```
to
```
[engine] split 297-1722-1     Truffle::RegexpOperations.match_in_region                   |AST   99|Tier 1|Calls/Thres       5/    1|CallsAndLoop/Thres      17/  400|SourceSection /Users/rwstauner/src/truffle-ws/truffleruby/src/main/ruby/truffleruby/core/truffle/regexp_operations.rb~29:881-943
[engine] opt done   id=1722  Truffle::RegexpOperations.match_in_region <split-1722> |Tier 2|Time    92(  42+50  )ms|AST   99|Inlined   2Y   0N|IR    326/   956|CodeSize    3804|Addr 0x1176b89c0|Timestamp 6604360084708|Src regexp_operations.rb:76
[engine] transferToInterpreter at
  Truffle::RegexpOperations.match_in_region(../../../truffle-ws/truffleruby/src/main/ruby/truffleruby/core/truffle/regexp_operations.rb:76) <split-1722>
```

The `id` is a `public final`
https://github.com/oracle/graal/blob/2a77e42419b9fcefb45d0fc5546fd6456359b4f7/truffle/src/com.oracle.truffle.runtime/src/com/oracle/truffle/runtime/OptimizedCallTarget.java#L357

Currently this keeps the format of "splitCount-splitId-callCount" in the TraceSplittingListener the same, but if that isn't valuable it might be nice to reformat it so that each line has `split-1722` which might make finding those easier.

What do you think about this?  Do we need anything else here?