### PR TITLE
[GR-65899] JFR substitutions for JDK 25+26.

### DIFF
--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/Target_jdk_jfr_internal_JVM.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/Target_jdk_jfr_internal_JVM.java
@@ -662,10 +662,10 @@ public final class Target_jdk_jfr_internal_JVM {
     /** See {@link JVM#setMethodTraceFilters}. */
     @Substitute
     public static long[] setMethodTraceFilters(
-            String[] classes,
-            String[] methods,
-            String[] annotations,
-            int[] modification) {
+                    String[] classes,
+                    String[] methods,
+                    String[] annotations,
+                    int[] modification) {
         // JFR method tracing is not supported. No filters can be used so return null.
         return null;
     }

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/Target_jdk_jfr_internal_JVM.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/Target_jdk_jfr_internal_JVM.java
@@ -296,6 +296,12 @@ public final class Target_jdk_jfr_internal_JVM {
         SubstrateJVM.get().setMethodSamplingInterval(type, intervalMillis);
     }
 
+    /** See {@code JVM#setCPUThrottle}. */
+    @Substitute
+    public static void setCPUThrottle(double rate, boolean autoAdapt) {
+        // JFR CPUTimeSample is not supported.
+    }
+
     /** See {@link JVM#setOutput}. */
     @Substitute
     public static void setOutput(String file) {
@@ -651,6 +657,24 @@ public final class Target_jdk_jfr_internal_JVM {
          * implement it nevertheless and return true to disable non-product features.
          */
         return true;
+    }
+
+    /** See {@link JVM#setMethodTraceFilters}. */
+    @Substitute
+    public static long[] setMethodTraceFilters(
+            String[] classes,
+            String[] methods,
+            String[] annotations,
+            int[] modification) {
+        // JFR method tracing is not supported. No filters can be used so return null.
+        return null;
+    }
+
+    /** See {@link JVM#drainStaleMethodTracerIds}. */
+    @Substitute
+    public static long[] drainStaleMethodTracerIds() {
+        // JFR method tracing is not supported. Return no stale IDs.
+        return null;
     }
 }
 


### PR DESCRIPTION
This PR adds some substitutions related to the the new JFR features recently integrated into OpenJDK:
JEP 520: [JFR Method Timing & Tracing](https://openjdk.org/jeps/520)
JEP 509: [JFR CPU-Time Profiling (Experimental)](https://openjdk.org/jeps/509)

Without them we get warnings like this:
```
[warn][jfr,system ] Exception occurred during execution of event jdk.MethodTiming(13364). jdk.jfr.internal.JVM.drainStaleMethodTracerIds()[J [symbol: Java_jdk_jfr_internal_JVM_drainStaleMethodTracerIds or Java_jdk_jfr_internal_JVM_drainStaleMethodTracerIds__]
[warn][jfr,setting] Exception occurred when setting value "false". jdk.jfr.internal.JVM.setCPUThrottle(DZ)V [symbol: Java_jdk_jfr_internal_JVM_setCPUThrottle or Java_jdk_jfr_internal_JVM_setCPUThrottle__DZ] ==> expected: <true> but was: <false>

```