### PR TITLE
[GR-63550] Fix bug in JFR type repository

### DIFF
--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/JfrTypeRepository.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/JfrTypeRepository.java
@@ -104,6 +104,7 @@ public class JfrTypeRepository implements JfrRepository {
 
     private void visitClass(TypeInfo typeInfo, Class<?> clazz) {
         if (clazz != null && addClass(typeInfo, clazz)) {
+            visitClassLoader(typeInfo, clazz.getClassLoader());
             visitPackage(typeInfo, clazz.getPackage(), clazz.getModule());
             visitClass(typeInfo, clazz.getSuperclass());
         }


### PR DESCRIPTION
This is a fix for the bug reported by: https://github.com/oracle/graal/issues/10742

The problem was that, for each class used during the epoch, we only visited its module's classloader (if the class' package and it's module were both non null).  However, later on when serializing classes, we attempt to write the class' classloader.  This classloader is never explicitly visited so may not have been processed. 