### PR TITLE
Avoid adding same (AArch64|AMD64)SaveRegistersOp object twice to basic block

### DIFF
--- a/compiler/src/jdk.graal.compiler/src/jdk/graal/compiler/hotspot/aarch64/AArch64HotSpotNodeLIRBuilder.java
+++ b/compiler/src/jdk.graal.compiler/src/jdk/graal/compiler/hotspot/aarch64/AArch64HotSpotNodeLIRBuilder.java
@@ -105,7 +105,6 @@ public class AArch64HotSpotNodeLIRBuilder extends AArch64NodeLIRBuilder implemen
             assert stub.getLinkage().getDescriptor().getTransition() != HotSpotForeignCallDescriptor.Transition.SAFEPOINT : stub;
             Register[] savedRegisters = getGen().getRegisterConfig().getAllocatableRegisters().toArray();
             AArch64SaveRegistersOp saveOp = getGen().emitSaveAllRegisters(savedRegisters);
-            append(saveOp);
             result.setSaveOnEntry(saveOp);
         }
 

--- a/compiler/src/jdk.graal.compiler/src/jdk/graal/compiler/hotspot/amd64/AMD64HotSpotNodeLIRBuilder.java
+++ b/compiler/src/jdk.graal.compiler/src/jdk/graal/compiler/hotspot/amd64/AMD64HotSpotNodeLIRBuilder.java
@@ -102,7 +102,6 @@ public class AMD64HotSpotNodeLIRBuilder extends AMD64NodeLIRBuilder implements H
         if (stub != null && stub.getLinkage().getEffect() == HotSpotForeignCallLinkage.RegisterEffect.KILLS_NO_REGISTERS) {
             assert stub.getLinkage().getDescriptor().getTransition() != HotSpotForeignCallDescriptor.Transition.SAFEPOINT : stub;
             AMD64SaveRegistersOp saveOp = getGen().emitSaveAllRegisters(false);
-            append(saveOp);
             result.setSaveOnEntry(saveOp);
         }
 

--- a/compiler/src/jdk.graal.compiler/src/jdk/graal/compiler/lir/gen/LIRGenerator.java
+++ b/compiler/src/jdk.graal.compiler/src/jdk/graal/compiler/lir/gen/LIRGenerator.java
@@ -343,6 +343,8 @@ public abstract class LIRGenerator extends CoreProvidersDelegate implements LIRG
         assert verify(op);
         ArrayList<LIRInstruction> lirForBlock = lir.getLIRforBlock(getCurrentBlock());
         op.setPosition(currentPosition);
+
+        assert !lirForBlock.contains(op) : "added " + op + " twice";
         lirForBlock.add(op);
         return op;
     }


### PR DESCRIPTION
This is not necessarily a performance issue. Or at least, I didn't check whether this actually leads to the instructions being emitted twice. Though, it violates basic assumptions at the LIR level, for instance, that individual instructions are separate objects.

The indirectly called `emitSaveRegisters(.)` methods already store the instructions.
But just to make sure, I added an assert that they are indeed already added.

This is code that hasn't been touched in years. Though, @tkrodriguez and @rschatz touched related bits (5 and 11 years ago).

For me, it causes issues when trying to revive @zapster's Trace Register Allocator (https://github.com/smarr/truffle/tree/trace-ra) for our work on optimizing the code produced for bytecode loops (without PE).

/cc @davleopo 