### PR TITLE
[GR-57064] Lazy virtual thread JFR registration and epoch generation caching

### DIFF
--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/JfrNativeEventWriter.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/JfrNativeEventWriter.java
@@ -250,12 +250,14 @@ public final class JfrNativeEventWriter {
         if (thread == null) {
             putThread(data, 0L);
         } else {
+            SubstrateJVM.maybeRegisterVirtualThread(thread);
             putThread(data, SubstrateJVM.getThreadId(thread));
         }
     }
 
     @Uninterruptible(reason = "Accesses a native JFR buffer.", callerMustBe = true)
     public static void putThread(JfrNativeEventWriterData data, long threadId) {
+        SubstrateJVM.maybeRegisterVirtualThread(threadId);
         putLong(data, threadId);
     }
 

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/JfrThreadRepository.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/JfrThreadRepository.java
@@ -92,11 +92,6 @@ public final class JfrThreadRepository implements JfrRepository {
             Thread thread = PlatformThreads.fromVMThread(isolateThread);
             if (thread != null) {
                 registerThread(thread);
-                // Re-register vthreads that are already mounted.
-                Thread vthread = PlatformThreads.getMountedVirtualThread(thread);
-                if (vthread != null) {
-                    registerThread(vthread);
-                }
             }
         }
     }

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/SubstrateJVM.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/SubstrateJVM.java
@@ -26,6 +26,7 @@ package com.oracle.svm.core.jfr;
 
 import java.util.List;
 
+import com.oracle.svm.core.SubstrateUtil;
 import org.graalvm.nativeimage.ImageSingletons;
 import org.graalvm.nativeimage.IsolateThread;
 import org.graalvm.nativeimage.Platform;
@@ -42,6 +43,7 @@ import com.oracle.svm.core.jfr.oldobject.JfrOldObjectProfiler;
 import com.oracle.svm.core.jfr.oldobject.JfrOldObjectRepository;
 import com.oracle.svm.core.jfr.sampler.JfrExecutionSampler;
 import com.oracle.svm.core.jfr.throttling.JfrEventThrottling;
+import com.oracle.svm.core.jfr.traceid.JfrTraceIdEpoch;
 import com.oracle.svm.core.log.Log;
 import com.oracle.svm.core.sampler.SamplerBufferPool;
 import com.oracle.svm.core.sampler.SamplerBuffersAccess;
@@ -49,6 +51,7 @@ import com.oracle.svm.core.sampler.SamplerStatistics;
 import com.oracle.svm.core.sampler.SubstrateSigprofHandler;
 import com.oracle.svm.core.thread.JavaThreads;
 import com.oracle.svm.core.thread.JavaVMOperation;
+import com.oracle.svm.core.thread.Target_java_lang_VirtualThread;
 import com.oracle.svm.core.thread.VMThreads;
 import com.oracle.svm.core.util.VMError;
 
@@ -303,6 +306,7 @@ public class SubstrateJVM {
     @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
     public static long getThreadId(Thread thread) {
         if (HasJfrSupport.get()) {
+            maybeRegisterVirtualThread(thread);
             return JavaThreads.getThreadId(thread);
         }
         return 0;
@@ -311,9 +315,27 @@ public class SubstrateJVM {
     @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
     public static long getCurrentThreadId() {
         if (HasJfrSupport.get()) {
+            maybeRegisterVirtualThread(Thread.currentThread());
             return JavaThreads.getCurrentThreadId();
         }
         return 0;
+    }
+
+    /**
+     * Register virtual threads if they aren't registered already. Platform threads are registered
+     * eagerly when started and at chunk rotations.
+     */
+    @Uninterruptible(reason = "Epoch should not change while checking generation.")
+    private static void maybeRegisterVirtualThread(Thread thread) {
+        // Do quick preliminary checks to avoid global locking unless necessary.
+        if (JavaThreads.isVirtual(thread)) {
+            Target_java_lang_VirtualThread tjlv = SubstrateUtil.cast(thread, Target_java_lang_VirtualThread.class);
+            int currentEpochGen = JfrTraceIdEpoch.getInstance().currentEpochGeneration();
+            if (tjlv.jfrGeneration != currentEpochGen) {
+                getThreadRepo().registerThread(thread);
+                tjlv.jfrGeneration = currentEpochGen;
+            }
+        }
     }
 
     /**

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/events/ExecutionSampleEvent.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/events/ExecutionSampleEvent.java
@@ -41,7 +41,7 @@ public final class ExecutionSampleEvent {
 
             JfrNativeEventWriter.beginSmallEvent(data, JfrEvent.ExecutionSample);
             JfrNativeEventWriter.putLong(data, elapsedTicks);
-            JfrNativeEventWriter.putLong(data, threadId);
+            JfrNativeEventWriter.putThread(data, threadId);
             JfrNativeEventWriter.putLong(data, stackTraceId);
             JfrNativeEventWriter.putLong(data, threadState);
             JfrNativeEventWriter.endSmallEvent(data);

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/events/JavaMonitorEnterEvent.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/events/JavaMonitorEnterEvent.java
@@ -39,14 +39,14 @@ import com.oracle.svm.core.jfr.JfrTicks;
 import com.oracle.svm.core.jfr.SubstrateJVM;
 
 public class JavaMonitorEnterEvent {
-    public static void emit(Object obj, long previousOwnerTid, long startTicks) {
+    public static void emit(Object obj, Thread previousOwner, long startTicks) {
         if (HasJfrSupport.get()) {
-            emit0(obj, previousOwnerTid, startTicks);
+            emit0(obj, previousOwner, startTicks);
         }
     }
 
     @Uninterruptible(reason = "Accesses a JFR buffer.")
-    public static void emit0(Object obj, long previousOwnerTid, long startTicks) {
+    public static void emit0(Object obj, Thread previousOwner, long startTicks) {
         long duration = JfrTicks.duration(startTicks);
         if (JfrEvent.JavaMonitorEnter.shouldEmit(duration)) {
             JfrNativeEventWriterData data = StackValue.get(JfrNativeEventWriterData.class);
@@ -58,7 +58,7 @@ public class JavaMonitorEnterEvent {
             JfrNativeEventWriter.putEventThread(data);
             JfrNativeEventWriter.putLong(data, SubstrateJVM.get().getStackTraceId(JfrEvent.JavaMonitorEnter, 0));
             JfrNativeEventWriter.putClass(data, obj.getClass());
-            JfrNativeEventWriter.putLong(data, previousOwnerTid);
+            JfrNativeEventWriter.putThread(data, previousOwner);
             JfrNativeEventWriter.putLong(data, Word.objectToUntrackedPointer(obj).rawValue());
             JfrNativeEventWriter.endSmallEvent(data);
         }

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/events/JavaMonitorWaitEvent.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/events/JavaMonitorWaitEvent.java
@@ -40,7 +40,7 @@ import com.oracle.svm.core.jfr.Target_jdk_jfr_internal_management_HiddenWait;
 import jdk.graal.compiler.word.Word;
 
 public class JavaMonitorWaitEvent {
-    public static void emit(long startTicks, Object obj, long notifier, long timeout, boolean timedOut) {
+    public static void emit(long startTicks, Object obj, Thread notifier, long timeout, boolean timedOut) {
         if (HasJfrSupport.get() && obj != null && !Target_jdk_jfr_internal_JVM_ChunkRotationMonitor.class.equals(obj.getClass()) &&
                         !Target_jdk_jfr_internal_management_HiddenWait.class.equals(obj.getClass())) {
             emit0(startTicks, obj, notifier, timeout, timedOut);
@@ -48,7 +48,7 @@ public class JavaMonitorWaitEvent {
     }
 
     @Uninterruptible(reason = "Accesses a JFR buffer.")
-    private static void emit0(long startTicks, Object obj, long notifier, long timeout, boolean timedOut) {
+    private static void emit0(long startTicks, Object obj, Thread notifier, long timeout, boolean timedOut) {
         long duration = JfrTicks.duration(startTicks);
         if (JfrEvent.JavaMonitorWait.shouldEmit(duration)) {
             JfrNativeEventWriterData data = org.graalvm.nativeimage.StackValue.get(JfrNativeEventWriterData.class);
@@ -60,7 +60,7 @@ public class JavaMonitorWaitEvent {
             JfrNativeEventWriter.putEventThread(data);
             JfrNativeEventWriter.putLong(data, SubstrateJVM.get().getStackTraceId(JfrEvent.JavaMonitorWait, 0));
             JfrNativeEventWriter.putClass(data, obj.getClass());
-            JfrNativeEventWriter.putLong(data, notifier);
+            JfrNativeEventWriter.putThread(data, notifier);
             JfrNativeEventWriter.putLong(data, timeout);
             JfrNativeEventWriter.putBoolean(data, timedOut);
             JfrNativeEventWriter.putLong(data, Word.objectToUntrackedPointer(obj).rawValue());

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/events/ThreadStartEvent.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/events/ThreadStartEvent.java
@@ -47,7 +47,7 @@ public class ThreadStartEvent {
             JfrNativeEventWriter.putEventThread(data);
             JfrNativeEventWriter.putLong(data, SubstrateJVM.get().getStackTraceId(JfrEvent.ThreadStart, 0));
             JfrNativeEventWriter.putThread(data, thread);
-            JfrNativeEventWriter.putLong(data, JavaThreads.getParentThreadId(thread));
+            JfrNativeEventWriter.putThread(data, JavaThreads.getParentThreadId(thread));
             JfrNativeEventWriter.endSmallEvent(data);
         }
     }

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/traceid/JfrTraceIdEpoch.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/traceid/JfrTraceIdEpoch.java
@@ -42,7 +42,6 @@ public class JfrTraceIdEpoch {
     private static final long EPOCH_0_BIT = 0b01;
     private static final long EPOCH_1_BIT = 0b10;
 
-    private boolean epoch;
     private int epochGeneration;
 
     @Fold
@@ -53,27 +52,29 @@ public class JfrTraceIdEpoch {
     @Platforms(Platform.HOSTED_ONLY.class)
     public JfrTraceIdEpoch() {
     }
-
+    @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
+    private boolean getEpoch() {
+        return (epochGeneration & 1) == 0;
+    }
     @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
     public void changeEpoch() {
         assert VMOperation.isInProgressAtSafepoint();
-        epoch = !epoch;
         epochGeneration++;
     }
 
     @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
     long thisEpochBit() {
-        return epoch ? EPOCH_1_BIT : EPOCH_0_BIT;
+        return getEpoch() ? EPOCH_1_BIT : EPOCH_0_BIT;
     }
 
     @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
     long previousEpochBit() {
-        return epoch ? EPOCH_0_BIT : EPOCH_1_BIT;
+        return getEpoch() ? EPOCH_0_BIT : EPOCH_1_BIT;
     }
 
     @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
     public boolean currentEpoch() {
-        return epoch;
+        return getEpoch();
     }
 
     @Uninterruptible(reason = "Avoid epoch changing while checking generation.", callerMustBe = true)
@@ -83,6 +84,6 @@ public class JfrTraceIdEpoch {
 
     @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
     public boolean previousEpoch() {
-        return !epoch;
+        return !getEpoch();
     }
 }

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/traceid/JfrTraceIdEpoch.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/traceid/JfrTraceIdEpoch.java
@@ -43,6 +43,7 @@ public class JfrTraceIdEpoch {
     private static final long EPOCH_1_BIT = 0b10;
 
     private boolean epoch;
+    private int epochGeneration;
 
     @Fold
     public static JfrTraceIdEpoch getInstance() {
@@ -57,6 +58,7 @@ public class JfrTraceIdEpoch {
     public void changeEpoch() {
         assert VMOperation.isInProgressAtSafepoint();
         epoch = !epoch;
+        epochGeneration++;
     }
 
     @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
@@ -72,6 +74,11 @@ public class JfrTraceIdEpoch {
     @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
     public boolean currentEpoch() {
         return epoch;
+    }
+
+    @Uninterruptible(reason = "Avoid epoch changing while checking generation.", callerMustBe = true)
+    public int currentEpochGeneration() {
+        return epochGeneration;
     }
 
     @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/traceid/JfrTraceIdEpoch.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/traceid/JfrTraceIdEpoch.java
@@ -52,10 +52,12 @@ public class JfrTraceIdEpoch {
     @Platforms(Platform.HOSTED_ONLY.class)
     public JfrTraceIdEpoch() {
     }
+
     @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
     private boolean getEpoch() {
         return (epochGeneration & 1) == 0;
     }
+
     @Uninterruptible(reason = "Called from uninterruptible code.", mayBeInlined = true)
     public void changeEpoch() {
         assert VMOperation.isInProgressAtSafepoint();

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/monitor/JavaMonitorQueuedSynchronizer.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/monitor/JavaMonitorQueuedSynchronizer.java
@@ -32,7 +32,6 @@ import java.util.concurrent.locks.LockSupport;
 
 import com.oracle.svm.core.Uninterruptible;
 import com.oracle.svm.core.jfr.JfrTicks;
-import com.oracle.svm.core.jfr.SubstrateJVM;
 import com.oracle.svm.core.jfr.events.JavaMonitorWaitEvent;
 import com.oracle.svm.core.thread.JavaThreads;
 import com.oracle.svm.core.util.BasedOnJDKClass;
@@ -120,7 +119,7 @@ abstract class JavaMonitorQueuedSynchronizer {
     @BasedOnJDKClass(value = AbstractQueuedLongSynchronizer.class, innerClass = "ConditionNode")
     static final class ConditionNode extends Node {
         ConditionNode nextWaiter;
-        long notifierJfrTid;
+        Thread notifierJfr;
 
         // see AbstractQueuedLongSynchronizer.ConditionNode.isReleasable()
         public boolean isReleasable() {
@@ -457,7 +456,7 @@ abstract class JavaMonitorQueuedSynchronizer {
                     first.nextWaiter = null; // GC assistance
                 }
                 if ((first.getAndUnsetStatus(COND) & COND) != 0) {
-                    first.notifierJfrTid = SubstrateJVM.getCurrentThreadId();
+                    first.notifierJfr = Thread.currentThread();
                     enqueue(first);
                     if (!all) {
                         break;
@@ -564,7 +563,7 @@ abstract class JavaMonitorQueuedSynchronizer {
         public void await(Object obj) throws InterruptedException {
             long startTicks = JfrTicks.elapsedTicks();
             if (Thread.interrupted()) {
-                JavaMonitorWaitEvent.emit(startTicks, obj, 0, 0L, false);
+                JavaMonitorWaitEvent.emit(startTicks, obj, null, 0L, false);
                 throw new InterruptedException();
             }
             ConditionNode node = newConditionNode();
@@ -587,7 +586,7 @@ abstract class JavaMonitorQueuedSynchronizer {
             }
             node.clearStatus();
             // waiting is done, emit wait event
-            JavaMonitorWaitEvent.emit(startTicks, obj, node.notifierJfrTid, 0L, false);
+            JavaMonitorWaitEvent.emit(startTicks, obj, node.notifierJfr, 0L, false);
             acquire(node, savedAcquisitions);
             if (interrupted) {
                 if (cancelled) {
@@ -604,7 +603,7 @@ abstract class JavaMonitorQueuedSynchronizer {
             long startTicks = JfrTicks.elapsedTicks();
             long nanosTimeout = unit.toNanos(time);
             if (Thread.interrupted()) {
-                JavaMonitorWaitEvent.emit(startTicks, obj, 0, 0L, false);
+                JavaMonitorWaitEvent.emit(startTicks, obj, null, 0L, false);
                 throw new InterruptedException();
             }
             ConditionNode node = newConditionNode();
@@ -627,7 +626,7 @@ abstract class JavaMonitorQueuedSynchronizer {
             }
             node.clearStatus();
             // waiting is done, emit wait event
-            JavaMonitorWaitEvent.emit(startTicks, obj, node.notifierJfrTid, time, cancelled);
+            JavaMonitorWaitEvent.emit(startTicks, obj, node.notifierJfr, time, cancelled);
             acquire(node, savedAcquisitions);
             if (cancelled) {
                 unlinkCancelledWaiters(node);

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/monitor/MultiThreadedMonitorSupport.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/monitor/MultiThreadedMonitorSupport.java
@@ -260,7 +260,7 @@ public class MultiThreadedMonitorSupport extends MonitorSupport {
                 monitor = (JavaMonitor) UNSAFE.compareAndExchangeReference(obj, monitorOffset, null, newMonitor);
                 if (monitor == null) { // successful
                     JavaMonitorInflateEvent.emit(obj, startTicks, MonitorInflationCause.MONITOR_ENTER);
-                    newMonitor.latestJfrTid = current;
+                    newMonitor.latest = Thread.currentThread();
                     return;
                 }
             }

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/thread/Target_java_lang_VirtualThread.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/thread/Target_java_lang_VirtualThread.java
@@ -47,8 +47,6 @@ import com.oracle.svm.core.annotate.TargetClass;
 import com.oracle.svm.core.annotate.TargetElement;
 import com.oracle.svm.core.jdk.JDK21OrEarlier;
 import com.oracle.svm.core.jdk.JDKLatest;
-import com.oracle.svm.core.jfr.HasJfrSupport;
-import com.oracle.svm.core.jfr.SubstrateJVM;
 import com.oracle.svm.core.monitor.MonitorInflationCause;
 import com.oracle.svm.core.monitor.MonitorSupport;
 import com.oracle.svm.core.util.VMError;
@@ -112,6 +110,10 @@ public final class Target_java_lang_VirtualThread {
     @Inject @RecomputeFieldValue(kind = RecomputeFieldValue.Kind.Custom, declClass = NondefaultSchedulerSupplier.class) //
     private Executor nondefaultScheduler;
     // Checkstyle: resume
+
+    @Inject //
+    @RecomputeFieldValue(kind = RecomputeFieldValue.Kind.Reset) //
+    public volatile int jfrGeneration = -1;
 
     @Alias
     private static native ForkJoinPool createDefaultScheduler();
@@ -330,9 +332,6 @@ public final class Target_java_lang_VirtualThread {
         }
 
         carrier.setCurrentThread(asThread(this));
-        if (HasJfrSupport.get()) {
-            SubstrateJVM.getThreadRepo().registerThread(asThread(this));
-        }
     }
 
     @Substitute // not needed on newer JDKs that use safe disableSuspendAndPreempt()


### PR DESCRIPTION
### Summary
In Hotspot, JFR registers virtual threads lazily when they emit an event. Currently, in SubstrateVM, we register virtual threads eagerly whenever they are mounted. This can be problematic if many virtual threads mount/unmount while not emitting many events. This is especially bad since SubstrateVM uses a [global mutex](https://github.com/oracle/graal/blob/7345dd6076979a24fa0f39a2cf52a32f40524e83/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/JfrThreadRepository.java#L116) to protect the "thread constant pool repository".  This mutex must be  acquired every time we register **or even just check** thread registration status. In Hotspot, there is no such global "thread constant pool repository", and no global synchronization -- instead a thread "checkpoint event" is written to thread local JFR buffers lazily when needed.  

This PR does 2 things:
1. Make virtual thread registration lazy instead of eager. Register virtual threads only when they need to emit an event, not upon mounting.
2.  Avoid  locking global "thread constant pool repo" mutex every time we need to check virtual thread registration status. Do this by caching the "epoch generation" in the `Target_java_lang_VirtualThread.java` object (similar to [`Target_java_lang_Thread.jfrExcluded`](https://github.com/oracle/graal/blob/7345dd6076979a24fa0f39a2cf52a32f40524e83/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/thread/Target_java_lang_Thread.java#L86). Before locking the thread repo mutex, first compare "epoch generation" in case the virtual thread is already registered. A very similar techniqie is used in Hotspot to avoid writing thread checkpoint events unless necessary. 

#### Results
**Scenario 1**: Many virtual thread mounts/unmounts while not emitting JFR events.
Used [test app 1](https://gist.github.com/roberttoyonaga/ce00cbe0ecd2a7ce0bbf0adf267db5f8). The new lazy method takes ~1105ms to complete, while the old eager approach takes ~1140ms. 
 
**Scenario 2**: Many JFR events emitted concurrently by many virtual threads.
Used [test app 2](https://gist.github.com/roberttoyonaga/fbef15e61bd1c555b249699b83d82e3c). The registration with cached epoch generation checking takes ~42.600s to complete, while registration with global locking takes ~73.650s. 


Related issue: https://github.com/oracle/graal/issues/9536
