### PR TITLE
On branch edburns/11556-duplicate-closing-punctuation-in-compiler-mes…

### DIFF
--- a/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/SerialGCOptions.java
+++ b/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/SerialGCOptions.java
@@ -127,7 +127,7 @@ public final class SerialGCOptions {
     }
 
     public static class DeprecatedOptions {
-        @Option(help = "Ignore the maximum heap size while in VM-internal code. Serial GC only.", type = OptionType.Expert, deprecated = true, deprecationMessage = "Please use the option 'IgnoreMaxHeapSizeWhileInVMInternalCode' instead.")//
+        @Option(help = "Ignore the maximum heap size while in VM-internal code. Serial GC only.", type = OptionType.Expert, deprecated = true, deprecationMessage = "Please use the option 'IgnoreMaxHeapSizeWhileInVMInternalCode' instead")//
         public static final HostedOptionKey<Boolean> IgnoreMaxHeapSizeWhileInVMOperation = new HostedOptionKey<>(false, SerialGCOptions::validateSerialHostedOption) {
             @Override
             protected void onValueUpdate(EconomicMap<OptionKey<?>, Object> values, Boolean oldValue, Boolean newValue) {

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/SubstrateOptions.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/SubstrateOptions.java
@@ -782,7 +782,7 @@ public class SubstrateOptions {
     @Option(help = "Deprecated, option no longer has any effect.", type = OptionType.User, deprecated = true, deprecationMessage = "It no longer has any effect, and no replacement is available")//
     public static final HostedOptionKey<Boolean> BuildOutputPrefix = new HostedOptionKey<>(false);
 
-    @Option(help = "Color build output (enabled by default if colors are supported by terminal)", type = OptionType.User, deprecated = true, deprecationMessage = "Please use '--color' instead.")//
+    @Option(help = "Color build output (enabled by default if colors are supported by terminal)", type = OptionType.User, deprecated = true, deprecationMessage = "Please use '--color' instead")//
     public static final HostedOptionKey<Boolean> BuildOutputColorful = new HostedOptionKey<>(false);
 
     @Option(help = "Show links in build output (defaults to the value of BuildOutputColorful)", type = OptionType.User)//
@@ -1516,7 +1516,7 @@ public class SubstrateOptions {
     public static final HostedOptionKey<Boolean> ReduceImplicitExceptionStackTraceInformation = new HostedOptionKey<>(false);
 
     @Option(help = "Allow all instantiated types to be allocated via Unsafe.allocateInstance().", type = OptionType.Expert, //
-                    deprecated = true, deprecationMessage = "ThrowMissingRegistrationErrors is the preferred way of configuring this on a per-type level.") //
+                    deprecated = true, deprecationMessage = "ThrowMissingRegistrationErrors is the preferred way of configuring this on a per-type level") //
     public static final HostedOptionKey<Boolean> AllowUnsafeAllocationOfAllInstantiatedTypes = new HostedOptionKey<>(null);
 
     @Option(help = "Enable fallback to mremap for initializing the image heap.")//

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/configure/ConfigurationFiles.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/configure/ConfigurationFiles.java
@@ -85,7 +85,7 @@ public final class ConfigurationFiles {
                         AccumulatingLocatableMultiOptionValue.Paths.buildWithCommaDelimiter());
         @Option(help = "Resources describing program elements to be made available for reflection (see ProxyConfigurationFiles).", type = OptionType.User, deprecated = true, //
                         deprecationMessage = "This can be caused by a proxy-config.json file in your META-INF directory. " +
-                                        "Consider including proxy configuration in the reflection section of reachability-metadata.md instead.")//
+                                        "Consider including proxy configuration in the reflection section of reachability-metadata.md instead")//
         public static final HostedOptionKey<AccumulatingLocatableMultiOptionValue.Strings> DynamicProxyConfigurationResources = new HostedOptionKey<>(
                         AccumulatingLocatableMultiOptionValue.Strings.buildWithCommaDelimiter());
 

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/option/RuntimeOptionParser.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/option/RuntimeOptionParser.java
@@ -215,7 +215,7 @@ public final class RuntimeOptionParser implements DuplicableImageSingleton {
             // Checkstyle: Allow raw info or warning printing - end
             String deprecationMessage = descriptor.getDeprecationMessage();
             if (deprecationMessage != null && !deprecationMessage.isEmpty()) {
-                log.string(": ").string(deprecationMessage);
+                log.string(": ").string(deprecationMessage).string(".");
             }
             log.newline();
         }

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/NativeImageOptions.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/NativeImageOptions.java
@@ -100,7 +100,7 @@ public class NativeImageOptions {
     };
 
     @Option(help = "Uses the native architecture, i.e., the architecture of a machine that builds an image.", type = User, //
-                    deprecated = true, deprecationMessage = "Please use '-march=native' instead. See '--help' for details.") //
+                    deprecated = true, deprecationMessage = "Please use '-march=native' instead. See '--help' for details") //
     public static final HostedOptionKey<Boolean> NativeArchitecture = new HostedOptionKey<>(false) {
         @Override
         protected void onValueUpdate(EconomicMap<OptionKey<?>, Object> values, Boolean oldValue, Boolean newValue) {
@@ -231,7 +231,7 @@ public class NativeImageOptions {
         }
     }
 
-    @Option(help = "Deprecated, option no longer has any effect", deprecated = true, deprecationMessage = "Please use '--parallelism' instead.")//
+    @Option(help = "Deprecated, option no longer has any effect", deprecated = true, deprecationMessage = "Please use '--parallelism' instead")//
     public static final HostedOptionKey<Integer> NumberOfAnalysisThreads = new HostedOptionKey<>(-1);
 
     @Option(help = "Return after analysis")//

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/jdk/localization/LocalizationFeature.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/jdk/localization/LocalizationFeature.java
@@ -174,7 +174,7 @@ public class LocalizationFeature implements InternalFeature {
         public static final HostedOptionKey<Boolean> AddAllCharsets = new HostedOptionKey<>(false);
 
         @Option(help = "Default locale of the image, by the default it is the same as the default locale of the image builder.", type = OptionType.User, //
-                        deprecated = true, deprecationMessage = "Please switch to using system properties such as '-Duser.country=CH -Duser.language=de'.")//
+                        deprecated = true, deprecationMessage = "Please switch to using system properties such as '-Duser.country=CH -Duser.language=de'")//
         public static final HostedOptionKey<String> DefaultLocale = new HostedOptionKey<>(Locale.getDefault().toLanguageTag());
 
         @Option(help = "Default charset of the image, by the default it is the same as the default charset of the image builder.", type = OptionType.User)//

--- a/truffle/src/com.oracle.truffle.api.test/src/com/oracle/truffle/api/test/option/OptionProcessorTest.java
+++ b/truffle/src/com.oracle.truffle.api.test/src/com/oracle/truffle/api/test/option/OptionProcessorTest.java
@@ -444,17 +444,17 @@ public class OptionProcessorTest {
         static final OptionKey<OptionMap<String>> Error9 = OptionKey.mapOf(String.class);
 
         @ExpectError("Deprecation message can be specified only for deprecated options.") //
-        @Option(help = "A", category = OptionCategory.USER, deprecationMessage = "Deprecated with no replacement.") //
+        @Option(help = "A", category = OptionCategory.USER, deprecationMessage = "Deprecated with no replacement") //
         static final OptionKey<String> Error10 = new OptionKey<>("defaultValue");
 
         @ExpectError("Option deprecation message must start with upper case letter.") //
-        @Option(help = "A", category = OptionCategory.USER, deprecated = true, deprecationMessage = "deprecated with no replacement.") //
+        @Option(help = "A", category = OptionCategory.USER, deprecated = true, deprecationMessage = "deprecated with no replacement") //
         static final OptionKey<String> Error11 = new OptionKey<>("defaultValue");
 
         @Option(help = "A", name = "", deprecated = true, category = OptionCategory.USER) //
         static final OptionKey<String> EmptyNameAllowed = new OptionKey<>("defaultValue");
 
-        @Option(help = "A", category = OptionCategory.USER, deprecated = true, deprecationMessage = "Deprecated with no replacement.") //
+        @Option(help = "A", category = OptionCategory.USER, deprecated = true, deprecationMessage = "Deprecated with no replacement") //
         static final OptionKey<String> ValidDeprecationMessage = new OptionKey<>("defaultValue");
 
     }

--- a/truffle/src/com.oracle.truffle.polyglot/src/com/oracle/truffle/polyglot/PolyglotEngineOptions.java
+++ b/truffle/src/com.oracle.truffle.polyglot/src/com/oracle/truffle/polyglot/PolyglotEngineOptions.java
@@ -78,7 +78,7 @@ final class PolyglotEngineOptions {
 
     @Option(category = OptionCategory.INTERNAL, stability = OptionStability.EXPERIMENTAL, help = "Enables conservative context references. " +
                     "This allows invalid sharing between contexts. " +
-                    "For testing purposes only.", deprecated = true, deprecationMessage = "Has no longer any effect. Scheduled for removal in in 22.1.")//
+                    "For testing purposes only.", deprecated = true, deprecationMessage = "Has no longer any effect. Scheduled for removal in in 22.1")//
     static final OptionKey<Boolean> UseConservativeContextReferences = new OptionKey<>(false);
 
     @Option(category = OptionCategory.INTERNAL, stability = OptionStability.EXPERIMENTAL, help = "Enables specialization statistics for nodes generated with Truffle DSL and prints the result on exit. " +

--- a/wasm/src/org.graalvm.wasm/src/org/graalvm/wasm/WasmOptions.java
+++ b/wasm/src/org.graalvm.wasm/src/org/graalvm/wasm/WasmOptions.java
@@ -53,11 +53,11 @@ public class WasmOptions {
     public static final OptionKey<String> Builtins = new OptionKey<>("");
 
     @Option(help = "The minimal binary size for which to use async parsing. If threads are not supported, async parsing will not be used.", category = OptionCategory.USER, stability = OptionStability.STABLE, usageSyntax = "[0, inf)", //
-                    deprecated = true, deprecationMessage = "Option no longer has any effect and can be safely omitted.")//
+                    deprecated = true, deprecationMessage = "Option no longer has any effect and can be safely omitted")//
     public static final OptionKey<Integer> AsyncParsingBinarySize = new OptionKey<>(100_000);
 
     @Option(help = "The stack size in kilobytes to use during async parsing, or zero to use defaults.", category = OptionCategory.USER, stability = OptionStability.STABLE, usageSyntax = "[0, inf)", //
-                    deprecated = true, deprecationMessage = "Option no longer has any effect and can be safely omitted.")//
+                    deprecated = true, deprecationMessage = "Option no longer has any effect and can be safely omitted")//
     public static final OptionKey<Integer> AsyncParsingStackSize = new OptionKey<>(0);
 
     @Option(help = "A comma-separated list of pre-opened Wasi directories.", category = OptionCategory.USER, stability = OptionStability.STABLE, usageSyntax = "[<virtualDir>::]<hostDir>,[<virtualDir>::]<hostDir>,...")//


### PR DESCRIPTION
…sages

modified:   substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/SerialGCOptions.java
modified:   substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/SubstrateOptions.java
modified:   substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/configure/ConfigurationFiles.java
modified:   substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/option/RuntimeOptionParser.java
modified:   substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/NativeImageOptions.java
modified:   substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/jdk/localization/LocalizationFeature.java
modified:   truffle/src/com.oracle.truffle.api.test/src/com/oracle/truffle/api/test/option/OptionProcessorTest.java
modified:   truffle/src/com.oracle.truffle.polyglot/src/com/oracle/truffle/polyglot/PolyglotEngineOptions.java
modified:   wasm/src/org.graalvm.wasm/src/org/graalvm/wasm/WasmOptions.java

- The party doing the interpolation is responsible for the closing punctuation, not the source of the interpolated text.