### PR TITLE
Support agent by attaching it at build time

### DIFF
--- a/substratevm/mx.substratevm/mx_substratevm.py
+++ b/substratevm/mx.substratevm/mx_substratevm.py
@@ -2290,6 +2290,7 @@ def java_agent_test(args):
                 agent_test_classpath = join('com', 'oracle', 'svm', 'test', 'javaagent', 'agent' + str(i))
                 class_list = [join('com', 'oracle', 'svm', 'test', 'javaagent', 'agent' + str(i), f) for f in os.listdir(agent_test_classpath) if os.path.isfile(os.path.join(agent_test_classpath, f)) and f.endswith(".class")]
                 class_list.append(join('com', 'oracle', 'svm', 'test', 'javaagent', 'AgentPremainHelper.class'))
+                class_list.append(join('com', 'oracle', 'svm', 'test', 'javaagent', 'AssertInAgent.class'))
                 mx.run([mx.get_jdk().jar, 'cmf', join(test_classpath, 'resources', 'javaagent' + str(i), 'MANIFEST.MF'), agent] + class_list, cwd = test_classpath)
                 agents.append(agent)
                 os.chdir(current_dir)

--- a/substratevm/mx.substratevm/mx_substratevm.py
+++ b/substratevm/mx.substratevm/mx_substratevm.py
@@ -1616,6 +1616,7 @@ native_image = mx_sdk_vm.GraalVmJreComponent(
                 'substratevm:SVM_CONFIGURE',
                 'substratevm:JVMTI_AGENT_BASE',
                 'substratevm:SVM_AGENT',
+                'substratevm:SVM_AGENT_PROXY'
             ],
             build_args=driver_build_args + [
                 '--features=com.oracle.svm.agent.NativeImageAgent$RegistrationFeature',
@@ -2264,7 +2265,7 @@ def java_agent_test(args):
         mx.run_java( agents_arg +  ['-cp', java_run_cp, 'com.oracle.svm.test.javaagent.AgentTest'])
         test_cp = os.pathsep.join([test_cp] + agents)
         native_agent_premain_options = ['-XXpremain:com.oracle.svm.test.javaagent.agent1.TestJavaAgent1:test.agent1=true', '-XXpremain:com.oracle.svm.test.javaagent.agent2.TestJavaAgent2:test.agent2=true']
-        image_args = ['-cp', test_cp, '-J-ea', '-J-esa', '-H:+ReportExceptionStackTraces', '-H:Class=com.oracle.svm.test.javaagent.AgentTest']
+        image_args = ['-cp', test_cp, '-J-ea', '-J-esa', '-H:+ReportExceptionStackTraces', '-H:Class=com.oracle.svm.test.javaagent.AgentTest', '-H:+AllowDeprecatedBuilderClassesOnImageClasspath']
         native_image(image_args + svm_experimental_options(agents_arg) + ['-o', binary_path] + args)
         mx.run([binary_path] + native_agent_premain_options)
 
@@ -2300,6 +2301,56 @@ def java_agent_test(args):
 
             # Switch the premain sequence of agent1 and agent2
             build_and_run(args, join(tmp_dir, 'agenttest2'), native_image, agents, [f'-javaagent:{agents[1]}=test.agent2=true', f'-javaagent:{agents[0]}=test.agent1=true'])
+
+            # Test that ClassFileTransformerProxy suppresses transformations targeting protected
+            # GraalVM system modules.
+            #
+            # TestJavaAgent1 attempts to intercept InstrumentFeature#getRequiredFeatures() and make
+            # it return an empty list.  Because InstrumentFeature lives in the
+            # org.graalvm.nativeimage.builder module (which is in SYSTEM_MODULES), the proxy must
+            # suppress the live transformation.
+            #
+            # Verification strategy:
+            #   1. Enable DEBUG mode via com.oracle.svm.agentproxy.debug=true (passed to the
+            #      builder JVM with -J-D).
+            #   2. Point com.oracle.svm.agentproxy.shaded.dump.file at a temp file so that every
+            #      shaded class name is appended there.
+            #   3. After the build, assert that the dump file contains the shaded name of
+            #      InstrumentFeature, proving the proxy intercepted and shaded the class instead of
+            #      passing the transformation through.
+            mx.log("Testing ClassFileTransformerProxy suppression of protected system module classes")
+            shaded_dump_file = join(tmp_dir, 'shaded_classes.txt')
+            # Remove a stale dump file from a previous run to avoid false positives.
+            if os.path.exists(shaded_dump_file):
+                os.remove(shaded_dump_file)
+            agents_arg_debug = [f'-javaagent:{agents[0]}=test.agent1=true', f'-javaagent:{agents[1]}=test.agent2=true']
+            debug_jvm_args = [
+                '-J-Dcom.oracle.svm.agentproxy.debug=true',
+                f'-J-Dcom.oracle.svm.agentproxy.shaded.dump.file={shaded_dump_file}',
+            ]
+            test_cp_debug = os.pathsep.join([classpath('com.oracle.svm.test')] + agents)
+            image_args_debug = ['-cp', test_cp_debug, '-J-ea', '-J-esa',
+                                 '-H:+ReportExceptionStackTraces',
+                                 '-H:Class=com.oracle.svm.test.javaagent.AgentTest',
+                                 '-H:+AllowDeprecatedBuilderClassesOnImageClasspath']
+            native_image(image_args_debug + debug_jvm_args +
+                         svm_experimental_options(agents_arg_debug) +
+                         ['-o', join(tmp_dir, 'agenttest_debug')] + args)
+            # Verify that InstrumentFeature was shaded (i.e. the proxy intercepted the
+            # transformation attempt targeting the protected system module).
+            expected_shaded = 'com.oracle.svm.hosted.InstrumentFeature'
+            if not os.path.exists(shaded_dump_file):
+                mx.abort(f"Shaded class dump file not found: {shaded_dump_file}. "
+                         "ClassFileTransformerProxy DEBUG mode may not be active.")
+            with open(shaded_dump_file, 'r') as f:
+                shaded_lines = [line.strip() for line in f.readlines()]
+            if expected_shaded not in shaded_lines:
+                mx.abort(f"[FAIL] Expected suppressed class '{expected_shaded}' not found in dump file "
+                         f"{shaded_dump_file}. Contents: {shaded_lines}\n"
+                         "This indicates ClassFileTransformerProxy did NOT suppress the "
+                         "InstrumentFeature transformation as required.")
+            mx.log(f"[PASS] ClassFileTransformerProxy suppression test passed: "
+                   f"'{expected_shaded}' was correctly intercepted and recorded in the dump file.")
 
     native_image_context_run(build_and_test_java_agent_image, args)
 

--- a/substratevm/mx.substratevm/mx_substratevm.py
+++ b/substratevm/mx.substratevm/mx_substratevm.py
@@ -2258,10 +2258,15 @@ def cinterfacetutorial(args):
 @mx.command(suite.name, 'javaagenttest', 'Runs tests for java agent with native image')
 def java_agent_test(args):
     def build_and_run(args, binary_path, native_image, agents, agents_arg):
-        test_cp = os.pathsep.join([classpath('com.oracle.svm.test')] + agents)
+        mx.log('Run agent with JVM as baseline')
+        test_cp = os.pathsep.join([classpath('com.oracle.svm.test')])
+        java_run_cp = os.pathsep.join([test_cp, mx.dependency('org.graalvm.nativeimage').classpath_repr()])
+        mx.run_java( agents_arg +  ['--add-exports=java.base/jdk.internal.org.objectweb.asm=ALL-UNNAMED',
+                     '-cp', java_run_cp, 'com.oracle.svm.test.javaagent.AgentTest'])
+        test_cp = os.pathsep.join([test_cp] + agents)
         native_agent_premain_options = ['-XXpremain:com.oracle.svm.test.javaagent.agent1.TestJavaAgent1:test.agent1=true', '-XXpremain:com.oracle.svm.test.javaagent.agent2.TestJavaAgent2:test.agent2=true']
-        image_args = ['-cp', test_cp, '-J-ea', '-J-esa', '-H:+ReportExceptionStackTraces', '-H:Class=com.oracle.svm.test.javaagent.AgentTest']
-        native_image(image_args + svm_experimental_options(['-H:PremainClasses=' + agents_arg]) + ['-o', binary_path] + args)
+        image_args = ['-cp', test_cp, '-J-ea', '-J-esa', '-H:+ReportExceptionStackTraces', '-J--add-exports=java.base/jdk.internal.org.objectweb.asm=ALL-UNNAMED', '-H:Class=com.oracle.svm.test.javaagent.AgentTest']
+        native_image(image_args + svm_experimental_options(agents_arg) + ['-o', binary_path] + args)
         mx.run([binary_path] + native_agent_premain_options)
 
     def build_and_test_java_agent_image(native_image, args):
@@ -2278,18 +2283,23 @@ def java_agent_test(args):
             # Note: we are not using MX here to avoid polluting the suite.py and requiring extra build flags
             mx.log("Building agent jars from " + test_classpath)
             agents = []
-            for i in range(1, 2):
+            for i in range(1, 3):
                 agent = join(tmp_dir, "testagent%d.jar" % (i))
-                agent_test_classpath = join(test_classpath, 'com', 'oracle', 'svm', 'test', 'javaagent', 'agent' + str(i))
-                class_list = [join(test_classpath, 'com', 'oracle', 'svm', 'test', 'javaagent', 'agent' + str(i), f) for f in os.listdir(agent_test_classpath) if os.path.isfile(os.path.join(agent_test_classpath, f)) and f.endswith(".class")]
-                mx.run([mx.get_jdk().jar, 'cmf', join(test_classpath, 'resources', 'javaagent' + str(i), 'MANIFEST.MF'), agent] + class_list, cwd = tmp_dir)
+                current_dir = os.getcwd()
+                # Change to test classpath to create agent jar file
+                os.chdir(test_classpath)
+                agent_test_classpath = join('com', 'oracle', 'svm', 'test', 'javaagent', 'agent' + str(i))
+                class_list = [join('com', 'oracle', 'svm', 'test', 'javaagent', 'agent' + str(i), f) for f in os.listdir(agent_test_classpath) if os.path.isfile(os.path.join(agent_test_classpath, f)) and f.endswith(".class")]
+                class_list.append(join('com', 'oracle', 'svm', 'test', 'javaagent', 'AgentPremainHelper.class'))
+                mx.run([mx.get_jdk().jar, 'cmf', join(test_classpath, 'resources', 'javaagent' + str(i), 'MANIFEST.MF'), agent] + class_list, cwd = test_classpath)
                 agents.append(agent)
+                os.chdir(current_dir)
 
             mx.log("Building images with different agent orders ")
-            build_and_run(args, join(tmp_dir, 'agenttest1'), native_image, agents,'com.oracle.svm.test.javaagent.agent1.TestJavaAgent1,com.oracle.svm.test.javaagent.agent2.TestJavaAgent2')
+            build_and_run(args, join(tmp_dir, 'agenttest1'), native_image, agents,[f'-javaagent:{agents[0]}=test.agent1=true', f'-javaagent:{agents[1]}=test.agent2=true'])
 
             # Switch the premain sequence of agent1 and agent2
-            build_and_run(args, join(tmp_dir, 'agenttest2'), native_image, agents, 'com.oracle.svm.test.javaagent.agent2.TestJavaAgent2,com.oracle.svm.test.javaagent.agent1.TestJavaAgent1')
+            build_and_run(args, join(tmp_dir, 'agenttest2'), native_image, agents, [f'-javaagent:{agents[1]}=test.agent2=true', f'-javaagent:{agents[0]}=test.agent1=true'])
 
     native_image_context_run(build_and_test_java_agent_image, args)
 

--- a/substratevm/mx.substratevm/mx_substratevm.py
+++ b/substratevm/mx.substratevm/mx_substratevm.py
@@ -2261,11 +2261,10 @@ def java_agent_test(args):
         mx.log('Run agent with JVM as baseline')
         test_cp = os.pathsep.join([classpath('com.oracle.svm.test')])
         java_run_cp = os.pathsep.join([test_cp, mx.dependency('org.graalvm.nativeimage').classpath_repr()])
-        mx.run_java( agents_arg +  ['--add-exports=java.base/jdk.internal.org.objectweb.asm=ALL-UNNAMED',
-                     '-cp', java_run_cp, 'com.oracle.svm.test.javaagent.AgentTest'])
+        mx.run_java( agents_arg +  ['-cp', java_run_cp, 'com.oracle.svm.test.javaagent.AgentTest'])
         test_cp = os.pathsep.join([test_cp] + agents)
         native_agent_premain_options = ['-XXpremain:com.oracle.svm.test.javaagent.agent1.TestJavaAgent1:test.agent1=true', '-XXpremain:com.oracle.svm.test.javaagent.agent2.TestJavaAgent2:test.agent2=true']
-        image_args = ['-cp', test_cp, '-J-ea', '-J-esa', '-H:+ReportExceptionStackTraces', '-J--add-exports=java.base/jdk.internal.org.objectweb.asm=ALL-UNNAMED', '-H:Class=com.oracle.svm.test.javaagent.AgentTest']
+        image_args = ['-cp', test_cp, '-J-ea', '-J-esa', '-H:+ReportExceptionStackTraces', '-H:Class=com.oracle.svm.test.javaagent.AgentTest']
         native_image(image_args + svm_experimental_options(agents_arg) + ['-o', binary_path] + args)
         mx.run([binary_path] + native_agent_premain_options)
 

--- a/substratevm/mx.substratevm/suite.py
+++ b/substratevm/mx.substratevm/suite.py
@@ -1852,6 +1852,25 @@ suite = {
             "workingSets": "SVM",
             "jacoco": "exclude",
         },
+
+        "com.oracle.svm.agentproxy" : {
+            "subDir": "src",
+            "sourceDirs": [
+                "src"
+            ],
+            "requires" : [
+                "java.instrument",
+            ],
+            "requiresConcealed" : {
+                "java.base": [
+                    "jdk.internal.module",
+                ],
+            },
+            "checkstyle" : "com.oracle.svm.hosted",
+            "workingSets": "SVM",
+            "javaCompliance" : "24+",
+            "jacoco" : "exclude",
+        },
     },
 
     "distributions": {
@@ -2931,6 +2950,30 @@ suite = {
             ],
             "moduleInfo" : {
                 "name" : "com.oracle.svm.jdwp.server",
+            },
+            "maven" : False,
+        },
+
+        "SVM_AGENT_PROXY": {
+            "subDir" : "src",
+            "dependencies" : ["com.oracle.svm.agentproxy"],
+            "manifestEntries":{
+                "Manifest-Version": "1.0",
+                "Agent-Class": "com.oracle.svm.agentproxy.ProxyAgent",
+                "Can-Redefine-Classes": "true",
+                "Can-Retransform-Classes": "true",
+                "Premain-Class": "com.oracle.svm.agentproxy.ProxyAgent"
+            },
+            "moduleInfo" : {
+                "name" : "com.oracle.svm.agentproxy",
+                "exports" : [
+                    "com.oracle.svm.agentproxy",
+                ],
+                "requiresConcealed" : {
+                    "java.base": [
+                        "jdk.internal.module",
+                    ]
+                }
             },
             "maven" : False,
         },

--- a/substratevm/mx.substratevm/suite.py
+++ b/substratevm/mx.substratevm/suite.py
@@ -1179,6 +1179,7 @@ suite = {
                     "jdk.internal.misc",
                     "jdk.internal.vm",
                     "sun.security.jca",
+                    "jdk.internal.org.objectweb.asm"
                 ],
                 "jdk.internal.vm.ci": [
                     "jdk.vm.ci.meta"

--- a/substratevm/mx.substratevm/suite.py
+++ b/substratevm/mx.substratevm/suite.py
@@ -1179,7 +1179,6 @@ suite = {
                     "jdk.internal.misc",
                     "jdk.internal.vm",
                     "sun.security.jca",
-                    "jdk.internal.org.objectweb.asm"
                 ],
                 "jdk.internal.vm.ci": [
                     "jdk.vm.ci.meta"

--- a/substratevm/src/com.oracle.graal.pointsto/src/com/oracle/graal/pointsto/api/HostVM.java
+++ b/substratevm/src/com.oracle.graal.pointsto/src/com/oracle/graal/pointsto/api/HostVM.java
@@ -500,6 +500,10 @@ public abstract class HostVM {
         }
     }
 
+    public boolean isFromJavaAgent(@SuppressWarnings("unused") Class<?> clazz) {
+        return false;
+    }
+
     /**
      * Helpers to determine what analysis actions should be taken for a given method variant.
      */

--- a/substratevm/src/com.oracle.graal.pointsto/src/com/oracle/graal/pointsto/infrastructure/WrappedConstantPool.java
+++ b/substratevm/src/com.oracle.graal.pointsto/src/com/oracle/graal/pointsto/infrastructure/WrappedConstantPool.java
@@ -26,11 +26,13 @@ package com.oracle.graal.pointsto.infrastructure;
 
 import static jdk.vm.ci.common.JVMCIError.unimplemented;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 
 import com.oracle.graal.pointsto.constraints.UnresolvedElementException;
 import com.oracle.svm.util.OriginalMethodProvider;
+import com.oracle.graal.pointsto.meta.AnalysisUniverse;
 
 import jdk.graal.compiler.debug.GraalError;
 import jdk.vm.ci.meta.ConstantPool;
@@ -40,6 +42,7 @@ import jdk.vm.ci.meta.JavaMethod;
 import jdk.vm.ci.meta.JavaType;
 import jdk.vm.ci.meta.ResolvedJavaMethod;
 import jdk.vm.ci.meta.ResolvedJavaType;
+import jdk.vm.ci.meta.UnresolvedJavaMethod;
 
 public class WrappedConstantPool implements ConstantPool, ConstantPoolPatch {
 
@@ -96,7 +99,26 @@ public class WrappedConstantPool implements ConstantPool, ConstantPoolPatch {
     @Override
     public JavaMethod lookupMethod(int cpi, int opcode, ResolvedJavaMethod caller) {
         try {
-            return universe.lookupAllowUnresolved(wrapped.lookupMethod(cpi, opcode, OriginalMethodProvider.getOriginalMethod(caller)));
+            JavaMethod ret = universe.lookupAllowUnresolved(wrapped.lookupMethod(cpi, opcode, OriginalMethodProvider.getOriginalMethod(caller)));
+            /**
+             * The java agent classes are loaded by appClassloader, but their dependencies could be
+             * loaded by NativeImageClassloader. So if the required method could not be resolved, we
+             * look further into classes loaded by nativeImageClassloader.
+             */
+            if (ret instanceof UnresolvedJavaMethod && universe.hostVM().isFromJavaAgent(OriginalClassProvider.getJavaClass(caller.getDeclaringClass()))) {
+                UnresolvedJavaMethod unresolvedResult = (UnresolvedJavaMethod) ret;
+                String className = unresolvedResult.format("%H");
+                String methodNameWithSignature = unresolvedResult.format("%n(%P)");
+                try {
+                    Class<?> loadedClass = ((AnalysisUniverse) universe).getConcurrentAnalysisAccess().findClassByName(className);
+                    ResolvedJavaType resolvedType = ((AnalysisUniverse) universe).getOriginalMetaAccess().lookupJavaType(loadedClass);
+                    ResolvedJavaMethod resolvedMethod = Arrays.stream(resolvedType.getDeclaredMethods(false)).filter(m -> m.format("%n(%P)").equals(methodNameWithSignature)).findFirst().get();
+                    return universe.lookupAllowUnresolved(resolvedMethod);
+                } catch (Exception e) {
+                    // Could not get the resolved method, get to the unresolved path
+                }
+            }
+            return ret;
         } catch (Throwable ex) {
             Throwable cause = ex;
             if (ex instanceof ExceptionInInitializerError && ex.getCause() != null) {

--- a/substratevm/src/com.oracle.graal.pointsto/src/com/oracle/graal/pointsto/infrastructure/WrappedConstantPool.java
+++ b/substratevm/src/com.oracle.graal.pointsto/src/com/oracle/graal/pointsto/infrastructure/WrappedConstantPool.java
@@ -26,13 +26,11 @@ package com.oracle.graal.pointsto.infrastructure;
 
 import static jdk.vm.ci.common.JVMCIError.unimplemented;
 
-import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 
 import com.oracle.graal.pointsto.constraints.UnresolvedElementException;
 import com.oracle.svm.util.OriginalMethodProvider;
-import com.oracle.graal.pointsto.meta.AnalysisUniverse;
 
 import jdk.graal.compiler.debug.GraalError;
 import jdk.vm.ci.meta.ConstantPool;
@@ -42,7 +40,6 @@ import jdk.vm.ci.meta.JavaMethod;
 import jdk.vm.ci.meta.JavaType;
 import jdk.vm.ci.meta.ResolvedJavaMethod;
 import jdk.vm.ci.meta.ResolvedJavaType;
-import jdk.vm.ci.meta.UnresolvedJavaMethod;
 
 public class WrappedConstantPool implements ConstantPool, ConstantPoolPatch {
 
@@ -99,26 +96,7 @@ public class WrappedConstantPool implements ConstantPool, ConstantPoolPatch {
     @Override
     public JavaMethod lookupMethod(int cpi, int opcode, ResolvedJavaMethod caller) {
         try {
-            JavaMethod ret = universe.lookupAllowUnresolved(wrapped.lookupMethod(cpi, opcode, OriginalMethodProvider.getOriginalMethod(caller)));
-            /**
-             * The java agent classes are loaded by appClassloader, but their dependencies could be
-             * loaded by NativeImageClassloader. So if the required method could not be resolved, we
-             * look further into classes loaded by nativeImageClassloader.
-             */
-            if (ret instanceof UnresolvedJavaMethod && universe.hostVM().isFromJavaAgent(OriginalClassProvider.getJavaClass(caller.getDeclaringClass()))) {
-                UnresolvedJavaMethod unresolvedResult = (UnresolvedJavaMethod) ret;
-                String className = unresolvedResult.format("%H");
-                String methodNameWithSignature = unresolvedResult.format("%n(%P)");
-                try {
-                    Class<?> loadedClass = ((AnalysisUniverse) universe).getConcurrentAnalysisAccess().findClassByName(className);
-                    ResolvedJavaType resolvedType = ((AnalysisUniverse) universe).getOriginalMetaAccess().lookupJavaType(loadedClass);
-                    ResolvedJavaMethod resolvedMethod = Arrays.stream(resolvedType.getDeclaredMethods(false)).filter(m -> m.format("%n(%P)").equals(methodNameWithSignature)).findFirst().get();
-                    return universe.lookupAllowUnresolved(resolvedMethod);
-                } catch (Exception e) {
-                    // Could not get the resolved method, get to the unresolved path
-                }
-            }
-            return ret;
+            return universe.lookupAllowUnresolved(wrapped.lookupMethod(cpi, opcode, OriginalMethodProvider.getOriginalMethod(caller)));
         } catch (Throwable ex) {
             Throwable cause = ex;
             if (ex instanceof ExceptionInInitializerError && ex.getCause() != null) {

--- a/substratevm/src/com.oracle.svm.agentproxy/src/com/oracle/svm/agentproxy/ClassFileTransformerProxy.java
+++ b/substratevm/src/com.oracle.svm.agentproxy/src/com/oracle/svm/agentproxy/ClassFileTransformerProxy.java
@@ -1,0 +1,254 @@
+package com.oracle.svm.agentproxy;
+
+import jdk.internal.module.ModuleLoaderMap;
+
+import java.io.IOException;
+import java.lang.instrument.ClassFileTransformer;
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardOpenOption;
+import java.util.Set;
+
+/**
+ * A JDK dynamic proxy for {@link ClassFileTransformer} that guards GraalVM
+ * framework classes from being transformed by target agents during a Native
+ * Image build.
+ *
+ * <p>
+ * When a target agent registers a {@link ClassFileTransformer} via
+ * {@link java.lang.instrument.Instrumentation#addTransformer},
+ * {@link InstrumentationProxy} wraps it with this proxy. Each {@code transform}
+ * invocation then checks whether the class belongs to a protected module (JDK
+ * boot/platform modules or GraalVM system modules listed in
+ * {@link #SYSTEM_MODULES}). If so, the transformation is suppressed by
+ * returning {@code null}. Otherwise the call is forwarded to the actual
+ * transformer.
+ *
+ * <p>
+ * When {@code DEBUG} mode is enabled, the binary name of each suppressed class
+ * is appended (one per line) to the file specified by the system property
+ * {@code com.oracle.svm.agentproxy.suppressed.dump.file} for offline
+ * verification.
+ */
+public class ClassFileTransformerProxy implements InvocationHandler {
+
+    /**
+     * GraalVM framework module names that must not be transformed by target agents
+     * during a Native Image build.
+     *
+     * <p>
+     * This set covers all GraalVM compiler, SDK, and Substrate VM framework modules
+     * that are loaded into the host JVM during the build. Transforming any of these
+     * modules by a user-registered agent could silently corrupt the compilation
+     * pipeline or analysis results.
+     *
+     * <p>
+     * The core subset (compiler, nativeimage, word) is kept in sync with
+     * {@code com.oracle.svm.util.HostedModuleSupport#SYSTEM_MODULES}.
+     * Additional modules covering the full GraalVM SDK, SVM hosted infrastructure,
+     * and Truffle runtime are included here because they are all present in the
+     * host JVM classpath during a build and must equally be protected.
+     */
+    private static final Set<String> SYSTEM_MODULES = Set.of(
+            // ---- Enterprise overlays ----
+            "com.oracle.graal.graal_enterprise",
+            "com.oracle.svm.svm_enterprise",
+
+            // ---- Graal compiler ----
+            "jdk.graal.compiler",
+            "jdk.graal.compiler.options",
+            "jdk.graal.compiler.vmaccess",
+            "jdk.graal.compiler.vmaccess.guest",
+            "jdk.graal.compiler.hostvmaccess",
+            "jdk.graal.compiler.libgraal",
+            "jdk.graal.compiler.management",
+
+            // ---- JVMCI ----
+            "jdk.internal.vm.ci",
+
+            // ---- GraalVM SDK ----
+            "org.graalvm.sdk",
+            "org.graalvm.collections",
+            "org.graalvm.word",
+            "org.graalvm.nativebridge",
+            "org.graalvm.jniutils",
+            "org.graalvm.polyglot",
+            "org.graalvm.launcher",
+            "org.graalvm.nativeimage",
+            "org.graalvm.nativeimage.libgraal",
+
+            // ---- Substrate VM / Native Image builder ----
+            "org.graalvm.nativeimage.base",
+            "org.graalvm.nativeimage.builder",
+            "org.graalvm.nativeimage.shared",
+            "org.graalvm.nativeimage.guest",
+            "org.graalvm.nativeimage.guest.staging",
+            "org.graalvm.nativeimage.driver",
+            "org.graalvm.nativeimage.librarysupport",
+            "org.graalvm.nativeimage.objectfile",
+            "org.graalvm.nativeimage.configure",
+            "org.graalvm.nativeimage.pointsto",
+            "org.graalvm.nativeimage.llvm",
+            "org.graalvm.nativeimage.foreign",
+
+            // ---- Native Image agents (SVM-hosted) ----
+            "org.graalvm.nativeimage.agent.tracing",
+            "org.graalvm.nativeimage.agent.jvmtibase",
+            "org.graalvm.nativeimage.agent.diagnostics",
+
+            // ---- Truffle ----
+            "org.graalvm.truffle.compiler",
+            "org.graalvm.truffle.runtime.svm",
+
+            // ---- JDWP server ----
+            "com.oracle.svm.jdwp.server");
+
+    /** The actual {@link ClassFileTransformer} registered by the target agent. */
+    private ClassFileTransformer target;
+
+    /**
+     * When {@code true}, the binary name of each suppressed class is appended to
+     * the file specified by {@link #SHADED_DUMP_FILE} for offline verification.
+     * Controlled by the system property {@code com.oracle.svm.agentproxy.debug}.
+     */
+    private static final boolean DEBUG = Boolean
+            .parseBoolean(System.getProperty("com.oracle.svm.agentproxy.debug", "false"));
+
+    /**
+     * Optional path to a file where the binary names of suppressed classes are
+     * appended (one per line) when {@link #DEBUG} is {@code true}. Set via the
+     * system property {@code com.oracle.svm.agentproxy.shaded.dump.file}. When the
+     * property is absent or empty, no file output is produced.
+     */
+    private static final String SHADED_DUMP_FILE = System.getProperty("com.oracle.svm.agentproxy.shaded.dump.file", "");
+
+    private ClassFileTransformerProxy(ClassFileTransformer target) {
+        this.target = target;
+    }
+
+    /**
+     * Intercepts both overloads of {@link ClassFileTransformer#transform} and
+     * enforces the
+     * following policy:
+     * <ul>
+     * <li>If the class being transformed belongs to a JDK boot module, a JDK
+     * platform module,
+     * or one of the GraalVM {@link #SYSTEM_MODULES}, the transformation is
+     * suppressed
+     * (returns {@code null}) to protect the framework from unintended bytecode
+     * modifications during the Native Image build.</li>
+     * <li>Otherwise the call is forwarded to the actual {@link #target} transformer
+     * and its
+     * result is returned verbatim.</li>
+     * </ul>
+     *
+     * <p>
+     * {@link ClassFileTransformer} defines two {@code transform} overloads:
+     * <ol>
+     * <li>{@code transform(Module, ClassLoader, String, Class, ProtectionDomain, byte[])}
+     * –
+     * the first argument is a {@link Module}; class bytes are at index 5.</li>
+     * <li>{@code transform(ClassLoader, String, Class, ProtectionDomain, byte[])} –
+     * no leading {@link Module} argument; the module is derived from the
+     * {@code classBeingRedefined} argument at index 3; class bytes are at index
+     * 4.</li>
+     * </ol>
+     * Both overloads are dispatched here and handled uniformly.
+     *
+     * @param proxy  the proxy instance the method was invoked on
+     * @param method the {@code transform} method being invoked
+     * @param args   arguments passed to the method
+     * @return the transformed class bytes, or {@code null} if the transformation is
+     *         suppressed
+     *         or an error occurs
+     * @throws Throwable if an unexpected error occurs outside the guarded block
+     */
+    @Override
+    public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
+        Module module;
+        byte[] originalClass;
+        String className;
+
+        // Distinguish the two transform overloads by checking whether the first
+        // argument is a Module.
+        if (args[0] instanceof Module) {
+            // Overload: transform(Module, ClassLoader, String, Class, ProtectionDomain,
+            // byte[])
+            module = (Module) args[0];
+            originalClass = (byte[]) args[5];
+            className = (String) args[2];
+        } else {
+            // Overload: transform(ClassLoader, String, Class, ProtectionDomain, byte[])
+            Class<?> classBeingRedefined = (Class<?>) args[3];
+            module = classBeingRedefined == null ? null : classBeingRedefined.getModule();
+            originalClass = (byte[]) args[4];
+            className = (String) args[1];
+        }
+
+        String moduleName = module == null ? null : module.getName();
+        try {
+            if (moduleName != null &&
+                    SYSTEM_MODULES.contains(moduleName)) {
+                // The class belongs to a protected module; suppress the transformation to
+                // prevent
+                // target agents from inadvertently modifying GraalVM framework classes.
+                if (DEBUG) {
+                    // In DEBUG mode, record the suppressed class name for offline verification.
+                    recordSuppressedClass(className);
+                }
+                return null;
+            } else {
+                // The class is not protected; forward to the actual transformer.
+                return (byte[]) method.invoke(target, args);
+            }
+        } catch (Throwable t) {
+            if (DEBUG) {
+                t.printStackTrace();
+            }
+            return null;
+        }
+    }
+
+    /**
+     * Appends the binary name of a suppressed class to {@link #SHADED_DUMP_FILE}
+     * (one per line) when the file path is configured. The internal class name
+     * (e.g. {@code com/example/Foo}) is converted to binary form
+     * (e.g. {@code com.example.Foo}) before writing.
+     *
+     * @param internalClassName the internal name of the suppressed class
+     */
+    private static void recordSuppressedClass(String internalClassName) {
+        if (SHADED_DUMP_FILE.isEmpty()) {
+            return;
+        }
+        String binaryName = internalClassName.replace("/", ".");
+        try {
+            Path dumpPath = Paths.get(SHADED_DUMP_FILE);
+            Files.writeString(dumpPath, binaryName + System.lineSeparator(),
+                    StandardOpenOption.CREATE, StandardOpenOption.APPEND);
+        } catch (IOException e) {
+            if (DEBUG) {
+                e.printStackTrace();
+            }
+        }
+    }
+
+    /**
+     * Creates a JDK dynamic proxy for the given {@link ClassFileTransformer}.
+     *
+     * @param target the actual transformer registered by the target agent
+     * @return a proxy that implements {@link ClassFileTransformer} and suppresses
+     *         transformations
+     *         targeting protected modules
+     */
+    public static ClassFileTransformer createProxy(ClassFileTransformer target) {
+        return (ClassFileTransformer) Proxy.newProxyInstance(
+                target.getClass().getClassLoader(),
+                new Class<?>[] { ClassFileTransformer.class },
+                new ClassFileTransformerProxy(target));
+    }
+}

--- a/substratevm/src/com.oracle.svm.agentproxy/src/com/oracle/svm/agentproxy/InstrumentationProxy.java
+++ b/substratevm/src/com.oracle.svm.agentproxy/src/com/oracle/svm/agentproxy/InstrumentationProxy.java
@@ -1,0 +1,82 @@
+package com.oracle.svm.agentproxy;
+
+import java.lang.instrument.ClassFileTransformer;
+import java.lang.instrument.Instrumentation;
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+
+/**
+ * A JDK dynamic proxy for {@link Instrumentation} that intercepts
+ * {@link Instrumentation#addTransformer(ClassFileTransformer, boolean)} calls
+ * and wraps the
+ * supplied {@link ClassFileTransformer} with a
+ * {@link ClassFileTransformerProxy}.
+ *
+ * <p>
+ * The interception is necessary because transformers registered by target
+ * agents may attempt
+ * to rewrite classes that belong to boot/platform modules or GraalVM system
+ * modules. By routing
+ * every transformer through {@link ClassFileTransformerProxy}, such
+ * transformations are silently
+ * suppressed for protected modules while still being applied to application
+ * classes.
+ *
+ * <p>
+ * All other {@link Instrumentation} methods are forwarded to the original
+ * instance unchanged.
+ */
+public class InstrumentationProxy implements InvocationHandler {
+
+    /** The actual {@link Instrumentation} instance provided by the JVM. */
+    private Instrumentation originalInst;
+
+    private InstrumentationProxy(Instrumentation originalInst) {
+        this.originalInst = originalInst;
+    }
+
+    /**
+     * Intercepts calls to the two-argument {@code addTransformer} method and wraps
+     * the provided
+     * {@link ClassFileTransformer} with a {@link ClassFileTransformerProxy} before
+     * forwarding to
+     * the actual {@link Instrumentation}. All other method calls are forwarded
+     * directly.
+     *
+     * @param proxy  the proxy instance the method was invoked on
+     * @param method the interface method being invoked
+     * @param args   the arguments passed to the method
+     * @return the result of the delegated call on the original
+     *         {@link Instrumentation}
+     * @throws Throwable if the delegated call throws
+     */
+    @Override
+    public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
+        if (method.getName().equals("addTransformer") && args.length == 2) {
+            // Wrap the transformer so that transformations targeting protected modules are
+            // filtered out.
+            ClassFileTransformer classFileTransformerProxy = ClassFileTransformerProxy
+                    .createProxy((ClassFileTransformer) args[0]);
+            args[0] = classFileTransformerProxy;
+            return method.invoke(originalInst, args);
+        } else {
+            // All other Instrumentation methods are forwarded transparently.
+            return method.invoke(originalInst, args);
+        }
+    }
+
+    /**
+     * Creates a JDK dynamic proxy for the given {@link Instrumentation} instance.
+     *
+     * @param target the actual {@link Instrumentation} to wrap
+     * @return a proxy that implements {@link Instrumentation} and intercepts
+     *         transformer registration
+     */
+    public static Instrumentation createProxy(Instrumentation target) {
+        return (Instrumentation) Proxy.newProxyInstance(
+                target.getClass().getClassLoader(),
+                new Class<?>[] { Instrumentation.class },
+                new InstrumentationProxy(target));
+    }
+}

--- a/substratevm/src/com.oracle.svm.agentproxy/src/com/oracle/svm/agentproxy/ProxyAgent.java
+++ b/substratevm/src/com.oracle.svm.agentproxy/src/com/oracle/svm/agentproxy/ProxyAgent.java
@@ -202,41 +202,63 @@ public class ProxyAgent {
                 throw new RuntimeException("Can't find the proxy target class " + className, e);
             }
 
-            // Locate the target agent's premain method. Prefer the two-argument form
-            // (String, Instrumentation); fall back to the one-argument form (String) if
-            // absent.
-            Method premain;
+            // Prefer the target agent's prelink method (build-time entry point) over
+            // premain (run-time entry point). If prelink(String, Instrumentation) is
+            // present, invoke it; otherwise fall back to the standard premain lookup.
+            Method prelink = null;
             try {
-                premain = targetAgentClass.getDeclaredMethod("premain", String.class, Instrumentation.class);
-            } catch (NoSuchMethodException e) {
+                prelink = targetAgentClass.getDeclaredMethod("prelink", String.class, Instrumentation.class);
+            } catch (NoSuchMethodException ignored) {
+                // prelink not provided; will fall back to premain below.
+            }
+
+            if (prelink != null) {
+                // Invoke prelink as a static method (null receiver). Wrap Instrumentation
+                // via InstrumentationProxy so that ClassFileTransformer registrations are
+                // intercepted by ClassFileTransformerProxy.
+                Object[] prelinkArgs = new Object[]{opts, InstrumentationProxy.createProxy(inst)};
                 try {
-                    premain = targetAgentClass.getDeclaredMethod("premain", String.class);
-                } catch (NoSuchMethodException e1) {
-                    throw new RuntimeException("Can't find premain method in " + targetAgentClass, e1);
+                    prelink.invoke(null, prelinkArgs);
+                } catch (ReflectiveOperationException e) {
+                    throw new RuntimeException(e);
                 }
-            }
-
-            // Build the argument array for the target premain invocation.
-            // premain is public static, so no instance is needed (pass null as the
-            // receiver).
-            // When two arguments are expected, wrap the Instrumentation via
-            // InstrumentationProxy
-            // so that ClassFileTransformer registrations are intercepted by
-            // ClassFileTransformerProxy.
-            Object[] targetArgs;
-            if (premain.getParameterCount() == 1) {
-                targetArgs = new Object[1];
             } else {
-                targetArgs = new Object[2];
-                targetArgs[1] = InstrumentationProxy.createProxy(inst);
-            }
-            targetArgs[0] = opts;
+                // Locate the target agent's premain method. Prefer the two-argument form
+                // (String, Instrumentation); fall back to the one-argument form (String) if
+                // absent.
+                Method premain;
+                try {
+                    premain = targetAgentClass.getDeclaredMethod("premain", String.class, Instrumentation.class);
+                } catch (NoSuchMethodException e) {
+                    try {
+                        premain = targetAgentClass.getDeclaredMethod("premain", String.class);
+                    } catch (NoSuchMethodException e1) {
+                        throw new RuntimeException("Can't find premain method in " + targetAgentClass, e1);
+                    }
+                }
 
-            try {
-                // Invoke as a static method (null receiver).
-                premain.invoke(null, targetArgs);
-            } catch (ReflectiveOperationException e) {
-                throw new RuntimeException(e);
+                // Build the argument array for the target premain invocation.
+                // premain is public static, so no instance is needed (pass null as the
+                // receiver).
+                // When two arguments are expected, wrap the Instrumentation via
+                // InstrumentationProxy
+                // so that ClassFileTransformer registrations are intercepted by
+                // ClassFileTransformerProxy.
+                Object[] targetArgs;
+                if (premain.getParameterCount() == 1) {
+                    targetArgs = new Object[1];
+                } else {
+                    targetArgs = new Object[2];
+                    targetArgs[1] = InstrumentationProxy.createProxy(inst);
+                }
+                targetArgs[0] = opts;
+
+                try {
+                    // Invoke as a static method (null receiver).
+                    premain.invoke(null, targetArgs);
+                } catch (ReflectiveOperationException e) {
+                    throw new RuntimeException(e);
+                }
             }
         });
     }

--- a/substratevm/src/com.oracle.svm.agentproxy/src/com/oracle/svm/agentproxy/ProxyAgent.java
+++ b/substratevm/src/com.oracle.svm.agentproxy/src/com/oracle/svm/agentproxy/ProxyAgent.java
@@ -1,0 +1,243 @@
+package com.oracle.svm.agentproxy;
+
+import java.io.BufferedReader;
+import java.io.FileReader;
+import java.io.IOException;
+import java.lang.instrument.Instrumentation;
+import java.lang.reflect.Method;
+import java.io.File;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * A Java agent that acts as a proxy to delegate to one or more target agents.
+ *
+ * <p>
+ * This agent is intended to be attached to a JVM and will forward the
+ * {@code premain} call to each
+ * configured target agent. The target agent's {@code premain} method is
+ * expected to be
+ * {@code public static}. The {@link Instrumentation} instance passed to each
+ * target agent is
+ * wrapped via {@link InstrumentationProxy} so that
+ * {@link java.lang.instrument.ClassFileTransformer} registrations go through
+ * {@link ClassFileTransformerProxy}.
+ *
+ * <h2>Agent argument format</h2>
+ * <p>
+ * The {@code agentArgs} parameter supports two forms:
+ * <ul>
+ * <li>{@code @<file>} – read commands from a file, one per line, each in the
+ * form
+ * {@code <className>@<jarPath>[:<options>]}.</li>
+ * <li>{@code target=<className>@<jarPath>[:<options>][,target=<className>@<jarPath>[:<options>]]…}
+ * – specify one or more target agents inline, separated by
+ * {@code ,target=}.</li>
+ * </ul>
+ * <p>
+ * In both forms each individual agent entry uses the same syntax:
+ * {@code <className>@<jarPath>[:<options>]}, where {@code @<jarPath>} is
+ * optional (the class is
+ * then looked up via the current class loader).
+ */
+public class ProxyAgent {
+
+    /**
+     * Prefix used in the inline {@code target=} argument form to introduce each
+     * agent entry.
+     * Multiple agents are separated by {@code ,} followed immediately by this
+     * prefix.
+     */
+    static final String TARGET_PREFIX = "target=";
+
+    /**
+     * Describes a single target agent to be invoked.
+     *
+     * @param premainClass fully-qualified class name of the target agent
+     * @param jarPath      absolute path to the agent jar, used to build a dedicated
+     *                     {@link URLClassLoader} for loading the agent class; may
+     *                     be {@code null}
+     *                     when not provided
+     * @param opts         option string forwarded to the target agent's
+     *                     {@code premain}, may be
+     *                     {@code null}
+     */
+    record AgentCommand(String premainClass, String jarPath, String opts) {
+    }
+
+    /**
+     * Parses a single agent entry of the form
+     * {@code <className>@<jarPath>[:<options>]} and
+     * returns the corresponding {@link AgentCommand}.
+     *
+     * <p>
+     * The {@code @<jarPath>} part is optional. When absent,
+     * {@link AgentCommand#jarPath()} is
+     * {@code null} and the agent class will be resolved via the current class
+     * loader. The
+     * {@code :<options>} part is also optional; when absent,
+     * {@link AgentCommand#opts()} is
+     * {@code null}.
+     *
+     * @param entry a single agent entry string
+     * @return the parsed {@link AgentCommand}
+     * @throws RuntimeException if the entry is malformed
+     */
+    static AgentCommand parseAgentCommand(String entry) {
+        // Split on '@' to separate <className> from <jarPath>[:<options>]
+        int atPos = entry.indexOf('@');
+        String className;
+        String jarPath = null;
+        String opts = null;
+        if (atPos == -1) {
+            // No jar path: entire entry is the class name (no options either in this form)
+            className = entry;
+        } else {
+            className = entry.substring(0, atPos);
+            String rest = entry.substring(atPos + 1);
+            // Split <jarPath>[:<options>] on the first ':'
+            int colonPos = rest.indexOf(':');
+            if (colonPos == -1) {
+                jarPath = rest;
+            } else {
+                jarPath = rest.substring(0, colonPos);
+                opts = rest.substring(colonPos + 1);
+            }
+        }
+        return new AgentCommand(className, jarPath, opts);
+    }
+
+    /**
+     * Agent entry point invoked by the JVM before the application's {@code main}
+     * method.
+     *
+     * <p>
+     * Parses {@code agentArgs} to build a list of {@link AgentCommand}s and then
+     * invokes the
+     * {@code premain} method of each target agent in order.
+     *
+     * @param agentArgs the agent argument string supplied via {@code -javaagent}
+     * @param inst      the {@link Instrumentation} instance provided by the JVM
+     * @throws RuntimeException if argument parsing fails, a target class cannot be
+     *                          found, or
+     *                          invoking a target {@code premain} throws an
+     *                          exception
+     */
+    public static void premain(String agentArgs, Instrumentation inst) {
+        List<AgentCommand> targetAgents = new ArrayList<>();
+
+        if (agentArgs.startsWith("@")) {
+            // Read target agent commands from an option file, one entry per line.
+            // Each line has the form: <className>@<absoluteJarPath>[:<options>]
+            String optionFile = agentArgs.substring(1);
+            try (BufferedReader br = new BufferedReader(new FileReader(optionFile))) {
+                String line;
+                while ((line = br.readLine()) != null) {
+                    if (line.isEmpty()) {
+                        continue;
+                    }
+                    targetAgents.add(parseAgentCommand(line));
+                }
+            } catch (IOException e) {
+                throw new RuntimeException("Cannot load ProxyAgent because failed to load the specified option file "
+                        + optionFile, e);
+            }
+
+        } else if (agentArgs.startsWith(TARGET_PREFIX)) {
+            // Parse one or more inline target agents.
+            // The full string has the form:
+            // target=<entry1>[,target=<entry2>[,target=<entry3>]…]
+            // Strip the leading "target=" prefix, then split on ",target=" so that every
+            // resulting segment is a plain entry: <className>@<jarPath>[:<options>]
+            String withoutPrefix = agentArgs.substring(TARGET_PREFIX.length());
+            for (String entry : withoutPrefix.split("," + TARGET_PREFIX)) {
+                if (!entry.isEmpty()) {
+                    targetAgents.add(parseAgentCommand(entry));
+                }
+            }
+            if (targetAgents.isEmpty()) {
+                throw new RuntimeException(
+                        "Cannot load ProxyAgent because no valid target entries found in: " + agentArgs);
+            }
+        } else {
+            throw new RuntimeException(
+                    "Cannot load ProxyAgent: unrecognized agent argument format: \"" + agentArgs + "\". " +
+                            "Expected either \"@<optionFile>\" or one or more inline agents in the form " +
+                            "\"" + TARGET_PREFIX + "<className>@<jarPath>[:<options>]" +
+                            "[," + TARGET_PREFIX + "<className>@<jarPath>[:<options>]]…\".");
+        }
+
+        targetAgents.forEach(entry -> {
+            String className = entry.premainClass();
+            String jarPath = entry.jarPath();
+            String opts = entry.opts();
+
+            // Load the target agent class using a dedicated URLClassLoader constructed from
+            // the
+            // jar path embedded in the command. This keeps the agent jar off the builder
+            // JVM's
+            // -cp so it does not appear in builderURILocations, which would otherwise
+            // trigger a
+            // spurious "Class-path entry contains class that is part of the image builder"
+            // warning when the same class also exists on the image classpath.
+            Class<?> targetAgentClass;
+            try {
+                ClassLoader classLoader;
+                if (jarPath != null && !jarPath.isEmpty()) {
+                    URL jarUrl;
+                    try {
+                        jarUrl = new File(jarPath).toURI().toURL();
+                    } catch (MalformedURLException e) {
+                        throw new RuntimeException("Invalid target agent jar path: " + jarPath, e);
+                    }
+                    classLoader = new URLClassLoader(new URL[] { jarUrl }, ProxyAgent.class.getClassLoader());
+                } else {
+                    classLoader = ProxyAgent.class.getClassLoader();
+                }
+                targetAgentClass = Class.forName(className, true, classLoader);
+            } catch (ClassNotFoundException e) {
+                throw new RuntimeException("Can't find the proxy target class " + className, e);
+            }
+
+            // Locate the target agent's premain method. Prefer the two-argument form
+            // (String, Instrumentation); fall back to the one-argument form (String) if
+            // absent.
+            Method premain;
+            try {
+                premain = targetAgentClass.getDeclaredMethod("premain", String.class, Instrumentation.class);
+            } catch (NoSuchMethodException e) {
+                try {
+                    premain = targetAgentClass.getDeclaredMethod("premain", String.class);
+                } catch (NoSuchMethodException e1) {
+                    throw new RuntimeException("Can't find premain method in " + targetAgentClass, e1);
+                }
+            }
+
+            // Build the argument array for the target premain invocation.
+            // premain is public static, so no instance is needed (pass null as the
+            // receiver).
+            // When two arguments are expected, wrap the Instrumentation via
+            // InstrumentationProxy
+            // so that ClassFileTransformer registrations are intercepted by
+            // ClassFileTransformerProxy.
+            Object[] targetArgs;
+            if (premain.getParameterCount() == 1) {
+                targetArgs = new Object[1];
+            } else {
+                targetArgs = new Object[2];
+                targetArgs[1] = InstrumentationProxy.createProxy(inst);
+            }
+            targetArgs[0] = opts;
+
+            try {
+                // Invoke as a static method (null receiver).
+                premain.invoke(null, targetArgs);
+            } catch (ReflectiveOperationException e) {
+                throw new RuntimeException(e);
+            }
+        });
+    }
+}

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/SubstrateOptions.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/SubstrateOptions.java
@@ -191,6 +191,13 @@ public class SubstrateOptions {
     public static OptionEnabledHandler<Boolean> imageLayerEnabledHandler;
     public static OptionEnabledHandler<Boolean> imageLayerCreateEnabledHandler;
 
+    @APIOption(name = "-javaagent", valueSeparator = ':')//
+    @Option(help = "Enable the specified java agent in native image. Usage: -javaagent:<jarpath>[=<options>]. " +
+                    "The java agent will run at image build time to take its effects in the output native image. " +
+                    "Be noticed: The java agent's premain method will be re-executed at native image runtime. " +
+                    "The agent should isolate the executions according to runtime environment.", type = User, stability = OptionStability.EXPERIMENTAL)//
+    public static final HostedOptionKey<AccumulatingLocatableMultiOptionValue.Strings> JavaAgent = new HostedOptionKey<>(AccumulatingLocatableMultiOptionValue.Strings.build());
+
     @Fold
     public static boolean getSourceLevelDebug() {
         return SourceLevelDebug.getValue();

--- a/substratevm/src/com.oracle.svm.driver/src/com/oracle/svm/driver/NativeImage.java
+++ b/substratevm/src/com.oracle.svm.driver/src/com/oracle/svm/driver/NativeImage.java
@@ -291,6 +291,8 @@ public class NativeImage {
     final String oHDeadlockWatchdogInterval = oH(SubstrateOptions.DeadlockWatchdogInterval);
     final String oHLayerCreate = oH(LayeredImageOptions.LayerCreate);
 
+    final String oHJavaAgent = oH(SubstrateOptions.JavaAgent);
+
     final Map<String, String> imageBuilderEnvironment = new HashMap<>();
     private final ArrayList<String> imageBuilderArgs = new ArrayList<>();
     private final Set<String> imageBuilderUniqueLeftoverArgs = Collections.newSetFromMap(new IdentityHashMap<>());
@@ -1478,6 +1480,7 @@ public class NativeImage {
         String agentOptions = "";
         List<ArgumentEntry> traceClassInitializationOpts = getHostedOptionArgumentValues(imageBuilderArgs, oHTraceClassInitialization);
         List<ArgumentEntry> traceObjectInstantiationOpts = getHostedOptionArgumentValues(imageBuilderArgs, oHTraceObjectInstantiation);
+        List<ArgumentEntry> javaAgentOpts = getHostedOptionArgumentValues(imageBuilderArgs, oHJavaAgent);
         if (!traceClassInitializationOpts.isEmpty()) {
             agentOptions = getAgentOptions(traceClassInitializationOpts, "c");
         }
@@ -1494,6 +1497,12 @@ public class NativeImage {
                                 "/ + " + oHTraceObjectInstantiation + ").");
             }
             args.add("-agentlib:native-image-diagnostics-agent=" + agentOptions);
+        }
+
+        if (!javaAgentOpts.isEmpty()) {
+            for (ArgumentEntry javaAgentOpt : javaAgentOpts) {
+                args.add("-javaagent:" + javaAgentOpt.value);
+            }
         }
 
         return args;

--- a/substratevm/src/com.oracle.svm.driver/src/com/oracle/svm/driver/NativeImage.java
+++ b/substratevm/src/com.oracle.svm.driver/src/com/oracle/svm/driver/NativeImage.java
@@ -27,7 +27,9 @@ package com.oracle.svm.driver;
 import static com.oracle.svm.core.util.EnvVariableUtils.EnvironmentVariable;
 
 import java.io.BufferedReader;
+import java.io.BufferedWriter;
 import java.io.File;
+import java.io.FileWriter;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -1343,7 +1345,7 @@ public class NativeImage {
      * forbid than try to support.
      *
      * @param suffixVmArgs VM arguments that will be appended to the Native Image JVM launcher after
-     *            {@code vmArgs}
+     *                         {@code vmArgs}
      */
     private static void disableJarGraalJIT(List<String> vmArgs, HostFlags hostFlags, List<String> suffixVmArgs) {
         Boolean useJVMCINativeLibrary = getXXBoolArg(suffixVmArgs, "UseJVMCINativeLibrary");
@@ -1500,8 +1502,57 @@ public class NativeImage {
         }
 
         if (!javaAgentOpts.isEmpty()) {
+            Path proxyAgentPath = config.getJavaHome().resolve("lib/graalvm/svm-agent-proxy.jar");
+            if (Files.notExists(proxyAgentPath)) {
+                throw NativeImage.showError("Could not build with -javaagent option because the proxy agent " + proxyAgentPath + " that should be provided by GraalVM is not found.");
+            }
+            StringBuilder agentCmd = new StringBuilder();
             for (ArgumentEntry javaAgentOpt : javaAgentOpts) {
-                args.add("-javaagent:" + javaAgentOpt.value);
+                int firstPos = javaAgentOpt.value.indexOf('=');
+                String jarFile;
+                String agentOpt = null;
+                if (firstPos == -1) {
+                    jarFile = javaAgentOpt.value;
+                } else {
+                    jarFile = javaAgentOpt.value.substring(0, firstPos);
+                    agentOpt = javaAgentOpt.value.substring(firstPos + 1);
+                }
+                Path targetJarPath = Paths.get(jarFile);
+                addImageClasspath(targetJarPath);
+                imageBuilderJavaArgs.add("--add-exports=java.base/jdk.internal.module=ALL-UNNAMED");
+                /*
+                 * Each line in the option file has the format:
+                 * <Premain-Class>@<absoluteJarPath>[:<agentOptions>]
+                 *
+                 * The jar path is embedded directly in the option file line so that ProxyAgent can
+                 * build a per-agent URLClassLoader without placing the target jar on the builder
+                 * JVM's -cp. Keeping the jar off -cp prevents it from appearing in
+                 * builderURILocations (via getBuildClassPath()), which would otherwise trigger a
+                 * spurious "Class-path entry contains class that is part of the image builder"
+                 * warning when the same class also exists on the image classpath.
+                 */
+                final String absoluteJarPath = targetJarPath.toAbsolutePath().toString();
+                final String finalAgentOpt = agentOpt;
+                processJarManifestMainAttributes(targetJarPath, (file, attributes) -> {
+                    String premainClass = attributes.getValue("Premain-Class");
+                    agentCmd.append(premainClass).append("@").append(absoluteJarPath);
+                    if (finalAgentOpt != null) {
+                        agentCmd.append(":").append(finalAgentOpt);
+                    }
+                    agentCmd.append("\n");
+                });
+            }
+            try {
+                Path agentOptionFilePath = Files.createTempFile("svm-driver-", "");
+                try (
+                                BufferedWriter bw = new BufferedWriter(new FileWriter(agentOptionFilePath.toFile()))) {
+                    bw.write(agentCmd.toString());
+                } catch (IOException e) {
+                    throw NativeImage.showError("Could not start build with -javaagent, because failed to prepare agent option file.", e);
+                }
+                args.add("-javaagent:" + proxyAgentPath + "=@" + agentOptionFilePath);
+            } catch (IOException e) {
+                throw NativeImage.showError("Could not start build with -javaagent, because failed to prepare agent option file.", e);
             }
         }
 

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/InstrumentFeature.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/InstrumentFeature.java
@@ -36,7 +36,10 @@ import org.graalvm.nativeimage.hosted.Feature;
 
 import com.oracle.svm.core.PreMainSupport;
 import com.oracle.svm.shared.feature.AutomaticallyRegisteredFeature;
+import com.oracle.svm.core.SubstrateOptions;
 import com.oracle.svm.core.feature.InternalFeature;
+import com.oracle.svm.core.option.SubstrateOptionsParser;
+import com.oracle.svm.shared.util.BasedOnJDKFile;
 import com.oracle.svm.core.util.UserError;
 import com.oracle.svm.hosted.reflect.ReflectionFeature;
 import com.oracle.svm.shared.option.AccumulatingLocatableMultiOptionValue;
@@ -48,8 +51,8 @@ import com.oracle.svm.shared.singletons.traits.BuiltinTraits.NoLayeredCallbacks;
 import com.oracle.svm.shared.singletons.traits.SingletonTraits;
 import com.oracle.svm.shared.util.BasedOnJDKFile;
 
-import jdk.graal.compiler.options.Option;
-import jdk.graal.compiler.options.OptionStability;
+import java.io.IOException;
+import java.util.jar.JarFile;
 
 /**
  * This feature supports instrumentation in native image.
@@ -57,16 +60,10 @@ import jdk.graal.compiler.options.OptionStability;
 @AutomaticallyRegisteredFeature
 @SingletonTraits(access = BuildtimeAccessOnly.class, layeredCallbacks = NoLayeredCallbacks.class, other = Disallowed.class)
 public class InstrumentFeature implements InternalFeature {
-    public static class Options {
-        @Option(help = "Specify premain-class list. Multiple classes are separated by comma, and order matters. This is an experimental option.", stability = OptionStability.EXPERIMENTAL)//
-        public static final HostedOptionKey<AccumulatingLocatableMultiOptionValue.Strings> PremainClasses = new HostedOptionKey<>(
-                        AccumulatingLocatableMultiOptionValue.Strings.buildWithCommaDelimiter());
-
-    }
 
     @Override
     public boolean isInConfiguration(IsInConfigurationAccess access) {
-        return !Options.PremainClasses.getValue().values().isEmpty();
+        return !SubstrateOptions.JavaAgent.getValue().values().isEmpty();
     }
 
     @Override
@@ -82,28 +79,50 @@ public class InstrumentFeature implements InternalFeature {
         PreMainSupport support = new PreMainSupport();
         ImageSingletons.add(PreMainSupport.class, support);
 
-        List<String> premainClasses = Options.PremainClasses.getValue().values();
-        for (String clazz : premainClasses) {
-            addPremainClass(support, cl, clazz);
+        List<String> agentOptions = SubstrateOptions.JavaAgent.getValue().values();
+        for (String agentOption : agentOptions) {
+            addPremainClass(support, cl, agentOption);
         }
     }
 
-    private static void addPremainClass(PreMainSupport support, ClassLoader cl, String premainClass) {
+    private static void addPremainClass(PreMainSupport support, ClassLoader cl, String javaagentOption) {
+        int separatorIndex = javaagentOption.indexOf("=");
+        String agent;
+        String premainClass = null;
+        String options = "";
+        // Get the agent file
+        if (separatorIndex == -1) {
+            agent = javaagentOption;
+        } else {
+            agent = javaagentOption.substring(0, separatorIndex);
+            options = javaagentOption.substring(separatorIndex + 1);
+        }
+        // Read MANIFEST in agent jar
+        try {
+            JarFile agentJarFile = new JarFile(agent);
+            premainClass = agentJarFile.getManifest().getMainAttributes().getValue("Premain-Class");
+        } catch (IOException e) {
+            // This should never happen because the image build process (HotSpot) already loaded the
+            // agent during startup.
+            throw UserError.abort(e, "Can't read the agent jar %s. Please check option %s", agent,
+                            SubstrateOptionsParser.commandArgument(SubstrateOptions.JavaAgent, ""));
+        }
+
         try {
             Class<?> clazz = Class.forName(premainClass, false, cl);
             Method premain = findPremainMethod(premainClass, clazz);
 
             List<Object> args = new ArrayList<>();
             /* The first argument contains the premain options, which will be set at runtime. */
-            args.add("");
+            args.add(options);
             if (premain.getParameterCount() == 2) {
                 args.add(new PreMainSupport.NativeImageNoOpRuntimeInstrumentation());
             }
 
             support.registerPremainMethod(premainClass, premain, args.toArray(new Object[0]));
         } catch (ClassNotFoundException e) {
-            UserError.abort("Could not register agent premain method because class %s was not found. Please check your %s setting.", premainClass,
-                            SubstrateOptionsParser.commandArgument(Options.PremainClasses, ""));
+            throw UserError.abort("Could not register agent premain method because class %s was not found. Please check your %s setting.", premainClass,
+                            SubstrateOptionsParser.commandArgument(SubstrateOptions.JavaAgent, ""));
         }
     }
 

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/InstrumentFeature.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/InstrumentFeature.java
@@ -26,32 +26,26 @@
 
 package com.oracle.svm.hosted;
 
-import java.lang.instrument.Instrumentation;
-import java.lang.reflect.Method;
-import java.util.ArrayList;
-import java.util.List;
-
-import org.graalvm.nativeimage.ImageSingletons;
-import org.graalvm.nativeimage.hosted.Feature;
-
 import com.oracle.svm.core.PreMainSupport;
 import com.oracle.svm.shared.feature.AutomaticallyRegisteredFeature;
 import com.oracle.svm.core.SubstrateOptions;
 import com.oracle.svm.core.feature.InternalFeature;
-import com.oracle.svm.core.option.SubstrateOptionsParser;
-import com.oracle.svm.shared.util.BasedOnJDKFile;
 import com.oracle.svm.core.util.UserError;
 import com.oracle.svm.hosted.reflect.ReflectionFeature;
-import com.oracle.svm.shared.option.AccumulatingLocatableMultiOptionValue;
-import com.oracle.svm.shared.option.HostedOptionKey;
 import com.oracle.svm.shared.option.SubstrateOptionsParser;
 import com.oracle.svm.shared.singletons.traits.BuiltinTraits.BuildtimeAccessOnly;
 import com.oracle.svm.shared.singletons.traits.BuiltinTraits.Disallowed;
 import com.oracle.svm.shared.singletons.traits.BuiltinTraits.NoLayeredCallbacks;
 import com.oracle.svm.shared.singletons.traits.SingletonTraits;
 import com.oracle.svm.shared.util.BasedOnJDKFile;
+import org.graalvm.nativeimage.ImageSingletons;
+import org.graalvm.nativeimage.hosted.Feature;
 
 import java.io.IOException;
+import java.lang.instrument.Instrumentation;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.jar.JarFile;
 
 /**
@@ -120,6 +114,7 @@ public class InstrumentFeature implements InternalFeature {
             }
 
             support.registerPremainMethod(premainClass, premain, args.toArray(new Object[0]));
+
         } catch (ClassNotFoundException e) {
             throw UserError.abort("Could not register agent premain method because class %s was not found. Please check your %s setting.", premainClass,
                             SubstrateOptionsParser.commandArgument(SubstrateOptions.JavaAgent, ""));

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/SVMHost.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/SVMHost.java
@@ -1586,4 +1586,17 @@ public class SVMHost extends HostVM {
         }
         return loaderName(originalLoader) + "->" + loaderName(runtimeLoader);
     }
+
+    @Override
+    public boolean isFromJavaAgent(Class<?> clazz) {
+        if (SubstrateOptions.JavaAgent.hasBeenSet()) {
+            try {
+                String classLocation = clazz.getProtectionDomain().getCodeSource().getLocation().getFile();
+                return SubstrateOptions.JavaAgent.getValue().values().stream().map(s -> s.split("=")[0]).anyMatch(s -> s.equals(classLocation));
+            } catch (Exception e) {
+                return false;
+            }
+        }
+        return false;
+    }
 }

--- a/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/javaagent/AgentPremainHelper.java
+++ b/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/javaagent/AgentPremainHelper.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2024, 2024, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2024, 2024, Alibaba Group Holding Limited. All rights reserved.
+ * Copyright (c) 2025, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2025, 2025, Alibaba Group Holding Limited. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,14 +34,6 @@ public class AgentPremainHelper {
         } else {
             System.setProperty("first.load.agent", agentClass.getName());
         }
-    }
-
-    public static String getFirst() {
-        return System.getProperty("first.load.agent");
-    }
-
-    public static String getSecond() {
-        return System.getProperty("second.load.agent");
     }
 
     public static void parseOptions(String agentArgs) {

--- a/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/javaagent/AgentTest.java
+++ b/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/javaagent/AgentTest.java
@@ -42,8 +42,8 @@ public class AgentTest {
     }
 
     private static void testPremainSequence() {
-        String first = AgentPremainHelper.getFirst();
-        String second = AgentPremainHelper.getSecond();
+        String first = System.getProperty("first.load.agent");
+        String second = System.getProperty("second.load.agent");
         Assert.assertNotNull(first);
         if (second != null) {
             String agentName = TestJavaAgent1.class.getName();

--- a/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/javaagent/AgentTest.java
+++ b/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/javaagent/AgentTest.java
@@ -58,10 +58,20 @@ public class AgentTest {
         }
     }
 
+    private static void testInstrumentation() {
+        // The return value of getCounter() should be changed by agent
+        Assert.assertEquals(11, getCounter());
+    }
+
+    private static int getCounter() {
+        return 10;
+    }
+
     public static void main(String[] args) {
         testPremain();
         testAgentOptions();
         testPremainSequence();
+        testInstrumentation();
         System.out.println("Finished running Agent test.");
     }
 }

--- a/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/javaagent/AgentTest.java
+++ b/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/javaagent/AgentTest.java
@@ -28,7 +28,10 @@ package com.oracle.svm.test.javaagent;
 
 import com.oracle.svm.test.javaagent.agent1.TestJavaAgent1;
 import com.oracle.svm.test.javaagent.agent2.TestJavaAgent2;
+import org.graalvm.nativeimage.ImageInfo;
 import org.junit.Assert;
+
+import java.lang.reflect.Field;
 
 public class AgentTest {
 

--- a/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/javaagent/AssertInAgent.java
+++ b/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/javaagent/AssertInAgent.java
@@ -27,7 +27,7 @@
 package com.oracle.svm.test.javaagent;
 
 /**
- * Assertions used inside agent when not using JUNIT
+ * Assertions used inside agent when not using JUNIT.
  */
 public class AssertInAgent {
     public static void assertNotNull(Object o) {
@@ -60,8 +60,6 @@ public class AssertInAgent {
             }
         }
     }
-
-
 
     public static void assertTrue(boolean actual) {
         assertEquals(true, actual);

--- a/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/javaagent/AssertInAgent.java
+++ b/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/javaagent/AssertInAgent.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2025, 2025, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2025, 2025, Alibaba Group Holding Limited. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package com.oracle.svm.test.javaagent;
+
+/**
+ * Assertions used inside agent when not using JUNIT
+ */
+public class AssertInAgent {
+    public static void assertNotNull(Object o) {
+        if (o == null) {
+            throw new RuntimeException("Object input is null, but expected to be non-null");
+        }
+    }
+
+    public static void assertEquals(boolean expected, boolean actual) {
+        if (expected != actual) {
+            throw new RuntimeException(String.format("Expected(%s) is not equal to actual(%s)", expected, actual));
+        }
+    }
+
+    public static void assertEquals(long expected, long actual) {
+        if (expected != actual) {
+            throw new RuntimeException(String.format("Expected(%s) is not equal to actual(%s)", expected, actual));
+        }
+    }
+
+    public static void assertEquals(Object expected, Object actual) {
+        if (expected != actual) {
+            if (expected != null) {
+                assertNotNull(actual);
+                if (!expected.equals(actual)) {
+                    throw new RuntimeException(String.format("Expected(%s) is not equal to actual(%s)", expected, actual));
+                }
+            } else {
+                throw new RuntimeException(String.format("Expected(null) is not equal to actual(%s)", actual));
+            }
+        }
+    }
+
+
+
+    public static void assertTrue(boolean actual) {
+        assertEquals(true, actual);
+    }
+}

--- a/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/javaagent/agent1/TestJavaAgent1.java
+++ b/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/javaagent/agent1/TestJavaAgent1.java
@@ -26,8 +26,8 @@
 package com.oracle.svm.test.javaagent.agent1;
 
 import com.oracle.svm.test.javaagent.AgentPremainHelper;
+import com.oracle.svm.test.javaagent.AssertInAgent;
 import org.graalvm.nativeimage.ImageInfo;
-import org.junit.Assert;
 
 import java.lang.classfile.ClassFile;
 import java.lang.classfile.ClassModel;
@@ -53,22 +53,22 @@ public class TestJavaAgent1 {
              * Test {@code inst} is {@link NativeImageNoOpRuntimeInstrumentation} and behaves as
              * defined.
              */
-            Assert.assertNotNull(inst);
-            Assert.assertEquals(false, inst.isRetransformClassesSupported());
-            Assert.assertEquals(false, inst.removeTransformer(null));
-            Assert.assertEquals(false, inst.isRedefineClassesSupported());
+            AssertInAgent.assertNotNull(inst);
+            AssertInAgent.assertEquals(false, inst.isRetransformClassesSupported());
+            AssertInAgent.assertEquals(false, inst.removeTransformer(null));
+            AssertInAgent.assertEquals(false, inst.isRedefineClassesSupported());
 
-            Assert.assertEquals(false, inst.isModifiableClass(null));
+            AssertInAgent.assertEquals(false, inst.isModifiableClass(null));
 
             Class<?>[] allClasses = inst.getAllLoadedClasses();
-            Assert.assertTrue(allClasses.length > 0);
+            AssertInAgent.assertTrue(allClasses.length > 0);
             Class<?> currentAgentClassFromAllLoaded = null;
             for (Class<?> c : allClasses) {
                 if (c.equals(TestJavaAgent1.class)) {
                     currentAgentClassFromAllLoaded = c;
                 }
             }
-            Assert.assertNotNull(currentAgentClassFromAllLoaded);
+            AssertInAgent.assertNotNull(currentAgentClassFromAllLoaded);
 
             // redefineClasses should throw UnsupportedOperationException
             Exception exception = null;
@@ -77,8 +77,8 @@ public class TestJavaAgent1 {
             } catch (Exception e) {
                 exception = e;
             }
-            Assert.assertNotNull(exception);
-            Assert.assertEquals(UnsupportedOperationException.class, exception.getClass());
+            AssertInAgent.assertNotNull(exception);
+            AssertInAgent.assertEquals(UnsupportedOperationException.class, exception.getClass());
 
             // getInitiatedClasses should throw UnsupportedOperationException
             exception = null;
@@ -87,8 +87,8 @@ public class TestJavaAgent1 {
             } catch (Exception e) {
                 exception = e;
             }
-            Assert.assertNotNull(exception);
-            Assert.assertEquals(UnsupportedOperationException.class, exception.getClass());
+            AssertInAgent.assertNotNull(exception);
+            AssertInAgent.assertEquals(UnsupportedOperationException.class, exception.getClass());
 
             // retransformClasses should throw UnsupportedOperationException
             exception = null;
@@ -97,8 +97,8 @@ public class TestJavaAgent1 {
             } catch (Exception e) {
                 exception = e;
             }
-            Assert.assertNotNull(exception);
-            Assert.assertEquals(UnsupportedOperationException.class, exception.getClass());
+            AssertInAgent.assertNotNull(exception);
+            AssertInAgent.assertEquals(UnsupportedOperationException.class, exception.getClass());
 
             // appendToBootstrapClassLoaderSearch should throw UnsupportedOperationException
             exception = null;
@@ -107,8 +107,8 @@ public class TestJavaAgent1 {
             } catch (Exception e) {
                 exception = e;
             }
-            Assert.assertNotNull(exception);
-            Assert.assertEquals(UnsupportedOperationException.class, exception.getClass());
+            AssertInAgent.assertNotNull(exception);
+            AssertInAgent.assertEquals(UnsupportedOperationException.class, exception.getClass());
 
             // appendToSystemClassLoaderSearch should throw UnsupportedOperationException
             exception = null;
@@ -117,14 +117,14 @@ public class TestJavaAgent1 {
             } catch (Exception e) {
                 exception = e;
             }
-            Assert.assertNotNull(exception);
-            Assert.assertEquals(UnsupportedOperationException.class, exception.getClass());
+            AssertInAgent.assertNotNull(exception);
+            AssertInAgent.assertEquals(UnsupportedOperationException.class, exception.getClass());
 
-            Assert.assertEquals(-1, inst.getObjectSize(null));
-            Assert.assertEquals(false, inst.isNativeMethodPrefixSupported());
+            AssertInAgent.assertEquals(-1, inst.getObjectSize(null));
+            AssertInAgent.assertEquals(false, inst.isNativeMethodPrefixSupported());
 
             Module currentModule = TestJavaAgent1.class.getModule();
-            Assert.assertEquals(true, inst.isModifiableModule(currentModule));
+            AssertInAgent.assertEquals(true, inst.isModifiableModule(currentModule));
 
             // redefineModule only does checks, no actual actions.
             inst.redefineModule(currentModule, Set.of(Class.class.getModule()), Collections.emptyMap(), null, null, null);

--- a/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/javaagent/agent1/TestJavaAgent1.java
+++ b/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/javaagent/agent1/TestJavaAgent1.java
@@ -41,7 +41,7 @@ import java.util.Set;
 public class TestJavaAgent1 {
 
     public static void premain(
-            String agentArgs, Instrumentation inst) {
+                    String agentArgs, Instrumentation inst) {
         AgentPremainHelper.parseOptions(agentArgs);
         System.setProperty("instrument.enable", "true");
         AgentPremainHelper.load(TestJavaAgent1.class);
@@ -144,18 +144,17 @@ public class TestJavaAgent1 {
 
         @Override
         public byte[] transform(
-                ClassLoader loader,
-                String className,
-                Class<?> classBeingRedefined,
-                ProtectionDomain protectionDomain,
-                byte[] classfileBuffer) {
+                        ClassLoader loader,
+                        String className,
+                        Class<?> classBeingRedefined,
+                        ProtectionDomain protectionDomain,
+                        byte[] classfileBuffer) {
             if (internalClassName.equals(className)) {
                 ClassFile classFile = ClassFile.of();
                 ClassModel classModel = classFile.parse(classfileBuffer);
 
                 return classFile.transformClass(classModel, (classbuilder, ce) -> {
-                    if (ce instanceof MethodModel mm && mm.methodName().equalsString("getCounter")
-                            && mm.methodType().equalsString("()I")) {
+                    if (ce instanceof MethodModel mm && mm.methodName().equalsString("getCounter") && mm.methodType().equalsString("()I")) {
                         classbuilder.transformMethod(mm, (mb, me) -> {
                             mb.withCode(cb -> {
                                 cb.loadConstant(11);

--- a/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/javaagent/agent1/TestJavaAgent1.java
+++ b/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/javaagent/agent1/TestJavaAgent1.java
@@ -26,28 +26,37 @@
 package com.oracle.svm.test.javaagent.agent1;
 
 import com.oracle.svm.test.javaagent.AgentPremainHelper;
+import com.oracle.svm.test.javaagent.AgentTest;
 import com.oracle.svm.test.javaagent.AssertInAgent;
 import org.graalvm.nativeimage.ImageInfo;
 
 import java.lang.classfile.ClassFile;
 import java.lang.classfile.ClassModel;
+import java.lang.classfile.CodeModel;
 import java.lang.classfile.MethodModel;
+
+import java.lang.constant.ClassDesc;
+import java.lang.constant.MethodTypeDesc;
 import java.lang.instrument.ClassFileTransformer;
 import java.lang.instrument.Instrumentation;
+import java.lang.instrument.UnmodifiableClassException;
 import java.security.ProtectionDomain;
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.List;
 import java.util.Set;
 
 public class TestJavaAgent1 {
 
     public static void premain(
-                    String agentArgs, Instrumentation inst) {
+                    String agentArgs, Instrumentation inst) throws UnmodifiableClassException {
         AgentPremainHelper.parseOptions(agentArgs);
         System.setProperty("instrument.enable", "true");
         AgentPremainHelper.load(TestJavaAgent1.class);
         if (!ImageInfo.inImageRuntimeCode()) {
             DemoTransformer dt = new DemoTransformer();
             inst.addTransformer(dt, true);
+            inst.retransformClasses(dt.getTargetClasses());
         } else {
             /**
              * Test {@code inst} is {@link NativeImageNoOpRuntimeInstrumentation} and behaves as
@@ -132,14 +141,35 @@ public class TestJavaAgent1 {
     }
 
     /**
-     * Change the return value of {@code AgentTest#getCounter()} from 10 to 11 in the agent.
+     * Change the return value of {@code AgentTest#getCounter()} from 10 to 11 in the agent. Also
+     * intercept {@code com.oracle.svm.hosted.InstrumentFeature#getRequiredFeatures()} to return an
+     * empty list.
+     *
+     * <p>
+     * Note: the interception of {@code InstrumentFeature#getRequiredFeatures()} is expected to be
+     * suppressed by {@code ClassFileTransformerProxy} during a Native Image build, because
+     * {@code InstrumentFeature} belongs to the {@code org.graalvm.nativeimage.builder} module which
+     * is in the protected {@code SYSTEM_MODULES} set. Therefore the build-time
+     * {@code getRequiredFeatures()} will still return its original value; only the shaded copy
+     * (loaded under the {@code shaded.*} namespace in DEBUG mode) will reflect the transformation.
      */
     static class DemoTransformer implements ClassFileTransformer {
 
-        private String internalClassName;
+        private static final String AGENT_TEST_CLASS = "com/oracle/svm/test/javaagent/AgentTest";
+        private static final String INSTRUMENT_FEATURE_CLASS = "com/oracle/svm/hosted/InstrumentFeature";
+
+        private final List<Class<?>> targetClasses = new ArrayList<>();
 
         DemoTransformer() {
-            internalClassName = "com/oracle/svm/test/javaagent/AgentTest";
+            try {
+                targetClasses.add(AgentTest.class);
+            } catch (NoClassDefFoundError e) {
+                // AgentTest may not be available at this point
+            }
+        }
+
+        public Class<?>[] getTargetClasses() {
+            return targetClasses.toArray(new Class[0]);
         }
 
         @Override
@@ -149,7 +179,8 @@ public class TestJavaAgent1 {
                         Class<?> classBeingRedefined,
                         ProtectionDomain protectionDomain,
                         byte[] classfileBuffer) {
-            if (internalClassName.equals(className)) {
+            if (AGENT_TEST_CLASS.equals(className)) {
+                // Change getCounter() return value from 10 to 11
                 ClassFile classFile = ClassFile.of();
                 ClassModel classModel = classFile.parse(classfileBuffer);
 
@@ -165,8 +196,45 @@ public class TestJavaAgent1 {
                         classbuilder.with(ce);
                     }
                 });
+            } else if (INSTRUMENT_FEATURE_CLASS.equals(className)) {
+                // Attempt to intercept InstrumentFeature#getRequiredFeatures() to return an empty
+                // list. This transformation targets a protected GraalVM system module and will be
+                // suppressed by ClassFileTransformerProxy during a Native Image build.
+                return transformInstrumentFeatureGetRequiredFeatures(classfileBuffer);
             }
             return null;
+        }
+
+        /**
+         * Transforms {@code InstrumentFeature#getRequiredFeatures()} so that it returns an empty
+         * list ({@code Collections.emptyList()}) instead of its actual value.
+         */
+        private static byte[] transformInstrumentFeatureGetRequiredFeatures(byte[] classfileBuffer) {
+            ClassFile classFile = ClassFile.of();
+            ClassModel classModel = classFile.parse(classfileBuffer);
+            ClassDesc collectionsDesc = ClassDesc.of("java.util.Collections");
+            ClassDesc listDesc = ClassDesc.of("java.util.List");
+            return classFile.transformClass(classModel, (cb, ce) -> {
+                if (ce instanceof MethodModel mm &&
+                                mm.methodName().equalsString("getRequiredFeatures") &&
+                                mm.methodType().equalsString("()Ljava/util/List;")) {
+                    cb.transformMethod(mm, (mb, me) -> {
+                        if (me instanceof CodeModel) {
+                            mb.withCode(codeBuilder -> {
+                                // return Collections.emptyList();
+                                codeBuilder.invokestatic(
+                                                collectionsDesc, "emptyList",
+                                                MethodTypeDesc.of(listDesc));
+                                codeBuilder.areturn();
+                            });
+                        } else {
+                            mb.with(me);
+                        }
+                    });
+                } else {
+                    cb.with(ce);
+                }
+            });
         }
     }
 }

--- a/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/javaagent/agent1/TestJavaAgent1.java
+++ b/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/javaagent/agent1/TestJavaAgent1.java
@@ -37,6 +37,7 @@ import java.lang.classfile.MethodModel;
 
 import java.lang.constant.ClassDesc;
 import java.lang.constant.MethodTypeDesc;
+import java.lang.classfile.MethodTransform;
 import java.lang.instrument.ClassFileTransformer;
 import java.lang.instrument.Instrumentation;
 import java.lang.instrument.UnmodifiableClassException;
@@ -48,15 +49,27 @@ import java.util.Set;
 
 public class TestJavaAgent1 {
 
+    private static void doTransform(Instrumentation inst) throws UnmodifiableClassException {
+            DemoTransformer dt = new DemoTransformer();
+            inst.addTransformer(dt, true);
+            inst.retransformClasses(dt.getTargetClasses());
+    }
+
+    public static void prelink(String agentArgs, Instrumentation inst) throws UnmodifiableClassException {
+        doTransform(inst);
+    }
+
     public static void premain(
                     String agentArgs, Instrumentation inst) throws UnmodifiableClassException {
         AgentPremainHelper.parseOptions(agentArgs);
         System.setProperty("instrument.enable", "true");
         AgentPremainHelper.load(TestJavaAgent1.class);
+        /**
+         * Agent can do anything here for runtime usage only.
+         * e.g. A time stamp at which the agent is loaded.
+         */
         if (!ImageInfo.inImageRuntimeCode()) {
-            DemoTransformer dt = new DemoTransformer();
-            inst.addTransformer(dt, true);
-            inst.retransformClasses(dt.getTargetClasses());
+            doTransform(inst);
         } else {
             /**
              * Test {@code inst} is {@link NativeImageNoOpRuntimeInstrumentation} and behaves as
@@ -183,15 +196,16 @@ public class TestJavaAgent1 {
                 // Change getCounter() return value from 10 to 11
                 ClassFile classFile = ClassFile.of();
                 ClassModel classModel = classFile.parse(classfileBuffer);
-
+                @SuppressWarnings("unused")
+                MethodTransform methodTransformer = (mb, me) -> {
+                    mb.withCode(cb -> {
+                        cb.loadConstant(11);
+                        cb.ireturn();
+                    });
+                };
                 return classFile.transformClass(classModel, (classbuilder, ce) -> {
                     if (ce instanceof MethodModel mm && mm.methodName().equalsString("getCounter") && mm.methodType().equalsString("()I")) {
-                        classbuilder.transformMethod(mm, (mb, me) -> {
-                            mb.withCode(cb -> {
-                                cb.loadConstant(11);
-                                cb.ireturn();
-                            });
-                        });
+                        classbuilder.transformMethod(mm, methodTransformer);
                     } else {
                         classbuilder.with(ce);
                     }

--- a/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/javaagent/agent2/TestJavaAgent2.java
+++ b/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/javaagent/agent2/TestJavaAgent2.java
@@ -27,16 +27,11 @@
 package com.oracle.svm.test.javaagent.agent2;
 
 import com.oracle.svm.test.javaagent.AgentPremainHelper;
-import org.graalvm.nativeimage.ImageInfo;
 
 public class TestJavaAgent2 {
     public static void premain(String agentArgs) {
         AgentPremainHelper.parseOptions(agentArgs);
         System.setProperty("instrument.enable", "true");
-        if (!ImageInfo.inImageRuntimeCode()) {
-            // do class transformation
-        } else {
-            AgentPremainHelper.load(TestJavaAgent2.class);
-        }
+        AgentPremainHelper.load(TestJavaAgent2.class);
     }
 }


### PR DESCRIPTION
This PR enables GraalVM to accept java agents at build time and apply their class transformations in the native image.

The agent is passed to native-image by specifying `-javaagent:<jarpath>[=<options>]`, the same as using with JVM.
