### PR TITLE
Increase max heap size of Native Image builder to match Quarkus' CI

### DIFF
--- a/.github/workflows/quarkus.yml
+++ b/.github/workflows/quarkus.yml
@@ -56,7 +56,7 @@ env:
   DB_NAME: hibernate_orm_test
   DB_PASSWORD: hibernate_orm_test
   DB_USER: hibernate_orm_test
-  NATIVE_TEST_MAVEN_ARGS: "-Dtest-containers -Dstart-containers -Dquarkus.native.native-image-xmx=5g -Dnative -Dnative.surefire.skip -Dformat.skip -Dno-descriptor-tests install -DskipDocs -Dquarkus.native.container-build=false"
+  NATIVE_TEST_MAVEN_ARGS: "-Dtest-containers -Dstart-containers -Dquarkus.native.native-image-xmx=6g -Dnative -Dnative.surefire.skip -Dformat.skip -Dno-descriptor-tests install -DskipDocs -Dquarkus.native.container-build=false"
   QUARKUS_JAVA_VERSION: 17 # Use Java 17 to build Quarkus as that's the lowest supported JDK version currently
   QUARKUS_PATH: ${{ github.workspace }}/quarkus
 


### PR DESCRIPTION
Since https://github.com/quarkusio/quarkus/pull/43862 the quarkus nightly builds have started failing (stopped by the watchdog) in the analysis phase of the micrometer-prometheus integration test. The reason appears to be an increase in the memory usage of the Native Image
builder due to the aforementioned change.

![image](https://github.com/user-attachments/assets/e3847844-3db3-4172-a891-63c55ac07395)

Since [Quarkus CI is already using 6g as the max heap size](https://github.com/quarkusio/quarkus/blob/49870be7a5a6188bb33dfa0fd3c2256dbb771454/.github/workflows/ci-actions-incremental.yml#L53). It makes sense to align this workflow with that limit.

FYI @radcortez @geoand