### PR TITLE
[WIP] Allow experimental options in preinitialized contexts.

### DIFF
--- a/truffle/src/com.oracle.truffle.polyglot/src/com/oracle/truffle/polyglot/PolyglotContextConfig.java
+++ b/truffle/src/com.oracle.truffle.polyglot/src/com/oracle/truffle/polyglot/PolyglotContextConfig.java
@@ -235,7 +235,7 @@ final class PolyglotContextConfig {
                         null,
                         false,
                         false,
-                        false,
+                        Boolean.getBoolean("polyglot.image-build-time.PreinitializeAllowExperimentalOptions"),
                         null,
                         Collections.emptyMap(),
                         Collections.emptySet(),


### PR DESCRIPTION
Adds a flag which allows use of experimental Truffle context options in preinitialized contexts. If the flag `polyglot.image-build-time.PreinitializeAllowExperimentalOptions` is passed, `allowExperimentalOptions` is set to `true` by default at preinitialized context init.

Fixes and closes oracle/graal#10790
