### PR TITLE
Remove extra dot in Option.deprecationMessage in ConfigurationFiles.Options.DynamicProxyConfigurationResources

### DIFF
--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/configure/ConfigurationFiles.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/configure/ConfigurationFiles.java
@@ -84,7 +84,7 @@ public final class ConfigurationFiles {
                         AccumulatingLocatableMultiOptionValue.Paths.buildWithCommaDelimiter());
         @Option(help = "Resources describing program elements to be made available for reflection (see ProxyConfigurationFiles).", type = OptionType.User, deprecated = true, //
                         deprecationMessage = "This can be caused by a proxy-config.json file in your META-INF directory. " +
-                                        "Consider including proxy configuration in the reflection section of reachability-metadata.md instead.")//
+                                        "Consider including proxy configuration in the reflection section of reachability-metadata.md instead")//
         public static final HostedOptionKey<AccumulatingLocatableMultiOptionValue.Strings> DynamicProxyConfigurationResources = new HostedOptionKey<>(
                         AccumulatingLocatableMultiOptionValue.Strings.buildWithCommaDelimiter());
 


### PR DESCRIPTION
This PR removes an extra dot in `@Option` `deprecationMessage` attribute in the `ConfigurationFiles.Options.DynamicProxyConfigurationResources` as the ending dot doesn't seem to be expected as follows:

https://github.com/oracle/graal/blob/4b8e3db39b70849eb7e4a6a860084f8ab86d3db6/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/option/SubstrateOptionsParser.java#L108-L112

See https://github.com/spring-projects/spring-framework/issues/34855#issue-3041543510