### PR TITLE
Initialize ResolverConfigurationImpl at runtime on Windows

### DIFF
--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/jdk/JNIRegistrationsSunNetDns.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/jdk/JNIRegistrationsSunNetDns.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2025, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package com.oracle.svm.hosted.jdk;
+
+import com.oracle.svm.core.feature.AutomaticallyRegisteredFeature;
+import com.oracle.svm.core.feature.InternalFeature;
+import com.oracle.svm.core.jdk.JNIRegistrationUtil;
+import org.graalvm.nativeimage.Platform;
+import org.graalvm.nativeimage.Platforms;
+import org.graalvm.nativeimage.hosted.RuntimeJNIAccess;
+
+/**
+ * Registration of classes, methods, and fields accessed via JNI by C code of the JDK.
+ */
+@Platforms(Platform.WINDOWS.class)
+@AutomaticallyRegisteredFeature
+class JNIRegistrationsSunNetDns extends JNIRegistrationUtil implements InternalFeature {
+
+    @Override
+    public void duringSetup(DuringSetupAccess a) {
+        initializeAtRunTime(a, "sun.net.dns.ResolverConfigurationImpl");
+    }
+
+    @Override
+    public void beforeAnalysis(BeforeAnalysisAccess a) {
+        a.registerReachabilityHandler(JNIRegistrationsSunNetDns::registerResolverConfigurationImplInit0,
+                method(a, "sun.net.dns.ResolverConfigurationImpl", "init0"));
+    }
+
+    private static void registerResolverConfigurationImplInit0(DuringAnalysisAccess a) {
+        RuntimeJNIAccess.register(fields(a, "sun.net.dns.ResolverConfigurationImpl", "os_searchlist", "os_nameservers"));
+    }
+}


### PR DESCRIPTION
The `ResolverConfigurationImpl` class in the JDK is initialized at build time by default. This causes a NullPointerException to occur at runtime only in Windows. To fix this issue, I have changed the `ResolverConfigurationImpl` to be initialized at runtime. For details, please refer to issue #4304.

This is my first PR for this repository, and I would greatly appreciate your review.