### PR TITLE
[GR-57624] Fix Locale NPE in JDK 24+10 and better

### DIFF
--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/Target_jdk_internal_util_StaticProperty.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/Target_jdk_internal_util_StaticProperty.java
@@ -139,6 +139,6 @@ final class Target_jdk_internal_util_StaticProperty {
 
     @Substitute
     public static String javaLocaleUseOldISOCodes() {
-        return SystemPropertiesSupport.singleton().savedProperties.get("java.locale.useOldISOCodes");
+        return SystemPropertiesSupport.singleton().savedProperties.getOrDefault("java.locale.useOldISOCodes", "");
     }
 }


### PR DESCRIPTION
The JDK's StaticProperty class uses a default of the empty string for the java.locale.useOldISOCodes static property. Ensure to also use the empty string as the default in substratevm avoiding the NullPointerException.

Closes: #9526

Testing:
 - Passes the provided reproducer in #9526. Throws NPE before.
 - Quarkus tests from https://github.com/graalvm/mandrel/issues/778 which triggered this investigation.