### PR TITLE
[GR-54994] Remove duplicate ThreadSleep JFR events and use nanosNow() to timestamp JFR chunks.

### DIFF
--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/JfrTicks.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/JfrTicks.java
@@ -26,6 +26,7 @@ package com.oracle.svm.core.jfr;
 
 import com.oracle.svm.core.Uninterruptible;
 import com.oracle.svm.core.util.TimeUtils;
+import com.oracle.svm.core.util.PlatformTimeUtils;
 
 /**
  * Utility class to manage ticks for event timestamps based on an initial start point when the
@@ -72,6 +73,6 @@ public final class JfrTicks {
     }
 
     public static long currentTimeNanos() {
-        return TimeUtils.millisToNanos(System.currentTimeMillis());
+        return PlatformTimeUtils.singleton().nanosNow();
     }
 }

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/thread/PlatformThreads.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/thread/PlatformThreads.java
@@ -89,7 +89,6 @@ import com.oracle.svm.core.heap.ReferenceHandlerThread;
 import com.oracle.svm.core.heap.VMOperationInfos;
 import com.oracle.svm.core.jdk.StackTraceUtils;
 import com.oracle.svm.core.jdk.UninterruptibleUtils;
-import com.oracle.svm.core.jfr.HasJfrSupport;
 import com.oracle.svm.core.locks.VMMutex;
 import com.oracle.svm.core.log.Log;
 import com.oracle.svm.core.memory.NativeMemory;
@@ -110,7 +109,6 @@ import com.oracle.svm.util.ReflectionUtil;
 
 import jdk.graal.compiler.api.replacements.Fold;
 import jdk.graal.compiler.core.common.SuppressFBWarnings;
-import jdk.internal.event.ThreadSleepEvent;
 import jdk.internal.misc.Unsafe;
 
 /**
@@ -983,23 +981,11 @@ public abstract class PlatformThreads {
     }
 
     /**
-     * Sleeps for the given number of nanoseconds, dealing with JFR events, wakups and
-     * interruptions.
+     * Sleeps for the given number of nanoseconds, wake-ups and interruptions.
      */
     static void sleep(long nanos) throws InterruptedException {
         assert !isCurrentThreadVirtual();
-        if (HasJfrSupport.get() && ThreadSleepEvent.isTurnedOn()) {
-            ThreadSleepEvent event = new ThreadSleepEvent();
-            try {
-                event.time = nanos;
-                event.begin();
-                sleep0(nanos);
-            } finally {
-                event.commit();
-            }
-        } else {
-            sleep0(nanos);
-        }
+        sleep0(nanos);
     }
 
     /** Sleep for the given number of nanoseconds, dealing with early wakeups and interruptions. */


### PR DESCRIPTION
Related issues: https://github.com/oracle/graal/issues/9201 and  https://github.com/oracle/graal/issues/9199

This pull request:

1. Updates JfrTicks to use the new `PlatformTimeUtils.nanosNow()` method. This ensures that [borrowed java-level JDK code](https://github.com/openjdk/jdk/pull/19799/files#diff-c5bdd08f039200bb96baffb6b5ad5716d506c0a53e1f768bf18cb1d6570a4027R340) that uses `JVM.nanosNow()` is using the same clock that we timestamp chunk files with. See [the comment here](https://github.com/openjdk/jdk/pull/19799/files#diff-b7f754817501bf15b4cb8004fc066e46fbd97b30b15ef406aa09fd00ca2e5f14R174). Currently we use `System.currentTimeMillis()` to timestamp chunks, which is a different clock and only has ms precision. This might cause inconsistencies if JDK code uses `JVM.nanosNow()` and compares it to times retrieved from `System.currentTimeMillis()` .  
2.  Removes the duplicate emission of `jdk.ThreadSleep` events from SVM code. Previously the events were being emitted from borrowed Java-level JDK code and then again from SubstrateVM code. 


Before
![image](https://github.com/oracle/graal/assets/35396843/f6665e03-46fb-42b7-88ab-0556bc9365ed)

After: 
![image](https://github.com/oracle/graal/assets/35396843/0258a2a7-5b84-45fc-bf47-03ac6852984c)

