### PR TITLE
Garbage collect on allocation exceeding max memory pool size

### DIFF
--- a/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/AbstractCollectionPolicy.java
+++ b/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/AbstractCollectionPolicy.java
@@ -87,11 +87,11 @@ abstract class AbstractCollectionPolicy implements CollectionPolicy {
     }
 
     @Override
-    public boolean shouldCollectOnAllocation() {
+    public boolean shouldCollectOnAllocation(UnsignedWord allocationSize) {
         if (sizes == null) {
             return false; // updateSizeParameters() has never been called
         }
-        UnsignedWord edenUsed = HeapImpl.getAccounting().getEdenUsedBytes();
+        UnsignedWord edenUsed = HeapImpl.getAccounting().getEdenUsedBytes().add(allocationSize);
         return edenUsed.aboveOrEqual(edenSize);
     }
 

--- a/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/BasicCollectionPolicies.java
+++ b/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/BasicCollectionPolicies.java
@@ -57,8 +57,8 @@ final class BasicCollectionPolicies {
         }
 
         @Override
-        public boolean shouldCollectOnAllocation() {
-            UnsignedWord youngUsed = HeapImpl.getAccounting().getYoungUsedBytes();
+        public boolean shouldCollectOnAllocation(UnsignedWord allocationSize) {
+            UnsignedWord youngUsed = HeapImpl.getAccounting().getYoungUsedBytes().add(allocationSize);
             return youngUsed.aboveOrEqual(getMaximumYoungGenerationSize());
         }
 
@@ -243,7 +243,7 @@ final class BasicCollectionPolicies {
     public static final class NeverCollect extends BasicPolicy {
 
         @Override
-        public boolean shouldCollectOnAllocation() {
+        public boolean shouldCollectOnAllocation(UnsignedWord allocationSize) {
             throw VMError.shouldNotReachHere("Caller is supposed to be aware of never-collect policy");
         }
 

--- a/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/CollectionPolicy.java
+++ b/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/CollectionPolicy.java
@@ -119,7 +119,7 @@ public interface CollectionPolicy {
      * {@code true} will initiate a safepoint during which {@link #shouldCollectCompletely} will be
      * called followed by the collection.
      */
-    boolean shouldCollectOnAllocation();
+    boolean shouldCollectOnAllocation(UnsignedWord allocationSize);
 
     /**
      * Called when an application provides a hint to the GC that it might be a good time to do a

--- a/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/GCImpl.java
+++ b/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/GCImpl.java
@@ -159,7 +159,7 @@ public final class GCImpl implements GC {
         if (hasNeverCollectPolicy()) {
             UnsignedWord edenUsed = HeapImpl.getAccounting().getEdenUsedBytes();
             outOfMemory = edenUsed.aboveThan(GCImpl.getPolicy().getMaximumHeapSize());
-        } else if (getPolicy().shouldCollectOnAllocation()) {
+        } else if (getPolicy().shouldCollectOnAllocation(allocationSize)) {
             AllocationRequiringGCEvent.emit(getCollectionEpoch(), allocationSize);
             outOfMemory = collectWithoutAllocating(GenScavengeGCCause.OnAllocation, false);
         }


### PR DESCRIPTION
### Summary 
Garbage collection is currently done on the allocation slow path after the max eden size was already exceeded by a **previous** allocation.  For example, if new TLAB allocationA causes the max size to be exceeded, the pool max size will remain exceeded until new TLAB allocationB happens.  It would be better to do GC when the allocation that actually causes the threshold to be exceeded happens. 

This is because, on the slow path, [`maybeCollectOnAllocation`](https://github.com/oracle/graal/blob/master/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/GCImpl.java#L157) is called too early. `maybeCollectOnAllocation` calls [`shouldCollectOnAllocation`](https://github.com/oracle/graal/blob/master/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/AbstractCollectionPolicy.java#L90) which checks whether the eden size threshold is exceeded.
The problem is that `maybeCollectOnAllocation` is called before `increaseEdenUsedBytes` is called, so `shouldCollectOnAllocation` doesn't take into account the size of the current allocation. Is there a reason for this, or is this a bug? 

I've just made a small change so that `shouldCollectOnAllocation` takes into account the size of the current allocation that is requiring a new TLAB (and potentially causing the memory pool max to be exceeded). 

See https://github.com/oracle/graal/pull/6930 for more context. 