### PR TITLE
Intrinsic for AArch64 Arrays.fill(array, constant)

### DIFF
--- a/compiler/src/jdk.graal.compiler.test/src/jdk/graal/compiler/replacements/test/ArraysFillTest.java
+++ b/compiler/src/jdk.graal.compiler.test/src/jdk/graal/compiler/replacements/test/ArraysFillTest.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package jdk.graal.compiler.replacements.test;
+
+import java.util.Arrays;
+
+import org.junit.Assume;
+import org.junit.Test;
+
+import jdk.graal.compiler.nodes.Invoke;
+import jdk.graal.compiler.nodes.StructuredGraph;
+import jdk.graal.compiler.nodes.graphbuilderconf.GraphBuilderConfiguration;
+import jdk.graal.compiler.replacements.ConstantBindingParameterPlugin;
+import jdk.graal.compiler.replacements.nodes.ArrayFillNode;
+import jdk.vm.ci.aarch64.AArch64;
+import jdk.vm.ci.code.InstalledCode;
+import jdk.vm.ci.meta.ResolvedJavaMethod;
+
+public class ArraysFillTest extends ArraysSubstitutionsTestBase {
+    private static final int[] LENGTHS = {0, 1, 2, 3, 4, 5, 7, 8, 9, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 31, 65, 127, 255, 1023, 1024, 1025};
+
+    private void testFills(Class<?> type, Object constant) {
+        Assume.assumeTrue((getTarget().arch instanceof AArch64));
+        for (int length : LENGTHS) {
+            testFillsSubstitution(new ArraysFillTestConfig(type, length, constant));
+        }
+    }
+
+    @Test
+    public void testFillBooleanFalse() {
+        testFills(boolean.class, false);
+    }
+
+    @Test
+    public void testFillBooleanTrue() {
+        testFills(boolean.class, true);
+    }
+
+    @Test
+    public void testFillCharA() {
+        testFills(char.class, 'A');
+    }
+
+    @Test
+    public void testFillChar0() {
+        testFills(char.class, '0');
+    }
+
+    @Test
+    public void testFillByteMin() {
+        testFills(byte.class, Byte.MIN_VALUE);
+    }
+
+    @Test
+    public void testFillByteMax() {
+        testFills(byte.class, Byte.MAX_VALUE);
+    }
+
+    @Test
+    public void testFillShortMin() {
+        testFills(short.class, Short.MIN_VALUE);
+    }
+
+    @Test
+    public void testFillShortMax() {
+        testFills(short.class, Short.MAX_VALUE);
+    }
+
+    @Test
+    public void testFillIntMin() {
+        testFills(int.class, Integer.MIN_VALUE);
+    }
+
+    @Test
+    public void testFillIntMax() {
+        testFills(int.class, Integer.MAX_VALUE);
+    }
+
+    @Test
+    public void testFillLongMin() {
+        testFills(long.class, Long.MIN_VALUE);
+    }
+
+    @Test
+    public void testFillLongMax() {
+        testFills(long.class, Long.MAX_VALUE);
+    }
+
+    @Test
+    public void testFillFloatMin() {
+        testFills(float.class, Float.MIN_VALUE);
+    }
+
+    @Test
+    public void testFillFloatMax() {
+        testFills(float.class, Float.MAX_VALUE);
+    }
+
+    @Test
+    public void testFillDoubleMin() {
+        testFills(double.class, Double.MIN_VALUE);
+    }
+
+    @Test
+    public void testFillDoubleMax() {
+        testFills(double.class, Double.MAX_VALUE);
+    }
+
+    private Object[] constantArgs;
+
+    @Override
+    protected GraphBuilderConfiguration editGraphBuilderConfiguration(GraphBuilderConfiguration conf) {
+        if (constantArgs != null) {
+            ConstantBindingParameterPlugin constantBinding = new ConstantBindingParameterPlugin(constantArgs, this.getMetaAccess(), this.getSnippetReflection());
+            conf.getPlugins().appendParameterPlugin(constantBinding);
+        }
+        return super.editGraphBuilderConfiguration(conf);
+    }
+
+    protected void testFillsSubstitution(ArraysFillTestConfig config) {
+        ResolvedJavaMethod realMethod = getResolvedJavaMethod(Arrays.class, "fill", config.parameterType());
+        ResolvedJavaMethod testMethod = getResolvedJavaMethod(config.testMethodName());
+        StructuredGraph graph = testGraph(config.testMethodName());
+
+        // Check to see if the resulting graph contains the expected node
+        StructuredGraph replacement = getReplacements().getInlineSubstitution(realMethod, 0, false, Invoke.InlineControl.Normal, false, null, graph.allowAssumptions(), graph.getOptions());
+        if (replacement == null) {
+            assertInGraph(graph, ArrayFillNode.class);
+        }
+
+        // Force compilation
+        InstalledCode code = getCode(testMethod, null, true);
+        assert code != null;
+
+        Object array1 = config.newArray();
+        Object array2 = config.newArray();
+        Object array3 = config.newArray();
+
+        invokeSafe(realMethod, null, array1, config.getConstant());
+        invokeSafe(testMethod, null, array2, config.getConstant());
+        executeVarargsSafe(code, array3, config.getConstant());
+
+        // Verify that the original method and the substitution produce the same value
+        assertDeepEquals(array1, array2);
+
+        // Verify that the generated code and the original produce the same value
+        assertDeepEquals(array2, array3);
+    }
+}

--- a/compiler/src/jdk.graal.compiler.test/src/jdk/graal/compiler/replacements/test/ArraysFillTestConfig.java
+++ b/compiler/src/jdk.graal.compiler.test/src/jdk/graal/compiler/replacements/test/ArraysFillTestConfig.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package jdk.graal.compiler.replacements.test;
+
+import jdk.graal.compiler.replacements.test.ArraysSubstitutionsTestBase.ArrayBuilder;
+
+class ArraysFillTestConfig {
+    private Class<?> type = null;
+    private Object constant = null;
+    private int length = 0;
+
+    private Object[] parameterTypes = new Object[]{
+                    new Class<?>[]{boolean[].class, boolean.class},
+                    new Class<?>[]{byte[].class, byte.class},
+                    new Class<?>[]{char[].class, char.class},
+                    new Class<?>[]{short[].class, short.class},
+                    new Class<?>[]{int[].class, int.class},
+                    new Class<?>[]{long[].class, long.class},
+                    new Class<?>[]{float[].class, float.class},
+                    new Class<?>[]{double[].class, double.class}
+    };
+
+    private ArrayBuilder[] builders = new ArrayBuilder[]{
+                    ArraysSubstitutionsTestBase::booleanArray,
+                    ArraysSubstitutionsTestBase::byteArray,
+                    ArraysSubstitutionsTestBase::charArray,
+                    ArraysSubstitutionsTestBase::shortArray,
+                    ArraysSubstitutionsTestBase::intArray,
+                    ArraysSubstitutionsTestBase::longArray,
+                    ArraysSubstitutionsTestBase::floatArray,
+                    ArraysSubstitutionsTestBase::doubleArray,
+    };
+
+    private String[] testMethodNames = new String[]{
+                    "arraysFillBoolean",
+                    "arraysFillByte",
+                    "arraysFillChar",
+                    "arraysFillShort",
+                    "arraysFillInt",
+                    "arraysFillLong",
+                    "arraysFillFloat",
+                    "arraysFillDouble",
+    };
+
+    ArraysFillTestConfig(Class<?> type, int length, Object constant) {
+        this.type = type;
+        this.length = length;
+        this.constant = constant;
+    }
+
+    public String testMethodName() throws IllegalArgumentException {
+        return testMethodNames[index()];
+    }
+
+    public Object newArray() throws IllegalArgumentException {
+        ArrayBuilder builder = builders[index()];
+        return builder.newArray(this.length, 0, 0);
+    }
+
+    public Class<?>[] parameterType() throws IllegalArgumentException {
+        return (Class<?>[]) parameterTypes[index()];
+    }
+
+    public Object getConstant() {
+        return this.constant;
+    }
+
+    private int index() {
+        if (type == boolean.class) {
+            return 0;
+        } else if (type == byte.class) {
+            return 1;
+        } else if (type == char.class) {
+            return 2;
+        } else if (type == short.class) {
+            return 3;
+        } else if (type == int.class) {
+            return 4;
+        } else if (type == long.class) {
+            return 5;
+        } else if (type == float.class) {
+            return 6;
+        } else if (type == double.class) {
+            return 7;
+        } else {
+            throw new IllegalArgumentException("Unexpected type for 'type' field: " + type);
+        }
+    }
+}

--- a/compiler/src/jdk.graal.compiler.test/src/jdk/graal/compiler/replacements/test/ArraysSubstitutionsTestBase.java
+++ b/compiler/src/jdk.graal.compiler.test/src/jdk/graal/compiler/replacements/test/ArraysSubstitutionsTestBase.java
@@ -63,6 +63,38 @@ public class ArraysSubstitutionsTestBase extends MethodSubstitutionTest {
         return Arrays.equals(a, b);
     }
 
+    public static void arraysFillBoolean(boolean[] a, boolean b) {
+        Arrays.fill(a, b);
+    }
+
+    public static void arraysFillByte(byte[] a, byte b) {
+        Arrays.fill(a, b);
+    }
+
+    public static void arraysFillChar(char[] a, char b) {
+        Arrays.fill(a, b);
+    }
+
+    public static void arraysFillShort(short[] a, short b) {
+        Arrays.fill(a, b);
+    }
+
+    public static void arraysFillInt(int[] a, int b) {
+        Arrays.fill(a, b);
+    }
+
+    public static void arraysFillLong(long[] a, long b) {
+        Arrays.fill(a, b);
+    }
+
+    public static void arraysFillFloat(float[] a, float b) {
+        Arrays.fill(a, b);
+    }
+
+    public static void arraysFillDouble(double[] a, double b) {
+        Arrays.fill(a, b);
+    }
+
     interface ArrayBuilder {
         Object newArray(int length, int firstValue, int lastValue);
     }
@@ -139,6 +171,34 @@ public class ArraysSubstitutionsTestBase extends MethodSubstitutionTest {
 
     static long[] longArray(int length, int firstValue, int lastValue) {
         long[] arr = new long[length];
+        for (int i = 0; i < length; i++) {
+            arr[i] = i;
+        }
+        if (length > 0) {
+            arr[0] = firstValue;
+        }
+        if (length > 1) {
+            arr[length - 1] = lastValue;
+        }
+        return arr;
+    }
+
+    static float[] floatArray(int length, float firstValue, float lastValue) {
+        float[] arr = new float[length];
+        for (int i = 0; i < length; i++) {
+            arr[i] = i;
+        }
+        if (length > 0) {
+            arr[0] = firstValue;
+        }
+        if (length > 1) {
+            arr[length - 1] = lastValue;
+        }
+        return arr;
+    }
+
+    static double[] doubleArray(int length, double firstValue, double lastValue) {
+        double[] arr = new double[length];
         for (int i = 0; i < length; i++) {
             arr[i] = i;
         }

--- a/compiler/src/jdk.graal.compiler/src/jdk/graal/compiler/asm/aarch64/AArch64Assembler.java
+++ b/compiler/src/jdk.graal.compiler/src/jdk/graal/compiler/asm/aarch64/AArch64Assembler.java
@@ -2463,6 +2463,21 @@ public abstract class AArch64Assembler extends Assembler<CPUFeature> {
     }
 
     /**
+     * C6.2.30 Bitfield insert.
+     *
+     * @param size register size. Has to be 32 or 64.
+     * @param dst general purpose register. May not be null, stackpointer or zero-register.
+     * @param src general purpose register. May not be null, stackpointer or zero-register.
+     * @param lsb start index of target register to override with bits from src register.
+     * @param width number of bits to copy from src register.
+     */
+    public void bfi(int size, Register dst, Register src, int lsb, int width) {
+        assert verifySizeAndRegistersRR(size, dst, src);
+
+        bfm(size, dst, src, ((size - lsb) & (size - 1)), (width - 1));
+    }
+
+    /**
      * C6.2.337 Unsigned bitfield move.
      *
      * @param size register size. Has to be 32 or 64.

--- a/compiler/src/jdk.graal.compiler/src/jdk/graal/compiler/core/aarch64/AArch64LIRGenerator.java
+++ b/compiler/src/jdk.graal.compiler/src/jdk/graal/compiler/core/aarch64/AArch64LIRGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -55,6 +55,7 @@ import jdk.graal.compiler.lir.aarch64.AArch64AddressValue;
 import jdk.graal.compiler.lir.aarch64.AArch64ArithmeticOp;
 import jdk.graal.compiler.lir.aarch64.AArch64ArrayCompareToOp;
 import jdk.graal.compiler.lir.aarch64.AArch64ArrayCopyWithConversionsOp;
+import jdk.graal.compiler.lir.aarch64.AArch64ArrayFillOp;
 import jdk.graal.compiler.lir.aarch64.AArch64ArrayEqualsOp;
 import jdk.graal.compiler.lir.aarch64.AArch64ArrayIndexOfOp;
 import jdk.graal.compiler.lir.aarch64.AArch64ArrayRegionCompareToOp;
@@ -621,6 +622,11 @@ public abstract class AArch64LIRGenerator extends LIRGenerator {
     public void emitArrayCopyWithConversion(EnumSet<?> runtimeCheckedCPUFeatures, Value arraySrc, Value offsetSrc, Value arrayDst, Value offsetDst, Value length, Value dynamicStrides) {
         append(new AArch64ArrayCopyWithConversionsOp(this, null, null,
                         emitConvertNullToZero(arrayDst), asAllocatable(offsetDst), emitConvertNullToZero(arraySrc), asAllocatable(offsetSrc), asAllocatable(length), asAllocatable(dynamicStrides)));
+    }
+
+    @Override
+    public void emitArrayFill(JavaKind kind, EnumSet<?> runtimeCheckedCPUFeatures, Value array, Value arrayBaseOffset, Value length, Value value) {
+        append(new AArch64ArrayFillOp(kind, emitConvertNullToZero(array), asAllocatable(arrayBaseOffset), asAllocatable(length), asAllocatable(value)));
     }
 
     @Override

--- a/compiler/src/jdk.graal.compiler/src/jdk/graal/compiler/hightiercodegen/NodeLowerer.java
+++ b/compiler/src/jdk.graal.compiler/src/jdk/graal/compiler/hightiercodegen/NodeLowerer.java
@@ -97,6 +97,7 @@ import jdk.graal.compiler.nodes.java.StoreFieldNode;
 import jdk.graal.compiler.nodes.java.StoreIndexedNode;
 import jdk.graal.compiler.nodes.memory.ReadNode;
 import jdk.graal.compiler.nodes.spi.ValueProxy;
+import jdk.graal.compiler.replacements.nodes.ArrayFillNode;
 import jdk.graal.compiler.replacements.nodes.ArrayEqualsNode;
 import jdk.graal.compiler.replacements.nodes.BasicArrayCopyNode;
 import jdk.graal.compiler.replacements.nodes.BinaryMathIntrinsicNode;
@@ -255,6 +256,8 @@ public abstract class NodeLowerer {
             lower((InstanceOfNode) node);
         } else if (node instanceof InstanceOfDynamicNode) {
             lower((InstanceOfDynamicNode) node);
+        } else if (node instanceof ArrayFillNode) {
+            lower((ArrayFillNode) node);
         } else if (node instanceof ArrayEqualsNode) {
             lower((ArrayEqualsNode) node);
         } else if (node instanceof NewMultiArrayNode) {
@@ -406,6 +409,8 @@ public abstract class NodeLowerer {
     protected abstract void lower(NewMultiArrayNode node);
 
     protected abstract void lower(ArrayEqualsNode node);
+
+    protected abstract void lower(ArrayFillNode node);
 
     protected abstract void lower(InstanceOfDynamicNode node);
 

--- a/compiler/src/jdk.graal.compiler/src/jdk/graal/compiler/hotspot/meta/HotSpotHostForeignCallsProvider.java
+++ b/compiler/src/jdk.graal.compiler/src/jdk/graal/compiler/hotspot/meta/HotSpotHostForeignCallsProvider.java
@@ -140,6 +140,7 @@ import jdk.graal.compiler.replacements.arraycopy.ArrayCopyForeignCalls;
 import jdk.graal.compiler.replacements.nodes.AESNode;
 import jdk.graal.compiler.replacements.nodes.ArrayCompareToForeignCalls;
 import jdk.graal.compiler.replacements.nodes.ArrayCopyWithConversionsForeignCalls;
+import jdk.graal.compiler.replacements.nodes.ArrayFillNode;
 import jdk.graal.compiler.replacements.nodes.ArrayEqualsForeignCalls;
 import jdk.graal.compiler.replacements.nodes.ArrayEqualsWithMaskForeignCalls;
 import jdk.graal.compiler.replacements.nodes.ArrayIndexOfForeignCalls;
@@ -684,6 +685,7 @@ public abstract class HotSpotHostForeignCallsProvider extends HotSpotForeignCall
 
     private void registerSnippetStubs(HotSpotProviders providers, OptionValues options) {
         linkSnippetStubs(providers, options, IntrinsicStubsGen::new, ArrayIndexOfForeignCalls.STUBS);
+        linkSnippetStubs(providers, options, IntrinsicStubsGen::new, ArrayFillNode.STUBS);
         linkSnippetStubs(providers, options, IntrinsicStubsGen::new, ArrayEqualsForeignCalls.STUBS);
         linkSnippetStubs(providers, options, IntrinsicStubsGen::new, ArrayEqualsWithMaskForeignCalls.STUBS);
         linkSnippetStubs(providers, options, IntrinsicStubsGen::new, ArrayCompareToForeignCalls.STUBS);

--- a/compiler/src/jdk.graal.compiler/src/jdk/graal/compiler/hotspot/stubs/IntrinsicStubs.java
+++ b/compiler/src/jdk.graal.compiler/src/jdk/graal/compiler/hotspot/stubs/IntrinsicStubs.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,6 +31,7 @@ import jdk.graal.compiler.replacements.nodes.AESNode;
 import jdk.graal.compiler.replacements.nodes.ArrayCompareToNode;
 import jdk.graal.compiler.replacements.nodes.ArrayCopyWithConversionsNode;
 import jdk.graal.compiler.replacements.nodes.ArrayEqualsNode;
+import jdk.graal.compiler.replacements.nodes.ArrayFillNode;
 import jdk.graal.compiler.replacements.nodes.ArrayIndexOfNode;
 import jdk.graal.compiler.replacements.nodes.ArrayRegionCompareToNode;
 import jdk.graal.compiler.replacements.nodes.ArrayRegionEqualsNode;
@@ -55,6 +56,7 @@ import jdk.graal.compiler.replacements.nodes.VectorizedMismatchNode;
 @GeneratedStubsHolder(targetVM = "hotspot", sources = {
                 ArrayIndexOfNode.class,
                 ArrayEqualsNode.class,
+                ArrayFillNode.class,
                 ArrayRegionEqualsNode.class,
                 ArrayRegionEqualsWithMaskNode.class,
                 ArrayCompareToNode.class,

--- a/compiler/src/jdk.graal.compiler/src/jdk/graal/compiler/lir/aarch64/AArch64ArrayFillOp.java
+++ b/compiler/src/jdk.graal.compiler/src/jdk/graal/compiler/lir/aarch64/AArch64ArrayFillOp.java
@@ -1,0 +1,339 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package jdk.graal.compiler.lir.aarch64;
+
+import static jdk.graal.compiler.asm.aarch64.AArch64Address.AddressingMode.IMMEDIATE_PAIR_SIGNED_SCALED;
+import static jdk.graal.compiler.asm.aarch64.AArch64Address.AddressingMode.IMMEDIATE_POST_INDEXED;
+import static jdk.graal.compiler.asm.aarch64.AArch64MacroAssembler.PREFERRED_LOOP_ALIGNMENT;
+import static jdk.graal.compiler.lir.LIRInstruction.OperandFlag.REG;
+import static jdk.vm.ci.aarch64.AArch64.r10;
+import static jdk.vm.ci.aarch64.AArch64.r5;
+import static jdk.vm.ci.aarch64.AArch64.r6;
+import static jdk.vm.ci.aarch64.AArch64.r7;
+import static jdk.vm.ci.code.ValueUtil.asRegister;
+
+import jdk.graal.compiler.asm.Label;
+import jdk.graal.compiler.asm.aarch64.AArch64Address;
+import jdk.graal.compiler.asm.aarch64.AArch64Assembler.ConditionFlag;
+import jdk.graal.compiler.asm.aarch64.AArch64Assembler.ShiftType;
+import jdk.graal.compiler.asm.aarch64.AArch64MacroAssembler;
+import jdk.graal.compiler.debug.GraalError;
+import jdk.graal.compiler.lir.LIRInstructionClass;
+import jdk.graal.compiler.lir.Opcode;
+import jdk.graal.compiler.lir.SyncPort;
+import jdk.graal.compiler.lir.asm.CompilationResultBuilder;
+import jdk.vm.ci.aarch64.AArch64Kind;
+import jdk.vm.ci.code.Register;
+import jdk.vm.ci.meta.JavaKind;
+import jdk.vm.ci.meta.Value;
+
+/**
+ * Emits code for setting all elements of {@link #array} with copies of {@link #value}. The value
+ * must be a primitive integer, and its bit size must match the array's {@link #elementType}.
+ * Filling of floating-point arrays is supported by handling the floating-point value as plain
+ * values. The assembly code in this intrinsic was based in the HotSpot's version of the same
+ * intrinsic.
+ */
+@Opcode("ARRAYS_FILL")
+// @formatter:off
+@SyncPort(from = "https://github.com/openjdk/jdk/blob/master/src/hotspot/cpu/aarch64/stubGenerator_aarch64.cpp#L2411-L2548",
+          sha1 = "0a5ef827b06ca9fc6a7cbc059e4331cfd3cd2e62")
+@SyncPort(from = "https://github.com/openjdk/jdk/blob/master/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp#L6281-L6351",
+          sha1 = "0a5ef827b06ca9fc6a7cbc059e4331cfd3cd2e62")
+// @formatter:on
+public final class AArch64ArrayFillOp extends AArch64ComplexVectorOp {
+    public static final LIRInstructionClass<AArch64ArrayFillOp> TYPE = LIRInstructionClass.create(AArch64ArrayFillOp.class);
+
+    private JavaKind elementType;
+    @Alive({REG}) protected Value array;
+    @Alive({REG}) protected Value arrayBaseOffset;
+    @Alive({REG}) protected Value length;
+    @Alive({REG}) protected Value value;
+    @Temp protected Value[] temps;
+
+    public AArch64ArrayFillOp(JavaKind kind, Value array, Value arrayBaseOffset, Value length, Value value) {
+        super(TYPE);
+
+        GraalError.guarantee(array.getPlatformKind() == AArch64Kind.QWORD, "pointer value expected");
+        GraalError.guarantee(length.getPlatformKind() == AArch64Kind.DWORD, "integer value expected in 'length'");
+
+        this.elementType = kind;
+        this.array = array;
+        this.arrayBaseOffset = arrayBaseOffset;
+        this.length = length;
+        this.value = value;
+
+        this.temps = new Value[]{
+                        r5.asValue(),
+                        r6.asValue(),
+                        r7.asValue(),
+                        r10.asValue()};
+    }
+
+    @Override
+    @SuppressWarnings("fallthrough")
+    public void emitCode(CompilationResultBuilder crb, AArch64MacroAssembler masm) {
+        int shift = -1;
+
+        try (AArch64MacroAssembler.ScratchRegister sc1 = masm.getScratchRegister();
+                        AArch64MacroAssembler.ScratchRegister sc2 = masm.getScratchRegister()) {
+            Register targetArray = r7;
+            Register valueToFillWith = sc1.getRegister();
+            Register numberOfElements = sc2.getRegister();
+            Register numberOfEightByteWords = r10;
+
+            Label fillElementsLabel = new Label();
+            Label skipAlign1Label = new Label();
+            Label skipAlign2Label = new Label();
+            Label skipAlign4Label = new Label();
+            Label fill2Label = new Label();
+            Label fill4Label = new Label();
+            Label doneLabel = new Label();
+
+            masm.add(64, targetArray, asRegister(this.array), asRegister(this.arrayBaseOffset));
+            masm.mov(64, valueToFillWith, asRegister(value));
+            masm.mov(64, numberOfElements, asRegister(length));
+
+            // Will jump to fillElementsLabel if there are less than 8 bytes to fill in target
+            // array.
+            // Before jumping, adjust valueToFillWith to contain the 'pattern' to fill target
+            // array with.
+            switch (this.elementType) {
+                case JavaKind.Boolean:
+                case JavaKind.Byte:
+                    shift = 0;
+                    masm.compare(32, numberOfElements, 8);
+                    masm.bfi(32, valueToFillWith, valueToFillWith, 8, 8);
+                    masm.bfi(32, valueToFillWith, valueToFillWith, 16, 16);
+
+                    // jump to fillElementsLabel if numberOfElements < 8 elements
+                    masm.branchConditionally(ConditionFlag.LO, fillElementsLabel);
+                    break;
+                case JavaKind.Short:
+                    // Fallthrough
+                case JavaKind.Char:
+                    shift = 1;
+                    masm.compare(32, numberOfElements, 4);
+                    masm.bfi(32, valueToFillWith, valueToFillWith, 16, 16);
+                    // jump to fillElementsLabel if numberOfElements < 4 elements
+                    masm.branchConditionally(ConditionFlag.LO, fillElementsLabel);
+                    break;
+                case JavaKind.Int:
+                case JavaKind.Float:
+                    shift = 2;
+                    masm.compare(32, numberOfElements, 2);
+                    // jump to fillElementsLabel if numberOfElements < 2 elements
+                    masm.branchConditionally(ConditionFlag.LO, fillElementsLabel);
+                    break;
+                case JavaKind.Long:
+                case JavaKind.Double:
+                    shift = 3;
+                    masm.compare(32, numberOfElements, 1);
+                    // jump to doneLabel if numberOfElements < 1 elements
+                    masm.branchConditionally(ConditionFlag.LO, doneLabel);
+                    break;
+                default:
+                    GraalError.shouldNotReachHere("Should not reach here.");
+            }
+
+            // Align source address at 8 bytes address boundary.
+            switch (this.elementType) {
+                case JavaKind.Boolean:
+                case JavaKind.Byte:
+                    masm.tbz(targetArray, 0, skipAlign1Label);
+                    masm.str(8, valueToFillWith, AArch64Address.createImmediateAddress(8, IMMEDIATE_POST_INDEXED, targetArray, 1));
+                    masm.sub(32, numberOfElements, numberOfElements, 1);
+                    masm.bind(skipAlign1Label);
+                    // falls through
+                case JavaKind.Short:
+                case JavaKind.Char:
+                    masm.tbz(targetArray, 1, skipAlign2Label);
+                    masm.str(16, valueToFillWith, AArch64Address.createImmediateAddress(16, IMMEDIATE_POST_INDEXED, targetArray, 2));
+                    masm.sub(32, numberOfElements, numberOfElements, 2 >> shift);
+                    masm.bind(skipAlign2Label);
+                    // falls through
+                case JavaKind.Int:
+                case JavaKind.Float:
+                    masm.tbz(targetArray, 2, skipAlign4Label);
+                    masm.str(32, valueToFillWith, AArch64Address.createImmediateAddress(32, IMMEDIATE_POST_INDEXED, targetArray, 4));
+                    masm.sub(32, numberOfElements, numberOfElements, 4 >> shift);
+                    masm.bind(skipAlign4Label);
+                    break;
+                case JavaKind.Long:
+                case JavaKind.Double:
+                    break;
+                default:
+                    GraalError.shouldNotReachHere("Should not reach here.");
+            }
+
+            // Divide numberOfElements by 2^(3-shift), i.e., divide numberOfElements by the
+            // number of elements that fit into an 8 byte word.
+            masm.lsr(32, numberOfEightByteWords, numberOfElements, 3 - shift);
+
+            // If valueToFillWith isn't already 64 bits we'll make it so
+            if (this.elementType != JavaKind.Long && this.elementType != JavaKind.Double) {
+                masm.bfi(64, valueToFillWith, valueToFillWith, 32, 32);
+            }
+
+            // numberOfElements = numberOfElements - numberOfEightByteWords *
+            // elementsByEightByteWord
+            masm.sub(32, numberOfElements, numberOfElements, numberOfEightByteWords, ShiftType.LSL, 3 - shift);
+
+            // fill numberOfEightByteWords bytes of the target array
+            fillWords(masm, targetArray, numberOfEightByteWords, valueToFillWith);
+
+            // Remaining numberOfElements is less than 8 bytes. Fill it by a single store.
+            // Note that the total length is no less than 8 bytes.
+            if (this.elementType == JavaKind.Byte || this.elementType == JavaKind.Boolean || this.elementType == JavaKind.Short || this.elementType == JavaKind.Char) {
+                masm.cbz(32, numberOfElements, doneLabel);
+                masm.add(64, targetArray, targetArray, numberOfElements, ShiftType.LSL, shift);
+                masm.str(64, valueToFillWith, masm.makeAddress(64, targetArray, -8));
+                masm.jmp(doneLabel);
+            }
+
+            // Handle copies less than 8 bytes.
+            masm.bind(fillElementsLabel);
+            switch (this.elementType) {
+                case JavaKind.Boolean:
+                case JavaKind.Byte:
+                    masm.tbz(numberOfElements, 0, fill2Label);
+                    masm.str(8, valueToFillWith, AArch64Address.createImmediateAddress(8, IMMEDIATE_POST_INDEXED, targetArray, 1));
+                    masm.bind(fill2Label);
+                    masm.tbz(numberOfElements, 1, fill4Label);
+                    masm.str(16, valueToFillWith, AArch64Address.createImmediateAddress(16, IMMEDIATE_POST_INDEXED, targetArray, 2));
+                    masm.bind(fill4Label);
+                    masm.tbz(numberOfElements, 2, doneLabel);
+                    masm.str(32, valueToFillWith, AArch64Address.createBaseRegisterOnlyAddress(32, targetArray));
+                    break;
+                case JavaKind.Short:
+                case JavaKind.Char:
+                    masm.tbz(numberOfElements, 0, fill4Label);
+                    masm.str(16, valueToFillWith, AArch64Address.createImmediateAddress(16, IMMEDIATE_POST_INDEXED, targetArray, 2));
+                    masm.bind(fill4Label);
+                    masm.tbz(numberOfElements, 1, doneLabel);
+                    masm.str(32, valueToFillWith, AArch64Address.createBaseRegisterOnlyAddress(32, targetArray));
+                    break;
+                case JavaKind.Int:
+                case JavaKind.Float:
+                    masm.cbz(32, numberOfElements, doneLabel);
+                    masm.str(32, valueToFillWith, AArch64Address.createBaseRegisterOnlyAddress(32, targetArray));
+                    break;
+                case JavaKind.Long:
+                case JavaKind.Double:
+                    break;
+                default:
+                    GraalError.shouldNotReachHere("Should not reach here.");
+            }
+            masm.bind(doneLabel);
+        }
+    }
+
+    /**
+     * Algorithm:
+     *
+     * <code>
+     * if (cnt == 0) return ;
+     * if ((p & 8) != 0) *p++ = v;
+     *
+     * scratch1 = cnt & 14;
+     * cnt     -= scratch1;
+     * p       += scratch1;
+     *
+     * switch (scratch1 / 2) {
+     *     do {
+     *         cnt -= 16;
+     *         p[-16] = v;
+     *         p[-15] = v;
+     *         case 7:
+     *             p[-14] = v;
+     *             p[-13] = v;
+     *         case 6:
+     *             p[-12] = v;
+     *             p[-11] = v;
+     *         // ...
+     *         case 1:
+     *             p[-2] = v;
+     *             p[-1] = v;
+     *         case 0:
+     *             p += 16;
+     *     } while (cnt);
+     * }
+     *
+     * if ((cnt & 1) == 1) {
+     *     *p++ = v;
+     * }
+     * </code>
+     *
+     * Base will point to the end of the buffer after filling.
+     *
+     * @param masm
+     * @param targetArray Address of a buffer to be filled, 8 bytes aligned.
+     * @param numberOfEightByteWords Count in 8-byte unit.
+     * @param valueToFillWith Value to be filled with.
+     */
+    @SuppressWarnings("static-method")
+    private void fillWords(AArch64MacroAssembler masm, Register targetArray, Register numberOfEightByteWords, Register valueToFillWith) {
+        int unroll = 8;
+
+        Register scratch1 = r5;
+        Register scratch2 = r6;
+        Label finishedLabel = new Label();
+        Label skipLabel = new Label();
+        Label entryLabel = new Label();
+        Label loopHeadLabel = new Label();
+
+        // If nothing to do just jump to finishedLabel
+        masm.cbz(64, numberOfEightByteWords, finishedLabel);
+
+        // Because we didn't jump in the previous instruction then we certainly
+        // have at least 8 bytes to fill in the target array.
+
+        masm.tbz(targetArray, 3, skipLabel);
+        masm.str(64, valueToFillWith, AArch64Address.createImmediateAddress(64, IMMEDIATE_POST_INDEXED, targetArray, 8));
+        masm.sub(64, numberOfEightByteWords, numberOfEightByteWords, 1);
+        masm.bind(skipLabel);
+
+        masm.and(64, scratch1, numberOfEightByteWords, (unroll - 1) * 2);
+        masm.sub(64, numberOfEightByteWords, numberOfEightByteWords, scratch1);
+        masm.add(64, targetArray, targetArray, scratch1, ShiftType.LSL, 3);
+        masm.adr(scratch2, entryLabel);
+        masm.sub(64, scratch2, scratch2, scratch1, ShiftType.LSL, 1);
+        masm.jmp(scratch2);
+
+        masm.align(PREFERRED_LOOP_ALIGNMENT);
+        masm.bind(loopHeadLabel);
+        masm.add(64, targetArray, targetArray, unroll * 16);
+        for (int i = -unroll; i < 0; i++) {
+            masm.stp(64, valueToFillWith, valueToFillWith, AArch64Address.createImmediateAddress(64, IMMEDIATE_PAIR_SIGNED_SCALED, targetArray, i * 16));
+        }
+        masm.bind(entryLabel);
+        masm.subs(64, numberOfEightByteWords, numberOfEightByteWords, unroll * 2);
+        masm.branchConditionally(ConditionFlag.GE, loopHeadLabel);
+
+        masm.tbz(numberOfEightByteWords, 0, finishedLabel);
+        masm.str(64, valueToFillWith, AArch64Address.createImmediateAddress(64, IMMEDIATE_POST_INDEXED, targetArray, 8));
+        masm.bind(finishedLabel);
+    }
+}

--- a/compiler/src/jdk.graal.compiler/src/jdk/graal/compiler/lir/gen/LIRGeneratorTool.java
+++ b/compiler/src/jdk.graal.compiler/src/jdk/graal/compiler/lir/gen/LIRGeneratorTool.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -230,6 +230,11 @@ public interface LIRGeneratorTool extends CoreProviders, DiagnosticLIRGeneratorT
     @SuppressWarnings("unused")
     default Variable emitVectorizedHashCode(EnumSet<?> runtimeCheckedCPUFeatures, Value arrayStart, Value length, Value initialValue, JavaKind arrayKind) {
         throw GraalError.unimplemented("vectorizedHashCode substitution is not implemented on this architecture"); // ExcludeFromJacocoGeneratedReport
+    }
+
+    @SuppressWarnings("unused")
+    default void emitArrayFill(JavaKind commonElementKind, EnumSet<?> runtimeCheckedCPUFeatures, Value array, Value arrayBaseOffset, Value length, Value value) {
+        throw GraalError.unimplemented("Arrays.fill substitution is not implemented on this architecture"); // ExcludeFromJacocoGeneratedReport
     }
 
     @SuppressWarnings("unused")

--- a/compiler/src/jdk.graal.compiler/src/jdk/graal/compiler/replacements/nodes/ArrayFillNode.java
+++ b/compiler/src/jdk.graal.compiler/src/jdk/graal/compiler/replacements/nodes/ArrayFillNode.java
@@ -1,0 +1,238 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package jdk.graal.compiler.replacements.nodes;
+
+import static jdk.graal.compiler.core.common.spi.ForeignCallDescriptor.CallSideEffect.HAS_SIDE_EFFECT;
+
+import java.util.EnumSet;
+
+import org.graalvm.word.LocationIdentity;
+import org.graalvm.word.Pointer;
+
+import jdk.graal.compiler.core.common.spi.ForeignCallDescriptor;
+import jdk.graal.compiler.core.common.type.IntegerStamp;
+import jdk.graal.compiler.core.common.type.StampFactory;
+import jdk.graal.compiler.debug.GraalError;
+import jdk.graal.compiler.graph.NodeClass;
+import jdk.graal.compiler.lir.GenerateStub;
+import jdk.graal.compiler.nodeinfo.InputType;
+import jdk.graal.compiler.nodeinfo.NodeCycles;
+import jdk.graal.compiler.nodeinfo.NodeInfo;
+import jdk.graal.compiler.nodeinfo.NodeSize;
+import jdk.graal.compiler.nodes.NamedLocationIdentity;
+import jdk.graal.compiler.nodes.NodeView;
+import jdk.graal.compiler.nodes.StateSplit;
+import jdk.graal.compiler.nodes.ValueNode;
+import jdk.graal.compiler.nodes.memory.MemoryAccess;
+import jdk.graal.compiler.nodes.spi.NodeLIRBuilderTool;
+import jdk.vm.ci.aarch64.AArch64;
+import jdk.vm.ci.code.Architecture;
+import jdk.vm.ci.meta.JavaKind;
+
+// JaCoCo Exclude
+
+/**
+ * Fills an array by setting all elements to {@link #valueToFillWith}. The value must be a primitive
+ * integer, and its bit size must match the array's {@link #elementKind}. Filling of floating-point
+ * arrays is supported by passing a floating-point value reinterpreted as integer bits.
+ */
+@NodeInfo(cycles = NodeCycles.CYCLES_UNKNOWN, size = NodeSize.SIZE_UNKNOWN, allowedUsageTypes = InputType.Memory)
+public class ArrayFillNode extends MemoryKillStubIntrinsicNode
+                implements StateSplit, MemoryAccess {
+
+    public static final NodeClass<ArrayFillNode> TYPE = NodeClass.create(ArrayFillNode.class);
+    private static final ForeignCallDescriptor BOOLEAN_ARRAY_FILL_STUB = createForeignCallDescriptor(JavaKind.Boolean, byte.class);
+    private static final ForeignCallDescriptor BYTE_ARRAY_FILL_STUB = createForeignCallDescriptor(JavaKind.Byte, byte.class);
+    private static final ForeignCallDescriptor CHAR_ARRAY_FILL_STUB = createForeignCallDescriptor(JavaKind.Char, short.class);
+    private static final ForeignCallDescriptor SHORT_ARRAY_FILL_STUB = createForeignCallDescriptor(JavaKind.Short, short.class);
+    private static final ForeignCallDescriptor INT_ARRAY_FILL_STUB = createForeignCallDescriptor(JavaKind.Int, int.class);
+    private static final ForeignCallDescriptor FLOAT_ARRAY_FILL_STUB = createForeignCallDescriptor(JavaKind.Float, int.class);
+    private static final ForeignCallDescriptor LONG_ARRAY_FILL_STUB = createForeignCallDescriptor(JavaKind.Long, long.class);
+    private static final ForeignCallDescriptor DOUBLE_ARRAY_FILL_STUB = createForeignCallDescriptor(JavaKind.Double, long.class);
+
+    public static final ForeignCallDescriptor[] STUBS = {
+                    BOOLEAN_ARRAY_FILL_STUB,
+                    BYTE_ARRAY_FILL_STUB,
+                    CHAR_ARRAY_FILL_STUB,
+                    SHORT_ARRAY_FILL_STUB,
+                    INT_ARRAY_FILL_STUB,
+                    LONG_ARRAY_FILL_STUB,
+                    FLOAT_ARRAY_FILL_STUB,
+                    DOUBLE_ARRAY_FILL_STUB,
+    };
+
+    /** JavaKind of the array's entries. */
+    protected JavaKind elementKind;
+
+    /** Address of the array object on the Java heap. */
+    @Input protected ValueNode arrayBase;
+
+    /** Offset from start of array object in Java heap to its first element. */
+    @Input protected ValueNode offsetToFirstElement;
+
+    /** Number of entries in the array. */
+    @Input protected ValueNode arrayLength;
+
+    /** Value to fill array with. */
+    @Input protected ValueNode valueToFillWith;
+
+    public ArrayFillNode(ValueNode arrayBase, ValueNode offsetToFirstElement, ValueNode arrayLength, ValueNode valueToFillWith, @ConstantNodeParameter JavaKind elementKind) {
+        this(arrayBase, offsetToFirstElement, arrayLength, valueToFillWith, elementKind, null);
+    }
+
+    public ArrayFillNode(ValueNode arrayBase, ValueNode offsetToFirstElement, ValueNode arrayLength, ValueNode valueToFillWith, @ConstantNodeParameter JavaKind elementKind,
+                    @ConstantNodeParameter EnumSet<?> runtimeCheckedCPUFeatures) {
+        super(TYPE, StampFactory.forVoid(), runtimeCheckedCPUFeatures, NamedLocationIdentity.getArrayLocation(elementKind));
+        this.arrayBase = arrayBase;
+        this.offsetToFirstElement = offsetToFirstElement;
+        this.arrayLength = arrayLength;
+        this.valueToFillWith = valueToFillWith;
+        this.elementKind = elementKind;
+
+        GraalError.guarantee(valueToFillWith.stamp(NodeView.DEFAULT) instanceof IntegerStamp, "valueToFillWith needs to be an integer.");
+        GraalError.guarantee(elementKind.isPrimitive(), "elementKind needs to be a primitive type.");
+    }
+
+    @NodeIntrinsic
+    @GenerateStub(name = "booleanArrayFill", parameters = {"Boolean"})
+    @GenerateStub(name = "byteArrayFill", parameters = {"Byte"})
+    public static native void fill(Pointer array, long offset, int length, byte value,
+                    @ConstantNodeParameter JavaKind kind);
+
+    @NodeIntrinsic
+    public static native void fill(Pointer array, long offset, int length, byte value,
+                    @ConstantNodeParameter JavaKind kind,
+                    @ConstantNodeParameter EnumSet<?> runtimeCheckedCPUFeatures);
+
+    @NodeIntrinsic
+    @GenerateStub(name = "charArrayFill", parameters = {"Char"})
+    @GenerateStub(name = "shortArrayFill", parameters = {"Short"})
+    public static native void fill(Pointer array, long offset, int length, short value,
+                    @ConstantNodeParameter JavaKind kind);
+
+    @NodeIntrinsic
+    public static native void fill(Pointer array, long offset, int length, short value,
+                    @ConstantNodeParameter JavaKind kind,
+                    @ConstantNodeParameter EnumSet<?> runtimeCheckedCPUFeatures);
+
+    @NodeIntrinsic
+    @GenerateStub(name = "intArrayFill", parameters = {"Int"})
+    @GenerateStub(name = "floatArrayFill", parameters = {"Float"})
+    public static native void fill(Pointer array, long offset, int length, int value,
+                    @ConstantNodeParameter JavaKind kind);
+
+    @NodeIntrinsic
+    public static native void fill(Pointer array, long offset, int length, int value,
+                    @ConstantNodeParameter JavaKind kind,
+                    @ConstantNodeParameter EnumSet<?> runtimeCheckedCPUFeatures);
+
+    @NodeIntrinsic
+    @GenerateStub(name = "longArrayFill", parameters = {"Long"})
+    @GenerateStub(name = "doubleArrayFill", parameters = {"Double"})
+    public static native void fill(Pointer array, long offset, int length, long value,
+                    @ConstantNodeParameter JavaKind kind);
+
+    @NodeIntrinsic
+    public static native void fill(Pointer array, long offset, int length, long value,
+                    @ConstantNodeParameter JavaKind kind,
+                    @ConstantNodeParameter EnumSet<?> runtimeCheckedCPUFeatures);
+
+    @Override
+    public ForeignCallDescriptor getForeignCallDescriptor() {
+        switch (this.elementKind) {
+            case Boolean:
+                return BOOLEAN_ARRAY_FILL_STUB;
+            case Byte:
+                return BYTE_ARRAY_FILL_STUB;
+            case Char:
+                return CHAR_ARRAY_FILL_STUB;
+            case Short:
+                return SHORT_ARRAY_FILL_STUB;
+            case Int:
+                return INT_ARRAY_FILL_STUB;
+            case Long:
+                return LONG_ARRAY_FILL_STUB;
+            case Float:
+                return FLOAT_ARRAY_FILL_STUB;
+            case Double:
+                return DOUBLE_ARRAY_FILL_STUB;
+            default:
+                return null;
+        }
+    }
+
+    @Override
+    public ValueNode[] getForeignCallArguments() {
+        return new ValueNode[]{arrayBase, offsetToFirstElement, arrayLength, valueToFillWith};
+    }
+
+    @Override
+    public void emitIntrinsic(NodeLIRBuilderTool gen) {
+        gen.getLIRGeneratorTool().emitArrayFill(elementKind, getRuntimeCheckedCPUFeatures(), gen.operand(arrayBase), gen.operand(offsetToFirstElement), gen.operand(arrayLength),
+                        gen.operand(valueToFillWith));
+    }
+
+    @Override
+    public LocationIdentity[] getKilledLocationIdentities() {
+        return new LocationIdentity[]{NamedLocationIdentity.getArrayLocation(this.elementKind)};
+    }
+
+    public static boolean isSupported(Architecture arch) {
+        return (arch instanceof AArch64);
+    }
+
+    @Override
+    public boolean canBeEmitted(Architecture arch) {
+        return isSupported(arch);
+    }
+
+    private static ForeignCallDescriptor createForeignCallDescriptor(JavaKind kind, Class<?> cls) {
+        LocationIdentity[] locs = new LocationIdentity[]{NamedLocationIdentity.getArrayLocation(kind)};
+        Class<?>[] argTypes = new Class<?>[]{Pointer.class, long.class, int.class, cls};
+        String name = kind.getJavaName() + "ArrayFill";
+
+        return new ForeignCallDescriptor(name, void.class, argTypes, HAS_SIDE_EFFECT, locs, false, false);
+    }
+
+    public JavaKind getElementKind() {
+        return elementKind;
+    }
+
+    public ValueNode getArrayBase() {
+        return arrayBase;
+    }
+
+    public ValueNode getOffsetToFirstElement() {
+        return offsetToFirstElement;
+    }
+
+    public ValueNode getArrayLength() {
+        return arrayLength;
+    }
+
+    public ValueNode getValueToFillWith() {
+        return valueToFillWith;
+    }
+}

--- a/compiler/src/org.graalvm.micro.benchmarks/src/micro/benchmarks/ArrayFillBenchmark.java
+++ b/compiler/src/org.graalvm.micro.benchmarks/src/micro/benchmarks/ArrayFillBenchmark.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package micro.benchmarks;
+
+import java.util.Arrays;
+import java.util.Random;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.infra.Blackhole;
+
+/**
+ * Benchmarks for java.util.Arrays.fill.
+ */
+@State(Scope.Thread)
+public class ArrayFillBenchmark extends BenchmarkBase {
+    @Param({"16", "128", "1024", "4096"}) private int size;
+
+    // Just a random index that we'll use to feed to bh.consume
+    public int indexCheck;
+
+    // Target arrays
+    public boolean[] booleans;
+    public byte[] bytes;
+    public char[] chars;
+    public short[] shorts;
+    public int[] ints;
+    public long[] longs;
+    public float[] floats;
+    public double[] doubles;
+
+    @Setup
+    public void setup() {
+        Random rnd = new Random();
+
+        indexCheck = rnd.nextInt(size);
+        booleans = new boolean[size];
+        bytes = new byte[size];
+        chars = new char[size];
+        shorts = new short[size];
+        ints = new int[size];
+        longs = new long[size];
+        floats = new float[size];
+        doubles = new double[size];
+    }
+
+    @Benchmark
+    public void fillBooleans(Blackhole bh) {
+        Arrays.fill(booleans, Boolean.TRUE);
+        bh.consume(booleans[indexCheck]);
+    }
+
+    @Benchmark
+    public void fillBytes(Blackhole bh) {
+        Arrays.fill(bytes, Byte.MAX_VALUE);
+        bh.consume(bytes[indexCheck]);
+    }
+
+    @Benchmark
+    public void fillChars(Blackhole bh) {
+        Arrays.fill(chars, Character.MAX_VALUE);
+        bh.consume(chars[indexCheck]);
+    }
+
+    @Benchmark
+    public void fillShorts(Blackhole bh) {
+        Arrays.fill(shorts, Short.MAX_VALUE);
+        bh.consume(shorts[indexCheck]);
+    }
+
+    @Benchmark
+    public void fillInts(Blackhole bh) {
+        Arrays.fill(ints, Integer.MAX_VALUE);
+        bh.consume(ints[indexCheck]);
+    }
+
+    @Benchmark
+    public void fillLongs(Blackhole bh) {
+        Arrays.fill(longs, Long.MAX_VALUE);
+        bh.consume(longs[indexCheck]);
+    }
+
+    @Benchmark
+    public void fillFloats(Blackhole bh) {
+        Arrays.fill(floats, Float.MAX_VALUE);
+        bh.consume(floats[indexCheck]);
+    }
+
+    @Benchmark
+    public void fillDoubles(Blackhole bh) {
+        Arrays.fill(doubles, Double.MAX_VALUE);
+        bh.consume(doubles[indexCheck]);
+    }
+}

--- a/substratevm/src/com.oracle.svm.graal/src/com/oracle/svm/graal/stubs/AArch64StubForeignCallsFeature.java
+++ b/substratevm/src/com.oracle.svm.graal/src/com/oracle/svm/graal/stubs/AArch64StubForeignCallsFeature.java
@@ -38,6 +38,7 @@ import jdk.graal.compiler.replacements.nodes.ArrayCompareToForeignCalls;
 import jdk.graal.compiler.replacements.nodes.ArrayCopyWithConversionsForeignCalls;
 import jdk.graal.compiler.replacements.nodes.ArrayEqualsForeignCalls;
 import jdk.graal.compiler.replacements.nodes.ArrayEqualsWithMaskForeignCalls;
+import jdk.graal.compiler.replacements.nodes.ArrayFillNode;
 import jdk.graal.compiler.replacements.nodes.ArrayIndexOfForeignCalls;
 import jdk.graal.compiler.replacements.nodes.ArrayRegionCompareToForeignCalls;
 import jdk.graal.compiler.replacements.nodes.BigIntegerMulAddNode;
@@ -69,6 +70,7 @@ public class AArch64StubForeignCallsFeature extends StubForeignCallsFeatureBase 
                         new StubDescriptor(ArrayRegionCompareToForeignCalls.STUBS, EMPTY_CPU_FEATURES_AARCH64, EMPTY_CPU_FEATURES_AARCH64),
                         new StubDescriptor(ArrayEqualsForeignCalls.STUBS, EMPTY_CPU_FEATURES_AARCH64, EMPTY_CPU_FEATURES_AARCH64),
                         new StubDescriptor(ArrayEqualsWithMaskForeignCalls.STUBS, EMPTY_CPU_FEATURES_AARCH64, EMPTY_CPU_FEATURES_AARCH64),
+                        new StubDescriptor(ArrayFillNode.STUBS, EMPTY_CPU_FEATURES_AARCH64, EMPTY_CPU_FEATURES_AARCH64),
                         new StubDescriptor(ArrayIndexOfForeignCalls.STUBS, EMPTY_CPU_FEATURES_AARCH64, EMPTY_CPU_FEATURES_AARCH64),
                         new StubDescriptor(CalcStringAttributesForeignCalls.STUBS, CalcStringAttributesNode.minFeaturesAARCH64(), EMPTY_CPU_FEATURES_AARCH64),
                         new StubDescriptor(StringLatin1InflateNode.STUB, EMPTY_CPU_FEATURES_AARCH64, EMPTY_CPU_FEATURES_AARCH64),

--- a/substratevm/src/com.oracle.svm.graal/src/com/oracle/svm/graal/stubs/SVMIntrinsicStubs.java
+++ b/substratevm/src/com.oracle.svm.graal/src/com/oracle/svm/graal/stubs/SVMIntrinsicStubs.java
@@ -31,6 +31,7 @@ import jdk.graal.compiler.replacements.nodes.AESNode;
 import jdk.graal.compiler.replacements.nodes.ArrayCompareToNode;
 import jdk.graal.compiler.replacements.nodes.ArrayCopyWithConversionsNode;
 import jdk.graal.compiler.replacements.nodes.ArrayEqualsNode;
+import jdk.graal.compiler.replacements.nodes.ArrayFillNode;
 import jdk.graal.compiler.replacements.nodes.ArrayIndexOfNode;
 import jdk.graal.compiler.replacements.nodes.ArrayRegionCompareToNode;
 import jdk.graal.compiler.replacements.nodes.ArrayRegionEqualsNode;
@@ -55,6 +56,7 @@ import jdk.graal.compiler.replacements.nodes.VectorizedMismatchNode;
 @GeneratedStubsHolder(targetVM = "substrate", sources = {
                 ArrayIndexOfNode.class,
                 ArrayEqualsNode.class,
+                ArrayFillNode.class,
                 ArrayRegionEqualsNode.class,
                 ArrayCompareToNode.class,
                 ArrayRegionCompareToNode.class,


### PR DESCRIPTION
Please, consider this patch to intrinsify `Arrays.fill(array, constant)` for `byte`, `short` and `int` on AArch64 backend. The assembly code is a port of the HotSpot assembly for the same intrinsic. Thank you @gergo- for reviewing the draft version of this PR!

The below is a summary of some quick JMH tests that I ran on my dev machine.

```
Instr     Benchmark                       (size)   Mode  Cnt          Score          Error  Units
No        ArrayFillBenchmark.fill_bytes       16  thrpt    5  130,858,263.770 ±  7175243.892  ops/s
Yes       ArrayFillBenchmark.fill_bytes       16  thrpt    5  268,367,821.486 ±  2717945.345  ops/s
No        ArrayFillBenchmark.fill_bytes     1024  thrpt    5    7,284,374.553 ±   131421.427  ops/s
Yes       ArrayFillBenchmark.fill_bytes     1024  thrpt    5   94,448,799.400 ±  1096754.457  ops/s
No        ArrayFillBenchmark.fill_bytes     4096  thrpt    5    1,814,548.662 ±    33455.246  ops/s
Yes       ArrayFillBenchmark.fill_bytes     4096  thrpt    5   28,970,761.402 ±  2636159.892  ops/s

No        ArrayFillBenchmark.fill_shorts      16  thrpt    5  137,210,363.401 ±  6208453.450  ops/s
Yes       ArrayFillBenchmark.fill_shorts      16  thrpt    5  285,341,885.029 ± 11301099.208  ops/s
No        ArrayFillBenchmark.fill_shorts    1024  thrpt    5    7,178,718.150 ±   741170.216  ops/s
Yes       ArrayFillBenchmark.fill_shorts    1024  thrpt    5   53,996,849.866 ±  2353229.277  ops/s
No        ArrayFillBenchmark.fill_shorts    4096  thrpt    5    1,814,690.509 ±    13988.852  ops/s
Yes       ArrayFillBenchmark.fill_shorts    4096  thrpt    5   14,905,037.102 ±  1719260.337  ops/s

No        ArrayFillBenchmark.fill_ints        16  thrpt    5  132,083,594.942 ±  7995181.451  ops/s
Yes       ArrayFillBenchmark.fill_ints        16  thrpt    5  374,192,809.496 ±  5778630.471  ops/s
No        ArrayFillBenchmark.fill_ints      1024  thrpt    5    7,044,324.507 ±   130830.618  ops/s
Yes       ArrayFillBenchmark.fill_ints      1024  thrpt    5   28,677,308.237 ±  1515323.358  ops/s
No        ArrayFillBenchmark.fill_ints      4096  thrpt    5    1,648,798.029 ±     9113.592  ops/s
Yes       ArrayFillBenchmark.fill_ints      4096  thrpt    5    7,563,740.695 ±   627888.347  ops/s
```