### PR TITLE
Fix JFR substitutions for JDK Compatibility

### DIFF
--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/JDK23OrEarlier.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/JDK23OrEarlier.java
@@ -1,6 +1,5 @@
 /*
- * Copyright (c) 2023, 2023, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2023, 2023, Red Hat Inc. All rights reserved.
+ * Copyright (c) 2024, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,12 +22,15 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+package com.oracle.svm.core.jdk;
 
-package com.oracle.svm.core.jfr;
+import jdk.graal.compiler.serviceprovider.JavaVersionUtil;
 
-import com.oracle.svm.core.annotate.TargetClass;
-import com.oracle.svm.core.jdk.JDK23OrEarlier;
+import java.util.function.BooleanSupplier;
 
-@TargetClass(className = "jdk.jfr.internal.JVM$ChunkRotationMonitor", onlyWith = {HasJfrSupport.class, JDK23OrEarlier.class})
-public final class Target_jdk_jfr_internal_JVM_ChunkRotationMonitor {
+public class JDK23OrEarlier implements BooleanSupplier {
+    @Override
+    public boolean getAsBoolean() {
+        return JavaVersionUtil.JAVA_SPEC <= 23;
+    }
 }

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/JDK24OrLater.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/JDK24OrLater.java
@@ -1,6 +1,5 @@
 /*
- * Copyright (c) 2023, 2023, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2023, 2023, Red Hat Inc. All rights reserved.
+ * Copyright (c) 2024, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,12 +22,15 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+package com.oracle.svm.core.jdk;
 
-package com.oracle.svm.core.jfr;
+import jdk.graal.compiler.serviceprovider.JavaVersionUtil;
 
-import com.oracle.svm.core.annotate.TargetClass;
-import com.oracle.svm.core.jdk.JDK23OrEarlier;
+import java.util.function.BooleanSupplier;
 
-@TargetClass(className = "jdk.jfr.internal.JVM$ChunkRotationMonitor", onlyWith = {HasJfrSupport.class, JDK23OrEarlier.class})
-public final class Target_jdk_jfr_internal_JVM_ChunkRotationMonitor {
+public class JDK24OrLater implements BooleanSupplier {
+    @Override
+    public boolean getAsBoolean() {
+        return JavaVersionUtil.JAVA_SPEC >= 24;
+    }
 }

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/Target_jdk_jfr_internal_HiddenWait.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/Target_jdk_jfr_internal_HiddenWait.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2023, 2023, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2023, 2023, Red Hat Inc. All rights reserved.
+ * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2024, Red Hat Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,8 +27,8 @@
 package com.oracle.svm.core.jfr;
 
 import com.oracle.svm.core.annotate.TargetClass;
-import com.oracle.svm.core.jdk.JDK23OrEarlier;
+import com.oracle.svm.core.jdk.JDK24OrLater;
 
-@TargetClass(className = "jdk.jfr.internal.JVM$ChunkRotationMonitor", onlyWith = {HasJfrSupport.class, JDK23OrEarlier.class})
-public final class Target_jdk_jfr_internal_JVM_ChunkRotationMonitor {
+@TargetClass(className = "jdk.jfr.internal.HiddenWait", onlyWith = {HasJfrSupport.class, JDK24OrLater.class})
+public final class Target_jdk_jfr_internal_HiddenWait {
 }

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/Target_jdk_jfr_internal_JVM.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/Target_jdk_jfr_internal_JVM.java
@@ -42,6 +42,7 @@ import com.oracle.svm.core.annotate.TargetElement;
 import com.oracle.svm.core.heap.PhysicalMemory.PhysicalMemorySupport;
 import com.oracle.svm.core.jdk.JDK22OrLater;
 import com.oracle.svm.core.jdk.JDK23OrLater;
+import com.oracle.svm.core.jdk.JDK24OrLater;
 import com.oracle.svm.core.jfr.traceid.JfrTraceId;
 import com.oracle.svm.core.util.VMError;
 import com.oracle.svm.util.ReflectionUtil;
@@ -196,6 +197,12 @@ public final class Target_jdk_jfr_internal_JVM {
     @TargetElement(onlyWith = JDK22OrLater.class)
     public static long getTicksFrequency() {
         return JfrTicks.getTicksFrequency();
+    }
+
+    @Substitute
+    @TargetElement(onlyWith = JDK24OrLater.class)
+    public static long nanosNow() {
+        return JfrTicks.currentTimeNanos();
     }
 
     /** See {@link JVM#log}. */

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/events/JavaMonitorWaitEvent.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/events/JavaMonitorWaitEvent.java
@@ -27,7 +27,7 @@
 package com.oracle.svm.core.jfr.events;
 
 import jdk.graal.compiler.word.Word;
-
+import jdk.graal.compiler.serviceprovider.JavaVersionUtil;
 import com.oracle.svm.core.Uninterruptible;
 import com.oracle.svm.core.jfr.HasJfrSupport;
 import com.oracle.svm.core.jfr.JfrEvent;
@@ -37,11 +37,21 @@ import com.oracle.svm.core.jfr.JfrNativeEventWriterDataAccess;
 import com.oracle.svm.core.jfr.JfrTicks;
 import com.oracle.svm.core.jfr.SubstrateJVM;
 import com.oracle.svm.core.jfr.Target_jdk_jfr_internal_JVM_ChunkRotationMonitor;
+import com.oracle.svm.core.jfr.Target_jdk_jfr_internal_HiddenWait;
 
 public class JavaMonitorWaitEvent {
     public static void emit(long startTicks, Object obj, long notifier, long timeout, boolean timedOut) {
-        if (HasJfrSupport.get() && obj != null && !Target_jdk_jfr_internal_JVM_ChunkRotationMonitor.class.equals(obj.getClass())) {
-            emit0(startTicks, obj, notifier, timeout, timedOut);
+        if (!HasJfrSupport.get() || obj == null) {
+            return;
+        }
+        if (JavaVersionUtil.JAVA_SPEC >= 24) {
+            if (!Target_jdk_jfr_internal_HiddenWait.class.equals(obj.getClass())) {
+                emit0(startTicks, obj, notifier, timeout, timedOut);
+            }
+        } else {
+            if (!Target_jdk_jfr_internal_JVM_ChunkRotationMonitor.class.equals(obj.getClass())) {
+                emit0(startTicks, obj, notifier, timeout, timedOut);
+            }
         }
     }
 


### PR DESCRIPTION
Related Issue: https://github.com/oracle/graal/issues/9199

[A recent JDK change](https://github.com/openjdk/jdk/pull/19799) has caused some JFR substitutions to go out-of-date. Native Image binaries with JFR currently will not build with the latest LabsJDK.  This PR fixes those substitutions. 
