### PR TITLE
[GR-57310] NMT simplified virtual memory tracking.

### DIFF
--- a/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/HeapChunkProvider.java
+++ b/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/HeapChunkProvider.java
@@ -24,6 +24,7 @@
  */
 package com.oracle.svm.core.genscavenge;
 
+import com.oracle.svm.core.VMInspectionOptions;
 import org.graalvm.nativeimage.Platform;
 import org.graalvm.nativeimage.Platforms;
 import org.graalvm.word.Pointer;
@@ -40,6 +41,8 @@ import com.oracle.svm.core.heap.OutOfMemoryUtil;
 import com.oracle.svm.core.jdk.UninterruptibleUtils;
 import com.oracle.svm.core.jdk.UninterruptibleUtils.AtomicUnsigned;
 import com.oracle.svm.core.log.Log;
+import com.oracle.svm.core.nmt.NmtCategory;
+import com.oracle.svm.core.nmt.NativeMemoryTracking;
 import com.oracle.svm.core.os.ChunkBasedCommittedMemoryProvider;
 import com.oracle.svm.core.thread.VMOperation;
 import com.oracle.svm.core.thread.VMThreads;
@@ -93,7 +96,10 @@ final class HeapChunkProvider {
             if (result.isNull()) {
                 throw OutOfMemoryUtil.reportOutOfMemoryError(ALIGNED_OUT_OF_MEMORY_ERROR);
             }
-
+            if (VMInspectionOptions.hasNativeMemoryTrackingSupport()) {
+                NativeMemoryTracking.singleton().trackReserve(chunkSize.rawValue(), NmtCategory.JavaHeap);
+                NativeMemoryTracking.singleton().trackCommit(chunkSize.rawValue(), NmtCategory.JavaHeap);
+            }
             AlignedHeapChunk.initialize(result, chunkSize);
         }
         assert HeapChunk.getTopOffset(result).equal(AlignedHeapChunk.getObjectsStartOffset());
@@ -244,7 +250,10 @@ final class HeapChunkProvider {
         if (result.isNull()) {
             throw OutOfMemoryUtil.reportOutOfMemoryError(UNALIGNED_OUT_OF_MEMORY_ERROR);
         }
-
+        if (VMInspectionOptions.hasNativeMemoryTrackingSupport()) {
+            NativeMemoryTracking.singleton().trackReserve(chunkSize.rawValue(), NmtCategory.JavaHeap);
+            NativeMemoryTracking.singleton().trackCommit(chunkSize.rawValue(), NmtCategory.JavaHeap);
+        }
         UnalignedHeapChunk.initialize(result, chunkSize);
         assert objectSize.belowOrEqual(HeapChunk.availableObjectMemory(result)) : "UnalignedHeapChunk insufficient for requested object";
 
@@ -306,12 +315,22 @@ final class HeapChunkProvider {
 
     @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
     private static void freeAlignedChunk(AlignedHeader chunk) {
-        ChunkBasedCommittedMemoryProvider.get().freeAlignedChunk(chunk, HeapParameters.getAlignedHeapChunkSize(), HeapParameters.getAlignedHeapChunkAlignment());
+        UnsignedWord size = HeapParameters.getAlignedHeapChunkSize();
+        ChunkBasedCommittedMemoryProvider.get().freeAlignedChunk(chunk, size, HeapParameters.getAlignedHeapChunkAlignment());
+        if (VMInspectionOptions.hasNativeMemoryTrackingSupport()) {
+            NativeMemoryTracking.singleton().trackUncommit(size.rawValue(), NmtCategory.JavaHeap);
+            NativeMemoryTracking.singleton().trackFree(size.rawValue(), NmtCategory.JavaHeap);
+        }
     }
 
     @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
     private static void freeUnalignedChunk(UnalignedHeader chunk) {
-        ChunkBasedCommittedMemoryProvider.get().freeUnalignedChunk(chunk, unalignedChunkSize(chunk));
+        UnsignedWord size = unalignedChunkSize(chunk);
+        ChunkBasedCommittedMemoryProvider.get().freeUnalignedChunk(chunk, size);
+        if (VMInspectionOptions.hasNativeMemoryTrackingSupport()) {
+            NativeMemoryTracking.singleton().trackUncommit(size.rawValue(), NmtCategory.JavaHeap);
+            NativeMemoryTracking.singleton().trackFree(size.rawValue(), NmtCategory.JavaHeap);
+        }
     }
 
     @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)

--- a/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/HeapImpl.java
+++ b/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/HeapImpl.java
@@ -489,20 +489,12 @@ public final class HeapImpl extends Heap {
         return imageHeapSize;
     }
 
-    private static class ImageHeapSizeVisitor implements MemoryWalker.ImageHeapRegionVisitor, ObjectVisitor {
+    private static class ImageHeapSizeVisitor implements MemoryWalker.ImageHeapRegionVisitor {
         long size;
 
         @Override
         public <T> boolean visitNativeImageHeapRegion(T region, MemoryWalker.NativeImageHeapRegionAccess<T> access) {
-            if (!access.isWritable(region) && !access.consistsOfHugeObjects(region)) {
-                size += access.getSize(region).rawValue();
-            }
-            return true;
-        }
-
-        @Override
-        @RestrictHeapAccess(access = RestrictHeapAccess.Access.UNRESTRICTED, reason = "Allocation is fine: this method traverses only the image heap.")
-        public boolean visitObject(Object o) {
+            size += access.getSize(region).rawValue();
             return true;
         }
     }

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/heap/Heap.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/heap/Heap.java
@@ -96,6 +96,8 @@ public abstract class Heap {
      */
     public abstract boolean walkImageHeapObjects(ObjectVisitor visitor);
 
+    public abstract long getImageHeapSize();
+
     /**
      * Walk all heap objects except the native image heap objects. Must only be executed as part of
      * a VM operation that causes a safepoint.

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/nmt/NmtCategory.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/nmt/NmtCategory.java
@@ -37,6 +37,8 @@ public enum NmtCategory {
     GC("GC"),
     /** Heap dumping infrastructure. */
     HeapDump("Heap Dump"),
+    ImageHeap("Image Heap"),
+    JavaHeap("Java Heap"),
     /** Java Flight Recorder. */
     JFR("JFR"),
     /** Java Native Interface. */

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/nmt/NmtFeature.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/nmt/NmtFeature.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2023, 2023, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2023, 2023, Red Hat Inc. All rights reserved.
+ * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2024, Red Hat Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -48,5 +48,6 @@ public class NmtFeature implements InternalFeature {
     @Override
     public void beforeAnalysis(BeforeAnalysisAccess access) {
         RuntimeSupport.getRuntimeSupport().addShutdownHook(NativeMemoryTracking.shutdownHook());
+        RuntimeSupport.getRuntimeSupport().addStartupHook(NativeMemoryTracking.startupHook());
     }
 }

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/nmt/NmtVirtualMemoryInfo.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/nmt/NmtVirtualMemoryInfo.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2024, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, 2024, Red Hat Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package com.oracle.svm.core.nmt;
+
+import static com.oracle.svm.core.Uninterruptible.CALLED_FROM_UNINTERRUPTIBLE_CODE;
+
+import com.oracle.svm.core.Uninterruptible;
+import com.oracle.svm.core.jdk.UninterruptibleUtils.AtomicLong;
+import org.graalvm.nativeimage.Platform;
+import org.graalvm.nativeimage.Platforms;
+
+class NmtVirtualMemoryInfo {
+
+    private final AtomicLong peakReservedSize = new AtomicLong(0);
+    private final AtomicLong peakCommittedSize = new AtomicLong(0);
+    private final AtomicLong reservedSize = new AtomicLong(0);
+    private final AtomicLong committedSize = new AtomicLong(0);
+
+    @Platforms(Platform.HOSTED_ONLY.class)
+    NmtVirtualMemoryInfo() {
+    }
+
+    @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
+    void trackReserved(long size) {
+        long newReservedSize = reservedSize.addAndGet(size);
+        updatePeak(newReservedSize, peakReservedSize);
+    }
+
+    @Uninterruptible(reason = CALLED_FROM_UNINTERRUPTIBLE_CODE, mayBeInlined = true)
+    void trackCommitted(long size) {
+        long newCommittedSize = committedSize.addAndGet(size);
+        updatePeak(newCommittedSize, peakCommittedSize);
+    }
+
+    @Uninterruptible(reason = CALLED_FROM_UNINTERRUPTIBLE_CODE, mayBeInlined = true)
+    void trackUncommit(long size) {
+        long lastSize = committedSize.addAndGet(-size);
+        assert lastSize >= 0;
+
+    }
+
+    @Uninterruptible(reason = CALLED_FROM_UNINTERRUPTIBLE_CODE, mayBeInlined = true)
+    void trackFree(long size) {
+        long lastSize = reservedSize.addAndGet(-size);
+        assert lastSize >= 0;
+    }
+
+    @Uninterruptible(reason = CALLED_FROM_UNINTERRUPTIBLE_CODE, mayBeInlined = true)
+    private static void updatePeak(long newSize, AtomicLong peakToUpdate) {
+        long oldPeak = peakToUpdate.get();
+        while (oldPeak < newSize) {
+            if (peakToUpdate.compareAndSet(oldPeak, newSize)) {
+                return;
+            }
+            oldPeak = peakToUpdate.get();
+        }
+    }
+
+    @Uninterruptible(reason = CALLED_FROM_UNINTERRUPTIBLE_CODE, mayBeInlined = true)
+    long getReservedSize() {
+        return reservedSize.get();
+    }
+
+    @Uninterruptible(reason = CALLED_FROM_UNINTERRUPTIBLE_CODE, mayBeInlined = true)
+    long getCommittedSize() {
+        return committedSize.get();
+    }
+
+    @Uninterruptible(reason = CALLED_FROM_UNINTERRUPTIBLE_CODE, mayBeInlined = true)
+    long getPeakReservedSize() {
+        return peakReservedSize.get();
+    }
+
+    @Uninterruptible(reason = CALLED_FROM_UNINTERRUPTIBLE_CODE, mayBeInlined = true)
+    long getPeakCommittedSize() {
+        return peakCommittedSize.get();
+    }
+}

--- a/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/nmt/NativeMemoryTrackingTests.java
+++ b/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/nmt/NativeMemoryTrackingTests.java
@@ -87,11 +87,11 @@ public class NativeMemoryTrackingTests {
         assertEquals(0, getUsedMemory());
 
         Pointer ptr1 = NativeMemory.malloc(M, NmtCategory.Code);
-        long peakUsed = NativeMemoryTracking.singleton().getPeakUsedMemory(NmtCategory.Code);
+        long peakUsed = NativeMemoryTracking.singleton().getPeakMallocMemory(NmtCategory.Code);
         assertEquals(M, peakUsed);
 
         Pointer ptr2 = NativeMemory.malloc(M, NmtCategory.Code);
-        peakUsed = NativeMemoryTracking.singleton().getPeakUsedMemory(NmtCategory.Code);
+        peakUsed = NativeMemoryTracking.singleton().getPeakMallocMemory(NmtCategory.Code);
         assertEquals(2 * M, peakUsed);
 
         NativeMemory.free(ptr1);
@@ -101,20 +101,54 @@ public class NativeMemoryTrackingTests {
         ptr2 = WordFactory.nullPointer();
 
         assertEquals(0, getUsedMemory());
-        assertEquals(2 * M, NativeMemoryTracking.singleton().getPeakUsedMemory(NmtCategory.Code));
+        assertEquals(2 * M, NativeMemoryTracking.singleton().getPeakMallocMemory(NmtCategory.Code));
 
         Pointer ptr3 = NativeMemory.malloc(3 * M, NmtCategory.Code);
-        peakUsed = NativeMemoryTracking.singleton().getPeakUsedMemory(NmtCategory.Code);
+        peakUsed = NativeMemoryTracking.singleton().getPeakMallocMemory(NmtCategory.Code);
         assertEquals(3 * M, peakUsed);
 
         NativeMemory.free(ptr3);
         ptr3 = WordFactory.nullPointer();
 
         assertEquals(0, getUsedMemory());
-        assertEquals(3 * M, NativeMemoryTracking.singleton().getPeakUsedMemory(NmtCategory.Code));
+        assertEquals(3 * M, NativeMemoryTracking.singleton().getPeakMallocMemory(NmtCategory.Code));
     }
 
     private static long getUsedMemory() {
-        return NativeMemoryTracking.singleton().getUsedMemory(NmtCategory.Code);
+        return NativeMemoryTracking.singleton().getMallocMemory(NmtCategory.Code);
+    }
+
+    @Test
+    public void testVirtualMemoryTracking() {
+        // The application should already be using some virtual memory for the heap.
+        assertTrue(NativeMemoryTracking.singleton().getReservedVirtualMemory(NmtCategory.ImageHeap) > 0);
+        assertTrue(NativeMemoryTracking.singleton().getReservedVirtualMemory(NmtCategory.JavaHeap) > 0);
+
+        assertTrue(NativeMemoryTracking.singleton().getCommittedVirtualMemory(NmtCategory.JavaHeap) > 0);
+        assertTrue(NativeMemoryTracking.singleton().getCommittedVirtualMemory(NmtCategory.ImageHeap) > 0);
+
+        assertTrue(NativeMemoryTracking.singleton().getPeakCommittedVirtualMemory(NmtCategory.JavaHeap) > 0);
+        assertTrue(NativeMemoryTracking.singleton().getPeakCommittedVirtualMemory(NmtCategory.ImageHeap) > 0);
+
+        assertTrue(NativeMemoryTracking.singleton().getPeakReservedVirtualMemory(NmtCategory.JavaHeap) > 0);
+        assertTrue(NativeMemoryTracking.singleton().getPeakReservedVirtualMemory(NmtCategory.ImageHeap) > 0);
+
+        // Ensure we have a zero baseline
+        assertTrue(NativeMemoryTracking.singleton().getReservedVirtualMemory(NmtCategory.Code) == 0);
+        assertTrue(NativeMemoryTracking.singleton().getCommittedVirtualMemory(NmtCategory.Code) == 0);
+        assertTrue(NativeMemoryTracking.singleton().getPeakReservedVirtualMemory(NmtCategory.Code) == 0);
+        assertTrue(NativeMemoryTracking.singleton().getPeakCommittedVirtualMemory(NmtCategory.Code) == 0);
+
+        // Use some memory
+        NativeMemoryTracking.singleton().trackReserve(1024, NmtCategory.Code);
+        NativeMemoryTracking.singleton().trackCommit(512, NmtCategory.Code);
+        assertTrue(NativeMemoryTracking.singleton().getReservedVirtualMemory(NmtCategory.Code) == 1024);
+        assertTrue(NativeMemoryTracking.singleton().getCommittedVirtualMemory(NmtCategory.Code) == 512);
+
+        // Uncommit and check peaks
+        NativeMemoryTracking.singleton().trackUncommit(512, NmtCategory.Code);
+        NativeMemoryTracking.singleton().trackFree(1024, NmtCategory.Code);
+        assertTrue(NativeMemoryTracking.singleton().getPeakReservedVirtualMemory(NmtCategory.Code) == 1024);
+        assertTrue(NativeMemoryTracking.singleton().getPeakCommittedVirtualMemory(NmtCategory.Code) == 512);
     }
 }


### PR DESCRIPTION
### Summary
This is a simplified version of https://github.com/oracle/graal/pull/8630 
This PR adds virtual memory tracking, but makes the assumption that virtual memory is used neatly (no overlapping committed regions etc).  Please see the javadoc in `NativeMemoryTracking` for more info.

**Notes:**
There's 3 approaches we could take with this simplified version. 

1. The approach in this PR. This is a middle ground between 2 and 3. Instrument at the caller level (ie in `HeapChunkProvider`). This makes the caller responsible for correct instrumentation.
2. Get rid of "track" methods and `NmtVirtualMemoryInfo`. Instead, directly query `HeapAccounting` whenever we need to report virtual memory. This is probably less extensible than 1 or 3. 
3. Lower level instrumentation of `VirtualMemoryProvider` implementations. Similar to the [original PR](https://github.com/oracle/graal/pull/8630 ). This would ensure we don't miss any allocations if virtual memory becomes used in other places in the future.  However, I don't think this is necessary right now since virtual memory is used simply in SVM currently. We can avoid instrumenting in platform specific code. 