### PR TITLE
[GR-60383] Avoid recursive printing of exception causes

### DIFF
--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/NativeImageGeneratorRunner.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/NativeImageGeneratorRunner.java
@@ -714,11 +714,10 @@ public class NativeImageGeneratorRunner {
         } else {
             reportUserError(e.getMessage());
         }
-        Throwable current = e.getCause();
-        while (current != null) {
+        Throwable cause = e.getCause();
+        if (cause != null) {
             System.out.print("Caused by: ");
-            current.printStackTrace(System.out);
-            current = current.getCause();
+            cause.printStackTrace(System.out);
         }
         if (parsedHostedOptions != null && NativeImageOptions.ReportExceptionStackTraces.getValue(parsedHostedOptions)) {
             System.out.print("Internal exception: ");


### PR DESCRIPTION
`printStackTrace` already recursively prints the causes

Follow up to https://github.com/oracle/graal/pull/9140