### PR TITLE
Rerun `sun.nio.ch.NioSocketImpl` class initializer

### DIFF
--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/jdk/JNIRegistrationJavaNio.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/jdk/JNIRegistrationJavaNio.java
@@ -72,6 +72,7 @@ public class JNIRegistrationJavaNio extends JNIRegistrationUtil implements Inter
         initializeAtRunTime(a, "sun.nio.ch.Net", "sun.nio.ch.SocketOptionRegistry$LazyInitialization");
         initializeAtRunTime(a, "sun.nio.ch.AsynchronousSocketChannelImpl$DefaultOptionsHolder", "sun.nio.ch.AsynchronousServerSocketChannelImpl$DefaultOptionsHolder",
                         "sun.nio.ch.DatagramChannelImpl$DefaultOptionsHolder", "sun.nio.ch.ServerSocketChannelImpl$DefaultOptionsHolder", "sun.nio.ch.SocketChannelImpl$DefaultOptionsHolder");
+        initializeAtRunTime(a, "sun.nio.ch.NioSocketImpl");
         /* Ensure that the interrupt signal handler is initialized at runtime. */
         initializeAtRunTime(a, "sun.nio.ch.NativeThread");
         initializeAtRunTime(a, "sun.nio.ch.FileDispatcherImpl", "sun.nio.ch.FileChannelImpl$Unmapper");


### PR DESCRIPTION
Follow up to https://github.com/oracle/graal/pull/7440

Fixes issue observed in https://github.com/quarkusio/quarkus/pull/44752#issuecomment-2502209582 by preventing build time initialization [of supported options](https://github.com/openjdk/jdk/blob/4d18e5a1e26e04beb550d01ba5a3dbb8c0c37fa0/src/java.base/share/classes/sun/nio/ch/NioSocketImpl.java#L915-L948).