### PR TITLE
Fix substratevm after 'JDK-8347287: JFR: Remove use of Security Manager'

### DIFF
--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/JfrJdkCompatibility.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/JfrJdkCompatibility.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,6 +26,7 @@ package com.oracle.svm.core.jfr;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.nio.file.Path;
 import java.time.Duration;
 import java.time.LocalDateTime;
 
@@ -117,7 +118,7 @@ public final class JfrJdkCompatibility {
         }
     }
 
-    public static void setDumpDirectory(PlatformRecording platformRecording, SecuritySupport.SafePath directory) {
+    public static void setDumpDirectory(PlatformRecording platformRecording, Target_jdk_jfr_internal_SecuritySupport_SafePath directory) {
         Target_jdk_jfr_internal_PlatformRecording pr = SubstrateUtil.cast(platformRecording, Target_jdk_jfr_internal_PlatformRecording.class);
         if (JavaVersionUtil.JAVA_SPEC >= 23) {
             pr.setDumpDirectory(directory);
@@ -161,12 +162,16 @@ final class Target_jdk_jfr_internal_util_ValueFormatter {
 @TargetClass(className = "jdk.jfr.internal.PlatformRecording")
 final class Target_jdk_jfr_internal_PlatformRecording {
     @Alias
-    @TargetElement(onlyWith = JDKLatest.class)
-    public native void setDumpDirectory(SecuritySupport.SafePath directory);
+    @TargetElement(onlyWith = SecuritySupportSafePathAbsent.class)
+    public native void setDumpDirectory(Path directory);
 
     @Alias
-    @TargetElement(onlyWith = JDK21OrEarlier.class)
-    public native void setDumpOnExitDirectory(SecuritySupport.SafePath directory);
+    @TargetElement(onlyWith = {JDKLatest.class, SecuritySupportSafePathPresent.class})
+    public native void setDumpDirectory(Target_jdk_jfr_internal_SecuritySupport_SafePath directory);
+
+    @Alias
+    @TargetElement(onlyWith = {JDK21OrEarlier.class, SecuritySupportSafePathPresent.class})
+    public native void setDumpOnExitDirectory(Target_jdk_jfr_internal_SecuritySupport_SafePath directory);
 }
 
 final class JfrFilenameUtil {

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/JfrManager.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/JfrManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2025, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2024, 2024, Red Hat Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -31,6 +31,7 @@ import static com.oracle.svm.core.jfr.JfrArgumentParser.parseInteger;
 import static com.oracle.svm.core.jfr.JfrArgumentParser.parseJfrOptions;
 import static com.oracle.svm.core.jfr.JfrArgumentParser.parseMaxSize;
 
+import java.nio.file.Paths;
 import java.util.Map;
 
 import org.graalvm.nativeimage.ImageSingletons;
@@ -125,8 +126,12 @@ public class JfrManager {
 
         if (repositoryPath != null) {
             try {
-                SecuritySupport.SafePath repositorySafePath = new SecuritySupport.SafePath(repositoryPath);
-                Repository.getRepository().setBasePath(repositorySafePath);
+                if (new SecuritySupportSafePathPresent().getAsBoolean()) {
+                    Target_jdk_jfr_internal_SecuritySupport_SafePath repositorySafePath = new Target_jdk_jfr_internal_SecuritySupport_SafePath(repositoryPath);
+                    SubstrateUtil.cast(Repository.getRepository(), Target_jdk_jfr_internal_Repository.class).setBasePath(repositorySafePath);
+                } else {
+                    SubstrateUtil.cast(Repository.getRepository(), Target_jdk_jfr_internal_Repository.class).setBasePath(Paths.get(repositoryPath));
+                }
             } catch (Throwable e) {
                 throw new JfrArgumentParsingFailed("Could not use " + repositoryPath + " as repository. " + e.getMessage(), e);
             }

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/SecuritySupportSafePathPresent.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/SecuritySupportSafePathPresent.java
@@ -24,31 +24,40 @@
  */
 package com.oracle.svm.core.jfr;
 
-import java.util.List;
-
 import com.oracle.svm.core.annotate.Alias;
-import com.oracle.svm.core.annotate.RecomputeFieldValue;
-import com.oracle.svm.core.annotate.Substitute;
 import com.oracle.svm.core.annotate.TargetClass;
 import com.oracle.svm.core.annotate.TargetElement;
-import com.oracle.svm.core.util.VMError;
 
-import jdk.jfr.internal.SecuritySupport;
+import java.util.function.BooleanSupplier;
 
-@TargetClass(value = jdk.jfr.internal.SecuritySupport.class, onlyWith = HasJfrSupport.class)
-public final class Target_jdk_jfr_internal_SecuritySupport {
-    // Checkstyle: stop
-    @Alias @TargetElement(onlyWith = SecuritySupportSafePathPresent.class) @RecomputeFieldValue(kind = RecomputeFieldValue.Kind.Reset) //
-    static Target_jdk_jfr_internal_SecuritySupport_SafePath JFC_DIRECTORY;
-    @Alias @TargetElement(onlyWith = SecuritySupportSafePathPresent.class) @RecomputeFieldValue(kind = RecomputeFieldValue.Kind.Reset) //
-    static Target_jdk_jfr_internal_SecuritySupport_SafePath JAVA_IO_TMPDIR;
-    // Checkstyle: resume
-
-    @Substitute @TargetElement(onlyWith = SecuritySupportSafePathPresent.class)
-    public static List<Target_jdk_jfr_internal_SecuritySupport_SafePath> getPredefinedJFCFiles() {
-        throw VMError.shouldNotReachHere("Paths from the image build must not be embedded into the Native Image.");
+/**
+ * A predicate that returns {@code true} if {@code boolean jdk.jfr.internal.SecuritySupport.SafePath} exists.
+ */
+final class SecuritySupportSafePathPresent implements BooleanSupplier {
+    @Override
+    public boolean getAsBoolean() {
+        try {
+            Class.forName("jdk.jfr.internal.SecuritySupport$SafePath");
+            return true;
+        } catch (ClassNotFoundException e) {
+            return false;
+        }
     }
+}
 
-    @Alias @TargetElement(onlyWith = SecuritySupportSafePathPresent.class)
-    static native Target_jdk_jfr_internal_SecuritySupport_SafePath getPathInProperty(String prop, String subPath);
+final class SecuritySupportSafePathAbsent implements BooleanSupplier {
+    @Override
+    public boolean getAsBoolean() {
+        return !new SecuritySupportSafePathPresent().getAsBoolean();
+    }
+}
+
+@TargetClass(className = "jdk.jfr.internal.SecuritySupport$SafePath", onlyWith = SecuritySupportSafePathPresent.class)
+final class Target_jdk_jfr_internal_SecuritySupport_SafePath {
+    public Target_jdk_jfr_internal_SecuritySupport_SafePath(String p) {
+        originalConstructor(p);
+    }
+    @Alias
+    @TargetElement(name = TargetElement.CONSTRUCTOR_NAME)
+    native void originalConstructor(String p);
 }


### PR DESCRIPTION
[JDK-8347287: JFR: Remove use of Security Manage](https://bugs.openjdk.org/browse/JDK-8347287) which has removed the SecurityManager from the JFR files has screwed up the substratevm and the native image build.

This pull requests fixes the problem in such a way that substratevm/native image work again with both versions of the JDK, before and after [JDK-8347287](https://bugs.openjdk.org/browse/JDK-8347287).

`mx --primary-suite=substratevm --components=ni,nju,lg gate -t 'native unittests'` which were the only JFR tests I could find succeed after this PR with both versions of the JDK before and after [JDK-8347287](https://bugs.openjdk.org/browse/JDK-8347287). Please let me know if there are other tests which I can run.