### PR TITLE
[GR-60806] The Truffle Profiler somtimes incorrectly skips tiers in calltree mode

### DIFF
--- a/tools/src/com.oracle.truffle.tools.profiler.test/src/com/oracle/truffle/tools/profiler/test/ProfilerCLITest.java
+++ b/tools/src/com.oracle.truffle.tools.profiler.test/src/com/oracle/truffle/tools/profiler/test/ProfilerCLITest.java
@@ -117,6 +117,7 @@ public class ProfilerCLITest {
         Assert.assertTrue(output[14].matches(lineRegex));
         //    foo      ||              120ms  10.0% |   0.0% |  58.3% |  41.7% ||              120ms  10.0% |   0.0% |  58.3% |  41.7% || test~1:16-29
         Assert.assertTrue(output[15].matches(lineRegex));
+        // @formatter:on
     }
 
     @Test

--- a/tools/src/com.oracle.truffle.tools.profiler.test/src/com/oracle/truffle/tools/profiler/test/ProfilerCLITest.java
+++ b/tools/src/com.oracle.truffle.tools.profiler.test/src/com/oracle/truffle/tools/profiler/test/ProfilerCLITest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -50,8 +50,10 @@ import com.oracle.truffle.tools.profiler.ProfilerNode;
 public class ProfilerCLITest {
 
     public static final String SAMPLING_HISTOGRAM_REGEX = "Sampling Histogram. Recorded [0-9]* samples with period [0-9]*ms. Missed [0-9]* samples.";
+    public static final String SAMPLING_CALLTREE_REGEX = "Sampling Call Tree. Recorded [0-9]* samples with period [0-9]*ms. Missed [0-9]* samples.";
     public static final int EXEC_COUNT = 10;
-    public static final String NAME_REGEX = " [a-z]* +";
+    public static final int LOOP_COUNT = 10;
+    public static final String NAME_REGEX = " +[a-z]* +";
     public static final String SEPARATOR_REGEX = "\\|";
     public static final String TIME_REGEX = " *[0-9]*ms +[0-9]*\\.[0-9]\\% ";
     public static final String PERCENT_REGEX = " *[0-9]*\\.[0-9]\\% ";
@@ -64,6 +66,57 @@ public class ProfilerCLITest {
 
     protected Source makeSource(String s) {
         return Source.newBuilder(InstrumentationTestLanguage.ID, s, "test").buildLiteral();
+    }
+
+    @Test
+    public void testCallTreeWithTiers() {
+        Assume.assumeFalse(checkRuntime());
+        HashMap<String, String> options = new HashMap<>();
+        options.put("cpusampler", "true");
+        options.put("cpusampler.Output", "calltree");
+        options.put("cpusampler.ShowTiers", "true");
+        options.put("engine.FirstTierCompilationThreshold", Integer.toString(5 * LOOP_COUNT));
+        options.put("engine.LastTierCompilationThreshold", Integer.toString(7 * LOOP_COUNT));
+        options.put("engine.BackgroundCompilation", "false");
+        String[] output = runSampler(options);
+        // @formatter:off
+        // OUTPUT IS:
+        // ----------------------------------------------------------------------------------------------------------------------------------------------------
+        // Sampling Call Tree. Recorded 120 samples with period 10ms. Missed 6 samples.
+        Assert.assertTrue(output[1].matches(SAMPLING_CALLTREE_REGEX));
+        // Self Time: Time spent on the top of the stack.
+        Assert.assertEquals(SELF_TIME, output[2]);
+        // Total Time: Time spent somewhere on the stack.
+        Assert.assertEquals(TOTAL_TIME, output[3]);
+        // T0: Percent of time spent in interpreter.
+        Assert.assertEquals(INTERPRETER, output[4]);
+        // T1: Percent of time spent in code compiled by tier 1 compiler.
+        Assert.assertEquals(T1, output[5]);
+        // T2: Percent of time spent in code compiled by tier 2 compiler.
+        Assert.assertEquals(T2, output[6]);
+        // ----------------------------------------------------------------------------------------------------------------------------------------------------
+        //  Name       ||             Total Time    |   T0   |   T1   |   T2   ||              Self Time    |   T0   |   T1   |   T2   || Location
+        // ----------------------------------------------------------------------------------------------------------------------------------------------------
+        Assert.assertEquals(" Name       ||             Total Time    |   T0   |   T1   |   T2   ||              Self Time    |   T0   |   T1   |   T2   || Location             ", output[8]);
+        //             ||             1200ms 100.0% | 100.0% |   0.0% |   0.0% ||                0ms   0.0% |   0.0% |   0.0% |   0.0% || test~1:0-161
+        //   baz       ||             1080ms  90.0% |  72.2% |  27.8% |   0.0% ||                0ms   0.0% |   0.0% |   0.0% |   0.0% || test~1:98-139
+        String lineRegex = NAME_REGEX +
+                SEPARATOR_REGEX + SEPARATOR_REGEX +
+                TIME_REGEX + SEPARATOR_REGEX + PERCENT_REGEX + SEPARATOR_REGEX + PERCENT_REGEX + SEPARATOR_REGEX + PERCENT_REGEX +
+                SEPARATOR_REGEX + SEPARATOR_REGEX +
+                TIME_REGEX + SEPARATOR_REGEX + PERCENT_REGEX + SEPARATOR_REGEX + PERCENT_REGEX + SEPARATOR_REGEX + PERCENT_REGEX +
+                SEPARATOR_REGEX + SEPARATOR_REGEX +
+                LOCATION_REGEX;
+        Assert.assertTrue(output[10].matches(lineRegex));
+        Assert.assertTrue(output[11].matches(lineRegex));
+        //    bar      ||             1080ms  90.0% |  13.0% |  50.9% |  36.1% ||                0ms   0.0% |   0.0% |   0.0% |   0.0% || test~1:43-84
+        Assert.assertTrue(output[12].matches(lineRegex));
+        //     foo     ||             1080ms  90.0% |   3.7% |  58.3% |  38.0% ||             1080ms  90.0% |   3.7% |  58.3% |  38.0% || test~1:16-29
+        Assert.assertTrue(output[13].matches(lineRegex));
+        //   bar       ||              120ms  10.0% |   8.3% |  58.3% |  33.3% ||                0ms   0.0% |   0.0% |   0.0% |   0.0% || test~1:43-84
+        Assert.assertTrue(output[14].matches(lineRegex));
+        //    foo      ||              120ms  10.0% |   0.0% |  58.3% |  41.7% ||              120ms  10.0% |   0.0% |  58.3% |  41.7% || test~1:16-29
+        Assert.assertTrue(output[15].matches(lineRegex));
     }
 
     @Test
@@ -196,8 +249,8 @@ public class ProfilerCLITest {
         try (Context context = Context.newBuilder().in(System.in).out(out).err(err).options(options).build()) {
             context.eval(makeSource("ROOT(" +
                             "DEFINE(foo,ROOT(SLEEP(1)))," +
-                            "DEFINE(bar,ROOT(BLOCK(STATEMENT,LOOP(10, CALL(foo)))))," +
-                            "DEFINE(baz,ROOT(BLOCK(STATEMENT,LOOP(10, CALL(bar)))))," +
+                            "DEFINE(bar,ROOT(BLOCK(STATEMENT,LOOP(" + LOOP_COUNT + ", CALL(foo)))))," +
+                            "DEFINE(baz,ROOT(BLOCK(STATEMENT,LOOP(" + LOOP_COUNT + ", CALL(bar)))))," +
                             ")"));
             Runnable evalSource1 = new Runnable() {
                 @Override
@@ -241,8 +294,8 @@ public class ProfilerCLITest {
         try (Context context = Context.newBuilder().in(System.in).out(out).err(err).options(options).build()) {
             Source source = makeSource("ROOT(" +
                             "DEFINE(foo,ROOT(SLEEP(1)))," +
-                            "DEFINE(bar,ROOT(BLOCK(STATEMENT,LOOP(10, CALL(foo)))))," +
-                            "DEFINE(baz,ROOT(BLOCK(STATEMENT,LOOP(10, CALL(bar)))))," +
+                            "DEFINE(bar,ROOT(BLOCK(STATEMENT,LOOP(" + LOOP_COUNT + ", CALL(foo)))))," +
+                            "DEFINE(baz,ROOT(BLOCK(STATEMENT,LOOP(" + LOOP_COUNT + ", CALL(bar)))))," +
                             "CALL(baz),CALL(bar)" +
                             ")");
             for (int i = 0; i < EXEC_COUNT; i++) {
@@ -350,8 +403,8 @@ public class ProfilerCLITest {
         Context context = Context.newBuilder().in(System.in).out(out).err(err).option("cpusampler", "true").option("cpusampler.Output", "json").build();
         Source defaultSourceForSampling = makeSource("ROOT(" +
                         "DEFINE(foo,ROOT(SLEEP(1)))," +
-                        "DEFINE(bar,ROOT(BLOCK(STATEMENT,LOOP(10, CALL(foo)))))," +
-                        "DEFINE(baz,ROOT(BLOCK(STATEMENT,LOOP(10, CALL(bar)))))," +
+                        "DEFINE(bar,ROOT(BLOCK(STATEMENT,LOOP(" + LOOP_COUNT + ", CALL(foo)))))," +
+                        "DEFINE(baz,ROOT(BLOCK(STATEMENT,LOOP(" + LOOP_COUNT + ", CALL(bar)))))," +
                         "CALL(baz),CALL(bar)" +
                         ")");
         for (int i = 0; i < 10; i++) {

--- a/tools/src/com.oracle.truffle.tools.profiler/src/com/oracle/truffle/tools/profiler/impl/CPUSamplerCLI.java
+++ b/tools/src/com.oracle.truffle.tools.profiler/src/com/oracle/truffle/tools/profiler/impl/CPUSamplerCLI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -718,7 +718,10 @@ class CPUSamplerCLI extends ProfilerCLI {
 
         private void calculateMaxValuesRec(ProfilerNode<CPUSampler.Payload> node, int depth) {
             maxNameLength = Math.max(maxNameLength, node.getRootName().length() + OutputEntry.computeIndentSize(depth));
-            tiers.add(node.getPayload().getNumberOfTiers() - 1);
+            int numberOfTiers = node.getPayload().getNumberOfTiers();
+            for (int i = 0; i < numberOfTiers; i++) {
+                tiers.add(i);
+            }
             for (ProfilerNode<CPUSampler.Payload> child : node.getChildren()) {
                 calculateMaxValuesRec(child, depth + 1);
             }
@@ -759,7 +762,10 @@ class CPUSamplerCLI extends ProfilerCLI {
 
         private CallTreeOutputEntry makeEntry(ProfilerNode<CPUSampler.Payload> node, int depth) {
             maxNameLength = Math.max(maxNameLength, node.getRootName().length() + OutputEntry.computeIndentSize(depth));
-            tiers.add(node.getPayload().getNumberOfTiers() - 1);
+            int numberOfTiers = node.getPayload().getNumberOfTiers();
+            for (int i = 0; i < numberOfTiers; i++) {
+                tiers.add(i);
+            }
             CallTreeOutputEntry entry = new CallTreeOutputEntry(node);
             for (ProfilerNode<CPUSampler.Payload> child : node.getChildren()) {
                 entry.children.add(makeEntry(child, depth + 1));


### PR DESCRIPTION
The Truffle Profiler somtimes incorrectly skips tiers in calltree mode. Taking a "calltree" profile of the Truffle program from [`ProfilerCLITest::runSampler()`](https://github.com/oracle/graal/blob/261c38a7a47dd87f13ec3cbe0fbb85cfdff17963/tools/src/com.oracle.truffle.tools.profiler.test/src/com/oracle/truffle/tools/profiler/test/ProfilerCLITest.java#L238) currently looks as follows:
```
Sampling Call Tree. Recorded 113 samples with period 10ms. Missed 40 samples.
  Self Time: Time spent on the top of the stack.
  Total Time: Time spent somewhere on the stack.
  T0: Percent of time spent in interpreter.
  T2: Percent of time spent in code compiled by tier 2 compiler.
----------------------------------------------------------------------------------------------------------------------------------
 Name       ||             Total Time    |   T0   |   T2   ||              Self Time    |   T0   |   T2   || Location             
----------------------------------------------------------------------------------------------------------------------------------
            ||             1130ms 100.0% | 100.0% |   0.0% ||                0ms   0.0% |   0.0% |   0.0% || test~1:0-161
  baz       ||             1030ms  91.2% |  32.0% |  58.3% ||                0ms   0.0% |   0.0% |   0.0% || test~1:98-139
   bar      ||             1030ms  91.2% |   4.9% |  93.2% ||                0ms   0.0% |   0.0% |   0.0% || test~1:43-84
    foo     ||             1030ms  91.2% |   0.0% |  99.0% ||             1030ms  91.2% |   0.0% |  99.0% || test~1:16-29
  bar       ||              100ms   8.8% |   0.0% | 100.0% ||                0ms   0.0% |   0.0% |   0.0% || test~1:43-84
   foo      ||              100ms   8.8% |   0.0% | 100.0% ||              100ms   8.8% |   0.0% | 100.0% || test~1:16-29
----------------------------------------------------------------------------------------------------------------------------------
```
As you can see, the profile doesn't contain a column for time spent in code compiled by the tier 1 compiler. This is wrong and manifests e.g. in the line:
```
 baz       ||             1030ms  91.2% |  32.0% |  58.3% ||                0ms   0.0% |   0.0% |   0.0% || test~1:98-139
 ```
Where the time spent in the interpreter (32.0%) and the time spent in code compiled by the tier 2 compiler (58.3%) only add up to 90.3% instead of 100%  if there was really no time spent in code compiled by the tier 1 compiler.

I think the fix is trivial. Instead of just adding the highest tier of a `CPUSampler.Payload` to a new `CallTreeOutputEntry` in [`SamplingCallTree::makeEntry()`](https://github.com/oracle/graal/blob/261c38a7a47dd87f13ec3cbe0fbb85cfdff17963/tools/src/com.oracle.truffle.tools.profiler/src/com/oracle/truffle/tools/profiler/impl/CPUSamplerCLI.java#L760), simply add all the tiers to the `CallTreeOutputEntry` for which `CPUSampler.Payload` has samples.

With this fix, the previous calltree profile will then, correctly, look as follows:
```
Sampling Call Tree. Recorded 114 samples with period 10ms. Missed 39 samples.
  Self Time: Time spent on the top of the stack.
  Total Time: Time spent somewhere on the stack.
  T0: Percent of time spent in interpreter.
  T1: Percent of time spent in code compiled by tier 1 compiler.
  T2: Percent of time spent in code compiled by tier 2 compiler.
----------------------------------------------------------------------------------------------------------------------------------------------------
 Name       ||             Total Time    |   T0   |   T1   |   T2   ||              Self Time    |   T0   |   T1   |   T2   || Location             
----------------------------------------------------------------------------------------------------------------------------------------------------
            ||             1140ms 100.0% | 100.0% |   0.0% |   0.0% ||                0ms   0.0% |   0.0% |   0.0% |   0.0% || test~1:0-161
  baz       ||             1040ms  91.2% |  32.7% |   9.6% |  57.7% ||                0ms   0.0% |   0.0% |   0.0% |   0.0% || test~1:98-139
   bar      ||             1040ms  91.2% |   4.8% |   2.9% |  92.3% ||                0ms   0.0% |   0.0% |   0.0% |   0.0% || test~1:43-84
    foo     ||             1040ms  91.2% |   0.0% |   1.0% |  99.0% ||             1040ms  91.2% |   0.0% |   1.0% |  99.0% || test~1:16-29
  bar       ||              100ms   8.8% |   0.0% |   0.0% | 100.0% ||                0ms   0.0% |   0.0% |   0.0% |   0.0% || test~1:43-84
   foo      ||              100ms   8.8% |   0.0% |   0.0% | 100.0% ||              100ms   8.8% |   0.0% |   0.0% | 100.0% || test~1:16-29
----------------------------------------------------------------------------------------------------------------------------------------------------
```
E.g. it now also contains time spent in code compiled by the tier 1 compiler and for  for the line
```
  baz       ||             1040ms  91.2% |  32.7% |   9.6% |  57.7% ||                0ms   0.0% |   0.0% |   0.0% |   0.0% || test~1:98-139
```
the times spent in the interpreter (32.7%), tier 1 code (9.6%) and tier 2 code (57.7%) now correctly add up to 100%.

Fixes #10393 
