### PR TITLE
[WIP] Strict constant reflection

### DIFF
--- a/compiler/mx.compiler/suite.py
+++ b/compiler/mx.compiler/suite.py
@@ -120,6 +120,18 @@ suite = {
       "license" : "BSD-new",
     },
 
+    "ASM_ANALYSIS_9.7.1" : {
+      "digest" : "sha512:a8bd265c81d9bb4371cafd3f5d18f96ad79aec65031457d518c54599144d199d9feddf13b8dc822b2598b8b504a88edbd81d1f2c52991a70a6b343d8f5bb6fe5",
+      "sourceDigest" : "sha512:ddfa874109ce46473f0a2aca46880f484bc5f598fccd4ed6dd48df95257114833654d6aed07e3f28994465b8c7b02e01517fedb1fe54cb11b922b1bed97b21b8",
+      "maven" : {
+        "groupId" : "org.ow2.asm",
+        "artifactId" : "asm-analysis",
+        "version" : "9.7.1",
+      },
+      "dependencies" : ["ASM_TREE_9.7.1"],
+      "license" : "BSD-new",
+    },
+
     "HSDIS" : {
       "urlbase" : "https://lafo.ssw.uni-linz.ac.at/pub/graal-external-deps/hsdis",
       "packedResource" : True,
@@ -616,7 +628,7 @@ suite = {
           "jdk.graal.compiler.nodes.graphbuilderconf to org.graalvm.nativeimage.driver,org.graalvm.nativeimage.librarysupport",
           "jdk.graal.compiler.options                to org.graalvm.nativeimage.driver,org.graalvm.nativeimage.junitsupport",
           "jdk.graal.compiler.phases.common          to org.graalvm.nativeimage.agent.tracing,org.graalvm.nativeimage.configure",
-          "jdk.graal.compiler.serviceprovider        to jdk.graal.compiler.management,org.graalvm.nativeimage.driver,org.graalvm.nativeimage.agent.jvmtibase,org.graalvm.nativeimage.agent.diagnostics",
+          "jdk.graal.compiler.serviceprovider        to jdk.graal.compiler.management,org.graalvm.nativeimage.driver,org.graalvm.nativeimage.agent.jvmtibase,org.graalvm.nativeimage.agent.diagnostics,org.graalvm.nativeimage.agent.reflection",
           "jdk.graal.compiler.util.json              to org.graalvm.nativeimage.librarysupport,org.graalvm.nativeimage.agent.tracing,org.graalvm.nativeimage.configure,org.graalvm.nativeimage.driver",
         ],
         "uses" : [

--- a/compiler/src/jdk.graal.compiler/src/jdk/graal/compiler/nodes/graphbuilderconf/GraphBuilderContext.java
+++ b/compiler/src/jdk.graal.compiler/src/jdk/graal/compiler/nodes/graphbuilderconf/GraphBuilderContext.java
@@ -79,6 +79,9 @@ import jdk.vm.ci.meta.JavaKind;
 import jdk.vm.ci.meta.JavaType;
 import jdk.vm.ci.meta.ResolvedJavaMethod;
 
+import java.util.ArrayList;
+import java.util.List;
+
 /**
  * Used by a {@link GraphBuilderPlugin} to interface with an object that parses the bytecode of a
  * single {@linkplain #getMethod() method} as part of building a {@linkplain #getGraph() graph} .
@@ -276,6 +279,18 @@ public interface GraphBuilderContext extends GraphBuilderTool {
             parent = parent.getParent();
         }
         return result;
+    }
+
+    /**
+     * Gets the inlined call stack for this context. A list with only one element implies that no
+     * inlining has taken place.
+     */
+    default List<StackTraceElement> getCallStack() {
+        List<StackTraceElement> callStack = new ArrayList<>();
+        for (GraphBuilderContext cur = this; cur != null; cur = cur.getParent()) {
+            callStack.add(cur.getMethod().asStackTraceElement(cur.bci()));
+        }
+        return callStack;
     }
 
     /**

--- a/compiler/src/jdk.graal.compiler/src/jdk/graal/compiler/replacements/IntrinsicGraphBuilder.java
+++ b/compiler/src/jdk.graal.compiler/src/jdk/graal/compiler/replacements/IntrinsicGraphBuilder.java
@@ -76,6 +76,9 @@ import jdk.vm.ci.meta.ResolvedJavaMethod;
 import jdk.vm.ci.meta.ResolvedJavaType;
 import jdk.vm.ci.meta.Signature;
 
+import java.util.ArrayList;
+import java.util.List;
+
 /**
  * Implementation of {@link GraphBuilderContext} used to produce a graph for a method based on an
  * {@link InvocationPlugin} for the method.
@@ -323,6 +326,11 @@ public class IntrinsicGraphBuilder extends CoreProvidersDelegate implements Grap
     @Override
     public int getDepth() {
         return 0;
+    }
+
+    @Override
+    public List<StackTraceElement> getCallStack() {
+        return new ArrayList<>();
     }
 
     @Override

--- a/compiler/src/jdk.graal.compiler/src/jdk/graal/compiler/replacements/PEGraphDecoder.java
+++ b/compiler/src/jdk.graal.compiler/src/jdk/graal/compiler/replacements/PEGraphDecoder.java
@@ -413,6 +413,19 @@ public abstract class PEGraphDecoder extends SimplifyingGraphDecoder {
         }
 
         @Override
+        public List<StackTraceElement> getCallStack() {
+            List<StackTraceElement> callStack = new ArrayList<>(Arrays.asList(methodScope.getCallStack()));
+            /*
+             * If we're processing an invocation plugin, we want the top stack element to be the
+             * callee of the method targeted by the plugin, and not the target itself.
+             */
+            if (isParsingInvocationPlugin()) {
+                callStack.removeFirst();
+            }
+            return callStack;
+        }
+
+        @Override
         public int recursiveInliningDepth(ResolvedJavaMethod method) {
             int result = 0;
             for (PEMethodScope cur = methodScope; cur != null; cur = cur.caller) {

--- a/sdk/mx.sdk/suite.py
+++ b/sdk/mx.sdk/suite.py
@@ -837,6 +837,7 @@ suite = {
           "org.graalvm.nativeimage.c.constant",
           "org.graalvm.nativeimage.c",
           "org.graalvm.nativeimage",
+          "org.graalvm.nativeimage.impl.reflectiontags",
           """org.graalvm.nativeimage.impl to org.graalvm.nativeimage.pointsto,
                                              org.graalvm.nativeimage.base,
                                              org.graalvm.nativeimage.builder,

--- a/sdk/src/org.graalvm.nativeimage/src/org/graalvm/nativeimage/impl/reflectiontags/ConstantTags.java
+++ b/sdk/src/org.graalvm.nativeimage/src/org/graalvm/nativeimage/impl/reflectiontags/ConstantTags.java
@@ -1,0 +1,226 @@
+/*
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or
+ * data (collectively the "Software"), free of charge and under any and all
+ * copyright rights in the Software, and any and all patent rights owned or
+ * freely licensable by each licensor hereunder covering either (i) the
+ * unmodified Software as contributed to or provided by such licensor, or (ii)
+ * the Larger Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ *
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ *
+ * The above copyright notice and either this complete permission notice or at a
+ * minimum a reference to the UPL must be included in all copies or substantial
+ * portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.graalvm.nativeimage.impl.reflectiontags;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+import java.lang.invoke.VarHandle;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.lang.reflect.RecordComponent;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Used for representing constant reflection calls caught by {@link com.oracle.svm.reflectionagent}.
+ * <p>
+ * Due to build-time initialization, the calls must implement the equivalent logic of their corresponding
+ * reflection method. Since these calls will be folded into constants, they will never be executed during
+ * image run-time.
+ */
+public final class ConstantTags {
+
+    public static final Map<Method, Method> TAG_TO_ORIGINAL_MAPPING;
+
+    static {
+        Map<Method, Method> mapping = new HashMap<>();
+        try {
+            mapping.put(ConstantTags.class.getDeclaredMethod("forName", String.class), Class.class.getDeclaredMethod("forName", String.class));
+            mapping.put(ConstantTags.class.getDeclaredMethod("forName", String.class, boolean.class, ClassLoader.class), Class.class.getDeclaredMethod("forName", String.class, boolean.class, ClassLoader.class));
+            mapping.put(ConstantTags.class.getDeclaredMethod("getField", Class.class, String.class), Class.class.getDeclaredMethod("getField", String.class));
+            mapping.put(ConstantTags.class.getDeclaredMethod("getDeclaredField", Class.class, String.class), Class.class.getDeclaredMethod("getDeclaredField", String.class));
+            mapping.put(ConstantTags.class.getDeclaredMethod("getConstructor", Class.class, Class[].class), Class.class.getDeclaredMethod("getConstructor", Class[].class));
+            mapping.put(ConstantTags.class.getDeclaredMethod("getDeclaredConstructor", Class.class, Class[].class), Class.class.getDeclaredMethod("getDeclaredConstructor", Class[].class));
+            mapping.put(ConstantTags.class.getDeclaredMethod("getMethod", Class.class, String.class, Class[].class), Class.class.getDeclaredMethod("getMethod", String.class, Class[].class));
+            mapping.put(ConstantTags.class.getDeclaredMethod("getDeclaredMethod", Class.class, String.class, Class[].class), Class.class.getDeclaredMethod("getDeclaredMethod", String.class, Class[].class));
+            mapping.put(ConstantTags.class.getDeclaredMethod("getFields", Class.class), Class.class.getDeclaredMethod("getFields"));
+            mapping.put(ConstantTags.class.getDeclaredMethod("getDeclaredFields", Class.class), Class.class.getDeclaredMethod("getDeclaredFields"));
+            mapping.put(ConstantTags.class.getDeclaredMethod("getConstructors", Class.class), Class.class.getDeclaredMethod("getConstructors"));
+            mapping.put(ConstantTags.class.getDeclaredMethod("getDeclaredConstructors", Class.class), Class.class.getDeclaredMethod("getDeclaredConstructors"));
+            mapping.put(ConstantTags.class.getDeclaredMethod("getMethods", Class.class), Class.class.getDeclaredMethod("getMethods"));
+            mapping.put(ConstantTags.class.getDeclaredMethod("getDeclaredMethods", Class.class), Class.class.getDeclaredMethod("getDeclaredMethods"));
+            mapping.put(ConstantTags.class.getDeclaredMethod("getClasses", Class.class), Class.class.getDeclaredMethod("getClasses"));
+            mapping.put(ConstantTags.class.getDeclaredMethod("getDeclaredClasses", Class.class), Class.class.getDeclaredMethod("getDeclaredClasses"));
+            mapping.put(ConstantTags.class.getDeclaredMethod("getNestMembers", Class.class), Class.class.getDeclaredMethod("getNestMembers"));
+            mapping.put(ConstantTags.class.getDeclaredMethod("getPermittedSubclasses", Class.class), Class.class.getDeclaredMethod("getPermittedSubclasses"));
+            mapping.put(ConstantTags.class.getDeclaredMethod("getRecordComponents", Class.class), Class.class.getDeclaredMethod("getRecordComponents"));
+            mapping.put(ConstantTags.class.getDeclaredMethod("getSigners", Class.class), Class.class.getDeclaredMethod("getSigners"));
+            mapping.put(ConstantTags.class.getDeclaredMethod("findClass", MethodHandles.Lookup.class, String.class), MethodHandles.Lookup.class.getDeclaredMethod("findClass", String.class));
+            mapping.put(ConstantTags.class.getDeclaredMethod("findVirtual", MethodHandles.Lookup.class, Class.class, String.class, MethodType.class), MethodHandles.Lookup.class.getDeclaredMethod("findVirtual", Class.class, String.class, MethodType.class));
+            mapping.put(ConstantTags.class.getDeclaredMethod("findStatic", MethodHandles.Lookup.class, Class.class, String.class, MethodType.class), MethodHandles.Lookup.class.getDeclaredMethod("findStatic", Class.class, String.class, MethodType.class));
+            mapping.put(ConstantTags.class.getDeclaredMethod("findConstructor", MethodHandles.Lookup.class, Class.class, MethodType.class), MethodHandles.Lookup.class.getDeclaredMethod("findConstructor", Class.class, MethodType.class));
+            mapping.put(ConstantTags.class.getDeclaredMethod("findGetter", MethodHandles.Lookup.class, Class.class, String.class, Class.class), MethodHandles.Lookup.class.getDeclaredMethod("findGetter", Class.class, String.class, Class.class));
+            mapping.put(ConstantTags.class.getDeclaredMethod("findStaticGetter", MethodHandles.Lookup.class, Class.class, String.class, Class.class), MethodHandles.Lookup.class.getDeclaredMethod("findStaticGetter", Class.class, String.class, Class.class));
+            mapping.put(ConstantTags.class.getDeclaredMethod("findSetter", MethodHandles.Lookup.class, Class.class, String.class, Class.class), MethodHandles.Lookup.class.getDeclaredMethod("findSetter", Class.class, String.class, Class.class));
+            mapping.put(ConstantTags.class.getDeclaredMethod("findStaticSetter", MethodHandles.Lookup.class, Class.class, String.class, Class.class), MethodHandles.Lookup.class.getDeclaredMethod("findStaticSetter", Class.class, String.class, Class.class));
+            mapping.put(ConstantTags.class.getDeclaredMethod("findVarHandle", MethodHandles.Lookup.class, Class.class, String.class, Class.class), MethodHandles.Lookup.class.getDeclaredMethod("findVarHandle", Class.class, String.class, Class.class));
+            mapping.put(ConstantTags.class.getDeclaredMethod("findStaticVarHandle", MethodHandles.Lookup.class, Class.class, String.class, Class.class), MethodHandles.Lookup.class.getDeclaredMethod("findStaticVarHandle", Class.class, String.class, Class.class));
+        } catch (NoSuchMethodException e) {
+            throw new RuntimeException(e);
+        }
+        TAG_TO_ORIGINAL_MAPPING = Collections.unmodifiableMap(mapping);
+    }
+
+    private static final StackWalker stackWalker = StackWalker.getInstance(StackWalker.Option.RETAIN_CLASS_REFERENCE);
+
+    public static Class<?> forName(String className) throws ClassNotFoundException {
+        return Class.forName(className, true, stackWalker.getCallerClass().getClassLoader());
+    }
+
+    public static Class<?> forName(String className, boolean initialize, ClassLoader classLoader) throws ClassNotFoundException {
+        return Class.forName(className, initialize, classLoader);
+    }
+
+    public static Field getField(Class<?> clazz, String fieldName) throws NoSuchFieldException {
+        return clazz.getField(fieldName);
+    }
+
+    public static Field getDeclaredField(Class<?> clazz, String fieldName) throws NoSuchFieldException {
+        return clazz.getDeclaredField(fieldName);
+    }
+
+    public static Constructor<?> getConstructor(Class<?> clazz, Class<?>... parameterTypes) throws NoSuchMethodException {
+        return clazz.getConstructor(parameterTypes);
+    }
+
+    public static Constructor<?> getDeclaredConstructor(Class<?> clazz, Class<?>... parameterTypes) throws NoSuchMethodException {
+        return clazz.getDeclaredConstructor(parameterTypes);
+    }
+
+    public static Method getMethod(Class<?> clazz, String methodName, Class<?>... parameterTypes) throws NoSuchMethodException {
+        return clazz.getMethod(methodName, parameterTypes);
+    }
+
+    public static Method getDeclaredMethod(Class<?> clazz, String methodName, Class<?>... parameterTypes) throws NoSuchMethodException {
+        return clazz.getDeclaredMethod(methodName, parameterTypes);
+    }
+
+    public static Field[] getFields(Class<?> clazz) {
+        return clazz.getFields();
+    }
+
+    public static Field[] getDeclaredFields(Class<?> clazz) {
+        return clazz.getDeclaredFields();
+    }
+
+    public static Constructor<?>[] getConstructors(Class<?> clazz) {
+        return clazz.getConstructors();
+    }
+
+    public static Constructor<?>[] getDeclaredConstructors(Class<?> clazz) {
+        return clazz.getDeclaredConstructors();
+    }
+
+    public static Method[] getMethods(Class<?> clazz) {
+        return clazz.getMethods();
+    }
+
+    public static Method[] getDeclaredMethods(Class<?> clazz) {
+        return clazz.getDeclaredMethods();
+    }
+
+    public static Class<?>[] getClasses(Class<?> clazz) {
+        return clazz.getClasses();
+    }
+
+    public static Class<?>[] getDeclaredClasses(Class<?> clazz) {
+        return clazz.getDeclaredClasses();
+    }
+
+    public static Class<?>[] getNestMembers(Class<?> clazz) {
+        return clazz.getNestMembers();
+    }
+
+    public static Class<?>[] getPermittedSubclasses(Class<?> clazz) {
+        return clazz.getPermittedSubclasses();
+    }
+
+    public static RecordComponent[] getRecordComponents(Class<?> clazz) {
+        return clazz.getRecordComponents();
+    }
+
+    public static Object[] getSigners(Class<?> clazz) {
+        return clazz.getSigners();
+    }
+
+    public static Class<?> findClass(MethodHandles.Lookup lookup, String className) throws ClassNotFoundException, IllegalAccessException {
+        return lookup.findClass(className);
+    }
+
+    public static MethodHandle findVirtual(MethodHandles.Lookup lookup, Class<?> clazz, String methodName, MethodType methodType) throws NoSuchMethodException, IllegalAccessException {
+        return lookup.findVirtual(clazz, methodName, methodType);
+    }
+
+    public static MethodHandle findStatic(MethodHandles.Lookup lookup, Class<?> clazz, String methodName, MethodType methodType) throws NoSuchMethodException, IllegalAccessException {
+        return lookup.findStatic(clazz, methodName, methodType);
+    }
+
+    public static MethodHandle findConstructor(MethodHandles.Lookup lookup, Class<?> clazz, MethodType methodType) throws NoSuchMethodException, IllegalAccessException {
+        return lookup.findConstructor(clazz, methodType);
+    }
+
+    public static MethodHandle findGetter(MethodHandles.Lookup lookup, Class<?> clazz, String name, Class<?> type) throws NoSuchFieldException, IllegalAccessException {
+        return lookup.findGetter(clazz, name, type);
+    }
+
+    public static MethodHandle findStaticGetter(MethodHandles.Lookup lookup, Class<?> clazz, String name, Class<?> type) throws NoSuchFieldException, IllegalAccessException {
+        return lookup.findStaticGetter(clazz, name, type);
+    }
+
+    public static MethodHandle findSetter(MethodHandles.Lookup lookup, Class<?> clazz, String name, Class<?> type) throws NoSuchFieldException, IllegalAccessException {
+        return lookup.findSetter(clazz, name, type);
+    }
+
+    public static MethodHandle findStaticSetter(MethodHandles.Lookup lookup, Class<?> clazz, String name, Class<?> type) throws NoSuchFieldException, IllegalAccessException {
+        return lookup.findStaticSetter(clazz, name, type);
+    }
+
+    public static VarHandle findVarHandle(MethodHandles.Lookup lookup, Class<?> clazz, String name, Class<?> type) throws NoSuchFieldException, IllegalAccessException {
+        return lookup.findVarHandle(clazz, name, type);
+    }
+
+    public static VarHandle findStaticVarHandle(MethodHandles.Lookup lookup, Class<?> clazz, String name, Class<?> type) throws NoSuchFieldException, IllegalAccessException {
+        return lookup.findStaticVarHandle(clazz, name, type);
+    }
+}

--- a/substratevm/mx.substratevm/mx_substratevm.py
+++ b/substratevm/mx.substratevm/mx_substratevm.py
@@ -1362,6 +1362,20 @@ native_image = mx_sdk_vm.GraalVmJreComponent(
             headers=False,
             home_finder=False,
         ),
+        mx_sdk_vm.LibraryConfig(
+            use_modules='image',
+            destination="<lib:native-image-reflection-agent>",
+            jvm_library=True,
+            jar_distributions=[
+                'substratevm:JVMTI_AGENT_BASE',
+                'substratevm:SVM_REFLECTION_AGENT',
+            ],
+            build_args=driver_build_args + [
+                '--features=com.oracle.svm.reflectionagent.NativeImageReflectionAgent$RegistrationFeature',
+            ],
+            headers=False,
+            home_finder=False,
+        ),
     ],
     installable=True,
     stability="earlyadopter",

--- a/substratevm/mx.substratevm/suite.py
+++ b/substratevm/mx.substratevm/suite.py
@@ -265,6 +265,7 @@ suite = {
             "shadedDependencies" : [
                 "compiler:ASM_9.7.1",
                 "compiler:ASM_TREE_9.7.1",
+                "compiler:ASM_ANALYSIS_9.7.1",
             ],
             "class" : "ShadedLibraryProject",
             "shade" : {
@@ -1483,6 +1484,32 @@ suite = {
             "jacoco" : "exclude",
         },
 
+        "com.oracle.svm.reflectionagent": {
+            "subDir": "src",
+            "sourceDirs": [
+                "src",
+                "resources"
+            ],
+            "dependencies": [
+                "JVMTI_AGENT_BASE",
+                "com.oracle.svm.configure",
+            ],
+            "requiresConcealed" : {
+                "java.base" : [
+                    "jdk.internal.loader",
+                ],
+            },
+            "checkstyle": "com.oracle.svm.hosted",
+            "workingSets": "SVM",
+            "annotationProcessors": [
+                "compiler:GRAAL_PROCESSOR",
+                "SVM_PROCESSOR",
+            ],
+            "javaCompliance" : "21+",
+            "spotbugs": "false",
+            "jacoco" : "exclude",
+        },
+
         "com.oracle.svm.truffle.tck" : {
             "subDir": "src",
             "sourceDirs": ["src"],
@@ -1681,6 +1708,7 @@ suite = {
                             org.graalvm.nativeimage.agent.jvmtibase,
                             org.graalvm.nativeimage.agent.tracing,
                             org.graalvm.nativeimage.agent.diagnostics,
+                            org.graalvm.nativeimage.agent.reflection,
                             com.oracle.svm.svm_enterprise,
                             com.oracle.svm.svm_enterprise.llvm,
                             com.oracle.svm_enterprise.ml_dataset,
@@ -1706,6 +1734,7 @@ suite = {
                     "com.oracle.svm.hosted.fieldfolding           to jdk.graal.compiler",
                     "com.oracle.svm.hosted.phases                 to jdk.graal.compiler",
                     "com.oracle.svm.hosted.reflect                to jdk.graal.compiler",
+                    "com.oracle.svm.shaded.org.objectweb.asm",
                 ],
                 "requires": [
                     "java.management",
@@ -2110,6 +2139,30 @@ suite = {
             "maven": False,
         },
 
+        "SVM_REFLECTION_AGENT": {
+            "subDir": "src",
+            "description" : "Native-image agent for constant reflection detection",
+            "dependencies": [
+                "com.oracle.svm.reflectionagent",
+                "com.oracle.svm.configure",
+            ],
+            "distDependencies": [
+                "JVMTI_AGENT_BASE",
+                "LIBRARY_SUPPORT",
+                "SVM_CONFIGURE"
+            ],
+            "moduleInfo" : {
+                "name" : "org.graalvm.nativeimage.agent.reflection",
+                "exports" : [
+                    "com.oracle.svm.reflectionagent",
+                ],
+                "requires": [
+                  "org.graalvm.nativeimage.builder",
+                ],
+            },
+            "maven": False,
+        },
+
         "SVM_CONFIGURE": {
             "subDir": "src",
             "description" : "SubstrateVM native-image configuration tool",
@@ -2124,6 +2177,7 @@ suite = {
                 "name" : "org.graalvm.nativeimage.configure",
                 "exports" : [
                     "* to org.graalvm.nativeimage.agent.tracing",
+                    "* to org.graalvm.nativeimage.agent.reflection",
                     "com.oracle.svm.configure",
                     "com.oracle.svm.configure.command",
                 ],
@@ -2159,7 +2213,7 @@ suite = {
                     "org.graalvm.collections",
                 ],
                 "exports" : [
-                    "com.oracle.svm.util                   to org.graalvm.nativeimage.pointsto,org.graalvm.nativeimage.builder,org.graalvm.nativeimage.librarysupport,org.graalvm.nativeimage.driver,org.graalvm.nativeimage.llvm,org.graalvm.nativeimage.agent.jvmtibase,org.graalvm.nativeimage.agent.tracing,org.graalvm.nativeimage.agent.diagnostics,org.graalvm.nativeimage.junitsupport,com.oracle.svm.svm_enterprise,com.oracle.svm_enterprise.ml_dataset,org.graalvm.extraimage.builder,com.oracle.svm.extraimage_enterprise,org.graalvm.extraimage.librarysupport,org.graalvm.nativeimage.foreign,org.graalvm.truffle.runtime.svm,com.oracle.truffle.enterprise.svm",
+                    "com.oracle.svm.util                   to org.graalvm.nativeimage.pointsto,org.graalvm.nativeimage.builder,org.graalvm.nativeimage.librarysupport,org.graalvm.nativeimage.driver,org.graalvm.nativeimage.llvm,org.graalvm.nativeimage.agent.jvmtibase,org.graalvm.nativeimage.agent.tracing,org.graalvm.nativeimage.agent.diagnostics,nativeimage.agent.reflection,org,org.graalvm.nativeimage.junitsupport,com.oracle.svm.svm_enterprise,com.oracle.svm_enterprise.ml_dataset,org.graalvm.extraimage.builder,com.oracle.svm.extraimage_enterprise,org.graalvm.extraimage.librarysupport,org.graalvm.nativeimage.foreign,org.graalvm.truffle.runtime.svm,com.oracle.truffle.enterprise.svm",
                     "com.oracle.svm.common.meta            to org.graalvm.nativeimage.pointsto,org.graalvm.nativeimage.builder,org.graalvm.nativeimage.llvm,org.graalvm.extraimage.builder,org.graalvm.nativeimage.foreign,org.graalvm.truffle.runtime.svm,com.oracle.truffle.enterprise.svm",
                     "com.oracle.svm.common.option          to org.graalvm.nativeimage.pointsto,org.graalvm.nativeimage.builder,org.graalvm.nativeimage.driver,org.graalvm.nativeimage.foreign,org.graalvm.truffle.runtime.svm,com.oracle.truffle.enterprise.svm",
                 ],

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/SubstrateOptions.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/SubstrateOptions.java
@@ -1381,4 +1381,7 @@ public class SubstrateOptions {
 
     @Option(help = "file:doc-files/LibGraalClassLoader.txt")//
     public static final HostedOptionKey<String> LibGraalClassLoader = new HostedOptionKey<>("");
+
+    @Option(help = "Enable the deterministic, bytecode level analysis for constant reflection usage.")//
+    public static final HostedOptionKey<Boolean> EnableStrictReflection = new HostedOptionKey<>(true);
 }

--- a/substratevm/src/com.oracle.svm.driver/src/com/oracle/svm/driver/NativeImage.java
+++ b/substratevm/src/com.oracle.svm.driver/src/com/oracle/svm/driver/NativeImage.java
@@ -287,6 +287,7 @@ public class NativeImage {
     final String oHInspectServerContentPath = oH(PointstoOptions.InspectServerContentPath);
     final String oHDeadlockWatchdogInterval = oH(SubstrateOptions.DeadlockWatchdogInterval);
     final String oHLayerCreate = oH(SubstrateOptions.LayerCreate);
+    final String oHDisableStrictReflection = oHDisabled(SubstrateOptions.EnableStrictReflection);
 
     final Map<String, String> imageBuilderEnvironment = new HashMap<>();
     private final ArrayList<String> imageBuilderArgs = new ArrayList<>();
@@ -1267,6 +1268,11 @@ public class NativeImage {
         /* Perform option consolidation of imageBuilderArgs */
 
         imageBuilderJavaArgs.addAll(getAgentArguments());
+
+        Path reflectionAgentPath = config.rootDir.resolve(Paths.get("lib", "libnative-image-reflection-agent.so"));
+        if (imageBuilderArgs.stream().noneMatch(arg -> arg.contains(oHDisableStrictReflection)) && Files.exists(reflectionAgentPath)) {
+            imageBuilderJavaArgs.add("-agentlib:native-image-reflection-agent");
+        }
 
         Optional<ArgumentEntry> lastMainClass = getHostedOptionArgument(imageBuilderArgs, oHClass);
         mainClass = lastMainClass.map(ArgumentEntry::value).orElse(null);

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/classinitialization/SimulateClassInitializerSupport.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/classinitialization/SimulateClassInitializerSupport.java
@@ -30,6 +30,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.stream.Collectors;
 
+import com.oracle.svm.hosted.ReachabilityRegistrationNode;
 import org.graalvm.collections.EconomicSet;
 import org.graalvm.nativeimage.ImageSingletons;
 
@@ -531,6 +532,8 @@ public class SimulateClassInitializerSupport {
                     return;
                 }
             }
+        } else if (node instanceof ReachabilityRegistrationNode) {
+            return;
         }
 
         clusterMember.notInitializedReasons.add(node);

--- a/substratevm/src/com.oracle.svm.reflectionagent/src/com/oracle/svm/reflectionagent/MethodCallUtils.java
+++ b/substratevm/src/com.oracle.svm.reflectionagent/src/com/oracle/svm/reflectionagent/MethodCallUtils.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2024, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package com.oracle.svm.reflectionagent;
+
+import com.oracle.svm.shaded.org.objectweb.asm.Type;
+import com.oracle.svm.shaded.org.objectweb.asm.tree.MethodInsnNode;
+import com.oracle.svm.shaded.org.objectweb.asm.tree.analysis.Frame;
+import com.oracle.svm.shaded.org.objectweb.asm.tree.analysis.SourceValue;
+
+import java.util.Arrays;
+import java.util.stream.Collectors;
+
+import static com.oracle.svm.shaded.org.objectweb.asm.Opcodes.INVOKESTATIC;
+
+public final class MethodCallUtils {
+
+    private MethodCallUtils() {
+
+    }
+
+    public record Signature(String owner, String name, String desc) {
+
+        public Signature(MethodInsnNode methodCall) {
+            this(methodCall.owner, methodCall.name, methodCall.desc);
+        }
+
+        public Signature(Class<?> owner, String name, Class<?> returnType, Class<?>... parameterTypes) {
+            this(Type.getInternalName(owner), name, buildDescriptor(returnType, parameterTypes));
+        }
+
+        private static String buildDescriptor(Class<?> returnType, Class<?>... parameterTypes) {
+            return "(" + Arrays.stream(parameterTypes).map(Type::getDescriptor).collect(Collectors.joining()) + ")" + Type.getDescriptor(returnType);
+        }
+    }
+
+    public static SourceValue getCallArg(MethodInsnNode call, int argIdx, Frame<SourceValue> frame) {
+        int numOfArgs = Type.getArgumentTypes(call.desc).length + (call.getOpcode() == INVOKESTATIC ? 0 : 1);
+        int stackPos = frame.getStackSize() - numOfArgs + argIdx;
+        return frame.getStack(stackPos);
+    }
+
+    public static String getTypeDescOfArg(MethodInsnNode methodCall, int argIdx) {
+        if (methodCall.getOpcode() != INVOKESTATIC) {
+            return argIdx == 0 ? "L" + methodCall.owner + ";" : Type.getArgumentTypes(methodCall.desc)[argIdx - 1].getDescriptor();
+        } else {
+            return Type.getArgumentTypes(methodCall.desc)[argIdx].getDescriptor();
+        }
+    }
+}

--- a/substratevm/src/com.oracle.svm.reflectionagent/src/com/oracle/svm/reflectionagent/NativeImageReflectionAgent.java
+++ b/substratevm/src/com.oracle.svm.reflectionagent/src/com/oracle/svm/reflectionagent/NativeImageReflectionAgent.java
@@ -1,0 +1,332 @@
+/*
+ * Copyright (c) 2024, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package com.oracle.svm.reflectionagent;
+
+import com.oracle.svm.configure.trace.AccessAdvisor;
+import com.oracle.svm.core.c.function.CEntryPointOptions;
+import com.oracle.svm.core.jni.headers.JNIEnvironment;
+import com.oracle.svm.core.jni.headers.JNIJavaVM;
+import com.oracle.svm.core.jni.headers.JNIObjectHandle;
+import com.oracle.svm.jvmtiagentbase.AgentIsolate;
+import com.oracle.svm.jvmtiagentbase.JNIHandleSet;
+import com.oracle.svm.jvmtiagentbase.JvmtiAgentBase;
+import com.oracle.svm.jvmtiagentbase.Support;
+import com.oracle.svm.jvmtiagentbase.jvmti.JvmtiEnv;
+import com.oracle.svm.jvmtiagentbase.jvmti.JvmtiEventCallbacks;
+import com.oracle.svm.jvmtiagentbase.jvmti.JvmtiEventMode;
+import com.oracle.svm.jvmtiagentbase.jvmti.JvmtiInterface;
+import com.oracle.svm.reflectionagent.analyzers.AnalyzerSuite;
+import com.oracle.svm.reflectionagent.analyzers.ConstantArrayAnalyzer;
+import com.oracle.svm.reflectionagent.analyzers.ConstantBooleanAnalyzer;
+import com.oracle.svm.reflectionagent.analyzers.ConstantClassAnalyzer;
+import com.oracle.svm.reflectionagent.analyzers.ConstantMethodHandlesLookupAnalyzer;
+import com.oracle.svm.reflectionagent.analyzers.ConstantMethodTypeAnalyzer;
+import com.oracle.svm.reflectionagent.analyzers.ConstantStringAnalyzer;
+import com.oracle.svm.reflectionagent.cfg.ControlFlowGraphAnalyzer;
+import com.oracle.svm.reflectionagent.cfg.ControlFlowGraphNode;
+import com.oracle.svm.shaded.org.objectweb.asm.ClassReader;
+import com.oracle.svm.shaded.org.objectweb.asm.ClassWriter;
+import com.oracle.svm.shaded.org.objectweb.asm.tree.AbstractInsnNode;
+import com.oracle.svm.shaded.org.objectweb.asm.tree.ClassNode;
+import com.oracle.svm.shaded.org.objectweb.asm.tree.MethodInsnNode;
+import com.oracle.svm.shaded.org.objectweb.asm.tree.MethodNode;
+import com.oracle.svm.shaded.org.objectweb.asm.tree.analysis.Analyzer;
+import com.oracle.svm.shaded.org.objectweb.asm.tree.analysis.AnalyzerException;
+import com.oracle.svm.shaded.org.objectweb.asm.tree.analysis.SourceInterpreter;
+import com.oracle.svm.shaded.org.objectweb.asm.tree.analysis.SourceValue;
+import org.graalvm.nativeimage.c.function.CEntryPoint;
+import org.graalvm.nativeimage.c.function.CEntryPointLiteral;
+import org.graalvm.nativeimage.c.function.CFunctionPointer;
+import org.graalvm.nativeimage.c.type.CCharPointer;
+import org.graalvm.nativeimage.c.type.CCharPointerPointer;
+import org.graalvm.nativeimage.c.type.CIntPointer;
+import org.graalvm.nativeimage.c.type.CTypeConversion;
+import org.graalvm.nativeimage.hosted.Feature;
+import org.graalvm.nativeimage.impl.reflectiontags.ConstantTags;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+import java.lang.invoke.VarHandle;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.RecordComponent;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import static com.oracle.svm.core.jni.JNIObjectHandles.nullHandle;
+import static com.oracle.svm.jvmtiagentbase.Support.check;
+import static com.oracle.svm.jvmtiagentbase.Support.jniFunctions;
+import static com.oracle.svm.jvmtiagentbase.jvmti.JvmtiEvent.JVMTI_EVENT_CLASS_FILE_LOAD_HOOK;
+import static com.oracle.svm.shaded.org.objectweb.asm.Opcodes.INVOKESTATIC;
+
+/**
+ * A JVMTI agent which analyzes user provided classes and tags reflective method calls which can be
+ * proven constant.
+ * <p>
+ * This way of marking reflective calls as constant decouples the analysis and image runtime
+ * behaviour w.r.t. reflection from various optimizations executed on IR graphs.
+ */
+@SuppressWarnings("unused")
+public class NativeImageReflectionAgent extends JvmtiAgentBase<NativeImageReflectionAgentJNIHandleSet> {
+
+    private static final Class<?> CONSTANT_TAGS_CLASS = ConstantTags.class;
+
+    /*
+     * Mapping from method signature to indices of arguments which must be constant in order for the
+     * call to that method to be considered constant. In case a method is not static, a 0 index
+     * corresponds to the method caller.
+     */
+    private static final Map<MethodCallUtils.Signature, int[]> REFLECTIVE_CALL_CONSTANT_DEFINITIONS = createReflectiveCallConstantDefinitions();
+    private static final Map<MethodCallUtils.Signature, int[]> NON_REFLECTIVE_CALL_CONSTANT_DEFINITIONS = createNonReflectiveCallConstantDefinitions();
+
+    /**
+     * Defines the reflective methods (which can potentially throw a
+     * {@link org.graalvm.nativeimage.MissingReflectionRegistrationError}) which we want to tag for
+     * folding in {@link com.oracle.svm.hosted.snippets.ReflectionPlugins}.
+     * <p>
+     * If proven as constant by our analysis, calls to these methods will be tagged by redirecting
+     * their owner to {@link org.graalvm.nativeimage.impl.reflectiontags.ConstantTags} (making them
+     * static invocations in the process if necessary).
+     */
+    private static Map<MethodCallUtils.Signature, int[]> createReflectiveCallConstantDefinitions() {
+        Map<MethodCallUtils.Signature, int[]> definitions = new HashMap<>();
+
+        definitions.put(new MethodCallUtils.Signature(Class.class, "forName", Class.class, String.class), new int[]{0});
+        definitions.put(new MethodCallUtils.Signature(Class.class, "forName", Class.class, String.class, boolean.class, ClassLoader.class), new int[]{0, 1});
+        definitions.put(new MethodCallUtils.Signature(Class.class, "getField", Field.class, String.class), new int[]{0, 1});
+        definitions.put(new MethodCallUtils.Signature(Class.class, "getDeclaredField", Field.class, String.class), new int[]{0, 1});
+        definitions.put(new MethodCallUtils.Signature(Class.class, "getConstructor", Constructor.class, Class[].class), new int[]{0, 1});
+        definitions.put(new MethodCallUtils.Signature(Class.class, "getDeclaredConstructor", Constructor.class, Class[].class), new int[]{0, 1});
+        definitions.put(new MethodCallUtils.Signature(Class.class, "getMethod", Method.class, String.class, Class[].class), new int[]{0, 1, 2});
+        definitions.put(new MethodCallUtils.Signature(Class.class, "getDeclaredMethod", Method.class, String.class, Class[].class), new int[]{0, 1, 2});
+
+        definitions.put(new MethodCallUtils.Signature(Class.class, "getFields", Field[].class), new int[]{0});
+        definitions.put(new MethodCallUtils.Signature(Class.class, "getDeclaredFields", Field[].class), new int[]{0});
+        definitions.put(new MethodCallUtils.Signature(Class.class, "getConstructors", Constructor[].class), new int[]{0});
+        definitions.put(new MethodCallUtils.Signature(Class.class, "getDeclaredConstructors", Constructor[].class), new int[]{0});
+        definitions.put(new MethodCallUtils.Signature(Class.class, "getMethods", Method[].class), new int[]{0});
+        definitions.put(new MethodCallUtils.Signature(Class.class, "getDeclaredMethods", Method[].class), new int[]{0});
+        definitions.put(new MethodCallUtils.Signature(Class.class, "getClasses", Class[].class), new int[]{0});
+        definitions.put(new MethodCallUtils.Signature(Class.class, "getDeclaredClasses", Class[].class), new int[]{0});
+        definitions.put(new MethodCallUtils.Signature(Class.class, "getNestMembers", Class[].class), new int[]{0});
+        definitions.put(new MethodCallUtils.Signature(Class.class, "getPermittedSubclasses", Class[].class), new int[]{0});
+        definitions.put(new MethodCallUtils.Signature(Class.class, "getRecordComponents", RecordComponent[].class), new int[]{0});
+        definitions.put(new MethodCallUtils.Signature(Class.class, "getSigners", Object[].class), new int[]{0});
+
+        definitions.put(new MethodCallUtils.Signature(MethodHandles.Lookup.class, "findClass", Class.class, String.class), new int[]{0, 1});
+        definitions.put(new MethodCallUtils.Signature(MethodHandles.Lookup.class, "findVirtual", MethodHandle.class, Class.class, String.class, MethodType.class), new int[]{0, 1, 2, 3});
+        definitions.put(new MethodCallUtils.Signature(MethodHandles.Lookup.class, "findStatic", MethodHandle.class, Class.class, String.class, MethodType.class), new int[]{0, 1, 2, 3});
+        definitions.put(new MethodCallUtils.Signature(MethodHandles.Lookup.class, "findConstructor", MethodHandle.class, Class.class, MethodType.class), new int[]{0, 1, 2});
+        definitions.put(new MethodCallUtils.Signature(MethodHandles.Lookup.class, "findGetter", MethodHandle.class, Class.class, String.class, Class.class), new int[]{0, 1, 2, 3});
+        definitions.put(new MethodCallUtils.Signature(MethodHandles.Lookup.class, "findStaticGetter", MethodHandle.class, Class.class, String.class, Class.class), new int[]{0, 1, 2, 3});
+        definitions.put(new MethodCallUtils.Signature(MethodHandles.Lookup.class, "findSetter", MethodHandle.class, Class.class, String.class, Class.class), new int[]{0, 1, 2, 3});
+        definitions.put(new MethodCallUtils.Signature(MethodHandles.Lookup.class, "findStaticSetter", MethodHandle.class, Class.class, String.class, Class.class), new int[]{0, 1, 2, 3});
+        definitions.put(new MethodCallUtils.Signature(MethodHandles.Lookup.class, "findVarHandle", VarHandle.class, Class.class, String.class, Class.class), new int[]{0, 1, 2, 3});
+        definitions.put(new MethodCallUtils.Signature(MethodHandles.Lookup.class, "findStaticVarHandle", VarHandle.class, Class.class, String.class, Class.class), new int[]{0, 1, 2, 3});
+
+        return definitions;
+    }
+
+    /**
+     * Defines methods which we still need to track, but not tag with
+     * {@link org.graalvm.nativeimage.impl.reflectiontags.ConstantTags}. An example of this are
+     * various methods for {@link java.lang.invoke.MethodType} construction.
+     */
+    private static Map<MethodCallUtils.Signature, int[]> createNonReflectiveCallConstantDefinitions() {
+        Map<MethodCallUtils.Signature, int[]> definitions = new HashMap<>();
+
+        definitions.put(new MethodCallUtils.Signature(MethodType.class, "methodType", MethodType.class, Class.class), new int[]{0});
+        definitions.put(new MethodCallUtils.Signature(MethodType.class, "methodType", MethodType.class, Class.class, Class.class), new int[]{0, 1});
+        definitions.put(new MethodCallUtils.Signature(MethodType.class, "methodType", MethodType.class, Class.class, Class[].class), new int[]{0, 1});
+        definitions.put(new MethodCallUtils.Signature(MethodType.class, "methodType", MethodType.class, Class.class, Class.class, Class[].class), new int[]{0, 1, 2});
+        definitions.put(new MethodCallUtils.Signature(MethodType.class, "methodType", MethodType.class, Class.class, MethodType.class), new int[]{0, 1});
+
+        definitions.put(new MethodCallUtils.Signature(MethodHandles.class, "lookup", MethodHandles.Lookup.class), new int[]{});
+        definitions.put(new MethodCallUtils.Signature(MethodHandles.class, "privateLookupIn", MethodHandles.Lookup.class, Class.class, MethodHandles.Lookup.class), new int[]{0, 1});
+
+        return definitions;
+    }
+
+    private static final CEntryPointLiteral<CFunctionPointer> ON_CLASS_FILE_LOAD_HOOK = CEntryPointLiteral.create(NativeImageReflectionAgent.class, "onClassFileLoadHook",
+                    JvmtiEnv.class, JNIEnvironment.class, JNIObjectHandle.class, JNIObjectHandle.class, CCharPointer.class, JNIObjectHandle.class, int.class, CCharPointer.class, CIntPointer.class,
+                    CCharPointerPointer.class);
+
+    @Override
+    protected JNIHandleSet constructJavaHandles(JNIEnvironment env) {
+        return new NativeImageReflectionAgentJNIHandleSet(env);
+    }
+
+    @Override
+    protected int onLoadCallback(JNIJavaVM vm, JvmtiEnv jvmti, JvmtiEventCallbacks callbacks, String options) {
+        System.out.println("Reflection agent started");
+        callbacks.setClassFileLoadHook(ON_CLASS_FILE_LOAD_HOOK.getFunctionPointer());
+        return 0;
+    }
+
+    @Override
+    protected void onVMInitCallback(JvmtiEnv jvmti, JNIEnvironment jni, JNIObjectHandle thread) {
+        check(jvmti.getFunctions().SetEventNotificationMode().invoke(jvmti, JvmtiEventMode.JVMTI_ENABLE, JVMTI_EVENT_CLASS_FILE_LOAD_HOOK, nullHandle()));
+    }
+
+    @CEntryPoint
+    @CEntryPointOptions(prologue = AgentIsolate.Prologue.class)
+    @SuppressWarnings("unused")
+    private static void onClassFileLoadHook(JvmtiEnv jvmti, JNIEnvironment jni, JNIObjectHandle classBeingRedefined,
+                    JNIObjectHandle loader, CCharPointer name, JNIObjectHandle protectionDomain, int classDataLen, CCharPointer classData,
+                    CIntPointer newClassDataLen, CCharPointerPointer newClassData) {
+        if (shouldIgnoreClassLoader(jni, loader)) {
+            return;
+        }
+
+        String className = CTypeConversion.toJavaString(name);
+        if (AccessAdvisor.PROXY_CLASS_NAME_PATTERN.matcher(className).matches()) {
+            return;
+        }
+
+        byte[] clazzData = new byte[classDataLen];
+        CTypeConversion.asByteBuffer(classData, classDataLen).get(clazzData);
+        try {
+            byte[] newClazzData = instrumentClass(clazzData);
+            int newClazzDataLen = newClazzData.length;
+            Support.check(jvmti.getFunctions().Allocate().invoke(jvmti, newClazzDataLen, newClassData));
+            CTypeConversion.asByteBuffer(newClassData.read(), newClazzDataLen).put(newClazzData);
+            newClassDataLen.write(newClazzDataLen);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * We're only interested in analyzing and instrumenting user provided classes, so we're handling
+     * that by checking which class loader the class was loaded by. In case a class was loaded by a
+     * builtin class loader, we ignore it.
+     */
+    private static boolean shouldIgnoreClassLoader(JNIEnvironment jni, JNIObjectHandle loader) {
+        NativeImageReflectionAgent agent = singleton();
+        JNIObjectHandle platformClassLoader = agent.handles().platformClassLoader;
+        JNIObjectHandle builtinAppClassLoader = agent.handles().builtinAppClassLoader;
+        JNIObjectHandle jdkInternalReflectDelegatingClassLoader = agent.handles().jdkInternalReflectDelegatingClassLoader;
+
+        return loader.equal(nullHandle()) // Bootstrap class loader
+                        || jniFunctions().getIsSameObject().invoke(jni, loader, agent.handles().systemClassLoader) ||
+                        !platformClassLoader.equal(nullHandle()) && jniFunctions().getIsSameObject().invoke(jni, loader, platformClassLoader) ||
+                        !builtinAppClassLoader.equal(nullHandle()) && jniFunctions().getIsSameObject().invoke(jni, loader, builtinAppClassLoader) ||
+                        !jdkInternalReflectDelegatingClassLoader.equal(nullHandle()) && jniFunctions().getIsInstanceOf().invoke(jni, loader, jdkInternalReflectDelegatingClassLoader);
+    }
+
+    private static byte[] instrumentClass(byte[] classData) throws AnalyzerException, NoSuchMethodException, InvocationTargetException, InstantiationException, IllegalAccessException {
+        Constructor<ClassReader> classReaderConstructor = ClassReader.class.getDeclaredConstructor(byte[].class, int.class, boolean.class);
+        classReaderConstructor.setAccessible(true);
+        ClassReader reader = classReaderConstructor.newInstance(classData, 0, false);
+        ClassNode classNode = new ClassNode();
+        reader.accept(classNode, 0);
+        for (MethodNode methodNode : classNode.methods) {
+            instrumentMethod(methodNode, classNode);
+        }
+        ClassWriter writer = new ClassWriter(0);
+        classNode.accept(writer);
+        return writer.toByteArray();
+    }
+
+    private static void instrumentMethod(MethodNode methodNode, ClassNode classNode) throws AnalyzerException {
+        Analyzer<SourceValue> analyzer = new ControlFlowGraphAnalyzer<>(new SourceInterpreter());
+
+        AbstractInsnNode[] instructions = methodNode.instructions.toArray();
+        @SuppressWarnings("unchecked")
+        ControlFlowGraphNode<SourceValue>[] frames = Arrays.stream(analyzer.analyze(classNode.name, methodNode))
+                        .map(frame -> (ControlFlowGraphNode<SourceValue>) frame).toArray(ControlFlowGraphNode[]::new);
+        Set<MethodInsnNode> constantCalls = new HashSet<>();
+
+        Set<MethodCallUtils.Signature> allCalls = new HashSet<>(REFLECTIVE_CALL_CONSTANT_DEFINITIONS.keySet());
+        allCalls.addAll(NON_REFLECTIVE_CALL_CONSTANT_DEFINITIONS.keySet());
+
+        AnalyzerSuite analyzerSuite = new AnalyzerSuite();
+        analyzerSuite.registerAnalyzer(new ConstantStringAnalyzer(instructions, frames, constantCalls));
+        analyzerSuite.registerAnalyzer(new ConstantBooleanAnalyzer(instructions, frames, constantCalls));
+        analyzerSuite.registerAnalyzer(new ConstantClassAnalyzer(instructions, frames, constantCalls));
+        analyzerSuite.registerAnalyzer(new ConstantArrayAnalyzer(instructions, frames, allCalls, new ConstantClassAnalyzer(instructions, frames, constantCalls)));
+        analyzerSuite.registerAnalyzer(new ConstantMethodTypeAnalyzer(instructions, frames, constantCalls));
+        analyzerSuite.registerAnalyzer(new ConstantMethodHandlesLookupAnalyzer(instructions, frames, constantCalls));
+
+        for (int i = 0; i < instructions.length; i++) {
+            if (instructions[i] instanceof MethodInsnNode methodCall) {
+                int[] mustBeConstantArgs = REFLECTIVE_CALL_CONSTANT_DEFINITIONS.get(new MethodCallUtils.Signature(methodCall));
+                if (mustBeConstantArgs == null) {
+                    mustBeConstantArgs = NON_REFLECTIVE_CALL_CONSTANT_DEFINITIONS.get(new MethodCallUtils.Signature(methodCall));
+                }
+                if (mustBeConstantArgs != null && analyzerSuite.isConstant(methodCall, frames[i], mustBeConstantArgs)) {
+                    constantCalls.add(methodCall);
+                }
+            }
+        }
+
+        constantCalls.stream()
+                        .filter(cc -> REFLECTIVE_CALL_CONSTANT_DEFINITIONS.containsKey(new MethodCallUtils.Signature(cc)))
+                        .forEach(NativeImageReflectionAgent::tagAsConstant);
+    }
+
+    private static void tagAsConstant(MethodInsnNode methodCall) {
+        if (methodCall.getOpcode() != INVOKESTATIC) {
+            methodCall.setOpcode(INVOKESTATIC);
+            methodCall.desc = "(L" + methodCall.owner + ";" + methodCall.desc.substring(1);
+        }
+        methodCall.owner = CONSTANT_TAGS_CLASS.getName().replace('.', '/');
+    }
+
+    @Override
+    protected int onUnloadCallback(JNIJavaVM vm) {
+        return 0;
+    }
+
+    @Override
+    protected void onVMStartCallback(JvmtiEnv jvmti, JNIEnvironment jni) {
+
+    }
+
+    @Override
+    protected void onVMDeathCallback(JvmtiEnv jvmti, JNIEnvironment jni) {
+
+    }
+
+    @Override
+    protected int getRequiredJvmtiVersion() {
+        return JvmtiInterface.JVMTI_VERSION_9;
+    }
+
+    @SuppressWarnings("unused")
+    public static class RegistrationFeature implements Feature {
+
+        @Override
+        public void afterRegistration(AfterRegistrationAccess access) {
+            JvmtiAgentBase.registerAgent(new NativeImageReflectionAgent());
+        }
+    }
+}

--- a/substratevm/src/com.oracle.svm.reflectionagent/src/com/oracle/svm/reflectionagent/NativeImageReflectionAgentJNIHandleSet.java
+++ b/substratevm/src/com.oracle.svm.reflectionagent/src/com/oracle/svm/reflectionagent/NativeImageReflectionAgentJNIHandleSet.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2024, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package com.oracle.svm.reflectionagent;
+
+import com.oracle.svm.core.jni.headers.JNIEnvironment;
+import com.oracle.svm.core.jni.headers.JNIMethodId;
+import com.oracle.svm.core.jni.headers.JNIObjectHandle;
+import com.oracle.svm.jvmtiagentbase.JNIHandleSet;
+import com.oracle.svm.jvmtiagentbase.Support;
+
+import static com.oracle.svm.core.jni.JNIObjectHandles.nullHandle;
+
+public class NativeImageReflectionAgentJNIHandleSet extends JNIHandleSet {
+
+    final JNIObjectHandle classLoader;
+    final JNIObjectHandle jdkInternalReflectDelegatingClassLoader;
+
+    final JNIObjectHandle systemClassLoader;
+    final JNIObjectHandle platformClassLoader;
+    final JNIObjectHandle builtinAppClassLoader;
+
+    @SuppressWarnings("this-escape")
+    public NativeImageReflectionAgentJNIHandleSet(JNIEnvironment env) {
+        super(env);
+        classLoader = newClassGlobalRef(env, "java/lang/ClassLoader");
+
+        JNIObjectHandle reflectLoader = findClassOptional(env, "jdk/internal/reflect/DelegatingClassLoader");
+        jdkInternalReflectDelegatingClassLoader = reflectLoader.equal(nullHandle()) ? nullHandle() : newTrackedGlobalRef(env, reflectLoader);
+
+        JNIMethodId getSystemClassLoader = getMethodId(env, classLoader, "getSystemClassLoader", "()Ljava/lang/ClassLoader;", true);
+        systemClassLoader = newTrackedGlobalRef(env, Support.callObjectMethod(env, classLoader, getSystemClassLoader));
+
+        JNIMethodId getPlatformClassLoader = getMethodIdOptional(env, classLoader, "getPlatformClassLoader", "()Ljava/lang/ClassLoader;", true);
+        platformClassLoader = getPlatformClassLoader.equal(nullHandle()) ? nullHandle() : newTrackedGlobalRef(env, Support.callObjectMethod(env, classLoader, getPlatformClassLoader));
+
+        JNIMethodId getBuiltinAppClassLoader = getMethodIdOptional(env, classLoader, "getBuiltinAppClassLoader", "()Ljava/lang/ClassLoader;", true);
+        builtinAppClassLoader = getBuiltinAppClassLoader.equal(nullHandle()) ? nullHandle() : newTrackedGlobalRef(env, Support.callObjectMethod(env, classLoader, getBuiltinAppClassLoader));
+    }
+}

--- a/substratevm/src/com.oracle.svm.reflectionagent/src/com/oracle/svm/reflectionagent/analyzers/AnalyzerSuite.java
+++ b/substratevm/src/com.oracle.svm.reflectionagent/src/com/oracle/svm/reflectionagent/analyzers/AnalyzerSuite.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2024, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package com.oracle.svm.reflectionagent.analyzers;
+
+import com.oracle.svm.reflectionagent.MethodCallUtils;
+import com.oracle.svm.reflectionagent.cfg.ControlFlowGraphNode;
+import com.oracle.svm.shaded.org.objectweb.asm.tree.MethodInsnNode;
+import com.oracle.svm.shaded.org.objectweb.asm.tree.analysis.SourceValue;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class AnalyzerSuite {
+
+    private final Map<String, ConstantValueAnalyzer> valueAnalyzers = new HashMap<>();
+    private final Map<String, ConstantArrayAnalyzer> arrayAnalyzers = new HashMap<>();
+
+    public void registerAnalyzer(ConstantValueAnalyzer analyzer) {
+        valueAnalyzers.put(analyzer.typeDescriptor(), analyzer);
+    }
+
+    public void registerAnalyzer(ConstantArrayAnalyzer analyzer) {
+        arrayAnalyzers.put(analyzer.typeDescriptor(), analyzer);
+    }
+
+    public boolean isConstant(MethodInsnNode methodCall, ControlFlowGraphNode<SourceValue> frame, int[] mustBeConstantArgs) {
+        for (int argIdx : mustBeConstantArgs) {
+            String argTypeName = MethodCallUtils.getTypeDescOfArg(methodCall, argIdx);
+            if (argTypeName.startsWith("[")) {
+                ConstantArrayAnalyzer analyzer = arrayAnalyzers.get(argTypeName);
+                assert analyzer != null : "Analyzer for " + argTypeName + " not found";
+                if (!analyzer.isConstant(MethodCallUtils.getCallArg(methodCall, argIdx, frame), methodCall)) {
+                    return false;
+                }
+            } else {
+                ConstantValueAnalyzer analyzer = valueAnalyzers.get(argTypeName);
+                assert analyzer != null : "Analyzer for " + argTypeName + " not found";
+                if (!analyzer.isConstant(MethodCallUtils.getCallArg(methodCall, argIdx, frame))) {
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+}

--- a/substratevm/src/com.oracle.svm.reflectionagent/src/com/oracle/svm/reflectionagent/analyzers/ConstantArrayAnalyzer.java
+++ b/substratevm/src/com.oracle.svm.reflectionagent/src/com/oracle/svm/reflectionagent/analyzers/ConstantArrayAnalyzer.java
@@ -1,0 +1,324 @@
+/*
+ * Copyright (c) 2024, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package com.oracle.svm.reflectionagent.analyzers;
+
+import com.oracle.svm.reflectionagent.MethodCallUtils;
+import com.oracle.svm.reflectionagent.cfg.ControlFlowGraphNode;
+import com.oracle.svm.shaded.org.objectweb.asm.Opcodes;
+import com.oracle.svm.shaded.org.objectweb.asm.Type;
+import com.oracle.svm.shaded.org.objectweb.asm.tree.AbstractInsnNode;
+import com.oracle.svm.shaded.org.objectweb.asm.tree.IntInsnNode;
+import com.oracle.svm.shaded.org.objectweb.asm.tree.LdcInsnNode;
+import com.oracle.svm.shaded.org.objectweb.asm.tree.MethodInsnNode;
+import com.oracle.svm.shaded.org.objectweb.asm.tree.TypeInsnNode;
+import com.oracle.svm.shaded.org.objectweb.asm.tree.VarInsnNode;
+import com.oracle.svm.shaded.org.objectweb.asm.tree.analysis.Frame;
+import com.oracle.svm.shaded.org.objectweb.asm.tree.analysis.SourceValue;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
+import static com.oracle.svm.shaded.org.objectweb.asm.Opcodes.AASTORE;
+import static com.oracle.svm.shaded.org.objectweb.asm.Opcodes.ALOAD;
+import static com.oracle.svm.shaded.org.objectweb.asm.Opcodes.ANEWARRAY;
+import static com.oracle.svm.shaded.org.objectweb.asm.Opcodes.ASTORE;
+import static com.oracle.svm.shaded.org.objectweb.asm.Opcodes.BIPUSH;
+import static com.oracle.svm.shaded.org.objectweb.asm.Opcodes.DUP;
+import static com.oracle.svm.shaded.org.objectweb.asm.Opcodes.ICONST_0;
+import static com.oracle.svm.shaded.org.objectweb.asm.Opcodes.ICONST_1;
+import static com.oracle.svm.shaded.org.objectweb.asm.Opcodes.ICONST_2;
+import static com.oracle.svm.shaded.org.objectweb.asm.Opcodes.ICONST_3;
+import static com.oracle.svm.shaded.org.objectweb.asm.Opcodes.ICONST_4;
+import static com.oracle.svm.shaded.org.objectweb.asm.Opcodes.ICONST_5;
+import static com.oracle.svm.shaded.org.objectweb.asm.Opcodes.ICONST_M1;
+import static com.oracle.svm.shaded.org.objectweb.asm.Opcodes.INVOKEINTERFACE;
+import static com.oracle.svm.shaded.org.objectweb.asm.Opcodes.INVOKESPECIAL;
+import static com.oracle.svm.shaded.org.objectweb.asm.Opcodes.INVOKESTATIC;
+import static com.oracle.svm.shaded.org.objectweb.asm.Opcodes.INVOKEVIRTUAL;
+import static com.oracle.svm.shaded.org.objectweb.asm.Opcodes.LDC;
+import static com.oracle.svm.shaded.org.objectweb.asm.Opcodes.PUTFIELD;
+import static com.oracle.svm.shaded.org.objectweb.asm.Opcodes.PUTSTATIC;
+import static com.oracle.svm.shaded.org.objectweb.asm.Opcodes.SIPUSH;
+
+public class ConstantArrayAnalyzer {
+
+    private final AbstractInsnNode[] instructions;
+    private final ControlFlowGraphNode<SourceValue>[] frames;
+    private final Set<MethodCallUtils.Signature> safeMethods;
+    private final ConstantValueAnalyzer valueAnalyzer;
+
+    public ConstantArrayAnalyzer(AbstractInsnNode[] instructions, ControlFlowGraphNode<SourceValue>[] frames, Set<MethodCallUtils.Signature> safeMethods, ConstantValueAnalyzer valueAnalyzer) {
+        this.instructions = instructions;
+        this.frames = frames;
+        this.safeMethods = safeMethods;
+        this.valueAnalyzer = valueAnalyzer;
+    }
+
+    public boolean isConstant(SourceValue value, AbstractInsnNode callSite) {
+        return referenceIsConstant(value, callSite) && elementsAreConstant(value, callSite);
+    }
+
+    private boolean referenceIsConstant(SourceValue value, AbstractInsnNode callSite) {
+        if (value.insns.size() != 1) {
+            return false;
+        }
+
+        AbstractInsnNode sourceInstruction = value.insns.iterator().next();
+        int sourceInstructionIndex = Arrays.asList(instructions).indexOf(sourceInstruction);
+        Frame<SourceValue> sourceInstructionFrame = frames[sourceInstructionIndex];
+
+        return switch (sourceInstruction.getOpcode()) {
+            case ANEWARRAY -> {
+                Optional<Integer> arraySize = extractConstInt(sourceInstructionFrame.getStack(sourceInstructionFrame.getStackSize() - 1));
+                yield arraySize.isPresent();
+            }
+            case ALOAD -> {
+                SourceValue sourceValue = sourceInstructionFrame.getLocal(((VarInsnNode) sourceInstruction).var);
+                yield referenceIsConstant(sourceValue, callSite) && noForbiddenUsages(sourceValue.insns.iterator().next(), callSite);
+            }
+            case ASTORE -> {
+                SourceValue sourceValue = sourceInstructionFrame.getStack(sourceInstructionFrame.getStackSize() - 1);
+                yield referenceIsConstant(sourceValue, callSite) && sourceValue.insns.iterator().next().getOpcode() == ANEWARRAY;
+            }
+            case DUP -> {
+                SourceValue sourceValue = sourceInstructionFrame.getStack(sourceInstructionFrame.getStackSize() - 1);
+                yield referenceIsConstant(sourceValue, callSite);
+            }
+            default -> false;
+        };
+    }
+
+    private static Optional<Integer> extractConstInt(SourceValue value) {
+        if (value.insns.size() != 1) {
+            return Optional.empty();
+        }
+
+        AbstractInsnNode sourceInstruction = value.insns.iterator().next();
+
+        return switch (sourceInstruction.getOpcode()) {
+            case ICONST_M1 -> Optional.of(-1);
+            case ICONST_0 -> Optional.of(0);
+            case ICONST_1 -> Optional.of(1);
+            case ICONST_2 -> Optional.of(2);
+            case ICONST_3 -> Optional.of(3);
+            case ICONST_4 -> Optional.of(4);
+            case ICONST_5 -> Optional.of(5);
+            case BIPUSH, SIPUSH -> Optional.of(((IntInsnNode) sourceInstruction).operand);
+            case LDC -> {
+                LdcInsnNode ldc = (LdcInsnNode) sourceInstruction;
+                if (ldc.cst instanceof Integer intValue) {
+                    yield Optional.of(intValue);
+                }
+                yield Optional.empty();
+            }
+            default -> Optional.empty();
+        };
+    }
+
+    private boolean noForbiddenUsages(AbstractInsnNode originalStoreInstruction, AbstractInsnNode callSite) {
+        int callSiteInstructionIndex = Arrays.asList(instructions).indexOf(callSite);
+
+        List<Integer> nodeIndices = new ArrayList<>();
+        nodeIndices.add(callSiteInstructionIndex);
+
+        /*
+         * Run a BFS in the reversed CFG from the call site, looking for any potential forbidden
+         * operations for constant arrays.
+         */
+        boolean[] visited = new boolean[frames.length];
+        while (!nodeIndices.isEmpty()) {
+            Integer currentNodeIndex = nodeIndices.removeLast();
+            visited[currentNodeIndex] = true;
+            if (isForbiddenStore(currentNodeIndex, originalStoreInstruction) || isForbiddenMethodCall(currentNodeIndex, originalStoreInstruction)) {
+                return false;
+            }
+
+            ControlFlowGraphNode<SourceValue> currentNode = frames[currentNodeIndex];
+            for (int adjacent : currentNode.predecessors) {
+                if (!visited[adjacent]) {
+                    nodeIndices.add(adjacent);
+                }
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * Checks if the instruction at {@code instructionIndex} is an assignment instruction (to a
+     * variable or a field) and its argument's value can be traced to
+     * {@code originalStoreInstruction} which represents the initial assignment of an array
+     * reference to a variable.
+     * <p>
+     * We want to avoid these cases when marking an array as constant because it could potentially
+     * be modified through a field or variable which we aren't tracking.
+     * <p>
+     * In the following example, we want to avoid marking the params array as constant when
+     * attempting to fold the second {@code getMethod} call:
+     *
+     * <pre>
+     * {@code
+     * Class<?>[] params = new Class<?>[2];
+     * params[0] = String.class;
+     * params[1] = int.class;
+     * Method m1 = Integer.class.getMethod("parseInt", params); // This call is foldable
+     * someField = params; // params could now be modified through someField
+     * // ...
+     * Method m2 = Integer.class.getMethod("parseInt", params); // We must not fold this
+     * }
+     * </pre>
+     */
+    private boolean isForbiddenStore(int instructionIndex, AbstractInsnNode originalStoreInstruction) {
+        AbstractInsnNode instruction = instructions[instructionIndex];
+        Frame<SourceValue> frame = frames[instructionIndex];
+
+        if (Stream.of(Opcodes.ASTORE, PUTFIELD, PUTSTATIC).noneMatch(opc -> opc == instruction.getOpcode())) {
+            return false;
+        }
+
+        SourceValue storeValue = frame.getStack(frame.getStackSize() - 1);
+        return loadedValueTracesToStore(storeValue, originalStoreInstruction);
+    }
+
+    /**
+     * Similar as with {@code isForbiddenStore}, arrays could be modified in methods they are passed
+     * to, so we want to avoid marking them as constant after that. An exception to this are the
+     * reflective methods we're already tracking with our analysis, as we know they won't modify the
+     * passed array in any way.
+     */
+    private boolean isForbiddenMethodCall(int instructionIndex, AbstractInsnNode originalStoreInstruction) {
+        AbstractInsnNode instruction = instructions[instructionIndex];
+        Frame<SourceValue> frame = frames[instructionIndex];
+
+        if (Stream.of(INVOKEVIRTUAL, INVOKESPECIAL, INVOKESTATIC, INVOKEINTERFACE).noneMatch(opc -> opc == instruction.getOpcode())) {
+            return false;
+        }
+
+        MethodInsnNode methodCall = (MethodInsnNode) instruction;
+        if (safeMethods.contains(new MethodCallUtils.Signature(methodCall))) {
+            return false;
+        }
+
+        int numOfArgs = Type.getArgumentTypes(methodCall.desc).length;
+        return IntStream.range(0, numOfArgs)
+                        .anyMatch(i -> loadedValueTracesToStore(MethodCallUtils.getCallArg(methodCall, i, frame), originalStoreInstruction));
+    }
+
+    private boolean loadedValueTracesToStore(SourceValue value, AbstractInsnNode originalStoreInstruction) {
+        return value.insns.stream().anyMatch(insn -> {
+            if (insn.getOpcode() != ALOAD) {
+                return false;
+            }
+
+            int loadInstructionIndex = Arrays.asList(instructions).indexOf(insn);
+            Frame<SourceValue> loadInstructionFrame = frames[loadInstructionIndex];
+            SourceValue loadSourceValue = loadInstructionFrame.getLocal(((VarInsnNode) insn).var);
+
+            return loadSourceValue.insns.stream().anyMatch(storeInsn -> storeInsn == originalStoreInstruction);
+        });
+    }
+
+    private Optional<TypeInsnNode> traceArrayRefToOrigin(SourceValue value) {
+        if (value.insns.size() != 1) {
+            return Optional.empty();
+        }
+
+        AbstractInsnNode sourceInstruction = value.insns.iterator().next();
+        int sourceInstructionIndex = Arrays.asList(instructions).indexOf(sourceInstruction);
+        Frame<SourceValue> sourceInstructionFrame = frames[sourceInstructionIndex];
+
+        return switch (sourceInstruction.getOpcode()) {
+            case ANEWARRAY -> Optional.of((TypeInsnNode) sourceInstruction);
+            case ALOAD -> {
+                SourceValue sourceValue = sourceInstructionFrame.getLocal(((VarInsnNode) sourceInstruction).var);
+                yield traceArrayRefToOrigin(sourceValue);
+            }
+            case ASTORE, DUP -> {
+                SourceValue sourceValue = sourceInstructionFrame.getStack(sourceInstructionFrame.getStackSize() - 1);
+                yield traceArrayRefToOrigin(sourceValue);
+            }
+            default -> Optional.empty();
+        };
+    }
+
+    private boolean elementsAreConstant(SourceValue value, AbstractInsnNode callSite) {
+        int callSiteInstructionIndex = Arrays.asList(instructions).indexOf(callSite);
+
+        Optional<TypeInsnNode> arrayInitInsn = traceArrayRefToOrigin(value);
+        if (arrayInitInsn.isEmpty()) {
+            return false;
+        }
+
+        int arrayInitInstructionIndex = Arrays.asList(instructions).indexOf(arrayInitInsn.get());
+        Frame<SourceValue> arrayInitInstructionFrame = frames[arrayInitInstructionIndex];
+
+        SourceValue arraySizeValue = arrayInitInstructionFrame.getStack(arrayInitInstructionFrame.getStackSize() - 1);
+        Optional<Integer> arraySize = extractConstInt(arraySizeValue);
+        if (arraySize.isEmpty()) {
+            return false;
+        }
+
+        Set<Integer> constantElements = new HashSet<>();
+
+        for (int i = arrayInitInstructionIndex; i < callSiteInstructionIndex; i++) {
+            AbstractInsnNode currentInstruction = instructions[i];
+            ControlFlowGraphNode<SourceValue> currentInstructionFrame = frames[i];
+
+            if (currentInstructionFrame.successors.size() != 1) {
+                return false;
+            }
+
+            if (currentInstruction.getOpcode() == AASTORE) {
+                SourceValue storedValue = currentInstructionFrame.getStack(currentInstructionFrame.getStackSize() - 1);
+                SourceValue indexValue = currentInstructionFrame.getStack(currentInstructionFrame.getStackSize() - 2);
+                SourceValue arrayRefValue = currentInstructionFrame.getStack(currentInstructionFrame.getStackSize() - 3);
+
+                Optional<TypeInsnNode> arrayReference = traceArrayRefToOrigin(arrayRefValue);
+                if (arrayReference.isEmpty() || arrayReference.get() != arrayInitInsn.get()) {
+                    continue;
+                }
+
+                Optional<Integer> elementIndex = extractConstInt(indexValue);
+                if (elementIndex.isEmpty() || !valueAnalyzer.isConstant(storedValue) || constantElements.contains(elementIndex.get())) {
+                    return false;
+                }
+
+                constantElements.add(elementIndex.get());
+            }
+        }
+
+        return constantElements.size() == arraySize.get();
+    }
+
+    public String typeDescriptor() {
+        return "[" + valueAnalyzer.typeDescriptor();
+    }
+}

--- a/substratevm/src/com.oracle.svm.reflectionagent/src/com/oracle/svm/reflectionagent/analyzers/ConstantBooleanAnalyzer.java
+++ b/substratevm/src/com.oracle.svm.reflectionagent/src/com/oracle/svm/reflectionagent/analyzers/ConstantBooleanAnalyzer.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2024, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package com.oracle.svm.reflectionagent.analyzers;
+
+import com.oracle.svm.shaded.org.objectweb.asm.tree.AbstractInsnNode;
+import com.oracle.svm.shaded.org.objectweb.asm.tree.MethodInsnNode;
+import com.oracle.svm.shaded.org.objectweb.asm.tree.analysis.Frame;
+import com.oracle.svm.shaded.org.objectweb.asm.tree.analysis.SourceValue;
+
+import java.util.Set;
+
+import static com.oracle.svm.shaded.org.objectweb.asm.Opcodes.ICONST_0;
+import static com.oracle.svm.shaded.org.objectweb.asm.Opcodes.ICONST_1;
+
+public class ConstantBooleanAnalyzer extends ConstantValueAnalyzer {
+
+    public ConstantBooleanAnalyzer(AbstractInsnNode[] instructions, Frame<SourceValue>[] frames, Set<MethodInsnNode> constantCalls) {
+        super(instructions, frames, constantCalls);
+    }
+
+    @Override
+    protected boolean isConstant(SourceValue value, AbstractInsnNode sourceInstruction, Frame<SourceValue> sourceInstructionFrame) {
+        return sourceInstruction.getOpcode() == ICONST_0 || sourceInstruction.getOpcode() == ICONST_1;
+    }
+
+    @Override
+    protected String typeDescriptor() {
+        return "Z";
+    }
+}

--- a/substratevm/src/com.oracle.svm.reflectionagent/src/com/oracle/svm/reflectionagent/analyzers/ConstantClassAnalyzer.java
+++ b/substratevm/src/com.oracle.svm.reflectionagent/src/com/oracle/svm/reflectionagent/analyzers/ConstantClassAnalyzer.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2024, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package com.oracle.svm.reflectionagent.analyzers;
+
+import com.oracle.svm.shaded.org.objectweb.asm.Type;
+import com.oracle.svm.shaded.org.objectweb.asm.tree.AbstractInsnNode;
+import com.oracle.svm.shaded.org.objectweb.asm.tree.FieldInsnNode;
+import com.oracle.svm.shaded.org.objectweb.asm.tree.LdcInsnNode;
+import com.oracle.svm.shaded.org.objectweb.asm.tree.MethodInsnNode;
+import com.oracle.svm.shaded.org.objectweb.asm.tree.analysis.Frame;
+import com.oracle.svm.shaded.org.objectweb.asm.tree.analysis.SourceValue;
+
+import java.util.Set;
+
+import static com.oracle.svm.shaded.org.objectweb.asm.Opcodes.GETSTATIC;
+import static com.oracle.svm.shaded.org.objectweb.asm.Opcodes.LDC;
+
+public class ConstantClassAnalyzer extends ConstantValueAnalyzer {
+
+    public ConstantClassAnalyzer(AbstractInsnNode[] instructions, Frame<SourceValue>[] frames, Set<MethodInsnNode> constantCalls) {
+        super(instructions, frames, constantCalls);
+    }
+
+    @Override
+    protected boolean isConstant(SourceValue value, AbstractInsnNode sourceInstruction, Frame<SourceValue> sourceInstructionFrame) {
+        return switch (sourceInstruction.getOpcode()) {
+            case LDC -> {
+                LdcInsnNode ldc = (LdcInsnNode) sourceInstruction;
+                yield ldc.cst instanceof Type type && (type.getSort() == Type.OBJECT || type.getSort() == Type.ARRAY);
+            }
+            case GETSTATIC -> {
+                FieldInsnNode field = (FieldInsnNode) sourceInstruction;
+                yield isPrimitiveType(field);
+            }
+            default -> false;
+        };
+    }
+
+    private static boolean isPrimitiveType(FieldInsnNode field) {
+        if (!field.name.equals("TYPE")) {
+            return false;
+        }
+
+        return switch (field.owner) {
+            case "java/lang/Byte", "java/lang/Char", "java/lang/Short", "java/lang/Integer", "java/lang/Long", "java/lang/Float", "java/lang/Double", "java/lang/Void" -> true;
+            default -> false;
+        };
+    }
+
+    @Override
+    protected String typeDescriptor() {
+        return "Ljava/lang/Class;";
+    }
+}

--- a/substratevm/src/com.oracle.svm.reflectionagent/src/com/oracle/svm/reflectionagent/analyzers/ConstantMethodHandlesLookupAnalyzer.java
+++ b/substratevm/src/com.oracle.svm.reflectionagent/src/com/oracle/svm/reflectionagent/analyzers/ConstantMethodHandlesLookupAnalyzer.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2024, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package com.oracle.svm.reflectionagent.analyzers;
+
+import com.oracle.svm.shaded.org.objectweb.asm.tree.AbstractInsnNode;
+import com.oracle.svm.shaded.org.objectweb.asm.tree.MethodInsnNode;
+import com.oracle.svm.shaded.org.objectweb.asm.tree.analysis.Frame;
+import com.oracle.svm.shaded.org.objectweb.asm.tree.analysis.SourceValue;
+
+import java.util.Set;
+
+public class ConstantMethodHandlesLookupAnalyzer extends ConstantValueAnalyzer {
+
+    public ConstantMethodHandlesLookupAnalyzer(AbstractInsnNode[] instructions, Frame<SourceValue>[] frames, Set<MethodInsnNode> constantCalls) {
+        super(instructions, frames, constantCalls);
+    }
+
+    @Override
+    protected boolean isConstant(SourceValue value, AbstractInsnNode sourceInstruction, Frame<SourceValue> sourceInstructionFrame) {
+        return false;
+    }
+
+    @Override
+    protected String typeDescriptor() {
+        return "Ljava/lang/invoke/MethodHandles$Lookup;";
+    }
+}

--- a/substratevm/src/com.oracle.svm.reflectionagent/src/com/oracle/svm/reflectionagent/analyzers/ConstantMethodTypeAnalyzer.java
+++ b/substratevm/src/com.oracle.svm.reflectionagent/src/com/oracle/svm/reflectionagent/analyzers/ConstantMethodTypeAnalyzer.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2024, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package com.oracle.svm.reflectionagent.analyzers;
+
+import com.oracle.svm.shaded.org.objectweb.asm.tree.AbstractInsnNode;
+import com.oracle.svm.shaded.org.objectweb.asm.tree.MethodInsnNode;
+import com.oracle.svm.shaded.org.objectweb.asm.tree.analysis.Frame;
+import com.oracle.svm.shaded.org.objectweb.asm.tree.analysis.SourceValue;
+
+import java.util.Set;
+
+public class ConstantMethodTypeAnalyzer extends ConstantValueAnalyzer {
+
+    public ConstantMethodTypeAnalyzer(AbstractInsnNode[] instructions, Frame<SourceValue>[] frames, Set<MethodInsnNode> constantCalls) {
+        super(instructions, frames, constantCalls);
+    }
+
+    @Override
+    protected boolean isConstant(SourceValue value, AbstractInsnNode sourceInstruction, Frame<SourceValue> sourceInstructionFrame) {
+        return false;
+    }
+
+    @Override
+    protected String typeDescriptor() {
+        return "Ljava/lang/invoke/MethodType;";
+    }
+}

--- a/substratevm/src/com.oracle.svm.reflectionagent/src/com/oracle/svm/reflectionagent/analyzers/ConstantStringAnalyzer.java
+++ b/substratevm/src/com.oracle.svm.reflectionagent/src/com/oracle/svm/reflectionagent/analyzers/ConstantStringAnalyzer.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2024, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package com.oracle.svm.reflectionagent.analyzers;
+
+import com.oracle.svm.shaded.org.objectweb.asm.tree.AbstractInsnNode;
+import com.oracle.svm.shaded.org.objectweb.asm.tree.LdcInsnNode;
+import com.oracle.svm.shaded.org.objectweb.asm.tree.MethodInsnNode;
+import com.oracle.svm.shaded.org.objectweb.asm.tree.analysis.Frame;
+import com.oracle.svm.shaded.org.objectweb.asm.tree.analysis.SourceValue;
+
+import java.util.Set;
+
+public class ConstantStringAnalyzer extends ConstantValueAnalyzer {
+
+    public ConstantStringAnalyzer(AbstractInsnNode[] instructions, Frame<SourceValue>[] frames, Set<MethodInsnNode> constantCalls) {
+        super(instructions, frames, constantCalls);
+    }
+
+    @Override
+    protected boolean isConstant(SourceValue value, AbstractInsnNode sourceInstruction, Frame<SourceValue> sourceInstructionFrame) {
+        return sourceInstruction instanceof LdcInsnNode ldc && ldc.cst instanceof String;
+    }
+
+    @Override
+    protected String typeDescriptor() {
+        return "Ljava/lang/String;";
+    }
+}

--- a/substratevm/src/com.oracle.svm.reflectionagent/src/com/oracle/svm/reflectionagent/analyzers/ConstantValueAnalyzer.java
+++ b/substratevm/src/com.oracle.svm.reflectionagent/src/com/oracle/svm/reflectionagent/analyzers/ConstantValueAnalyzer.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2024, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package com.oracle.svm.reflectionagent.analyzers;
+
+import com.oracle.svm.shaded.org.objectweb.asm.tree.AbstractInsnNode;
+import com.oracle.svm.shaded.org.objectweb.asm.tree.MethodInsnNode;
+import com.oracle.svm.shaded.org.objectweb.asm.tree.VarInsnNode;
+import com.oracle.svm.shaded.org.objectweb.asm.tree.analysis.Frame;
+import com.oracle.svm.shaded.org.objectweb.asm.tree.analysis.SourceValue;
+
+import java.util.Arrays;
+import java.util.Set;
+
+import static com.oracle.svm.shaded.org.objectweb.asm.Opcodes.ALOAD;
+import static com.oracle.svm.shaded.org.objectweb.asm.Opcodes.ASTORE;
+
+public abstract class ConstantValueAnalyzer {
+
+    private final AbstractInsnNode[] instructions;
+    private final Frame<SourceValue>[] frames;
+    private final Set<MethodInsnNode> constantCalls;
+
+    public ConstantValueAnalyzer(AbstractInsnNode[] instructions, Frame<SourceValue>[] frames, Set<MethodInsnNode> constantCalls) {
+        this.instructions = instructions;
+        this.frames = frames;
+        this.constantCalls = constantCalls;
+    }
+
+    public boolean isConstant(SourceValue value) {
+        if (value.insns.size() != 1) {
+            return false;
+        }
+
+        AbstractInsnNode sourceInstruction = value.insns.iterator().next();
+        int sourceInstructionIndex = Arrays.asList(instructions).indexOf(sourceInstruction);
+        Frame<SourceValue> sourceInstructionFrame = frames[sourceInstructionIndex];
+
+        if (sourceInstruction.getOpcode() == ALOAD) {
+            SourceValue sourceValue = sourceInstructionFrame.getLocal(((VarInsnNode) sourceInstruction).var);
+            return isConstant(sourceValue);
+        } else if (sourceInstruction.getOpcode() == ASTORE) {
+            SourceValue sourceValue = sourceInstructionFrame.getStack(sourceInstructionFrame.getStackSize() - 1);
+            return isConstant(sourceValue);
+        } else if (sourceInstruction instanceof MethodInsnNode methodCall) {
+            return constantCalls.contains(methodCall);
+        }
+
+        return isConstant(value, sourceInstruction, sourceInstructionFrame);
+    }
+
+    protected abstract boolean isConstant(SourceValue value, AbstractInsnNode sourceInstruction, Frame<SourceValue> sourceInstructionFrame);
+
+    protected abstract String typeDescriptor();
+}

--- a/substratevm/src/com.oracle.svm.reflectionagent/src/com/oracle/svm/reflectionagent/cfg/ControlFlowGraphAnalyzer.java
+++ b/substratevm/src/com.oracle.svm.reflectionagent/src/com/oracle/svm/reflectionagent/cfg/ControlFlowGraphAnalyzer.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2025, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package com.oracle.svm.reflectionagent.cfg;
+
+import com.oracle.svm.shaded.org.objectweb.asm.tree.analysis.Analyzer;
+import com.oracle.svm.shaded.org.objectweb.asm.tree.analysis.Frame;
+import com.oracle.svm.shaded.org.objectweb.asm.tree.analysis.Interpreter;
+import com.oracle.svm.shaded.org.objectweb.asm.tree.analysis.Value;
+
+public class ControlFlowGraphAnalyzer<V extends Value> extends Analyzer<V> {
+    public ControlFlowGraphAnalyzer(Interpreter<V> interpreter) {
+        super(interpreter);
+    }
+
+    @Override
+    protected Frame<V> newFrame(int numLocals, int numStack) {
+        return new ControlFlowGraphNode<>(numLocals, numStack);
+    }
+
+    @Override
+    protected Frame<V> newFrame(Frame<? extends V> frame) {
+        return new ControlFlowGraphNode<>(frame);
+    }
+
+    @Override
+    protected void newControlFlowEdge(int instructionIndex, int successorIndex) {
+        ControlFlowGraphNode<V> source = (ControlFlowGraphNode<V>) getFrames()[instructionIndex];
+        ControlFlowGraphNode<V> destination = (ControlFlowGraphNode<V>) getFrames()[successorIndex];
+        source.successors.add(successorIndex);
+        destination.predecessors.add(instructionIndex);
+    }
+}

--- a/substratevm/src/com.oracle.svm.reflectionagent/src/com/oracle/svm/reflectionagent/cfg/ControlFlowGraphNode.java
+++ b/substratevm/src/com.oracle.svm.reflectionagent/src/com/oracle/svm/reflectionagent/cfg/ControlFlowGraphNode.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2025, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package com.oracle.svm.reflectionagent.cfg;
+
+import com.oracle.svm.shaded.org.objectweb.asm.tree.analysis.Frame;
+import com.oracle.svm.shaded.org.objectweb.asm.tree.analysis.Value;
+
+import java.util.HashSet;
+import java.util.Set;
+
+public class ControlFlowGraphNode<V extends Value> extends Frame<V> {
+    public Set<Integer> successors = new HashSet<>();
+    public Set<Integer> predecessors = new HashSet<>();
+
+    public ControlFlowGraphNode(int numLocals, int maxStack) {
+        super(numLocals, maxStack);
+    }
+
+    public ControlFlowGraphNode(Frame<? extends V> frame) {
+        super(frame);
+    }
+}

--- a/vm/mx.vm/ni-ce
+++ b/vm/mx.vm/ni-ce
@@ -1,4 +1,4 @@
 DYNAMIC_IMPORTS=/substratevm
 DISABLE_INSTALLABLES=true
 EXCLUDE_COMPONENTS=pbm,pmh
-NATIVE_IMAGES=native-image,lib:native-image-agent,lib:native-image-diagnostics-agent
+NATIVE_IMAGES=native-image,lib:native-image-agent,lib:native-image-diagnostics-agent,lib:native-image-reflection-agent


### PR DESCRIPTION
Currently, the constant reflection analysis used by Native Image is optimization dependent. This can lead to unexpected results during image run-time when using reflection. For example, the `Class.forName` call in the following snippet will be folded by the analysis:

```java
static boolean isEven(int n) {
    return n % 2 == 0;
}

Class<?> grabClass() throws ClassNotFoundException {
    var className = isEven(4) ? "A" : "B";
    return Class.forName(className); // returns Class A
}
```

However, adding a simple printing statement to `isEven` or toggling different optimizations during build-time can cause the method to be non-inlinable and `Class.forName` call won't be folded:

```java
static boolean isEven(int n) {
    System.out.print("isEven was called");
    return n % 2 == 0;
}

Class<?> grabClass() throws ClassNotFoundException {
    var className = isEven(4) ? "A" : "B";
    return Class.forName(className); // throws ClassNotFoundException / MissingReflectionRegistrationError
}
```

In order to prevent this behavior, we can run a constant reflection analysis directly on the bytecode used as input to Native Image.

This PR implements a JVMTI agent (`com.oracle.svm.reflectionagent.NativeImageReflectionAgent`) which intercepts user provided class files, analyzes them for constant reflection usage and marks such reflective methods as constant by redirecting them to their counterparts in the `org.graalvm.nativeimage.impl.reflectiontags.ConstantTags`) class. If a reflective method invocation in a user provided class gets folded by `com.oracle.svm.hosted.snippets.ReflectionPlugins` without it being marked as constant by the agent, the user gets a warning during build-time:

```
Warning: Call to java.lang.Class.forName(String) reached in Demo.main(Demo.java:14) with arguments (A) was reduced to the constant class A outside of the strict constant reflection mode. Consider adding the appropriate entry to your reachability metadata (https://www.graalvm.org/latest/reference-manual/native-image/metadata/#reflection).
```

To enable the agent and warnings, use the `-H:+EnableStrictReflection`. In addition, three new options are provided for more accurate logging of constant reflection folding done by `ReflectionPlugins`:

- `-H:ReflectionPluginTraceLocation=<log_location>` - Location for the log file. If not set, the log isn't created.
- `-H:ReflectionPluginTraceFormat=json|plain` - Specify the format of the location log. Default value is json. If `ReflectionPluginTraceLocation` isn't set, this option has no effect.
- `-H:+ReflectionPluginTraceUserOnly` - Log only the constant folding which occurred in user classes. Default value is true. If `ReflectionPluginTraceLocation` isn't set, this option has no effect.