### PR TITLE
Run the Quarkus workflow weekly instead of nightly

### DIFF
--- a/.github/workflows/quarkus.yml
+++ b/.github/workflows/quarkus.yml
@@ -38,7 +38,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 #
-name: Nightly Quarkus Tests
+name: Weekly Quarkus Tests
 
 on:
   push:
@@ -48,7 +48,7 @@ on:
     paths:
       - '.github/workflows/quarkus.yml'
   schedule:
-  - cron: '0 3 * * *'
+  - cron: '0 3 * * 0'
   workflow_dispatch:
 
 env:


### PR DESCRIPTION
Reduce the frequency we run the Quarkus tests as they are quite resource hungry and lengthy.
