### PR TITLE
Add premain for static agent support

### DIFF
--- a/substratevm/CHANGELOG.md
+++ b/substratevm/CHANGELOG.md
@@ -3,6 +3,7 @@
 This changelog summarizes major changes to GraalVM Native Image.
 
 ## GraalVM for JDK 24 (Internal Version 24.2.0)
+* Together with Alibaba, we added java agent support for native image as experimental feature. 
 * (GR-54476): Issue a deprecation warning on first use of a legacy `graal.` prefix (see GR-49960 in [Compiler changelog](../compiler/CHANGELOG.md)).
   The warning is planned to be replaced by an error in GraalVM for JDK 25.
 * (GR-48384) Added a GDB Python script (`gdb-debughelpers.py`) to improve the Native Image debugging experience.

--- a/substratevm/mx.substratevm/mx_substratevm.py
+++ b/substratevm/mx.substratevm/mx_substratevm.py
@@ -1703,6 +1703,66 @@ def cinterfacetutorial(args):
     native_image_context_run(_cinterfacetutorial, args)
 
 
+@mx.command(suite.name, 'javaagenttest', 'Runs tests for java agent with native image')
+def agenttest(args):
+    def build_and_test_agent_image(native_image, args):
+        args = [] if args is None else args
+        build_dir = join(svmbuild_dir(), 'javaagenttest')
+
+        # clean / create output directory
+        if exists(build_dir):
+            mx.rmtree(build_dir)
+        mx_util.ensure_dir_exists(build_dir)
+        test_build_output = mx.dependency('com.oracle.svm.test').classpath_repr()
+
+        # create agent jar file
+        agent1 = join(build_dir, 'testagent1.jar')
+        mx.run([mx.get_jdk().jar, 'cmf', join(test_build_output, 'resources','agent1', 'MANIFEST.MF'),
+                agent1,
+                join('com', 'oracle', 'svm', 'test', 'agent', 'Agent.class'),
+                join('com', 'oracle', 'svm', 'test', 'agent', 'Agent$DemoTransformer.class'),
+                join('com', 'oracle', 'svm', 'test', 'agent', 'AgentPremainHelper.class')],
+               cwd = test_build_output)
+
+        agent2 = join(build_dir, 'testagent2.jar')
+        mx.run([mx.get_jdk().jar, 'cmf', join(test_build_output, 'resources','agent2', 'MANIFEST.MF'),
+                agent2,
+                join('com', 'oracle', 'svm', 'test', 'agent', 'Agent2.class'),
+                join('com', 'oracle', 'svm', 'test', 'agent', 'AgentPremainHelper.class')],
+               cwd = test_build_output)
+
+        # build test with agent
+        test_cp = os.pathsep.join([classpath('com.oracle.svm.test'), agent1, agent2])
+
+
+        nativeagent_premain_options=['-XXpremain:com.oracle.svm.test.agent.Agent:test.agent=true',
+                                     '-XXpremain:com.oracle.svm.test.agent.Agent2:test.agent2=true']
+
+        binary_path = join(build_dir, 'agenttest1')
+        native_image([
+                         '-cp', test_cp,
+                         '-J-ea', '-J-esa',
+                         '-o', binary_path,
+                         '-H:+ReportExceptionStackTraces',
+                         '-H:PremainClasses=com.oracle.svm.test.agent.Agent,com.oracle.svm.test.agent.Agent2',
+                         '-H:Class=com.oracle.svm.test.agent.AgentTest',
+                     ]  + args)
+        mx.run([binary_path] + nativeagent_premain_options)
+
+        # Switch the premain sequence of agent1 and agent2
+        binary_path = join(build_dir, 'agenttest2')
+        native_image([
+                         '-cp', test_cp,
+                         '-J-ea', '-J-esa',
+                         '-o', binary_path,
+                         '-H:+ReportExceptionStackTraces',
+                         '-H:PremainClasses=com.oracle.svm.test.agent.Agent2,com.oracle.svm.test.agent.Agent',
+                         '-H:Class=com.oracle.svm.test.agent.AgentTest',
+                     ]  + args)
+        mx.run([binary_path] + nativeagent_premain_options)
+
+    native_image_context_run(build_and_test_agent_image, args)
+
 @mx.command(suite.name, 'clinittest', 'Runs the ')
 def clinittest(args):
     def build_and_test_clinittest_image(native_image, args):

--- a/substratevm/mx.substratevm/suite.py
+++ b/substratevm/mx.substratevm/suite.py
@@ -308,6 +308,9 @@ suite = {
                     "jdk.internal.util",
                     "jdk.internal.org.objectweb.asm",
                 ],
+                "java.instrument":[
+                    "java.lang.instrument"
+                ],
                 "java.management": [
                     "com.sun.jmx.mbeanserver",
                     "sun.management",
@@ -640,6 +643,9 @@ suite = {
                     "sun.util.cldr",
                     "sun.util.locale",
                     "sun.invoke.util",
+                ],
+                "java.instrument":[
+                    "java.lang.instrument"
                 ],
                 "java.management": [
                     "com.sun.jmx.mbeanserver", # Needed for javadoc links (MXBeanIntrospector,DefaultMXBeanMappingFactory, MXBeanProxy)
@@ -981,6 +987,7 @@ suite = {
                 "jdk.jfr",
                 "java.management",
                 "jdk.management.jfr",
+                "java.instrument",
                 "java.rmi",
             ],
             "requiresConcealed" : {

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/JavaMainWrapper.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/JavaMainWrapper.java
@@ -166,19 +166,22 @@ public class JavaMainWrapper {
     }
 
     public static void invokeMain(String[] args) throws Throwable {
+        PreMainSupport preMainSupport = ImageSingletons.lookup(PreMainSupport.class);
+        String[] mainArgs = preMainSupport.retrievePremainArgs(args);
+        preMainSupport.invokePremain();
         JavaMainSupport javaMainSupport = ImageSingletons.lookup(JavaMainSupport.class);
         if (javaMainSupport.mainNonstatic) {
             Object instance = javaMainSupport.javaMainClassCtorHandle.invoke();
             if (javaMainSupport.mainWithoutArgs) {
                 javaMainSupport.javaMainHandle.invoke(instance);
             } else {
-                javaMainSupport.javaMainHandle.invoke(instance, args);
+                javaMainSupport.javaMainHandle.invoke(instance, mainArgs);
             }
         } else {
             if (javaMainSupport.mainWithoutArgs) {
                 javaMainSupport.javaMainHandle.invokeExact();
             } else {
-                javaMainSupport.javaMainHandle.invokeExact(args);
+                javaMainSupport.javaMainHandle.invokeExact(mainArgs);
             }
         }
     }

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/PreMainSupport.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/PreMainSupport.java
@@ -1,0 +1,297 @@
+/*
+ * Copyright (c) 2024, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, 2024, Alibaba Group Holding Limited. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package com.oracle.svm.core;
+
+import com.oracle.svm.core.c.NonmovableArrays;
+import com.oracle.svm.core.code.CodeInfo;
+import com.oracle.svm.core.code.CodeInfoAccess;
+import com.oracle.svm.core.code.CodeInfoTable;
+import com.oracle.svm.core.jdk.ModuleNative;
+import com.oracle.svm.core.util.VMError;
+import org.graalvm.nativeimage.Platform;
+import org.graalvm.nativeimage.Platforms;
+
+import java.lang.instrument.ClassDefinition;
+import java.lang.instrument.ClassFileTransformer;
+import java.lang.instrument.Instrumentation;
+import java.lang.instrument.UnmodifiableClassException;
+import java.lang.instrument.UnmodifiableModuleException;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.jar.JarFile;
+
+/**
+ * Java agent can do instrumentation initialization work in premain phase. This class supports
+ * registering such premain methods at native image build time and invoking them at native image
+ * runtime. <br>
+ * JVM supports two kind of premain methods:
+ * <ol>
+ * <li>{@code public static void premain(String agentArgs, Instrumentation inst)}</li>
+ * <li>{@code public static void premain(String agentArgs)}</li>
+ * </ol>
+ * For the first one, at registration time we will set the second parameter with an instance of
+ * {@link NativeImageNoOpRuntimeInstrumentation} class which does not do any actual work as no
+ * instrumentation can do in native code at runtime.
+ * <p>
+ * <b>Be noticed</b>, the original agent premain method may not work well at native image runtime
+ * even if the input {@link Instrumentation} class is replaced with
+ * {@link NativeImageNoOpRuntimeInstrumentation}.
+ * </p>
+ * <p>
+ * It is the agent developers' responsibility to implement a native version of their agent premain
+ * method. It can be implemented in two ways:
+ * <ul>
+ * <li>Isolate code by checking current runtime. For example: <code>
+ *         <pre>
+ *         if ("runtime".equals(System.getProperty("org.graalvm.nativeimage.imagecode"))) {
+ *           // native image runtime
+ *         } else{
+ *           // JVM runtime
+ *         }
+ *         </pre>
+ *     </code> Alternatively: Instead of directly getting property,
+ * <code>ImageInfo.inImageRuntimeCode()</code> can also be used to check if current runtime is
+ * native image runtime, but it requires extra dependency.</li>
+ * <li>Use {@link com.oracle.svm.core.annotate.TargetClass} API to implement a native image version
+ * premain.</li>
+ * </ul>
+ * </p>
+ */
+public class PreMainSupport {
+
+    private static final String PREMAIN_OPTION_PREFIX = "-XXpremain:";
+
+    /**
+     * A record for premain method.
+     *
+     * @param className the full qualified class name that declares the premain method
+     * @param method the premain method
+     * @param args the arguments of premain method
+     */
+    record PremainMethod(String className, Method method, Object[] args) {
+    }
+
+    private Map<String, String> premainOptions = new HashMap<>();
+    // Order matters
+    private List<PremainMethod> premainMethods = new ArrayList<>();
+
+    @Platforms({Platform.HOSTED_ONLY.class})
+    public void registerPremainMethod(String className, Method executable, Object... args) {
+        premainMethods.add(new PremainMethod(className, executable, args));
+    }
+
+    /**
+     * Retrieve premain options from input args. Keep premain options and return the rest args as
+     * main args. Multiple agent options should be given in separated {@code -XX-premain:} leading
+     * arguments. The premain options format: <br>
+     * -XX-premain:[full.qualified.premain.class]:[premain options]
+     * -XX-premain:[full.qualified.premain.class2]:[premain options] <br>
+     *
+     * @param args original arguments for premain and main
+     * @return arguments for main class
+     */
+    public String[] retrievePremainArgs(String[] args) {
+        List<String> mainArgs = new ArrayList<>();
+
+        for (String arg : args) {
+            if (arg.startsWith(PREMAIN_OPTION_PREFIX)) {
+                String premainOptionKeyValue = arg.substring(PREMAIN_OPTION_PREFIX.length());
+                String[] pair = premainOptionKeyValue.split(":");
+                if (pair.length == 2) {
+                    premainOptions.put(pair[0], pair[1]);
+                }
+            } else {
+                mainArgs.add(arg);
+            }
+        }
+        return mainArgs.toArray(new String[0]);
+    }
+
+    public void invokePremain() {
+        for (PremainMethod premainMethod : premainMethods) {
+
+            Object[] args = premainMethod.args;
+            if (premainOptions.containsKey(premainMethod.className)) {
+                args[0] = premainOptions.get(premainMethod.className);
+            }
+            try {
+                // premain method must be static
+                premainMethod.method.invoke(null, args);
+            } catch (Throwable t) {
+                if (t instanceof InvocationTargetException) {
+                    t = t.getCause();
+                }
+                VMError.shouldNotReachHere("Fail to execute " + premainMethod.className + ".premain", t);
+            }
+        }
+    }
+
+    /**
+     * This class is a dummy implementation of {@link Instrumentation} interface. It serves as the
+     * registered premain method's second parameter. At native image runtime, no actual
+     * instrumentation work can do. So all the methods here are empty.
+     */
+    public static class NativeImageNoOpRuntimeInstrumentation implements Instrumentation {
+
+        private static final Set<String> systemModules = Set.of("org.graalvm.nativeimage.builder", "org.graalvm.nativeimage", "org.graalvm.nativeimage.base", "com.oracle.svm.svm_enterprise",
+                        "org.graalvm.word", "jdk.internal.vm.ci", "jdk.graal.compiler", "com.oracle.graal.graal_enterprise");
+
+        @Override
+        public void addTransformer(ClassFileTransformer transformer, boolean canRetransform) {
+        }
+
+        @Override
+        public void addTransformer(ClassFileTransformer transformer) {
+        }
+
+        @Override
+        public boolean removeTransformer(ClassFileTransformer transformer) {
+            return false;
+        }
+
+        @Override
+        public boolean isRetransformClassesSupported() {
+            return false;
+        }
+
+        @Override
+        public void retransformClasses(Class<?>... classes) throws UnmodifiableClassException {
+            throw new UnsupportedOperationException("Native image doesn't support retransform class at runtime.");
+        }
+
+        @Override
+        public boolean isRedefineClassesSupported() {
+            return false;
+        }
+
+        @Override
+        public void redefineClasses(ClassDefinition... definitions) throws ClassNotFoundException, UnmodifiableClassException {
+            throw new UnsupportedOperationException("Native image doesn't support redefine class at runtime.");
+        }
+
+        @Override
+        public boolean isModifiableClass(Class<?> theClass) {
+            return false;
+        }
+
+        @Override
+        public Class<?>[] getAllLoadedClasses() {
+            ArrayList<Class<?>> userClasses = new ArrayList<>();
+            CodeInfo imageCodeInfo = CodeInfoTable.getFirstImageCodeInfo();
+            while (imageCodeInfo.isNonNull()) {
+                Class<?>[] classes = NonmovableArrays.heapCopyOfObjectArray(CodeInfoAccess.getClasses(imageCodeInfo));
+                if (classes != null) {
+                    for (Class<?> clazz : classes) {
+                        if (clazz != null) {
+                            Module module = clazz.getModule();
+                            if (module == null ||
+                                            module.getName() == null ||
+                                            !isSystemClass(module)) {
+                                userClasses.add(clazz);
+                            }
+                        }
+                    }
+                }
+                imageCodeInfo = CodeInfoAccess.getNextImageCodeInfo(imageCodeInfo);
+            }
+            return userClasses.toArray(new Class<?>[0]);
+        }
+
+        private static boolean isSystemClass(Module module) {
+            return systemModules.contains(module.getName());
+        }
+
+        @Override
+        public Class<?>[] getInitiatedClasses(ClassLoader loader) {
+            throw new UnsupportedOperationException("Native image has flat classloader hierarchy. Can't get classes by classloader. " +
+                            "Try to call getAllLoadedClasses() to get all loaded classes.");
+        }
+
+        @Override
+        public long getObjectSize(Object objectToSize) {
+            return -1;
+        }
+
+        @Override
+        public void appendToBootstrapClassLoaderSearch(JarFile jarfile) {
+            throw new UnsupportedOperationException("Native image doesn't support modification of the bootstrap classloader search path at run time." +
+                            " Please avoid calling this method in Native Image by checking \"runtime\".equals(System.getProperty(\"org.graalvm.nativeimage.imagecode\"))");
+        }
+
+        @Override
+        public void appendToSystemClassLoaderSearch(JarFile jarfile) {
+            throw new UnsupportedOperationException("Native image doesn't support modification of the system classloader search path at run time." +
+                            " Please avoid calling this method in Native Image by checking \"runtime\".equals(System.getProperty(\"org.graalvm.nativeimage.imagecode\"))");
+        }
+
+        @Override
+        public boolean isNativeMethodPrefixSupported() {
+            return false;
+        }
+
+        @Override
+        public void setNativeMethodPrefix(ClassFileTransformer transformer, String prefix) {
+        }
+
+        @Override
+        public void redefineModule(Module module, Set<Module> extraReads, Map<String, Set<Module>> extraExports, Map<String, Set<Module>> extraOpens, Set<Class<?>> extraUses,
+                        Map<Class<?>, List<Class<?>>> extraProvides) {
+            if (!module.isNamed()) {
+                return;
+            }
+
+            if (!isModifiableModule(module)) {
+                throw new UnmodifiableModuleException(module.getName());
+            }
+
+            for (Module extraRead : extraReads) {
+                ModuleNative.addReads(module, extraRead);
+            }
+
+            for (Map.Entry<String, Set<Module>> entry : extraExports.entrySet()) {
+                for (Module m : entry.getValue()) {
+                    ModuleNative.addExports(module, entry.getKey(), m);
+                }
+            }
+            // Ignore the extraOpens, extraUses and extraProvides as they are not supported by
+            // ModuleNative.
+        }
+
+        @Override
+        public boolean isModifiableModule(Module module) {
+            if (module == null) {
+                throw new NullPointerException("'module' is null");
+            }
+            return true;
+        }
+    }
+}

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/InstrumentFeature.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/InstrumentFeature.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2024, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, 2024, Alibaba Group Holding Limited. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package com.oracle.svm.hosted;
+
+import com.oracle.svm.core.PreMainSupport;
+import com.oracle.svm.core.feature.AutomaticallyRegisteredFeature;
+import com.oracle.svm.core.feature.InternalFeature;
+import com.oracle.svm.core.option.AccumulatingLocatableMultiOptionValue;
+import com.oracle.svm.core.option.HostedOptionKey;
+import com.oracle.svm.core.option.SubstrateOptionsParser;
+import com.oracle.svm.core.util.UserError;
+import com.oracle.svm.hosted.reflect.ReflectionFeature;
+import jdk.graal.compiler.options.Option;
+import jdk.graal.compiler.options.OptionStability;
+import org.graalvm.nativeimage.ImageSingletons;
+import org.graalvm.nativeimage.hosted.Feature;
+
+import java.lang.instrument.Instrumentation;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * This feature supports instrumentation in native image.
+ */
+@AutomaticallyRegisteredFeature
+public class InstrumentFeature implements InternalFeature {
+    private ClassLoader cl;
+    private PreMainSupport preMainSupport;
+
+    public static class Options {
+        @Option(help = "Specify premain-class list. Multiple classes are separated by comma, and order matters. This is an experimental option.", stability = OptionStability.EXPERIMENTAL)//
+        public static final HostedOptionKey<AccumulatingLocatableMultiOptionValue.Strings> PremainClasses = new HostedOptionKey<>(
+                        AccumulatingLocatableMultiOptionValue.Strings.buildWithCommaDelimiter());
+
+    }
+
+    /**
+     * {@link ReflectionFeature} must come before this feature, because many instrumentation methods
+     * are called by reflection, e.g. premain.
+     */
+    @Override
+    public List<Class<? extends Feature>> getRequiredFeatures() {
+        return List.of(ReflectionFeature.class);
+    }
+
+    @Override
+    public void afterRegistration(AfterRegistrationAccess access) {
+        FeatureImpl.AfterRegistrationAccessImpl a = (FeatureImpl.AfterRegistrationAccessImpl) access;
+        cl = a.getImageClassLoader().getClassLoader();
+        ImageSingletons.add(PreMainSupport.class, preMainSupport = new PreMainSupport());
+        if (Options.PremainClasses.hasBeenSet()) {
+            List<String> premains = Options.PremainClasses.getValue().values();
+            for (String premain : premains) {
+                addPremainClass(premain);
+            }
+        }
+    }
+
+    /**
+     * Find the premain method from the given class and register it for runtime usage. According to
+     * java.lang.instrument <a
+     * href=https://docs.oracle.com/en/java/javase/17/docs/api/java.instrument/java/lang/instrument/package-summary.html>API
+     * doc</a>, there are two premain methods:
+     * <ol>
+     * <li>{@code public static void premain(String agentArgs, Instrumentation inst)}</li>
+     * <li>{@code public static void premain(String agentArgs)}</li>
+     * </ol>
+     * The first one is taken with higher priority. The second one is taken only when the first one
+     * is absent. <br>
+     * So this method looks for them in the same order.
+     */
+    private void addPremainClass(String premainClass) {
+        try {
+            Class<?> clazz = Class.forName(premainClass, false, cl);
+            Method premain = null;
+            List<Object> args = new ArrayList<>();
+            args.add(""); // First argument is options which will be set at runtime
+            try {
+                premain = clazz.getDeclaredMethod("premain", String.class, Instrumentation.class);
+                args.add(new PreMainSupport.NativeImageNoOpRuntimeInstrumentation());
+            } catch (NoSuchMethodException e) {
+                try {
+                    premain = clazz.getDeclaredMethod("premain", String.class);
+                } catch (NoSuchMethodException e1) {
+                    UserError.abort(e1, "Can't register agent premain method, because can't find the premain method from the given class %s. Please check your %s setting.", premainClass,
+                                    SubstrateOptionsParser.commandArgument(Options.PremainClasses, ""));
+                }
+            }
+            preMainSupport.registerPremainMethod(premainClass, premain, args.toArray(new Object[0]));
+        } catch (ClassNotFoundException e) {
+            UserError.abort(e, "Can't register agent premain method, because the given class %s is not found. Please check your %s setting.", premainClass,
+                            SubstrateOptionsParser.commandArgument(Options.PremainClasses, ""));
+        }
+    }
+}

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/NativeImageGeneratorRunner.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/NativeImageGeneratorRunner.java
@@ -189,6 +189,7 @@ public class NativeImageGeneratorRunner {
 
         Set<String> expectedBuilderDependencies = Set.of(
                         "java.base",
+                        "java.instrument",
                         "java.management",
                         "java.logging",
                         // workaround for GR-47773 on the module-path which requires java.sql (like

--- a/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/agent/Agent.java
+++ b/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/agent/Agent.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright (c) 2024, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, 2024, Alibaba Group Holding Limited. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package com.oracle.svm.test.agent;
+
+import org.graalvm.nativeimage.ImageInfo;
+import org.junit.Assert;
+
+import java.lang.instrument.ClassFileTransformer;
+import java.lang.instrument.Instrumentation;
+import java.security.ProtectionDomain;
+import java.util.Collections;
+import java.util.Set;
+
+public class Agent {
+    public static void premain(
+                    String agentArgs, Instrumentation inst) {
+        AgentPremainHelper.parseOptions(agentArgs);
+        System.setProperty("instrument.enable", "true");
+        if (!ImageInfo.inImageRuntimeCode()) {
+            DemoTransformer dt = new DemoTransformer("com.oracle.svm.test.agent.AgentTest");
+            inst.addTransformer(dt, true);
+        } else {
+            AgentPremainHelper.load(Agent.class);
+            /**
+             * Test {@code inst} is {@link NativeImageNoOpRuntimeInstrumentation} and behaves as
+             * defined.
+             */
+            Assert.assertNotNull(inst);
+            Assert.assertEquals(false, inst.isRetransformClassesSupported());
+            Assert.assertEquals(false, inst.removeTransformer(null));
+            Assert.assertEquals(false, inst.isRedefineClassesSupported());
+
+            Assert.assertEquals(false, inst.isModifiableClass(null));
+
+            Class<?>[] allClasses = inst.getAllLoadedClasses();
+            Assert.assertTrue(allClasses.length > 0);
+            Class<?> currentAgentClassFromAllLoaded = null;
+            for (Class<?> c : allClasses) {
+                if (c.equals(Agent.class)) {
+                    currentAgentClassFromAllLoaded = c;
+                }
+            }
+            Assert.assertNotNull(currentAgentClassFromAllLoaded);
+
+            // redefineClasses should throw UnsupportedOperationException
+            Exception exception = null;
+            try {
+                inst.redefineClasses();
+            } catch (Exception e) {
+                exception = e;
+            }
+            Assert.assertNotNull(exception);
+            Assert.assertEquals(UnsupportedOperationException.class, exception.getClass());
+
+            // getInitiatedClasses should throw UnsupportedOperationException
+            exception = null;
+            try {
+                inst.getInitiatedClasses(null);
+            } catch (Exception e) {
+                exception = e;
+            }
+            Assert.assertNotNull(exception);
+            Assert.assertEquals(UnsupportedOperationException.class, exception.getClass());
+
+            // retransformClasses should throw UnsupportedOperationException
+            exception = null;
+            try {
+                inst.retransformClasses();
+            } catch (Exception e) {
+                exception = e;
+            }
+            Assert.assertNotNull(exception);
+            Assert.assertEquals(UnsupportedOperationException.class, exception.getClass());
+
+            // appendToBootstrapClassLoaderSearch should throw UnsupportedOperationException
+            exception = null;
+            try {
+                inst.appendToBootstrapClassLoaderSearch(null);
+            } catch (Exception e) {
+                exception = e;
+            }
+            Assert.assertNotNull(exception);
+            Assert.assertEquals(UnsupportedOperationException.class, exception.getClass());
+
+            // appendToSystemClassLoaderSearch should throw UnsupportedOperationException
+            exception = null;
+            try {
+                inst.appendToSystemClassLoaderSearch(null);
+            } catch (Exception e) {
+                exception = e;
+            }
+            Assert.assertNotNull(exception);
+            Assert.assertEquals(UnsupportedOperationException.class, exception.getClass());
+
+            Assert.assertEquals(-1, inst.getObjectSize(null));
+            Assert.assertEquals(false, inst.isNativeMethodPrefixSupported());
+
+            Module currentModule = Agent.class.getModule();
+            Assert.assertEquals(true, inst.isModifiableModule(currentModule));
+
+            // redefineModule only does checks, no actual actions.
+            inst.redefineModule(currentModule, Set.of(Class.class.getModule()), Collections.emptyMap(), null, null, null);
+        }
+    }
+
+    static class DemoTransformer implements ClassFileTransformer {
+
+        private String internalClassName;
+
+        DemoTransformer(String name) {
+            internalClassName = name.replaceAll("\\.", "/");
+        }
+
+        @Override
+        public byte[] transform(
+                        ClassLoader loader,
+                        String className,
+                        Class<?> classBeingRedefined,
+                        ProtectionDomain protectionDomain,
+                        byte[] classfileBuffer) {
+            byte[] byteCode = classfileBuffer;
+
+            if (internalClassName.equals(className)) {
+                System.out.println("Let's do transformation for " + className);
+                // Do class transformation here
+            }
+            return byteCode;
+        }
+    }
+}

--- a/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/agent/Agent2.java
+++ b/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/agent/Agent2.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2024, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, 2024, Alibaba Group Holding Limited. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package com.oracle.svm.test.agent;
+
+import org.graalvm.nativeimage.ImageInfo;
+
+public class Agent2 {
+    public static void premain(String agentArgs) {
+        AgentPremainHelper.parseOptions(agentArgs);
+        System.setProperty("instrument.enable", "true");
+        if (!ImageInfo.inImageRuntimeCode()) {
+            // do class transformation
+        } else {
+            AgentPremainHelper.load(Agent2.class);
+        }
+    }
+}

--- a/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/agent/AgentPremainHelper.java
+++ b/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/agent/AgentPremainHelper.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2024, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, 2024, Alibaba Group Holding Limited. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package com.oracle.svm.test.agent;
+
+public class AgentPremainHelper {
+    public static void load(Class<?> agentClass) {
+        String firstAgent = System.getProperty("first.load.agent", null);
+        if (firstAgent != null) {
+            System.setProperty("second.load.agent", agentClass.getName());
+        } else {
+            System.setProperty("first.load.agent", agentClass.getName());
+        }
+    }
+
+    public static String getFirst() {
+        return System.getProperty("first.load.agent");
+    }
+
+    public static String getSecond() {
+        return System.getProperty("second.load.agent");
+    }
+
+    public static void parseOptions(String agentArgs) {
+        if (agentArgs != null && !agentArgs.isBlank()) {
+            String[] argPairs = agentArgs.split(",");
+            for (String argPair : argPairs) {
+                String[] pair = argPair.split("=");
+                if (pair.length == 2) {
+                    System.setProperty(pair[0], pair[1]);
+                }
+            }
+        }
+    }
+}

--- a/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/agent/AgentTest.java
+++ b/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/agent/AgentTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2024, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, 2024, Alibaba Group Holding Limited. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package com.oracle.svm.test.agent;
+
+import org.junit.Assert;
+
+public class AgentTest {
+
+    private static void testPremain() {
+        Assert.assertEquals("true", System.getProperty("instrument.enable"));
+    }
+
+    private static void testAgentOptions() {
+        Assert.assertEquals("true", System.getProperty("test.agent"));
+        Assert.assertEquals("true", System.getProperty("test.agent2"));
+    }
+
+    private static void testPremainSequence() {
+        String first = AgentPremainHelper.getFirst();
+        String second = AgentPremainHelper.getSecond();
+        Assert.assertNotNull(first);
+        if (second != null) {
+            String agentName = Agent.class.getName();
+            String agent2Name = Agent2.class.getName();
+
+            if (first.equals(agentName)) {
+                Assert.assertEquals(agent2Name, second);
+            }
+            if (first.equals(agent2Name)) {
+                Assert.assertEquals(agentName, second);
+            }
+        }
+    }
+
+    public static void main(String[] args) {
+        testPremain();
+        testAgentOptions();
+        testPremainSequence();
+        System.out.println("Finished running Agent test.");
+    }
+}

--- a/substratevm/src/com.oracle.svm.test/src/resources/agent1/MANIFEST.MF
+++ b/substratevm/src/com.oracle.svm.test/src/resources/agent1/MANIFEST.MF
@@ -1,0 +1,5 @@
+Manifest-Version: 1.0
+Agent-Class: com.oracle.svm.test.agent.Agent
+Can-Redefine-Classes: true
+Can-Retransform-Classes: true
+Premain-Class: com.oracle.svm.test.agent.Agent

--- a/substratevm/src/com.oracle.svm.test/src/resources/agent2/MANIFEST.MF
+++ b/substratevm/src/com.oracle.svm.test/src/resources/agent2/MANIFEST.MF
@@ -1,0 +1,5 @@
+Manifest-Version: 1.0
+Agent-Class: com.oracle.svm.test.agent.Agent2
+Can-Redefine-Classes: true
+Can-Retransform-Classes: true
+Premain-Class: com.oracle.svm.test.agent.Agent2


### PR DESCRIPTION
Java agent always has a premain method to initialize the agent. SVM needs the premain as well to support agent in native image.

At compile time, -H:PremainClasses= option is used to set the premain classes.
At runtime, premain runtime options are set along with main class' arguments in the format of -XX-premain:[class]:[options]

This PR is part of https://github.com/oracle/graal/pull/8077