### PR TITLE
[GR-60176] JFR Old Object Sampler fixes

### DIFF
--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/oldobject/JfrOldObjectSampler.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/oldobject/JfrOldObjectSampler.java
@@ -120,9 +120,12 @@ final class JfrOldObjectSampler {
             next.increaseSpan(sample.getSpan());
             queue.add(next);
         } else {
-            /* No remaining elements, we can't redistribute the weight. */
+            /*
+             * No younger element, we can't redistribute the weight. The next sample should absorb
+             * the extra span.
+             */
             totalInQueue = totalInQueue.subtract(sample.getSpan());
-            assert totalInQueue.equal(0);
+            assert totalInQueue.aboveOrEqual(0);
         }
         queue.remove(sample);
         release(sample);

--- a/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/jfr/oldobject/TestOldObjectProfiler.java
+++ b/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/jfr/oldobject/TestOldObjectProfiler.java
@@ -48,8 +48,10 @@ import jdk.graal.compiler.api.directives.GraalDirectives;
 
 public class TestOldObjectProfiler extends AbstractJfrTest {
 
-    /* Old object samples will not have allocation ticks set correctly if JfrTicks is not first initialized.
-    * We need to create the first JFR recording to lazily initialize JfrTicks.*/
+    /*
+     * Old object samples will not have allocation ticks set correctly if JfrTicks is not first
+     * initialized. We need to create the first JFR recording to lazily initialize JfrTicks.
+     */
     @BeforeClass
     public static void initializeJfrTicks() {
         GraalDirectives.blackhole(new Recording());

--- a/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/jfr/oldobject/TestOldObjectProfiler.java
+++ b/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/jfr/oldobject/TestOldObjectProfiler.java
@@ -33,8 +33,10 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+import jdk.jfr.Recording;
 import org.graalvm.word.WordFactory;
 import org.junit.Assert;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import com.oracle.svm.core.jfr.HasJfrSupport;
@@ -45,6 +47,14 @@ import com.oracle.svm.test.jfr.AbstractJfrTest;
 import jdk.graal.compiler.api.directives.GraalDirectives;
 
 public class TestOldObjectProfiler extends AbstractJfrTest {
+
+    /* Old object samples will not have allocation ticks set correctly if JfrTicks is not first initialized.
+    * We need to create the first JFR recording to lazily initialize JfrTicks.*/
+    @BeforeClass
+    public static void initializeJfrTicks() {
+        GraalDirectives.blackhole(new Recording());
+    }
+
     @Test
     public void testScavenge() {
         int count = 10;


### PR DESCRIPTION
A couple small fixes.  To address the errors found here: https://github.com/oracle/graal/pull/10154#issuecomment-2506190888

1. Fix an incorrect assertion. Previously when a younger sample neighbor could not be found, we assumed that the queue was empty. This is not true. It might just be the case that the sample being removed already is the youngest in the queue, so has no younger neighbor. 
2. Initialize JFR before running the JFR leak profiler tests. Please see code comment for explanation. 