### PR TITLE
Add nativeimage-libgraal to module path for non-jlinked JDKs

### DIFF
--- a/substratevm/src/com.oracle.svm.driver/src/com/oracle/svm/driver/NativeImage.java
+++ b/substratevm/src/com.oracle.svm.driver/src/com/oracle/svm/driver/NativeImage.java
@@ -646,12 +646,13 @@ public class NativeImage {
          */
         public List<Path> getBuilderModulePath() {
             List<Path> result = new ArrayList<>();
-            // Non-jlinked JDKs need truffle and word, collections, nativeimage on the
-            // module path since they don't have those modules as part of the JDK. Note
-            // that graal-sdk is now obsolete after the split in GR-43819 (#7171)
+            // Non-jlinked JDKs need truffle and word, collections, nativeimage,
+            // nativeimage-libgraal on the module path since they don't have those
+            // modules as part of the JDK. Note that graal-sdk is now obsolete
+            // after the split in GR-43819 (#7171)
             if (libJvmciDir != null) {
                 result.addAll(getJars(libJvmciDir, "enterprise-graal"));
-                result.addAll(getJars(libJvmciDir, "word", "collections", "nativeimage"));
+                result.addAll(getJars(libJvmciDir, "word", "collections", "nativeimage", "nativeimage-libgraal"));
             }
             if (modulePathBuild) {
                 result.addAll(createTruffleBuilderModulePath());


### PR DESCRIPTION
Closes #10708 

Tested with (which failed earlier):

```
$ mx --primary-suite-path substratevm --no-jlinking build
$ GRAALVM_HOME=$(mx --primary-suite-path substratevm --no-jlinking graalvm-home)
$ $GRAALVM_HOME/bin/native-image --macro:native-image-agent-library
[...]
Top 10 origins of code area:                                Top 10 object types in image heap:
   6.81MB java.base                                            2.53MB byte[] for code metadata
   1.51MB svm.jar (Native Image)                               1.78MB byte[] for java.lang.String
 309.98kB org.graalvm.nativeimage.configure                    1.23MB java.lang.String
 235.73kB org.graalvm.nativeimage.agent.tracing              937.73kB com.oracle.svm.core.hub.DynamicHubCompanion
 224.31kB jdk.zipfs                                          678.06kB byte[] for general heap data
 106.37kB java.logging                                       649.54kB java.lang.Class
  75.07kB org.graalvm.nativeimage.base                       362.40kB java.util.HashMap$Node
  71.10kB jdk.charsets                                       292.18kB java.lang.Object[]
  49.80kB jdk.proxy2                                         234.43kB java.util.concurrent.ConcurrentHashMap$Node
  49.60kB jdk.graal.compiler                                 226.22kB java.util.HashMap$Node[]
 141.53kB for 9 more packages                                  2.81MB for 1376 more object types
------------------------------------------------------------------------------------------------------------------------
Recommendations:
 HEAP: Set max heap for improved and more predictable memory usage.
------------------------------------------------------------------------------------------------------------------------
                        2.1s (5.1% of total time) in 316 GCs | Peak RSS: 1.92GB | CPU load: 8.62
------------------------------------------------------------------------------------------------------------------------
Build artifacts:
 /disk/graal/upstream-sources/graal/sdk/mxbuild/linux-amd64/GRAALVM_757AAB922C_JAVA25/graalvm-757aab922c-java25-25.0.0-dev/lib/gdb-debughelpers.py (debug_info)
 /disk/graal/upstream-sources/graal/sdk/mxbuild/linux-amd64/GRAALVM_757AAB922C_JAVA25/graalvm-757aab922c-java25-25.0.0-dev/lib/graal_isolate.h (c_header)
 /disk/graal/upstream-sources/graal/sdk/mxbuild/linux-amd64/GRAALVM_757AAB922C_JAVA25/graalvm-757aab922c-java25-25.0.0-dev/lib/graal_isolate_dynamic.h (c_header)
 /disk/graal/upstream-sources/graal/sdk/mxbuild/linux-amd64/GRAALVM_757AAB922C_JAVA25/graalvm-757aab922c-java25-25.0.0-dev/lib/libnative-image-agent.h (c_header)
 /disk/graal/upstream-sources/graal/sdk/mxbuild/linux-amd64/GRAALVM_757AAB922C_JAVA25/graalvm-757aab922c-java25-25.0.0-dev/lib/libnative-image-agent.so (shared_library)
 /disk/graal/upstream-sources/graal/sdk/mxbuild/linux-amd64/GRAALVM_757AAB922C_JAVA25/graalvm-757aab922c-java25-25.0.0-dev/lib/libnative-image-agent.so.debug (debug_info)
 /disk/graal/upstream-sources/graal/sdk/mxbuild/linux-amd64/GRAALVM_757AAB922C_JAVA25/graalvm-757aab922c-java25-25.0.0-dev/lib/libnative-image-agent_dynamic.h (c_header)
 /disk/graal/upstream-sources/graal/sdk/mxbuild/linux-amd64/GRAALVM_757AAB922C_JAVA25/graalvm-757aab922c-java25-25.0.0-dev/lib/sources (debug_info)
========================================================================================================================
Finished generating 'libnative-image-agent' in 40.1s.
```