### PR TITLE
fix: EspressoFinalReference NoSuchMethodError

### DIFF
--- a/espresso/src/com.oracle.truffle.espresso/src/com/oracle/truffle/espresso/ref/ClassAssembler.java
+++ b/espresso/src/com.oracle.truffle.espresso/src/com/oracle/truffle/espresso/ref/ClassAssembler.java
@@ -118,15 +118,15 @@ final class ClassAssembler {
         AnnotationVisitor annotationVisitor0;
 
         classWriter.visit(V1_8, ACC_FINAL | ACC_SUPER, "com/oracle/truffle/espresso/ref/EspressoFinalReference",
-                        "Ljava/lang/ref/PublicFinalReference<Lcom/oracle/truffle/espresso/runtime/StaticObject;>;Lcom/oracle/truffle/espresso/ref/EspressoReference;",
+                        "Ljava/lang/ref/PublicFinalReference<Lcom/oracle/truffle/espresso/runtime/staticobject/StaticObject;>;Lcom/oracle/truffle/espresso/ref/EspressoReference;",
                         "java/lang/ref/PublicFinalReference", new String[]{"com/oracle/truffle/espresso/ref/EspressoReference"});
 
-        fieldVisitor = classWriter.visitField(ACC_PRIVATE | ACC_FINAL, "guestReference", "Lcom/oracle/truffle/espresso/runtime/StaticObject;", null, null);
+        fieldVisitor = classWriter.visitField(ACC_PRIVATE | ACC_FINAL, "guestReference", "Lcom/oracle/truffle/espresso/runtime/staticobject/StaticObject;", null, null);
         fieldVisitor.visitEnd();
 
         methodVisitor = classWriter.visitMethod(0, "<init>",
-                        "(Lcom/oracle/truffle/espresso/runtime/StaticObject;Lcom/oracle/truffle/espresso/runtime/StaticObject;Ljava/lang/ref/ReferenceQueue;)V",
-                        "(Lcom/oracle/truffle/espresso/runtime/StaticObject;Lcom/oracle/truffle/espresso/runtime/StaticObject;Ljava/lang/ref/ReferenceQueue<Lcom/oracle/truffle/espresso/runtime/StaticObject;>;)V",
+                        "(Lcom/oracle/truffle/espresso/runtime/staticobject/StaticObject;Lcom/oracle/truffle/espresso/runtime/staticobject/StaticObject;Ljava/lang/ref/ReferenceQueue;)V",
+                        "(Lcom/oracle/truffle/espresso/runtime/staticobject/StaticObject;Lcom/oracle/truffle/espresso/runtime/staticobject/StaticObject;Ljava/lang/ref/ReferenceQueue<Lcom/oracle/truffle/espresso/runtime/staticobject/StaticObject;>;)V",
                         null);
 
         annotationVisitor0 = methodVisitor.visitTypeAnnotation(369098752, null, "Lcom/oracle/truffle/espresso/substitutions/JavaType;", false);
@@ -144,24 +144,24 @@ final class ClassAssembler {
         methodVisitor.visitMethodInsn(INVOKESPECIAL, "java/lang/ref/PublicFinalReference", "<init>", "(Ljava/lang/Object;Ljava/lang/ref/ReferenceQueue;)V", false);
         methodVisitor.visitVarInsn(ALOAD, 0);
         methodVisitor.visitVarInsn(ALOAD, 1);
-        methodVisitor.visitFieldInsn(PUTFIELD, "com/oracle/truffle/espresso/ref/EspressoFinalReference", "guestReference", "Lcom/oracle/truffle/espresso/runtime/StaticObject;");
+        methodVisitor.visitFieldInsn(PUTFIELD, "com/oracle/truffle/espresso/ref/EspressoFinalReference", "guestReference", "Lcom/oracle/truffle/espresso/runtime/staticobject/StaticObject;");
         methodVisitor.visitInsn(RETURN);
         methodVisitor.visitMaxs(3, 4);
         methodVisitor.visitEnd();
 
-        methodVisitor = classWriter.visitMethod(ACC_PUBLIC, "getGuestReference", "()Lcom/oracle/truffle/espresso/runtime/StaticObject;", null, null);
+        methodVisitor = classWriter.visitMethod(ACC_PUBLIC, "getGuestReference", "()Lcom/oracle/truffle/espresso/runtime/staticobject/StaticObject;", null, null);
         methodVisitor.visitCode();
         methodVisitor.visitVarInsn(ALOAD, 0);
-        methodVisitor.visitFieldInsn(GETFIELD, "com/oracle/truffle/espresso/ref/EspressoFinalReference", "guestReference", "Lcom/oracle/truffle/espresso/runtime/StaticObject;");
+        methodVisitor.visitFieldInsn(GETFIELD, "com/oracle/truffle/espresso/ref/EspressoFinalReference", "guestReference", "Lcom/oracle/truffle/espresso/runtime/staticobject/StaticObject;");
         methodVisitor.visitInsn(ARETURN);
         methodVisitor.visitMaxs(1, 1);
         methodVisitor.visitEnd();
 
-        methodVisitor = classWriter.visitMethod(ACC_PUBLIC | ACC_BRIDGE | ACC_SYNTHETIC, "get", "()Lcom/oracle/truffle/espresso/runtime/StaticObject;", null, null);
+        methodVisitor = classWriter.visitMethod(ACC_PUBLIC | ACC_BRIDGE | ACC_SYNTHETIC, "get", "()Lcom/oracle/truffle/espresso/runtime/staticobject/StaticObject;", null, null);
         methodVisitor.visitCode();
         methodVisitor.visitVarInsn(ALOAD, 0);
         methodVisitor.visitMethodInsn(INVOKESPECIAL, "java/lang/ref/PublicFinalReference", "get", "()Ljava/lang/Object;", false);
-        methodVisitor.visitTypeInsn(CHECKCAST, "com/oracle/truffle/espresso/runtime/StaticObject");
+        methodVisitor.visitTypeInsn(CHECKCAST, "com/oracle/truffle/espresso/runtime/staticobject/StaticObject");
         methodVisitor.visitInsn(ARETURN);
         methodVisitor.visitMaxs(1, 1);
         methodVisitor.visitEnd();

--- a/espresso/src/com.oracle.truffle.espresso/src/com/oracle/truffle/espresso/ref/ClassAssembler.java
+++ b/espresso/src/com.oracle.truffle.espresso/src/com/oracle/truffle/espresso/ref/ClassAssembler.java
@@ -125,8 +125,12 @@ final class ClassAssembler {
         fieldVisitor.visitEnd();
 
         methodVisitor = classWriter.visitMethod(0, "<init>",
-                        "(Lcom/oracle/truffle/espresso/runtime/staticobject/StaticObject;Lcom/oracle/truffle/espresso/runtime/staticobject/StaticObject;Ljava/lang/ref/ReferenceQueue;)V",
-                        "(Lcom/oracle/truffle/espresso/runtime/staticobject/StaticObject;Lcom/oracle/truffle/espresso/runtime/staticobject/StaticObject;Ljava/lang/ref/ReferenceQueue<Lcom/oracle/truffle/espresso/runtime/staticobject/StaticObject;>;)V",
+                        "(Lcom/oracle/truffle/espresso/runtime/staticobject/StaticObject;" +
+                                "Lcom/oracle/truffle/espresso/runtime/staticobject/StaticObject;" +
+                                "Ljava/lang/ref/ReferenceQueue;)V",
+                        "(Lcom/oracle/truffle/espresso/runtime/staticobject/StaticObject;" +
+                                "Lcom/oracle/truffle/espresso/runtime/staticobject/StaticObject;" +
+                                "Ljava/lang/ref/ReferenceQueue<Lcom/oracle/truffle/espresso/runtime/staticobject/StaticObject;>;)V",
                         null);
 
         annotationVisitor0 = methodVisitor.visitTypeAnnotation(369098752, null, "Lcom/oracle/truffle/espresso/substitutions/JavaType;", false);

--- a/espresso/src/com.oracle.truffle.espresso/src/com/oracle/truffle/espresso/ref/ClassAssembler.java
+++ b/espresso/src/com.oracle.truffle.espresso/src/com/oracle/truffle/espresso/ref/ClassAssembler.java
@@ -125,12 +125,8 @@ final class ClassAssembler {
         fieldVisitor.visitEnd();
 
         methodVisitor = classWriter.visitMethod(0, "<init>",
-                        "(Lcom/oracle/truffle/espresso/runtime/staticobject/StaticObject;" +
-                                "Lcom/oracle/truffle/espresso/runtime/staticobject/StaticObject;" +
-                                "Ljava/lang/ref/ReferenceQueue;)V",
-                        "(Lcom/oracle/truffle/espresso/runtime/staticobject/StaticObject;" +
-                                "Lcom/oracle/truffle/espresso/runtime/staticobject/StaticObject;" +
-                                "Ljava/lang/ref/ReferenceQueue<Lcom/oracle/truffle/espresso/runtime/staticobject/StaticObject;>;)V",
+                        "(Lcom/oracle/truffle/espresso/runtime/staticobject/StaticObject;Lcom/oracle/truffle/espresso/runtime/staticobject/StaticObject;Ljava/lang/ref/ReferenceQueue;)V",
+                        "(Lcom/oracle/truffle/espresso/runtime/staticobject/StaticObject;Lcom/oracle/truffle/espresso/runtime/staticobject/StaticObject;Ljava/lang/ref/ReferenceQueue<Lcom/oracle/truffle/espresso/runtime/staticobject/StaticObject;>;)V",
                         null);
 
         annotationVisitor0 = methodVisitor.visitTypeAnnotation(369098752, null, "Lcom/oracle/truffle/espresso/substitutions/JavaType;", false);


### PR DESCRIPTION
bug fix: https://github.com/oracle/graal/issues/9599


```
Exception in thread "main" org.graalvm.polyglot.PolyglotException: com.oracle.truffle.espresso.meta.EspressoError: should not reach here: Error injecting while injecting classes to support finalization in the host (version 17)
	at com.oracle.truffle.espresso.meta.EspressoError.shouldNotReachHere(EspressoError.java:73)
	at com.oracle.truffle.espresso.ref.FinalizationSupport.<clinit>(FinalizationSupport.java:72)
	at com.oracle.truffle.espresso.runtime.EspressoEnv.<init>(EspressoEnv.java:139)
	at com.oracle.truffle.espresso.runtime.EspressoContext.<init>(EspressoContext.java:213)
	at com.oracle.truffle.espresso.EspressoLanguage.createContext(EspressoLanguage.java:192)
	at com.oracle.truffle.espresso.EspressoLanguage.createContext(EspressoLanguage.java:85)
	at com.oracle.truffle.api.LanguageAccessor$LanguageImpl.createEnvContext(LanguageAccessor.java:270)
	at com.oracle.truffle.polyglot.PolyglotLanguageContext.ensureCreated(PolyglotLanguageContext.java:652)
	at com.oracle.truffle.polyglot.PolyglotLanguageContext.ensureInitialized(PolyglotLanguageContext.java:731)
	at com.oracle.truffle.polyglot.PolyglotContextImpl.eval(PolyglotContextImpl.java:1681)
	at com.oracle.truffle.polyglot.PolyglotContextDispatch.eval(PolyglotContextDispatch.java:60)
	at org.graalvm.polyglot.Context.eval(Context.java:402)
	at aaaaaa.ScriptTest.script(ScriptTest.java:138)
	at aaaaaa.ScriptTest.main(ScriptTest.java:51)
	Suppressed: Attached Guest Language Frames (0)
Caused by: java.lang.NoSuchMethodException: no such constructor: com.oracle.truffle.espresso.ref.EspressoFinalReference.<init>(StaticObject,StaticObject,ReferenceQueue)void/newInvokeSpecial
	at java.base/java.lang.invoke.MemberName.makeAccessException(MemberName.java:974)
	at java.base/java.lang.invoke.MemberName$Factory.resolveOrFail(MemberName.java:1117)
	at java.base/java.lang.invoke.MethodHandles$Lookup.resolveOrFail(MethodHandles.java:3649)
	at java.base/java.lang.invoke.MethodHandles$Lookup.findConstructor(MethodHandles.java:2750)
	at com.oracle.truffle.espresso.ref.FinalizationSupport.<clinit>(FinalizationSupport.java:69)
	... 12 more
Caused by: java.lang.NoSuchMethodError: 'void com.oracle.truffle.espresso.ref.EspressoFinalReference.<init>(com.oracle.truffle.espresso.runtime.staticobject.StaticObject, com.oracle.truffle.espresso.runtime.staticobject.StaticObject, java.lang.ref.ReferenceQueue)'
	at java.base/java.lang.invoke.MethodHandleNatives.resolve(Native Method)
	at java.base/java.lang.invoke.MemberName$Factory.resolve(MemberName.java:1085)
	at java.base/java.lang.invoke.MemberName$Factory.resolveOrFail(MemberName.java:1114)
	... 15 more
Internal GraalVM error, please report at https://github.com/oracle/graal/issues/.
```