### PR TITLE
Update LIBFFI to 3.4.6

### DIFF
--- a/truffle/mx.truffle/mx_truffle.py
+++ b/truffle/mx.truffle/mx_truffle.py
@@ -1521,7 +1521,7 @@ class LibffiBuilderProject(mx.AbstractNativeProject, mx_native.NativeDependency)
         self.out_dir = self.get_output_root()
         if mx.get_os() == 'windows':
             self.delegate = mx_native.DefaultNativeProject(suite, name, subDir, [], [], None,
-                                                           os.path.join(self.out_dir, 'libffi-3.4.4'),
+                                                           os.path.join(self.out_dir, 'libffi-3.4.6'),
                                                            'static_lib',
                                                            deliverable='ffi',
                                                            cflags=['-MD', '-O2', '-DFFI_BUILDING_DLL'])
@@ -1558,7 +1558,7 @@ class LibffiBuilderProject(mx.AbstractNativeProject, mx_native.NativeDependency)
                                                   'include/ffi.h',
                                                   'include/ffitarget.h'],
                                                  os.path.join(self.out_dir, 'libffi-build'),
-                                                 os.path.join(self.out_dir, 'libffi-3.4.4'))
+                                                 os.path.join(self.out_dir, 'libffi-3.4.6'))
             configure_args = ['--disable-dependency-tracking',
                               '--disable-shared',
                               '--with-pic',

--- a/truffle/mx.truffle/suite.py
+++ b/truffle/mx.truffle/suite.py
@@ -72,12 +72,12 @@ suite = {
 
     "LIBFFI_SOURCES" : {
       "resource" : True,
-      "version" : "3.4.4",
+      "version" : "3.4.6",
       "urls" : [
         "https://lafo.ssw.uni-linz.ac.at/pub/graal-external-deps/libffi-{version}.tar.gz",
         "https://github.com/libffi/libffi/releases/download/v{version}/libffi-{version}.tar.gz",
       ],
-      "digest" : "sha512:88680aeb0fa0dc0319e5cd2ba45b4b5a340bc9b4bcf20b1e0613b39cd898f177a3863aa94034d8e23a7f6f44d858a53dcd36d1bb8dee13b751ef814224061889",
+      "digest" : "sha512:033d2600e879b83c6bce0eb80f69c5f32aa775bf2e962c9d39fbd21226fa19d1e79173d8eaa0d0157014d54509ea73315ad86842356fc3a303c0831c94c6ab39",
     },
 
     "ANTLR4": {

--- a/truffle/src/libffi/patches/windows-amd64/0001-Preconfigure-sources-for-x64-Windows-build.patch
+++ b/truffle/src/libffi/patches/windows-amd64/0001-Preconfigure-sources-for-x64-Windows-build.patch
@@ -231,7 +231,7 @@ index d38b781..6284190 100644
  
  /* Define to the full name and version of this package. */
 -#undef PACKAGE_STRING
-+#define PACKAGE_STRING "libffi 3.4.4"
++#define PACKAGE_STRING "libffi 3.4.6"
  
  /* Define to the one symbol short name of this package. */
 -#undef PACKAGE_TARNAME
@@ -243,7 +243,7 @@ index d38b781..6284190 100644
  
  /* Define to the version of this package. */
 -#undef PACKAGE_VERSION
-+#define PACKAGE_VERSION "3.4.4"
++#define PACKAGE_VERSION "3.4.6"
  
  /* The size of `double', as computed by sizeof. */
 -#undef SIZEOF_DOUBLE
@@ -283,7 +283,7 @@ index d38b781..6284190 100644
  
  /* Version number of package */
 -#undef VERSION
-+#define VERSION "3.4.4"
++#define VERSION "3.4.6"
  
  /* Define WORDS_BIGENDIAN to 1 if your processor stores words with the most
     significant byte first (like Motorola and SPARC, unlike Intel). */
@@ -312,7 +312,7 @@ index 227ac79..6318a33 100644
 @@ -1,5 +1,5 @@
  /* -----------------------------------------------------------------*-C-*-
 -   libffi @VERSION@
-+   libffi 3.4.4
++   libffi 3.4.6
       - Copyright (c) 2011, 2014, 2019, 2021, 2022 Anthony Green
       - Copyright (c) 1996-2003, 2007, 2008 Red Hat, Inc.
  


### PR DESCRIPTION
Note that this currently prints:

```
Error downloading from https://lafo.ssw.uni-linz.ac.at/pub/graal-external-deps/libffi-3.4.6.tar.gz to /home/zakkak/.mx/cache/LIBFFI_SOURCES_033d2600e879b83c6bce0eb80f69c5f32aa775bf2e962c9d39fbd21226fa19d1e79173d8eaa0d0157014d54509ea73315ad86842356fc3a303c0831c94c6ab39/libffi-sources.tar.gz: HTTP Error 404: Not Found
```

during the build, due to libffi-3.4.6 not being mirrored in https://lafo.ssw.uni-linz.ac.at/pub/graal-external-deps/ but it successfully fetches it from the upstream github repository.

Also note that this **has not been tested on windows**, so the windows patch file might need further adjustments.

Fixes https://github.com/oracle/graal/issues/9123
