### PR TITLE
[GR-55268] Report units in custom JFR NMT events.

### DIFF
--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/events/NativeMemoryUsagePeakEvent.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/events/NativeMemoryUsagePeakEvent.java
@@ -26,6 +26,7 @@
 package com.oracle.svm.core.jfr.events;
 
 import jdk.jfr.Category;
+import jdk.jfr.DataAmount;
 import jdk.jfr.Description;
 import jdk.jfr.Event;
 import jdk.jfr.Experimental;
@@ -42,7 +43,9 @@ import jdk.jfr.StackTrace;
 @StackTrace(false)
 public class NativeMemoryUsagePeakEvent extends Event {
     @Label("Memory Type") public String type;
-    @Label("Peak Reserved") public long peakReserved;
-    @Label("Peak Committed") public long peakCommitted;
+    @Label("Peak Reserved")//
+    @DataAmount public long peakReserved;
+    @Label("Peak Committed")//
+    @DataAmount public long peakCommitted;
     @Label("Count At Peak") public long countAtPeak;
 }

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/events/NativeMemoryUsageTotalPeakEvent.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/events/NativeMemoryUsageTotalPeakEvent.java
@@ -26,6 +26,7 @@
 package com.oracle.svm.core.jfr.events;
 
 import jdk.jfr.Category;
+import jdk.jfr.DataAmount;
 import jdk.jfr.Description;
 import jdk.jfr.Event;
 import jdk.jfr.Experimental;
@@ -41,7 +42,9 @@ import jdk.jfr.StackTrace;
 @Category({"Java Virtual Machine", "Memory"})
 @StackTrace(false)
 public class NativeMemoryUsageTotalPeakEvent extends Event {
-    @Label("Peak Reserved") public long peakReserved;
-    @Label("Peak Committed") public long peakCommitted;
+    @Label("Peak Reserved")//
+    @DataAmount public long peakReserved;
+    @Label("Peak Committed")//
+    @DataAmount public long peakCommitted;
     @Label("Count At Peak") public long countAtPeak;
 }


### PR DESCRIPTION
### Summary
This is a small change to add the `@DataAmount` annotation to `jdk.NativeMemoryUsagePeak` and `NativeMemoryUsageTotalPeakEvent` events.  This will allow them to report units with the memory size fields similar to `jdk.NativeMemoryUsage` and `jdk.NativeMemoryUsageTotal`.

------

Before change:
```
$jfr print --events jdk.NativeMemoryUsagePeak recording.jfr 

jdk.NativeMemoryUsagePeak {
  startTime = 15:47:35.221 (2024-04-25)
  type = "Threading"
  peakReserved = 424
  peakCommitted = 424
  countAtPeak = 4
  eventThread = "JFR Shutdown Hook" (javaThreadId = 64)
}

jdk.NativeMemoryUsagePeak {
  startTime = 15:47:35.221 (2024-04-25)
  type = "Unsafe"
  peakReserved = 14336
  peakCommitted = 14336
  countAtPeak = 2
  eventThread = "JFR Shutdown Hook" (javaThreadId = 64)
}
...
```

After change:
```
jdk.NativeMemoryUsagePeak {
  startTime = 13:18:50.605 (2024-04-30)
  type = "Threading"
  peakReserved = 424 bytes
  peakCommitted = 424 bytes
  countAtPeak = 4
  eventThread = "JFR Shutdown Hook" (javaThreadId = 63)
}

jdk.NativeMemoryUsagePeak {
  startTime = 13:18:50.605 (2024-04-30)
  type = "Unsafe"
  peakReserved = 14.0 kB
  peakCommitted = 14.0 kB
  countAtPeak = 2
  eventThread = "JFR Shutdown Hook" (javaThreadId = 63)
}
...
```