### PR TITLE
[GR-53596] Support dumping NMT reports on SIGUSR1

### DIFF
--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/Sigusr1Handler.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/Sigusr1Handler.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2024, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, 2024, Red Hat Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package com.oracle.svm.core;
+
+import com.oracle.svm.core.log.Log;
+import com.oracle.svm.core.heap.dump.HeapDumping;
+import com.oracle.svm.core.nmt.NativeMemoryTracking;
+import java.io.IOException;
+
+import jdk.internal.misc.Signal;
+
+public class Sigusr1Handler implements Signal.Handler {
+    static boolean installed;
+
+    /**
+     * Depending on which features are included in the image, this method may be called multiple
+     * times by the thread executing startup hooks.
+     */
+    public static void install() {
+        if (!installed) {
+            installed = true;
+            Signal.handle(new Signal("USR1"), new Sigusr1Handler());
+        }
+    }
+
+    @Override
+    public void handle(Signal arg0) {
+        if (VMInspectionOptions.hasNativeMemoryTrackingSupport()) {
+            try {
+                NativeMemoryTracking.singleton().dumpReport();
+            } catch (IOException e) {
+                Log.log().string("IOException during NMT report dump: ").string(e.getMessage()).newline();
+            }
+        }
+
+        if (VMInspectionOptions.hasHeapDumpSupport()) {
+            try {
+                HeapDumping.singleton().dumpHeap(true);
+            } catch (IOException e) {
+                Log.log().string("IOException during dumpHeap: ").string(e.getMessage()).newline();
+            }
+        }
+
+    }
+}

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/VMInspectionOptions.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/VMInspectionOptions.java
@@ -49,6 +49,8 @@ import jdk.graal.compiler.options.Option;
 import jdk.graal.compiler.options.OptionKey;
 import jdk.graal.compiler.options.OptionType;
 
+import static com.oracle.svm.core.option.RuntimeOptionKey.RuntimeOptionKeyFlag.Immutable;
+
 public final class VMInspectionOptions {
     private static final String ENABLE_MONITORING_OPTION = "enable-monitoring";
     private static final String MONITORING_DEFAULT_NAME = "<deprecated-default>";
@@ -82,6 +84,11 @@ public final class VMInspectionOptions {
 
     @Option(help = "Print native memory tracking statistics on shutdown if native memory tracking is enabled.", type = OptionType.User) //
     public static final RuntimeOptionKey<Boolean> PrintNMTStatistics = new RuntimeOptionKey<>(false);
+
+    @Option(help = "Path of the file or directory in which NMT report dumps are created. An empty value means a default file " +
+                    "name will be used. An existing directory means the dump will be placed in the directory and have " +
+                    "the default file name.") //
+    public static final RuntimeOptionKey<String> NmtDumpPath = new RuntimeOptionKey<>("", Immutable);
 
     @Platforms(Platform.HOSTED_ONLY.class)
     public static void validateEnableMonitoringFeatures(@SuppressWarnings("unused") OptionKey<?> optionKey) {

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/heap/dump/HeapDumpStartupHook.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/heap/dump/HeapDumpStartupHook.java
@@ -24,38 +24,19 @@
  */
 package com.oracle.svm.core.heap.dump;
 
-import java.io.IOException;
-
+import com.oracle.svm.core.Sigusr1Handler;
 import com.oracle.svm.core.SubstrateOptions;
 import com.oracle.svm.core.jdk.RuntimeSupport;
-import com.oracle.svm.core.log.Log;
-
-import jdk.internal.misc.Signal;
 
 public class HeapDumpStartupHook implements RuntimeSupport.Hook {
     @Override
     public void execute(boolean isFirstIsolate) {
         if (isFirstIsolate && SubstrateOptions.EnableSignalHandling.getValue()) {
-            DumpHeapReport.install();
+            Sigusr1Handler.install();
         }
 
         if (SubstrateOptions.HeapDumpOnOutOfMemoryError.getValue()) {
             HeapDumping.singleton().initializeDumpHeapOnOutOfMemoryError();
-        }
-    }
-}
-
-class DumpHeapReport implements Signal.Handler {
-    static void install() {
-        Signal.handle(new Signal("USR1"), new DumpHeapReport());
-    }
-
-    @Override
-    public void handle(Signal arg0) {
-        try {
-            HeapDumping.singleton().dumpHeap(true);
-        } catch (IOException e) {
-            Log.log().string("IOException during dumpHeap: ").string(e.getMessage()).newline();
         }
     }
 }

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/nmt/NmtFeature.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/nmt/NmtFeature.java
@@ -47,6 +47,7 @@ public class NmtFeature implements InternalFeature {
 
     @Override
     public void beforeAnalysis(BeforeAnalysisAccess access) {
+        RuntimeSupport.getRuntimeSupport().addStartupHook(NativeMemoryTracking.startupHook());
         RuntimeSupport.getRuntimeSupport().addShutdownHook(NativeMemoryTracking.shutdownHook());
     }
 }


### PR DESCRIPTION
### Summary
This PR adds support for dumping NTM reports on SIGUSR1.  SIGUSR1 is shared with the heap dump feature. If both heap dump and NMT features are included in the image, then both types of report will be dumped.

This change will allow users to sample NMT data at arbitrary points in application execution. Previously, you could only get a report once the application finishes.

Related GH issue: https://github.com/oracle/graal/issues/8814