### PR TITLE
Use offsets from `.bgv` file to select appropriate text

### DIFF
--- a/visualizer/IdealGraphVisualizer/Data/src/main/java/jdk/graal/compiler/graphio/parsing/BinaryReader.java
+++ b/visualizer/IdealGraphVisualizer/Data/src/main/java/jdk/graal/compiler/graphio/parsing/BinaryReader.java
@@ -246,6 +246,8 @@ public class BinaryReader implements GraphParser, ModelControl {
         public final String name;
 
         private Member(Klass holder, String name, int accessFlags) {
+            assert holder != null : "GraphElements.methodDeclaringClass must not return null!";
+            assert name != null;
             this.holder = holder;
             this.accessFlags = accessFlags;
             this.name = name;

--- a/visualizer/IdealGraphVisualizer/Data/src/main/java/jdk/graal/compiler/graphio/parsing/LocationStackFrame.java
+++ b/visualizer/IdealGraphVisualizer/Data/src/main/java/jdk/graal/compiler/graphio/parsing/LocationStackFrame.java
@@ -49,7 +49,7 @@ public final class LocationStackFrame {
         String sep = "";
         for (LocationStackFrame t = this; t != null; t = t.parent) {
             sb.append(sep);
-            sb.append(methodHolderName(t)).append(".").append(t.method.name);
+            sb.append(methodHolderName(t)).append(".").append(methodName(t));
             for (LocationStratum s : t.strata) {
                 if (s.file != null) {
                     sb.append("(").append(s.file).append(":").append(s.line).append(")");
@@ -63,6 +63,9 @@ public final class LocationStackFrame {
         return sb.toString();
     }
 
+    private static String methodName(LocationStackFrame t) {
+        return t != null && t.method != null ? t.method.name : null;
+    }
     private static String methodHolderName(LocationStackFrame t) {
         if (t != null && t.method != null && t.method.holder != null) {
             return t.method.holder.name;

--- a/visualizer/IdealGraphVisualizer/Data/src/test/java/org/graalvm/visualizer/data/serialization/lazy/BinaryReaderMockTest.java
+++ b/visualizer/IdealGraphVisualizer/Data/src/test/java/org/graalvm/visualizer/data/serialization/lazy/BinaryReaderMockTest.java
@@ -114,7 +114,7 @@ public class BinaryReaderMockTest extends NbTestCase {
         obj = b.group.getProperties().get("location");
         assertTrue("It is node: " + obj, obj instanceof LocationStackFrame);
         LocationStackFrame elem = (LocationStackFrame) obj;
-        assertEquals("null.mockMethod(unknown:97) [bci:97]", elem.toString());
+        assertEquals("org.graalvm.visualizer.data.serialization.lazy.BinaryReaderMockTest$MockMethod.mockMethod(unknown:97) [bci:97]", elem.toString());
     }
 
     public void testNodeEncodingInVersion60WithMethods() throws Exception {
@@ -153,7 +153,7 @@ public class BinaryReaderMockTest extends NbTestCase {
         obj = b.group.getProperties().get("location");
         assertTrue("It is node: " + obj, obj instanceof LocationStackFrame);
         LocationStackFrame elem = (LocationStackFrame) obj;
-        assertEquals("null.mockMethod(unknown:97) [bci:97]", elem.toString());
+        assertEquals("org.graalvm.visualizer.data.serialization.lazy.BinaryReaderMockTest$MockMethod.mockMethod(unknown:97) [bci:97]", elem.toString());
     }
 
     public void testNodeEncodingInVersion60WithMethodsAndStrata() throws Exception {
@@ -192,7 +192,7 @@ public class BinaryReaderMockTest extends NbTestCase {
         obj = b.group.getProperties().get("location");
         assertTrue("It is node: " + obj, obj instanceof LocationStackFrame);
         LocationStackFrame elem = (LocationStackFrame) obj;
-        assertEquals("null.mockMethod(wellknown:3)(wellknown:3)(wellknown:3) [bci:3]", elem.toString());
+        assertEquals("org.graalvm.visualizer.data.serialization.lazy.BinaryReaderMockTest$MockMethod.mockMethod(wellknown:3)(wellknown:3)(wellknown:3) [bci:3]", elem.toString());
     }
 
     public void testMixingTwoOutputsInOneStream() throws Exception {
@@ -397,7 +397,7 @@ public class BinaryReaderMockTest extends NbTestCase {
 
         @Override
         public Object methodDeclaringClass(MockMethod method) {
-            return null;
+            return method.getClass();
         }
 
         @Override

--- a/visualizer/IdealGraphVisualizer/JavaSources/src/main/java/org/graalvm/visualizer/source/java/impl/JavaStackProcessor2.java
+++ b/visualizer/IdealGraphVisualizer/JavaSources/src/main/java/org/graalvm/visualizer/source/java/impl/JavaStackProcessor2.java
@@ -271,7 +271,7 @@ public class JavaStackProcessor2 implements StackProcessor {
             }
 
             FileKey fk = ctx.file(filename, source);
-            Location newLoc = new Location(spec, fk, lineno, lastloc, depth, -1);
+            Location newLoc = new Location(spec, fk, lineno, -1, -1, lastloc, depth, -1);
             ctx.attachInfo(newLoc, javaInfo);
             javaInfo.withLocation(newLoc);
             result.add(newLoc);

--- a/visualizer/IdealGraphVisualizer/SourceRepository/src/main/java/org/graalvm/visualizer/source/Location.java
+++ b/visualizer/IdealGraphVisualizer/SourceRepository/src/main/java/org/graalvm/visualizer/source/Location.java
@@ -48,6 +48,9 @@ public final class Location {
      */
     private final int originLine;
 
+    private final int startOffset;
+    private final int endOffset;
+
     /**
      * Additional data/services, like OpenCookie, Node to present the data etc.
      */
@@ -62,10 +65,12 @@ public final class Location {
 
     private short frameFrom = -1, frameTo = -1;
 
-    public Location(String originSpec, FileKey originFile, int originLine, Location nested, int frame, int frameTo) {
+    public Location(String originSpec, FileKey originFile, int originLine, int startOffset, int endOffset, Location nested, int frame, int frameTo) {
         this.file = originFile;
         this.originSpec = originSpec;
         this.originLine = originLine;
+        this.startOffset = startOffset;
+        this.endOffset = endOffset;
         this.frameFrom = (short) frame;
         this.frameTo = (short) (frameTo == -1 ? frame : frameTo);
     }
@@ -103,6 +108,20 @@ public final class Location {
         return originLine;
     }
 
+    /** A pair of offsets.
+     *
+     * @return either {@code null} when there are no offsets or an {code @int} array
+     *   of size two. 0th element representing the start and 1st the end offset
+     *   in the document.
+     */
+    public int[] getOffsetsOrNull() {
+        if (startOffset >= 0 && endOffset > startOffset) {
+            return new int[] { startOffset, endOffset };
+        } else {
+            return null;
+        }
+    }
+
     Lookup getLookup() {
         return lookup;
     }
@@ -119,6 +138,8 @@ public final class Location {
         hash = 89 * hash + this.originLine;
         hash = 89 * hash + Objects.hashCode(this.file);
         hash = 89 * hash + Objects.hashCode(this.parent);
+        hash = 37 * hash + startOffset;
+        hash = 37 * hash + endOffset;
         cachedHash = hash == -1 ? 7 : hash;
         return cachedHash;
     }
@@ -136,6 +157,12 @@ public final class Location {
         }
         final Location other = (Location) obj;
         if (this.originLine != other.originLine) {
+            return false;
+        }
+        if (this.startOffset != other.startOffset) {
+            return false;
+        }
+        if (this.endOffset != other.endOffset) {
             return false;
         }
         if (this.parent != other.parent) {

--- a/visualizer/IdealGraphVisualizer/SourceRepository/src/main/java/org/graalvm/visualizer/source/SourceLocationUtils.java
+++ b/visualizer/IdealGraphVisualizer/SourceRepository/src/main/java/org/graalvm/visualizer/source/SourceLocationUtils.java
@@ -42,9 +42,9 @@ public final class SourceLocationUtils {
      * @param line the line number
      * @return location object
      */
-    public static Location createLocation(FileObject f, int line) {
+    private static Location createLocation(FileObject f, int line) {
         String spec = f.getPath() + ":" + line;
-        return new Location(spec, FileKey.fromFile(f), line, null, -1, -1);
+        return new Location(spec, FileKey.fromFile(f), line, -1, -1, null, -1, -1);
     }
 
     public static Collection<Location> atLine(List<Location> searchIn, int line) {

--- a/visualizer/IdealGraphVisualizer/SourceRepository/src/main/java/org/graalvm/visualizer/source/lang/FileStackProcessor.java
+++ b/visualizer/IdealGraphVisualizer/SourceRepository/src/main/java/org/graalvm/visualizer/source/lang/FileStackProcessor.java
@@ -139,7 +139,7 @@ public class FileStackProcessor implements StackProcessor {
                 fk = new FileKey(langMime, langStratum.uri);
             }
             Location newLoc = new Location(langStratum.uri,
-                    fk, langStratum.line, lastloc, lastDepth, depth);
+                    fk, langStratum.line, langStratum.startOffset, langStratum.endOffset, lastloc, lastDepth, depth);
             if (newLoc.equals(lastloc)) {
                 replaceTop(newLoc);
                 return null;

--- a/visualizer/IdealGraphVisualizer/SourceRepository/src/main/resources/org/graalvm/visualizer/source/resources/NodePositionOffset.xml
+++ b/visualizer/IdealGraphVisualizer/SourceRepository/src/main/resources/org/graalvm/visualizer/source/resources/NodePositionOffset.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+
+
+<!DOCTYPE type PUBLIC "-//NetBeans//DTD annotation type 1.0//EN" "http://www.netbeans.org/dtds/annotation-type-1_0.dtd">
+<type
+        name='NodePositionOffset'
+        description_key='Hint_NodePositionCurrent'
+        localizing_bundle='org.graalvm.visualizer.source.resources.Bundle'
+        visible='true'
+        glyph='nbresloc:/org/graalvm/visualizer/source/resources/extractNodes.gif'
+        highlight='0xC8FF00'
+        type='linepart'
+        priority='1100'
+        custom_sidebar_color='0xFFCCCC'
+/>

--- a/visualizer/IdealGraphVisualizer/SourceRepository/src/main/resources/org/graalvm/visualizer/source/resources/layer.xml
+++ b/visualizer/IdealGraphVisualizer/SourceRepository/src/main/resources/org/graalvm/visualizer/source/resources/layer.xml
@@ -84,6 +84,7 @@
             <file name="NodePositionCurrent.xml" url="NodePositionCurrent.xml"/>
             <file name="CallSiteCurrent.xml" url="CallSiteCurrent.xml"/>
             <file name="CalledSiteCurrent.xml" url="CalledSiteCurrent.xml"/>
+            <file name="NodePositionOffset.xml" url="NodePositionOffset.xml"/>
         </folder>
         <folder name="FontsColors">
             <folder name="NetBeans">

--- a/visualizer/IdealGraphVisualizer/SourceRepository/src/test/java/org/graalvm/visualizer/source/impl/ui/LocationOpenerTest.java
+++ b/visualizer/IdealGraphVisualizer/SourceRepository/src/test/java/org/graalvm/visualizer/source/impl/ui/LocationOpenerTest.java
@@ -1,0 +1,85 @@
+package org.graalvm.visualizer.source.impl.ui;
+
+import java.io.OutputStream;
+import java.util.List;
+import javax.swing.text.StyledDocument;
+import org.netbeans.junit.NbTestCase;
+import org.openide.cookies.EditorCookie;
+import org.openide.filesystems.FileObject;
+import org.openide.filesystems.FileUtil;
+import org.openide.loaders.DataObject;
+import org.openide.text.Annotatable;
+import org.openide.text.Line;
+
+public class LocationOpenerTest extends NbTestCase {
+
+    private DataObject data;
+    private EditorCookie ec;
+    private StyledDocument doc;
+
+    public LocationOpenerTest(String name) {
+        super(name);
+    }
+
+    @Override
+    protected void setUp() throws Exception {
+        clearWorkDir();
+        FileObject root = FileUtil.toFileObject(getWorkDir());
+        assertNotNull("Found fs root", root);
+        FileObject fo = root.createData("sample", "txt");
+        String txt = "First line\n"
+                + "Second line\n"
+                + "Third line\n";
+        try (OutputStream os = fo.getOutputStream()) {
+            os.write(txt.getBytes());
+        }
+        data = DataObject.find(fo);
+        ec = data.getLookup().lookup(EditorCookie.class);
+        assertNotNull("Has editor cookie", ec);
+        doc = ec.openDocument();
+        assertNotNull("Document found", doc);
+    }
+
+    public void testFindsALineWhenNoOffset() {
+        Annotatable line = findSingle(ec.getLineSet(), doc, 1, null);
+        assertTrue("It is line: " + line, line instanceof Line);
+        assertEquals("Second line\n", line.getText());
+    }
+
+    public void testIgnoresOffsetOnWrongLine() {
+        Annotatable line = findSingle(ec.getLineSet(), doc, 1, new int[] { 3, 5 });
+        assertTrue("It is line: " + line, line instanceof Line);
+        assertEquals("Second line\n", line.getText());
+    }
+
+    public void testUsesOffsetInsideOfTheSameLine() {
+        Annotatable part = findSingle(ec.getLineSet(), doc, 1, new int[] { 11, 17 });
+        assertTrue("It is line part: " + part, part instanceof Line.Part);
+        assertEquals("Second", part.getText());
+    }
+
+    public void testUsesOffsetWhenNoLine() {
+        Annotatable part = findSingle(ec.getLineSet(), doc, -1, new int[] { 11, 17 });
+        assertTrue("It is line part: " + part, part instanceof Line.Part);
+        assertEquals("Second", part.getText());
+    }
+
+    public void testNoLineAndNoOffsetsYieldsNull() {
+        Annotatable part = findSingle(ec.getLineSet(), doc, -1, null);
+        assertNull("Nothing found", part);
+    }
+
+    public void testMultipleLines() {
+        List<Annotatable> parts = LocationOpener.findLinesOrParts(ec.getLineSet(), doc, -1, new int[] { 6, 28 });
+        assertEquals("Three elements selected", 3, parts.size());
+        assertEquals("line\n", parts.get(0).getText());
+        assertEquals("Second line\n", parts.get(1).getText());
+        assertEquals("Third", parts.get(2).getText());
+    }
+
+    private static Annotatable findSingle(Line.Set set, StyledDocument doc, int lineNumber, int[] offsetPair) {
+        List<Annotatable> select = LocationOpener.findLinesOrParts(set, doc, lineNumber, offsetPair);
+        assertEquals("Expecting single result: " + select, 1, select.size());
+        return select.get(0);
+    }
+}


### PR DESCRIPTION
Enso is trying to [generate IGV graph](https://github.com/enso-org/enso/pull/12061#issuecomment-2598666306) for our internal `IR`:

- https://github.com/enso-org/enso/pull/12061 

We had issues to provide proper `nodeSourceLocation` information. I had to debug visualizer code to find out what's wrong. While doing that I made few fixes. 

-  we were providing `-1` as line location - IGV was then doing nothing - with 75d41ee8179929bdda1c5fed3220e6ef357092ca it at least opens the file
- I was getting `NullPointerException`s so I am adding checks and `assert` to catch that earlier
- Last, but not least: we do provide _start and end_ offsets for Enso nodes. Let's use them!

![Location used](https://github.com/user-attachments/assets/eca0a6ab-8c5c-4d8d-95d0-3280a657559d)

With these changes IGV picks up `start` and `end` offset from `location` property and is capable to select appropriate source range. CCing @tkrodriguez, @sdedic, @Akirathan 