### PR TITLE
[GR-60173] Register custom module-info compilation participant for JDK builds without JMODs

### DIFF
--- a/common.json
+++ b/common.json
@@ -4,7 +4,7 @@
     "Jsonnet files should not include this file directly but use ci/common.jsonnet instead."
   ],
 
-  "mx_version": "7.34.1",
+  "mx_version": "7.35.1",
 
   "COMMENT.jdks": "When adding or removing JDKs keep in sync with JDKs in ci/common.jsonnet",
   "jdks": {

--- a/substratevm/mx.substratevm/suite.py
+++ b/substratevm/mx.substratevm/suite.py
@@ -1,6 +1,6 @@
 # pylint: disable=line-too-long
 suite = {
-    "mxversion": "7.33.1",
+    "mxversion": "7.35.1",
     "name": "substratevm",
     "version" : "24.2.0",
     "release" : False,


### PR DESCRIPTION
With [JEP 493](https://openjdk.org/jeps/493), part of JDK 24, it's possible to have JDK builds without the `jmods` folder. Currently substratevm builds assume `jmods` are always present. This patch adds an extension to mx so as to produce custom javac args when specific substratevm dependencies get compiled.

All of this is activated only when `--no-jlinking` option is being used. It's a no-op for regular GraalVM builds.

This patch depends on (which adds the needed abstractions to mx):
https://github.com/graalvm/mx/pull/287

Edit: `mx` version `7.35.1` has the needed dependency. This is what https://github.com/oracle/graal/pull/10161/commits/485f2eb9d0788d2cfe7c99be6f50d9905a996929 updates to.

Closes: https://github.com/graalvm/mandrel/issues/808