### PR TITLE
Fix bug in JmxServerFeature resource registration

### DIFF
--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/jdk/JmxServerFeature.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/jdk/JmxServerFeature.java
@@ -83,7 +83,7 @@ public class JmxServerFeature implements InternalFeature {
                         "jdk.internal.agent.resources.agent");
 
         resourcesRegistry.addResourceBundles(ConfigurationCondition.alwaysTrue(),
-                        "sun.security.util.Resources"); // required for password auth
+                        "sun.security.util.resources.security"); // required for password auth
     }
 
     private static void configureProxy(BeforeAnalysisAccess access) {


### PR DESCRIPTION
This updates the resource bundle registration for the JMX server feature. This is needed to use remote JMX with password authentication. 

This OpenJDK upstream PR resulted in the original resource registration going out-of-date: https://github.com/openjdk/jdk/pull/22774
See this [commit](https://github.com/openjdk/jdk/commit/9a49418138b93bc8ed8879be5c9b9b9c85ef47e1#diff-fa5d9688ee9f2de0d3a71fb84220e8d39a10a196663ce91e8e2cc68430bc1de8R40).

Without this fix the following error can be expected when attempting password authentication: 
```
Exception in thread "main" java.lang.SecurityException: Authentication failed! java.util.MissingResourceException: Can't find bundle for base name sun.security.util.resources.security, locale en_US
		at java.base@25/java.util.ResourceBundle.throwMissingResourceException(ResourceBundle.java:2012)
		at java.base@25/java.util.ResourceBundle.getBundleImpl(ResourceBundle.java:1664)
		at org.graalvm.nativeimage.builder/com.oracle.svm.core.jdk.localization.substitutions.Target_java_util_ResourceBundle$1.get(Target_java_util_ResourceBundle.java:123)
		at org.graalvm.nativeimage.builder/com.oracle.svm.core.jdk.localization.substitutions.Target_java_util_ResourceBundle$1.get(Target_java_util_ResourceBundle.java:120)
		at org.graalvm.nativeimage.builder/com.oracle.svm.core.MissingRegistrationUtils.runIgnoringMissingRegistrations(MissingRegistrationUtils.java:122)
		at java.base@25/java.util.ResourceBundle.getBundleImpl(ResourceBundle.java:120)
		at java.base@25/java.util.ResourceBundle.getBundleImpl(ResourceBundle.java:1529)
		at java.base@25/java.util.ResourceBundle.getBundle(ResourceBundle.java:848)
		at java.base@25/java.util.concurrent.ConcurrentHashMap.computeIfAbsent(ConcurrentHashMap.java:1724)
		at java.base@25/sun.security.util.ResourcesMgr.getBundle(ResourcesMgr.java:54)
		at java.base@25/sun.security.util.ResourcesMgr.getString(ResourcesMgr.java:40)
		at java.base@25/javax.security.auth.Subject$SecureSet.contains(Subject.java:1084)
		at java.base@25/java.util.Collections$SynchronizedCollection.contains(Collections.java:2315)
		at java.management@25/com.sun.jmx.remote.security.FileLoginModule.commit(FileLoginModule.java:329)
		at java.base@25/javax.security.auth.login.LoginContext.invoke(LoginContext.java:606)
		at java.base@25/javax.security.auth.login.LoginContext.login(LoginContext.java:461)
		at java.management@25/com.sun.jmx.remote.security.JMXPluggableAuthenticator.authenticate(JMXPluggableAuthenticator.java:166)
		at jdk.management.agent@25/sun.management.jmxremote.ConnectorBootstrap$AccessFileCheckerAuthenticator.authenticate(ConnectorBootstrap.java:232)
		at java.management.rmi@25/javax.management.remote.rmi.RMIServerImpl.doNewClient(RMIServerImpl.java:231)
		at java.management.rmi@25/javax.management.remote.rmi.RMIServerImpl.newClient(RMIServerImpl.java:198)
		at java.base@25/java.lang.reflect.Method.invoke(Method.java:565)
		at java.rmi@25/sun.rmi.server.UnicastServerRef.dispatch(UnicastServerRef.java:351)
		at java.rmi@25/sun.rmi.transport.Transport.serviceCall(Transport.java:166)
		at java.rmi@25/sun.rmi.transport.tcp.TCPTransport.handleMessages(TCPTransport.java:543)
		at java.rmi@25/sun.rmi.transport.tcp.TCPTransport$ConnectionHandler.run0(TCPTransport.java:744)
		at java.rmi@25/sun.rmi.transport.tcp.TCPTransport$ConnectionHandler.run(TCPTransport.java:623)
		at java.base@25/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
		at java.base@25/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
		at java.base@25/java.lang.Thread.runWith(Thread.java:1487)
		at java.base@25/java.lang.Thread.run(Thread.java:1474)
		at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:832)
		at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:808)
    . . .
``` 
Steps to reproduce can be found here https://github.com/roberttoyonaga/RJMXTests/tree/main/Standalone  (the SSL configuration can be ignored). 

This bug affects the GraalVM for JDK 25 release branch (https://github.com/oracle/graal/tree/release/graal-vm/25.0) as well and should be backported to it.