### PR TITLE
Make IGV start on GraalVM 24.0.1

### DIFF
--- a/visualizer/IdealGraphVisualizer/Data/src/main/nbm/manifest.mf
+++ b/visualizer/IdealGraphVisualizer/Data/src/main/nbm/manifest.mf
@@ -2,4 +2,4 @@ Manifest-Version: 1.0
 OpenIDE-Module: org.graalvm.visualizer.data
 OpenIDE-Module-Localizing-Bundle: org/graalvm/visualizer/data/Bundle.properties
 OpenIDE-Module-Specification-Version: 1.5
-
+OpenIDE-Module-Hide-Classpath-Packages: jdk.graal.compiler.graphio.**

--- a/visualizer/IdealGraphVisualizer/pom.xml
+++ b/visualizer/IdealGraphVisualizer/pom.xml
@@ -117,7 +117,7 @@
         <module>ViewerApi</module>
     </modules>
     <properties>
-        <netbeans.version>RELEASE220</netbeans.version>
+        <netbeans.version>RELEASE260</netbeans.version>
         <brandingToken>idealgraphvisualizer</brandingToken>
         <swinglayouts.version>1.0.2</swinglayouts.version>
         <nbmmvnplugin.version>4.8</nbmmvnplugin.version>


### PR DESCRIPTION
I have problems launching IGV on GraalVM 24.0.1. It yields following error:
```
Executing: /bin/sh -c '/home/devel/NetBeansProjects/graalvm/graal/visualizer/IdealGraphVisualizer/application/target/idealgraphvisualizer/bin/idealgraphvisualizer' '--userdir' '/home/devel/NetBeansProjects/graalvm/graal/visualizer/IdealGraphVisualizer/application/target/userdir' '-J-Dnetbeans.logger.console=true' '-J-ea' '--branding' 'idealgraphvisualizer' '--jdkhome' '/home/devel/bin/graalvm-24'
WARNING: package com.sun.tools.javadoc.main not in jdk.javadoc
Error occurred during initialization of VM
java.lang.Error: A command line option has attempted to allow or enable the Security Manager. Enabling a Security Manager is not supported.
	at java.lang.System.initPhase3(java.base@24.0.1/System.java:1947)
```
The problem is that JDK 24 has removed [SecurityManager support](https://openjdk.org/jeps/486) and as the NetBeans Platform launcher needs to be adjusted to that. Such an adjustment has happened in NetBeans 26. Hence upgrading.