### PR TITLE
Only `--enable-native-access=org.graalvm.truffle` when svmt present

### DIFF
--- a/sdk/mx.sdk/vm/launcher_template.cmd
+++ b/sdk/mx.sdk/vm/launcher_template.cmd
@@ -51,7 +51,7 @@ for /f "delims=" %%i in ("%relcp:;=!newline!%") do (
     )
 )
 
-set "jvm_args=--enable-native-access=org.graalvm.truffle -Dorg.graalvm.launcher.shell=true "-Dorg.graalvm.launcher.executablename=%executablename%""
+set "jvm_args=<jvm_args> -Dorg.graalvm.launcher.shell=true "-Dorg.graalvm.launcher.executablename=%executablename%""
 set "launcher_args=<launcher_args>"
 
 :: Check option-holding variables.

--- a/sdk/mx.sdk/vm/launcher_template.sh
+++ b/sdk/mx.sdk/vm/launcher_template.sh
@@ -42,7 +42,7 @@ for e in "${relative_cp[@]}"; do
     absolute_cp+=("${location}/${e}")
 done
 
-jvm_args=("--enable-native-access=org.graalvm.truffle" "-Dorg.graalvm.launcher.shell=true" "-Dorg.graalvm.launcher.executablename=$0")
+jvm_args=(<jvm_args> "-Dorg.graalvm.launcher.shell=true" "-Dorg.graalvm.launcher.executablename=$0")
 launcher_args=(<launcher_args>)
 
 # Unfortunately, parsing of `--vm.*` arguments has to be done blind:


### PR DESCRIPTION
Since https://github.com/oracle/graal/pull/9892 got merged, passing the parameter `--enable-native-access=org.graalvm.truffle` to GraalVM builds not shipping the truffle api results in the following warning:

```
WARNING: Unknown module: org.graalvm.truffle specified to --enable-native-access
```

This patch checks whether the Truffle Runtime SVM component is part of the GraalVM distribution to figure out whether the parameter should be included or not.

Not sure if that's enough, or whether we should check for other components as well.

Fixes https://github.com/graalvm/mandrel/issues/805

cc @chumer @tzezula 