### PR TITLE
Implement Truffle compiler control based on HotSpot's CompileBroker compilation activity

### DIFF
--- a/truffle/src/com.oracle.truffle.compiler/src/com/oracle/truffle/compiler/TruffleCompilerRuntime.java
+++ b/truffle/src/com.oracle.truffle.compiler/src/com/oracle/truffle/compiler/TruffleCompilerRuntime.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * The Universal Permissive License (UPL), Version 1.0

--- a/truffle/src/com.oracle.truffle.compiler/src/com/oracle/truffle/compiler/TruffleCompilerRuntime.java
+++ b/truffle/src/com.oracle.truffle.compiler/src/com/oracle/truffle/compiler/TruffleCompilerRuntime.java
@@ -359,4 +359,31 @@ public interface TruffleCompilerRuntime {
      */
     boolean isSuppressedFailure(TruffleCompilable compilable, Supplier<String> serializedException);
 
+    /**
+     * Represents HotSpot's compilation activity mode which is one of:
+     * {@code stop_compilation = 0}, {@code run_compilation = 1} or {@code shutdown_compilation = 2}
+     * Should be in sync with the {@code CompilerActivity} enum in {@code hotspot/share/compiler/compileBroker.hpp}
+     */
+    enum CompilationActivityMode {
+        STOP_COMPILATION,
+        RUN_COMPILATION,
+        SHUTDOWN_COMPILATION;
+
+        static public CompilationActivityMode fromInteger(int i) {
+            return switch (i) {
+                case 0 -> STOP_COMPILATION;
+                case 1 -> RUN_COMPILATION;
+                case 2 -> SHUTDOWN_COMPILATION;
+                default -> throw new RuntimeException("Invalid CompilationActivityMode " + i);
+            };
+        }
+    }
+
+    /**
+     * Returns the current host compilation activity mode which is one of:
+     * {@code STOP_COMPILATION}, {@code RUN_COMPILATION} or {@code SHUTDOWN_COMPILATION}
+     */
+     default CompilationActivityMode getCompilationActivityMode() {
+         return CompilationActivityMode.RUN_COMPILATION;
+     }
 }

--- a/truffle/src/com.oracle.truffle.compiler/src/com/oracle/truffle/compiler/TruffleCompilerRuntime.java
+++ b/truffle/src/com.oracle.truffle.compiler/src/com/oracle/truffle/compiler/TruffleCompilerRuntime.java
@@ -358,32 +358,4 @@ public interface TruffleCompilerRuntime {
      * silent.
      */
     boolean isSuppressedFailure(TruffleCompilable compilable, Supplier<String> serializedException);
-
-    /**
-     * Represents HotSpot's compilation activity mode which is one of:
-     * {@code stop_compilation = 0}, {@code run_compilation = 1} or {@code shutdown_compilation = 2}
-     * Should be in sync with the {@code CompilerActivity} enum in {@code hotspot/share/compiler/compileBroker.hpp}
-     */
-    enum CompilationActivityMode {
-        STOP_COMPILATION,
-        RUN_COMPILATION,
-        SHUTDOWN_COMPILATION;
-
-        static public CompilationActivityMode fromInteger(int i) {
-            return switch (i) {
-                case 0 -> STOP_COMPILATION;
-                case 1 -> RUN_COMPILATION;
-                case 2 -> SHUTDOWN_COMPILATION;
-                default -> throw new RuntimeException("Invalid CompilationActivityMode " + i);
-            };
-        }
-    }
-
-    /**
-     * Returns the current host compilation activity mode which is one of:
-     * {@code STOP_COMPILATION}, {@code RUN_COMPILATION} or {@code SHUTDOWN_COMPILATION}
-     */
-     default CompilationActivityMode getCompilationActivityMode() {
-         return CompilationActivityMode.RUN_COMPILATION;
-     }
 }

--- a/truffle/src/com.oracle.truffle.runtime/src/com/oracle/truffle/runtime/BackgroundCompileQueue.java
+++ b/truffle/src/com.oracle.truffle.runtime/src/com/oracle/truffle/runtime/BackgroundCompileQueue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * The Universal Permissive License (UPL), Version 1.0

--- a/truffle/src/com.oracle.truffle.runtime/src/com/oracle/truffle/runtime/BackgroundCompileQueue.java
+++ b/truffle/src/com.oracle.truffle.runtime/src/com/oracle/truffle/runtime/BackgroundCompileQueue.java
@@ -218,7 +218,8 @@ public class BackgroundCompileQueue {
 
     /**
      * Return call targets waiting in queue. This does not include call targets currently being
-     * compiled.
+     * compiled. If {@code engine} is {@code null}, the call targets for all engines are returned,
+     * otherwise only the call targets belonging to {@code engine} will be returned.
      */
     public Collection<OptimizedCallTarget> getQueuedTargets(EngineData engine) {
         BlockingQueue<Runnable> queue = this.compilationQueue;
@@ -230,7 +231,7 @@ public class BackgroundCompileQueue {
         CompilationTask.ExecutorServiceWrapper[] array = queue.toArray(new CompilationTask.ExecutorServiceWrapper[0]);
         for (CompilationTask.ExecutorServiceWrapper wrapper : array) {
             OptimizedCallTarget target = wrapper.compileTask.targetRef.get();
-            if (target != null && target.engine == engine) {
+            if (target != null && (engine == null || target.engine == engine)) {
                 queuedTargets.add(target);
             }
         }

--- a/truffle/src/com.oracle.truffle.runtime/src/com/oracle/truffle/runtime/EngineData.java
+++ b/truffle/src/com.oracle.truffle.runtime/src/com/oracle/truffle/runtime/EngineData.java
@@ -502,7 +502,7 @@ public final class EngineData {
      * Only log compilation shutdowns (see {@code OptimizedCallTarget.isCompilationStopped()}) once
      * per engine.
      */
-    public final AtomicBoolean logShutdownCompilations() {
+    public AtomicBoolean logShutdownCompilations() {
         return logShutdownCompilations;
     }
 

--- a/truffle/src/com.oracle.truffle.runtime/src/com/oracle/truffle/runtime/EngineData.java
+++ b/truffle/src/com.oracle.truffle.runtime/src/com/oracle/truffle/runtime/EngineData.java
@@ -86,6 +86,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Function;
 import java.util.logging.Level;
 
@@ -493,6 +494,16 @@ public final class EngineData {
 
     public TruffleLogger getLogger(String loggerId) {
         return polyglotEngine != null ? loggerFactory.apply(loggerId) : null;
+    }
+
+    private final AtomicBoolean logShutdownCompilations = new AtomicBoolean(true);
+
+    /**
+     * Only log compilation shutdowns (see {@code OptimizedCallTarget.isCompilationStopped()}) once
+     * per engine.
+     */
+    public final AtomicBoolean logShutdownCompilations() {
+        return logShutdownCompilations;
     }
 
     @SuppressWarnings("static-method")

--- a/truffle/src/com.oracle.truffle.runtime/src/com/oracle/truffle/runtime/EngineData.java
+++ b/truffle/src/com.oracle.truffle.runtime/src/com/oracle/truffle/runtime/EngineData.java
@@ -68,6 +68,7 @@ import static com.oracle.truffle.runtime.OptimizedRuntimeOptions.SplittingGrowth
 import static com.oracle.truffle.runtime.OptimizedRuntimeOptions.SplittingMaxCalleeSize;
 import static com.oracle.truffle.runtime.OptimizedRuntimeOptions.SplittingMaxPropagationDepth;
 import static com.oracle.truffle.runtime.OptimizedRuntimeOptions.SplittingTraceEvents;
+import static com.oracle.truffle.runtime.OptimizedRuntimeOptions.StoppedCompilationRetryDelay;
 import static com.oracle.truffle.runtime.OptimizedRuntimeOptions.TraceCompilation;
 import static com.oracle.truffle.runtime.OptimizedRuntimeOptions.TraceCompilationDetails;
 import static com.oracle.truffle.runtime.OptimizedRuntimeOptions.TraceDeoptimizeFrame;
@@ -148,6 +149,7 @@ public final class EngineData {
     @CompilationFinal public boolean traceDeoptimizeFrame;
     @CompilationFinal public boolean compileAOTOnCreate;
     @CompilationFinal public boolean firstTierOnly;
+    @CompilationFinal public long stoppedCompilationRetryDelay;
 
     // compilation queue options
     @CompilationFinal public boolean priorityQueue;
@@ -305,6 +307,7 @@ public final class EngineData {
         this.firstTierOnly = options.get(Mode) == EngineModeEnum.LATENCY;
         this.propagateCallAndLoopCount = options.get(PropagateLoopCountToLexicalSingleCaller);
         this.propagateCallAndLoopCountMaxDepth = options.get(PropagateLoopCountToLexicalSingleCallerMaxDepth);
+        this.stoppedCompilationRetryDelay = options.get(StoppedCompilationRetryDelay);
 
         // compilation queue options
         priorityQueue = options.get(PriorityQueue);

--- a/truffle/src/com.oracle.truffle.runtime/src/com/oracle/truffle/runtime/OptimizedCallTarget.java
+++ b/truffle/src/com.oracle.truffle.runtime/src/com/oracle/truffle/runtime/OptimizedCallTarget.java
@@ -84,6 +84,7 @@ import com.oracle.truffle.api.nodes.NodeVisitor;
 import com.oracle.truffle.api.nodes.RootNode;
 import com.oracle.truffle.compiler.TruffleCompilable;
 import com.oracle.truffle.runtime.OptimizedRuntimeOptions.ExceptionAction;
+import com.oracle.truffle.runtime.OptimizedTruffleRuntime.CompilationActivityMode;
 
 import jdk.vm.ci.meta.JavaConstant;
 import jdk.vm.ci.meta.SpeculationLog;
@@ -858,58 +859,60 @@ public abstract class OptimizedCallTarget implements TruffleCompilable, RootCall
         return compilationFailed;
     }
 
-    final boolean isCompilationStopped() {
-        OptimizedTruffleRuntime.CompilationActivityMode compilationActivityMode = runtime().getCompilationActivityMode();
+    final CompilationActivityMode getCompilationActivityMode() {
+        CompilationActivityMode compilationActivityMode = runtime().getCompilationActivityMode();
         long sct = runtime().stoppedCompilationTime().get();
-        if (compilationActivityMode == OptimizedTruffleRuntime.CompilationActivityMode.STOP_COMPILATION) {
+        if (compilationActivityMode == CompilationActivityMode.STOP_COMPILATION) {
             if (sct != 0 && System.currentTimeMillis() - sct > engine.stoppedCompilationRetryDelay) {
                 runtime().stoppedCompilationTime().compareAndSet(sct, 0);
-                // Try again every StoppedCompilationRetryDelay milliseconds to potentially trigger a code cache sweep.
-                compilationActivityMode = OptimizedTruffleRuntime.CompilationActivityMode.RUN_COMPILATION;
+                // Try again every StoppedCompilationRetryDelay milliseconds to potentially trigger
+                // a code cache sweep.
+                compilationActivityMode = CompilationActivityMode.RUN_COMPILATION;
             }
         }
 
         switch (compilationActivityMode) {
-            case RUN_COMPILATION : {
+            case RUN_COMPILATION: {
                 // This is the common case - compilations are not stopped.
-                return false;
+                return CompilationActivityMode.RUN_COMPILATION;
             }
-            case STOP_COMPILATION : {
+            case STOP_COMPILATION: {
                 if (sct == 0) {
                     runtime().stoppedCompilationTime().compareAndSet(0, System.currentTimeMillis());
                 }
                 // Flush the compilations queue for now. There's still a chance that compilation
                 // will be re-enabled eventually, if the hosts code cache can be cleaned up.
                 Collection<OptimizedCallTarget> targets = runtime().getCompileQueue().getQueuedTargets(null);
-                // If there's just a single compilation target in the queue, the chance is high that it is
-                // the one we've just added after the StoppedCompilationRetryDelay ran out, so keep it to
-                // potentially trigger a code cache sweep.
+                // If there's just a single compilation target in the queue, the chance is high that
+                // it is the one we've just added after the StoppedCompilationRetryDelay ran out, so
+                // keep it to potentially trigger a code cache sweep.
                 if (targets.size() > 1) {
                     for (OptimizedCallTarget target : targets) {
                         target.cancelCompilation("Compilation temporary disabled due to full code cache.");
                     }
                 }
-                return true;
+                return CompilationActivityMode.STOP_COMPILATION;
             }
-            case SHUTDOWN_COMPILATION : {
+            case SHUTDOWN_COMPILATION: {
                 // Compilation was shut down permanently because the hosts code cache ran full and
                 // the host was configured without support for code cache sweeping.
                 TruffleLogger logger = engine.getLogger("engine");
                 // The logger can be null if the engine is closed.
-                if (logger != null && runtime().logShutdownCompilations().compareAndExchange(true, false)) {
-                    logger.log(Level.WARNING, "Truffle compilations permanently disabled because of full code cache. "  +
-                            "Increase the code cache size using '-XX:ReservedCodeCacheSize=' and/or run with '-XX:+UseCodeCacheFlushing -XX:+MethodFlushing'.");
+                if (logger != null && engine.logShutdownCompilations().compareAndExchange(true, false)) {
+                    logger.log(Level.WARNING, "Truffle compilations permanently disabled because of full code cache. " +
+                                    "Increase the code cache size using '-XX:ReservedCodeCacheSize=' and/or run with '-XX:+UseCodeCacheFlushing -XX:+MethodFlushing'.");
                 }
-                try {
-                    runtime().getCompileQueue().shutdownAndAwaitTermination(100 /* milliseconds */);
-                } catch (RuntimeException re) {
-                    // Best effort, ignore failure
+                // Flush the compilation queue and mark all methods as not compilable.
+                for (OptimizedCallTarget target : runtime().getCompileQueue().getQueuedTargets(null)) {
+                    target.cancelCompilation("Compilation permanently disabled due to full code cache.");
+                    target.compilationFailed = true;
                 }
-                return true;
+                return CompilationActivityMode.SHUTDOWN_COMPILATION;
             }
-            default : CompilerDirectives.shouldNotReachHere("Invalid compilation activity mode: " + compilationActivityMode);
+            default:
+                CompilerDirectives.shouldNotReachHere("Invalid compilation activity mode: " + compilationActivityMode);
         }
-        return false;
+        return CompilationActivityMode.RUN_COMPILATION;
     }
 
     /**
@@ -931,16 +934,21 @@ public abstract class OptimizedCallTarget implements TruffleCompilable, RootCall
                 return false;
             }
 
+            CompilationActivityMode cam = getCompilationActivityMode();
+            if (cam != CompilationActivityMode.RUN_COMPILATION) {
+                if (cam == CompilationActivityMode.SHUTDOWN_COMPILATION) {
+                    // Compilation was shut down permanently.
+                    compilationFailed = true;
+                }
+                return false;
+            }
+
             CompilationTask task = null;
             // Do not try to compile this target concurrently,
             // but do not block other threads if compilation is not asynchronous.
             synchronized (this) {
                 if (!needsCompile(lastTier)) {
                     return true;
-                }
-
-                if (isCompilationStopped()) {
-                    return false;
                 }
 
                 ensureInitialized();

--- a/truffle/src/com.oracle.truffle.runtime/src/com/oracle/truffle/runtime/OptimizedRuntimeOptions.java
+++ b/truffle/src/com.oracle.truffle.runtime/src/com/oracle/truffle/runtime/OptimizedRuntimeOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * The Universal Permissive License (UPL), Version 1.0
@@ -158,14 +158,14 @@ public final class OptimizedRuntimeOptions {
     // TODO: GR-29949
     public static final OptionKey<Long> CompilerIdleDelay = new OptionKey<>(10000L);
 
-    @Option(help = "Before the Truffle runtime submits an OptimizedCallTarget for compilation, it checks for the " +
-                   "compilation activity mode in the host VM. If the activity mode indicates a full code " +
-                   "cache, no new compilation requests are submitted and the compilation queue is flushed. " +
-                   "After 'StoppedCompilationRetryDelay' milliseconds new compilations will be submitted again " +
-                   "(which might trigger a sweep of the code cache and a reset of the compilation activity mode in the host JVM)." +
-                   "The option is only supported on the HotSpot Truffle runtime. On runtimes which don't support it the option has no effect. default: 1000",
-                   usageSyntax = "<ms>", category = OptionCategory.EXPERT)
-    public static final OptionKey<Long> StoppedCompilationRetryDelay = new OptionKey<>(1000L);
+    @Option(help = "Before the Truffle runtime submits an OptimizedCallTarget for compilation, it checks for the compilation " +
+                    "activity mode in the host VM. If the activity mode indicates a full code cache, no new compilation " +
+                    "requests are submitted and the compilation queue is flushed. After 'StoppedCompilationRetryDelay' " +
+                    "milliseconds new compilations will be submitted again (which might trigger a sweep of the code " +
+                    "cache and a reset of the compilation activity mode in the host JVM). The option is only supported on " +
+                    "the HotSpot Truffle runtime. On runtimes which don't support it the option has no effect. default: 5000", //
+                    usageSyntax = "<ms>", category = OptionCategory.EXPERT) //
+    public static final OptionKey<Long> StoppedCompilationRetryDelay = new OptionKey<>(5000L);
 
     @Option(help = "Manually set the number of compiler threads. By default, the number of compiler threads is scaled with the number of available cores on the CPU.", usageSyntax = "[1, inf)", category = OptionCategory.EXPERT, //
                     stability = OptionStability.STABLE, sandbox = SandboxPolicy.UNTRUSTED) //

--- a/truffle/src/com.oracle.truffle.runtime/src/com/oracle/truffle/runtime/OptimizedRuntimeOptions.java
+++ b/truffle/src/com.oracle.truffle.runtime/src/com/oracle/truffle/runtime/OptimizedRuntimeOptions.java
@@ -159,10 +159,11 @@ public final class OptimizedRuntimeOptions {
     public static final OptionKey<Long> CompilerIdleDelay = new OptionKey<>(10000L);
 
     @Option(help = "Before the Truffle runtime submits an OptimizedCallTarget for compilation, it checks for the " +
-                   "compilation activity mode in the host VM. If the activity mode is 'STOP_COMPILATION' because " +
-                   "of a full code cache, no new compilation requests are submitted and the compilation queue is flushed. " +
+                   "compilation activity mode in the host VM. If the activity mode indicates a full code " +
+                   "cache, no new compilation requests are submitted and the compilation queue is flushed. " +
                    "After 'StoppedCompilationRetryDelay' milliseconds new compilations will be submitted again " +
-                   "(which might trigger a sweep of the code cache and a reset of the compilation activity mode in the host JVM).",
+                   "(which might trigger a sweep of the code cache and a reset of the compilation activity mode in the host JVM)." +
+                   "The option is only supported on the HotSpot Truffle runtime. On runtimes which don't support it the option has no effect. default: 1000",
                    usageSyntax = "<ms>", category = OptionCategory.EXPERT)
     public static final OptionKey<Long> StoppedCompilationRetryDelay = new OptionKey<>(1000L);
 

--- a/truffle/src/com.oracle.truffle.runtime/src/com/oracle/truffle/runtime/OptimizedRuntimeOptions.java
+++ b/truffle/src/com.oracle.truffle.runtime/src/com/oracle/truffle/runtime/OptimizedRuntimeOptions.java
@@ -158,6 +158,14 @@ public final class OptimizedRuntimeOptions {
     // TODO: GR-29949
     public static final OptionKey<Long> CompilerIdleDelay = new OptionKey<>(10000L);
 
+    @Option(help = "Before the Truffle runtime submits an OptimizedCallTarget for compilation, it checks for the " +
+                   "compilation activity mode in the host VM. If the activity mode is 'STOP_COMPILATION' because " +
+                   "of a full code cache, no new compilation requests are submitted and the compilation queue is flushed. " +
+                   "After 'StoppedCompilationRetryDelay' milliseconds new compilations will be submitted again " +
+                   "(which might trigger a sweep of the code cache and a reset of the compilation activity mode in the host JVM).",
+                   usageSyntax = "<ms>", category = OptionCategory.EXPERT)
+    public static final OptionKey<Long> StoppedCompilationRetryDelay = new OptionKey<>(1000L);
+
     @Option(help = "Manually set the number of compiler threads. By default, the number of compiler threads is scaled with the number of available cores on the CPU.", usageSyntax = "[1, inf)", category = OptionCategory.EXPERT, //
                     stability = OptionStability.STABLE, sandbox = SandboxPolicy.UNTRUSTED) //
     public static final OptionKey<Integer> CompilerThreads = new OptionKey<>(-1);

--- a/truffle/src/com.oracle.truffle.runtime/src/com/oracle/truffle/runtime/OptimizedTruffleRuntime.java
+++ b/truffle/src/com.oracle.truffle.runtime/src/com/oracle/truffle/runtime/OptimizedTruffleRuntime.java
@@ -41,7 +41,6 @@
 package com.oracle.truffle.runtime;
 
 import static com.oracle.truffle.runtime.OptimizedRuntimeOptions.CompilerIdleDelay;
-import static com.oracle.truffle.runtime.OptimizedRuntimeOptions.StoppedCompilationRetryDelay;
 
 import java.io.CharArrayWriter;
 import java.io.PrintWriter;

--- a/truffle/src/com.oracle.truffle.runtime/src/com/oracle/truffle/runtime/OptimizedTruffleRuntime.java
+++ b/truffle/src/com.oracle.truffle.runtime/src/com/oracle/truffle/runtime/OptimizedTruffleRuntime.java
@@ -64,6 +64,8 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 import java.util.logging.Level;
@@ -913,45 +915,23 @@ public abstract class OptimizedTruffleRuntime implements TruffleRuntime, Truffle
     protected void onEngineCreated(EngineData engine) {
     }
 
-    private long stoppedCompilationTime = 0;
-    private boolean logShutdownCompilations = true;
+
+    private final AtomicLong stoppedCompilationTime = new AtomicLong(0);
+
+    public final AtomicLong stoppedCompilationTime() {
+        return stoppedCompilationTime;
+    }
+
+    private final AtomicBoolean logShutdownCompilations = new AtomicBoolean(true);
+
+    public final AtomicBoolean logShutdownCompilations() {
+        return logShutdownCompilations;
+    }
 
     @SuppressWarnings("try")
     public CompilationTask submitForCompilation(OptimizedCallTarget optimizedCallTarget, boolean lastTierCompilation) {
-        BackgroundCompileQueue queue = getCompileQueue();
-        CompilationActivityMode compilationActivityMode = getCompilationActivityMode();
-        if (compilationActivityMode == CompilationActivityMode.RUN_COMPILATION ||
-                (stoppedCompilationTime != 0 && System.currentTimeMillis() - stoppedCompilationTime > optimizedCallTarget.getOptionValue(StoppedCompilationRetryDelay))) {
-            stoppedCompilationTime = 0;
-            Priority priority = new Priority(optimizedCallTarget.getCallAndLoopCount(), lastTierCompilation ? Priority.Tier.LAST : Priority.Tier.FIRST);
-            return queue.submitCompilation(priority, optimizedCallTarget);
-        } else if (compilationActivityMode == CompilationActivityMode.STOP_COMPILATION) {
-            if (stoppedCompilationTime == 0) {
-                stoppedCompilationTime = System.currentTimeMillis();
-            }
-            // Flush the compilations queue. There's still a chance that compilation will be re-enabled
-            // eventually, if the hosts code cache can be cleaned up.
-            for (OptimizedCallTarget target : queue.getQueuedTargets(optimizedCallTarget.engine)) {
-                target.cancelCompilation("Compilation temporary disabled due to full code cache.");
-            }
-        } else {
-            // Compilation was shut down permanently because the hosts code cache ran full and
-            // the host was configured without support for code cache sweeping.
-            assert compilationActivityMode == CompilationActivityMode.SHUTDOWN_COMPILATION;
-            TruffleLogger logger = optimizedCallTarget.engine.getLogger("engine");
-            // The logger can be null if the engine is closed.
-            if (logger != null && logShutdownCompilations) {
-                logShutdownCompilations = false;
-                logger.log(Level.WARNING, "Truffle host compilations permanently disabled because of full code cache. "  +
-                    "Increase the code cache size using '-XX:ReservedCodeCacheSize=' and/or run with '-XX:+UseCodeCacheFlushing -XX:+MethodFlushing'.");
-            }
-            try {
-                queue.shutdownAndAwaitTermination(100 /* milliseconds */);
-            } catch (RuntimeException re) {
-                // Best effort, ignore failure
-            }
-        }
-        return null;
+        Priority priority = new Priority(optimizedCallTarget.getCallAndLoopCount(), lastTierCompilation ? Priority.Tier.LAST : Priority.Tier.FIRST);
+        return getCompileQueue().submitCompilation(priority, optimizedCallTarget);
     }
 
     @SuppressWarnings("all")
@@ -1519,4 +1499,30 @@ public abstract class OptimizedTruffleRuntime implements TruffleRuntime, Truffle
         }
     }
 
+    /**
+     * Represents HotSpot's compilation activity mode which is one of:
+     * {@code stop_compilation = 0}, {@code run_compilation = 1} or {@code shutdown_compilation = 2}
+     * Should be in sync with the {@code CompilerActivity} enum in {@code hotspot/share/compiler/compileBroker.hpp}
+     */
+    public enum CompilationActivityMode {
+        STOP_COMPILATION,
+        RUN_COMPILATION,
+        SHUTDOWN_COMPILATION;
+
+        static public CompilationActivityMode fromInteger(int i) {
+            return switch (i) {
+                case 0 -> STOP_COMPILATION;
+                case 1 -> RUN_COMPILATION;
+                case 2 -> SHUTDOWN_COMPILATION;
+                default -> throw new RuntimeException("Invalid CompilationActivityMode " + i);
+            };
+        }
+    }
+
+    /**
+     * Returns the current host compilation activity mode. The default is to run compilations.
+     */
+    public CompilationActivityMode getCompilationActivityMode() {
+        return CompilationActivityMode.RUN_COMPILATION;
+    }
 }

--- a/truffle/src/com.oracle.truffle.runtime/src/com/oracle/truffle/runtime/OptimizedTruffleRuntime.java
+++ b/truffle/src/com.oracle.truffle.runtime/src/com/oracle/truffle/runtime/OptimizedTruffleRuntime.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * The Universal Permissive License (UPL), Version 1.0
@@ -63,7 +63,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
@@ -914,17 +913,10 @@ public abstract class OptimizedTruffleRuntime implements TruffleRuntime, Truffle
     protected void onEngineCreated(EngineData engine) {
     }
 
-
     private final AtomicLong stoppedCompilationTime = new AtomicLong(0);
 
     public final AtomicLong stoppedCompilationTime() {
         return stoppedCompilationTime;
-    }
-
-    private final AtomicBoolean logShutdownCompilations = new AtomicBoolean(true);
-
-    public final AtomicBoolean logShutdownCompilations() {
-        return logShutdownCompilations;
     }
 
     @SuppressWarnings("try")
@@ -1499,9 +1491,9 @@ public abstract class OptimizedTruffleRuntime implements TruffleRuntime, Truffle
     }
 
     /**
-     * Represents HotSpot's compilation activity mode which is one of:
-     * {@code stop_compilation = 0}, {@code run_compilation = 1} or {@code shutdown_compilation = 2}
-     * Should be in sync with the {@code CompilerActivity} enum in {@code hotspot/share/compiler/compileBroker.hpp}
+     * Represents HotSpot's compilation activity mode which is one of: {@code stop_compilation = 0},
+     * {@code run_compilation = 1} or {@code shutdown_compilation = 2} Should be in sync with the
+     * {@code CompilerActivity} enum in {@code hotspot/share/compiler/compileBroker.hpp}
      */
     public enum CompilationActivityMode {
         STOP_COMPILATION,

--- a/truffle/src/com.oracle.truffle.runtime/src/com/oracle/truffle/runtime/OptimizedTruffleRuntime.java
+++ b/truffle/src/com.oracle.truffle.runtime/src/com/oracle/truffle/runtime/OptimizedTruffleRuntime.java
@@ -1492,15 +1492,15 @@ public abstract class OptimizedTruffleRuntime implements TruffleRuntime, Truffle
 
     /**
      * Represents HotSpot's compilation activity mode which is one of: {@code stop_compilation = 0},
-     * {@code run_compilation = 1} or {@code shutdown_compilation = 2} Should be in sync with the
-     * {@code CompilerActivity} enum in {@code hotspot/share/compiler/compileBroker.hpp}
+     * {@code run_compilation = 1} or {@code shutdown_compilation = 2}. Should be in sync with the
+     * {@code CompilerActivity} enum in {@code hotspot/share/compiler/compileBroker.hpp}.
      */
     public enum CompilationActivityMode {
         STOP_COMPILATION,
         RUN_COMPILATION,
         SHUTDOWN_COMPILATION;
 
-        static public CompilationActivityMode fromInteger(int i) {
+        public static CompilationActivityMode fromInteger(int i) {
             return switch (i) {
                 case 0 -> STOP_COMPILATION;
                 case 1 -> RUN_COMPILATION;

--- a/truffle/src/com.oracle.truffle.runtime/src/com/oracle/truffle/runtime/hotspot/HotSpotTruffleRuntime.java
+++ b/truffle/src/com.oracle.truffle.runtime/src/com/oracle/truffle/runtime/hotspot/HotSpotTruffleRuntime.java
@@ -695,19 +695,20 @@ public final class HotSpotTruffleRuntime extends OptimizedTruffleRuntime {
         return compilationSupport instanceof LibGraalTruffleCompilationSupport;
     }
 
-    static MethodHandle getCompilationActivityMode;
+    static final MethodHandle getCompilationActivityMode;
     static {
+        MethodHandle mHandle = null;
         try {
             MethodType mt = MethodType.methodType(int.class);
-            getCompilationActivityMode = MethodHandles.lookup().findVirtual(HotSpotJVMCIRuntime.class, "getCompilationActivityMode", mt);
+            mHandle = MethodHandles.lookup().findVirtual(HotSpotJVMCIRuntime.class, "getCompilationActivityMode", mt);
         } catch (NoSuchMethodException | IllegalAccessException e) {
             // Older JVMCI runtimes might not support `getCompilationActivityMode()`
         }
+        getCompilationActivityMode = mHandle;
     }
 
     /**
-     * Returns the current host compilation activity mode which is one of:
-     * {@code stop_compilation = 0}, {@code run_compilation = 1} or {@code shutdown_compilation = 2}
+     * Returns the current host compilation activity mode based on HotSpot's code cache state.
      */
     @Override
     public CompilationActivityMode getCompilationActivityMode() {
@@ -716,7 +717,7 @@ public final class HotSpotTruffleRuntime extends OptimizedTruffleRuntime {
             try {
                 activityMode = (int) getCompilationActivityMode.invokeExact(HotSpotJVMCIRuntime.runtime());
             } catch (Throwable t) {
-                // Ignore and go with the default mode
+                throw new RuntimeException("Can't get HotSpot's compilation activity mode", t);
             }
         }
         return CompilationActivityMode.fromInteger(activityMode);

--- a/truffle/src/com.oracle.truffle.runtime/src/com/oracle/truffle/runtime/hotspot/HotSpotTruffleRuntime.java
+++ b/truffle/src/com.oracle.truffle.runtime/src/com/oracle/truffle/runtime/hotspot/HotSpotTruffleRuntime.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * The Universal Permissive License (UPL), Version 1.0


### PR DESCRIPTION
Truffle compilations run in "hosted" mode, i.e. the Truffle runtimes triggers compilations independently of HotSpot's [`CompileBroker`](https://github.com/openjdk/jdk/blob/8f22db23a50fe537d8ef369e92f0d5f9970d98f0/src/hotspot/share/compiler/compileBroker.hpp). But the results of Truffle compilations are still stored as ordinary nmethods in HotSpot's code cache (with the help of the JVMCI method `jdk.vm.ci.hotspot.HotSpotCodeCacheProvider::installCode()`). The regular JIT compilers are controlled by the `CompileBroker` which is aware of the code cache occupancy. If the code cache runs full, the `CompileBroker` temporary pauses any subsequent JIT compilations until the code cache gets swept (if running with `-XX:+UseCodeCacheFlushing -XX:+MethodFlushing` which is the default) or completely shuts down the JIT compilers if running with `-XX:+UseCodeCacheFlushing`.

Truffle compiled methods can contribute significantly to the overall code cache occupancy and they can trigger JIT compilation stalls if they fill the code cache up. But the Truffle framework itself is neither aware of the current code cache occupancy, nor of the compilation activity of the `CompileBroker`. If Truffle tries to install a compiled method through JVMCI and the code cache is full, it will silently fail. Currently Truffle interprets such failures as transient errors and basically ignores it. Whenever the corresponding method gets hot again (usually immediately at the next invocation), Truffle will recompile it again just to fail again in the nmethod installation step, if the code cache is still full.

When the code cache is tight, this can lead to situations, where Truffle is unnecessarily and repeatedly compiling methods which can't be installed in the code cache but produce a significant CPU load. Instead, Truffle should poll HotSpot's `CompileBroker` compilation activity and paus compilations for the time the `CompileBroker` is pausing JIT compilations (or completely shutdown Truffle compilations if the `CompileBroker` shut down the JIT compilers).

The corresponding JVMCI change is tracked under [JDK-8344727: [JVMCI] Export the CompileBroker compilation activity mode for Truffle compiler control](https://bugs.openjdk.org/browse/JDK-8344727).

This PR fixes the problem by checking HotSpot's compilation activity mode in `OptimizedTruffleRuntime::submitForCompilation()` before actually submitting a compilation task to a compile queue. If the compilation activity mode is `RUN_COMPILATION` the task is submitted as before without any changes. However, if the compilation activity mode is `STOP_COMPILATION` (i.e. the `CompileBroker` has temporarily stopped JIT compilations, we flush the current compile queue (because compiled methods can not be installed anyway) and return `null`. We also start a timer which can be configured with the new `StoppedCompilationRetryDelay` parameter (defaults to 1000ms). After `StoppedCompilationRetryDelay` we submit a new compilation task, even if the compilation activity mode is not `RUN_COMPILATION`. This can help to trigger a code cache cleanup in situations when there are no JIT compilations, because code cache sweeping is only triggered when new nmethods are installed. Finally, when the compilation activity mode is `SHUTDOWN_COMPILATION`, we simply shutdown the compilation queue and issue a warning to inform users about the code cache shortage.

I've manually tested the change by running an octane benchmark with a very small code cache. Before the change, we could see the following results:
```
RayTrace: 484
----
Score (version 9): 484

[engine] Truffle runtime statistics for engine 1
    Compilations                : 2255
      Success                   : 549
      Temporary Bailouts        : 1703
        jdk.vm.ci.code.BailoutException: Code installation failed: code cache is full: 1702
      Permanent Bailouts        : 0
      Failed                    : 0
      Interrupted               : 3
    Invalidated                 : 0
    Queues                      : 2480
    Dequeues                    : 30
        Target inlined into only caller: 30
    Splits                      : 156
    Compilation Accuracy        : 1.000000
    Queue Accuracy              : 0.987903
    Compilation Utilization     : 2.948298
    Remaining Compilation Queue : 195
    Time to queue               : count=2480, sum=187025989722, min=   60029, average= 75413705.53, max=181007679, maxTarget=cross
    Time waiting in queue       : count=2254, sum=1385581671, min=      54, average=   614721.24, max=156182217, maxTarget=Function.prototype.apply <split-322>

    JVMCI CompileBroker Time:
       Compile:          0,000 s
       Install Code:     0,000 s (installs: 0, CodeBlob total size: 0, CodeBlob code size: 0)

    JVMCI Hosted Time:
       Install Code:    27,227 s (installs: 565, CodeBlob total size: 5916736, CodeBlob code size: 1713432)

  nmethod code size         :  6834896 bytes
  nmethod total size        : 14834520 bytes
CodeCache: size=3896Kb used=3458Kb max_used=3586Kb free=437Kb
 bounds [0x00007ffff436d000, 0x00007ffff473b000, 0x00007ffff473b000]
 total_blobs=1378 nmethods=566 adapters=714
 compilation: disabled (not enough contiguous free space left)
              stopped_count=26, restarted_count=25
 full_count=3200

real	3m11,398s
user	11m19,363s
sys	0m9,387s
```

As you can see, out of 2255 compilations, 1702 have been to no purpose, because they failed in the final installation step because of a full code cache (i.e. `BailoutException: Code installation failed: code cache is full: 1702`). The other interesting observation is that although the benchmark terminated after 3min11s wall clock time, it actually consumed 11m19s cpu time, because the Truffle compiler threads where continuously doing useless work.

With my changes applied, the picture looks as follows:
```
RayTrace: 531
----
Score (version 9): 531


[engine] Truffle runtime statistics for engine 1
    Compilations                : 128
      Success                   : 111
      Temporary Bailouts        : 17
        jdk.vm.ci.code.BailoutException: Code installation failed: code cache is full: 16
        org.graalvm.compiler.core.common.CancellationBailoutException: Compilation cancelled.: 1
      Permanent Bailouts        : 0
      Failed                    : 0
      Interrupted               : 0
    Invalidated                 : 0
    Queues                      : 410
    Dequeues                    : 283
        Compilation temporary disabled due to full code cache.: 277
        Target inlined into only caller: 6
    Splits                      : 156
    Compilation Accuracy        : 1.000000
    Queue Accuracy              : 0.309756
    Compilation Utilization     : 0.069104
    Remaining Compilation Queue : 0
    Time to queue               : count= 410, sum=24979066360, min=   88714, average= 60924552.10, max=186708180, maxTarget=blend
    Time waiting in queue       : count= 128, sum=  22955820, min=       6, average=   179342.35, max=  724639, maxTarget=:anonymous <split-344>

    JVMCI CompileBroker Time:
       Compile:          0,000 s
       Install Code:     0,000 s (installs: 0, CodeBlob total size: 0, CodeBlob code size: 0)

    JVMCI Hosted Time:
       Install Code:     0,637 s (installs: 124, CodeBlob total size: 1156760, CodeBlob code size: 321496)

  nmethod code size         :  2460456 bytes
  nmethod total size        :  4833272 bytes
CodeCache: size=3896Kb used=3464Kb max_used=3537Kb free=431Kb
 bounds [0x00007ffff436d000, 0x00007ffff473b000, 0x00007ffff473b000]
 total_blobs=1557 nmethods=745 adapters=714
 compilation: disabled (not enough contiguous free space left)
              stopped_count=5, restarted_count=4
 full_count=33

real	3m14,756s
user	3m22,013s
sys	0m1,044s
```

As you can see, we compile considerably fewer methods and we only have 16 compilation failures due to a full code cache. At the same time we can see that from the 410 methods which have been enqueued for compilation, 277 have been dequeued because of `Compilation temporary disabled due to full code cache`. Again, the wall clock time of the benchmark was 3m14s but this time, the overall cpu time was just slightly higher with 3m22s because we haven't done such a huge amount of unnecessary compilations any more. Also notice how HotSpot's code cache `full_count`, which is incremented every time when a nmethod can't be installed because of a full code cache, dropped from 3200 to 33.

These example were run with `-XX:+UseCodeCacheFlushing -XX:+MethodFlushing`. If the JVM is configured with `-XX:-UseCodeCacheFlushing`, the benefits of this change are even higher.

Fixes #10133 