### PR TITLE
Include Compilation ID in engine logs.

### DIFF
--- a/compiler/src/jdk.graal.compiler/src/jdk/graal/compiler/truffle/TruffleCompilerImpl.java
+++ b/compiler/src/jdk.graal.compiler/src/jdk/graal/compiler/truffle/TruffleCompilerImpl.java
@@ -407,6 +407,11 @@ public abstract class TruffleCompilerImpl implements TruffleCompiler, Compilatio
         }
 
         @Override
+        public String getCompilationId() {
+            return compResult.getCompilationId().toString(CompilationIdentifier.Verbosity.ID);
+        }
+
+        @Override
         public int getTargetCodeSize() {
             return compResult.getTargetCodeSize();
         }

--- a/truffle/src/com.oracle.truffle.compiler/src/com/oracle/truffle/compiler/TruffleCompilerListener.java
+++ b/truffle/src/com.oracle.truffle.compiler/src/com/oracle/truffle/compiler/TruffleCompilerListener.java
@@ -70,6 +70,9 @@ public interface TruffleCompilerListener {
      * Summary information for the result of a compilation.
      */
     interface CompilationResultInfo {
+        /** Gets the ID of the compilation. */
+        String getCompilationId();
+
         /**
          * Gets the size of the machine code generated.
          */

--- a/truffle/src/com.oracle.truffle.runtime/src/com/oracle/truffle/runtime/debug/TraceCompilationListener.java
+++ b/truffle/src/com.oracle.truffle.runtime/src/com/oracle/truffle/runtime/debug/TraceCompilationListener.java
@@ -78,14 +78,14 @@ public final class TraceCompilationListener extends AbstractGraalTruffleRuntimeL
 
     public static final String TIER_FORMAT = "Tier %d";
     private static final String QUEUE_FORMAT = "Queue: Size %4d Change %c%-2d Load %5.2f Time %5dus                    ";
-    private static final String TARGET_FORMAT = "engine=%-2d id=%-5d %-50s ";
+    private static final String TARGET_FORMAT = "engine=%-2d TargetId=%-5d %-50s ";
     public static final String COUNT_THRESHOLD_FORMAT = "Count/Thres  %9d/%9d";
     private static final DateTimeFormatter TIME_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS").withZone(ZoneId.of("UTC"));
     // @formatter:off
     private static final String QUEUED_FORMAT   = "opt queued " + TARGET_FORMAT + "|" + TIER_FORMAT + "|" + COUNT_THRESHOLD_FORMAT + "|" + QUEUE_FORMAT + "|UTC %s|Src %s";
     private static final String UNQUEUED_FORMAT = "opt unque. " + TARGET_FORMAT + "|" + TIER_FORMAT + "|" + COUNT_THRESHOLD_FORMAT + "|" + QUEUE_FORMAT + "|UTC %s|Src %s|Reason %s";
     private static final String START_FORMAT    = "opt start  " + TARGET_FORMAT + "|" + TIER_FORMAT + "|Priority %9d|Rate %.6f|"         + QUEUE_FORMAT + "|UTC %s|Src %s";
-    private static final String DONE_FORMAT     = "opt done   " + TARGET_FORMAT + "|" + TIER_FORMAT + "|Time %18s|AST %4d|Inlined %3dY %3dN|IR %6d/%6d|CodeSize %7d|Addr 0x%012x|UTC %s|Src %s";
+    private static final String DONE_FORMAT     = "opt done   " + TARGET_FORMAT + "|" + TIER_FORMAT + "|Time %18s|AST %4d|Inlined %3dY %3dN|IR %6d/%6d|CompilationId %s|CodeSize %7d|Addr 0x%012x|UTC %s|Src %s";
     private static final String FAILED_FORMAT   = "opt failed " + TARGET_FORMAT + "|" + TIER_FORMAT + "|Time %18s|Reason: %s|UTC %s|Src %s";
     private static final String INV_FORMAT      = "opt inval. " + TARGET_FORMAT + "                                                                                                                |UTC %s|Src %s|Reason %s";
     private static final String DEOPT_FORMAT    = "opt deopt  " + TARGET_FORMAT + "|                                                                                                               |UTC %s|Src %s";
@@ -243,6 +243,7 @@ public final class TraceCompilationListener extends AbstractGraalTruffleRuntimeL
                         inlinedAndDispatched[1],
                         compilation.nodeCountPartialEval,
                         graph == null ? 0 : graph.getNodeCount(),
+                        result == null ? 0 : result.getCompilationId(),
                         result == null ? 0 : result.getTargetCodeSize(),
                         target.getCodeAddress(),
                         TIME_FORMATTER.format(ZonedDateTime.now()),

--- a/truffle/src/com.oracle.truffle.runtime/src/com/oracle/truffle/runtime/hotspot/libgraal/LibGraalCompilationResultInfo.java
+++ b/truffle/src/com.oracle.truffle.runtime/src/com/oracle/truffle/runtime/hotspot/libgraal/LibGraalCompilationResultInfo.java
@@ -87,4 +87,8 @@ final class LibGraalCompilationResultInfo extends LibGraalScopedHandle implement
     public int getDataPatchesCount() {
         return TruffleToLibGraalCalls.getDataPatchesCount(getIsolateThread(), getHandle());
     }
+
+    public String getCompilationId() {
+        return "LibGraal";
+    }
 }


### PR DESCRIPTION
Please consider this patch to make engine trace messages print the compilation ID as part of `opt done` messages. This is useful when correlating the engine trace with HotSpot compilation/deoptimization/etc. messages.