### PR TITLE
[GR-55269] Don't include GC related JFR serializers unless Serial GC is used.

### DIFF
--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/JfrFeature.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/JfrFeature.java
@@ -27,6 +27,7 @@ package com.oracle.svm.core.jfr;
 import java.util.Collections;
 import java.util.List;
 
+import com.oracle.svm.core.SubstrateOptions;
 import org.graalvm.nativeimage.ImageSingletons;
 import org.graalvm.nativeimage.Platform;
 import org.graalvm.nativeimage.hosted.Feature;
@@ -168,10 +169,12 @@ public class JfrFeature implements InternalFeature {
         JfrSerializerSupport.get().register(new JfrFrameTypeSerializer());
         JfrSerializerSupport.get().register(new JfrThreadStateSerializer());
         JfrSerializerSupport.get().register(new JfrMonitorInflationCauseSerializer());
-        JfrSerializerSupport.get().register(new JfrGCCauseSerializer());
-        JfrSerializerSupport.get().register(new JfrGCNameSerializer());
+        if (SubstrateOptions.UseSerialGC.getValue()) {
+            JfrSerializerSupport.get().register(new JfrGCCauseSerializer());
+            JfrSerializerSupport.get().register(new JfrGCNameSerializer());
+            JfrSerializerSupport.get().register(new JfrGCWhenSerializer());
+        }
         JfrSerializerSupport.get().register(new JfrVMOperationNameSerializer());
-        JfrSerializerSupport.get().register(new JfrGCWhenSerializer());
         if (VMInspectionOptions.hasNativeMemoryTrackingSupport()) {
             JfrSerializerSupport.get().register(new JfrNmtCategorySerializer());
         }


### PR DESCRIPTION
Resolves Bug: https://github.com/oracle/graal/issues/8993

If epsilon or G1 GC is used, JFR does not emit any GC collection events. However, we were previously still serializing GC-related constant pools (which are empty in those cases). JFR consumer code, which parses chunks for jfr-streaming, expects these pools to be non-empty. 

This PR is just a small change to exclude those serializers when appropriate. 