### PR TITLE
[GR-53747] Enable debug mode for native-image and native-image-configure

### DIFF
--- a/substratevm/mx.substratevm/mx_substratevm.py
+++ b/substratevm/mx.substratevm/mx_substratevm.py
@@ -2024,12 +2024,10 @@ def native_image_on_jvm(args, **kwargs):
             args.append("-D" + key + "=" + value)
 
     arg = [executable]
-    debug_args = []
     jdk = get_jdk()
     if jdk.debug_args and not mx.is_debug_disabled():
-        debug_args = jdk.debug_args
-    for cur_arg in debug_args:
-        args.insert(0, '--vm.' + cur_arg[1:])
+        for cur_arg in jdk.debug_args:
+            args.insert(0, '--vm.' + cur_arg[1:])
     jacoco_args = mx_gate.get_jacoco_agent_args(agent_option_prefix='-J')
     if jacoco_args is not None:
         arg += jacoco_args
@@ -2042,12 +2040,10 @@ def native_image_configure_on_jvm(args, **kwargs):
     if not exists(executable):
         mx.abort("Can not find " + executable + "\nDid you forget to build? Try `mx build`")
 
-    debug_args = []
     jdk = get_jdk()
     if jdk.debug_args and not mx.is_debug_disabled():
-        debug_args = jdk.debug_args
-    for cur_arg in debug_args:
-        args.insert(0, '--vm.' + cur_arg[1:])
+        for cur_arg in jdk.debug_args:
+            args.insert(0, '--vm.' + cur_arg[1:])
     mx.run([executable] + args, **kwargs)
 
 

--- a/substratevm/mx.substratevm/mx_substratevm.py
+++ b/substratevm/mx.substratevm/mx_substratevm.py
@@ -2024,6 +2024,9 @@ def native_image_on_jvm(args, **kwargs):
             args.append("-D" + key + "=" + value)
 
     arg = [executable]
+    jdk_args = get_jdk().processArgs([])
+    for cur_arg in jdk_args:
+        args.insert(0, '--vm.' + cur_arg[1:])
     jacoco_args = mx_gate.get_jacoco_agent_args(agent_option_prefix='-J')
     if jacoco_args is not None:
         arg += jacoco_args
@@ -2035,6 +2038,10 @@ def native_image_configure_on_jvm(args, **kwargs):
     executable = vm_executable_path('native-image-configure')
     if not exists(executable):
         mx.abort("Can not find " + executable + "\nDid you forget to build? Try `mx build`")
+
+    jdk_args = get_jdk().processArgs([])
+    for cur_arg in jdk_args:
+        args.insert(0, '--vm.' + cur_arg[1:])
     mx.run([executable] + args, **kwargs)
 
 

--- a/substratevm/mx.substratevm/mx_substratevm.py
+++ b/substratevm/mx.substratevm/mx_substratevm.py
@@ -2024,8 +2024,11 @@ def native_image_on_jvm(args, **kwargs):
             args.append("-D" + key + "=" + value)
 
     arg = [executable]
-    jdk_args = get_jdk().processArgs([])
-    for cur_arg in jdk_args:
+    debug_args = []
+    jdk = get_jdk()
+    if jdk.debug_args and not mx.is_debug_disabled():
+        debug_args = jdk.debug_args
+    for cur_arg in debug_args:
         args.insert(0, '--vm.' + cur_arg[1:])
     jacoco_args = mx_gate.get_jacoco_agent_args(agent_option_prefix='-J')
     if jacoco_args is not None:
@@ -2039,8 +2042,11 @@ def native_image_configure_on_jvm(args, **kwargs):
     if not exists(executable):
         mx.abort("Can not find " + executable + "\nDid you forget to build? Try `mx build`")
 
-    jdk_args = get_jdk().processArgs([])
-    for cur_arg in jdk_args:
+    debug_args = []
+    jdk = get_jdk()
+    if jdk.debug_args and not mx.is_debug_disabled():
+        debug_args = jdk.debug_args
+    for cur_arg in debug_args:
         args.insert(0, '--vm.' + cur_arg[1:])
     mx.run([executable] + args, **kwargs)
 


### PR DESCRIPTION
Hi all,

When I use the command `mx -d -v native-image HelloWorld` to try to debug the compiler driver, the process doesn't stop and doesn't listen at port `8000`. After diving into the code, I find that the command `native-image` of the `mx` can't identify and process the JDK arguments. And I find the `native-image-configure` also has the same problem. This patch fixes them.

Thanks for taking the time to review. This is my first time contributing to GraalVM, maybe I need some guidance. Thanks again.

Best Regards,
-- Guoxiong