### PR TITLE
Substitution fails during NI build when `java.prefs` module is not present

### DIFF
--- a/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/darwin/DarwinSubstitutions.java
+++ b/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/darwin/DarwinSubstitutions.java
@@ -28,6 +28,7 @@ import static com.oracle.svm.core.posix.headers.darwin.DarwinTime.NoTransitions.
 import static com.oracle.svm.core.posix.headers.darwin.DarwinTime.NoTransitions.mach_timebase_info;
 
 import java.util.Objects;
+import java.util.function.BooleanSupplier;
 
 import org.graalvm.nativeimage.ImageSingletons;
 import org.graalvm.nativeimage.Platform;
@@ -122,7 +123,7 @@ final class DarwinTimeUtil {
  * Native functions don't exist on Darwin because this whole class is used, and should exist, only
  * on Linux. See <code>java.util.prefs.Preferences#factory</code>.
  */
-@TargetClass(className = "java.util.prefs.FileSystemPreferences")
+@TargetClass(className = "java.util.prefs.FileSystemPreferences", onlyWith = IsJavaUtilPrefsPresent.class)
 final class Target_java_util_prefs_FileSystemPreferences {
     @Delete
     private static native int[] lockFile0(String fileName, int permission, boolean shared);
@@ -132,6 +133,14 @@ final class Target_java_util_prefs_FileSystemPreferences {
 
     @Delete
     private static native int chmod(String fileName, int permission);
+}
+
+final class IsJavaUtilPrefsPresent implements BooleanSupplier {
+    @Override
+    public boolean getAsBoolean() {
+        var prefsMod = ModuleLayer.boot().findModule("java.prefs");
+        return prefsMod.isPresent();
+    }
 }
 
 /**


### PR DESCRIPTION
In [enso](https://github.com/enso-org/enso), we are building NI from a small JDK created by `jlink`. On latest [GraalVM CE 25.0.0](https://github.com/graalvm/graalvm-ce-builds/releases/tag/jdk-25.0.0), it is no longer possible to build NI from small JDK without `java.prefs` module on MacOS.

## Minimal reproducer
Makefile:
```make
NI_BUILDER_MODULES = "org.graalvm.nativeimage.builder,org.graalvm.nativeimage.driver,org.graalvm.nativeimage.librarysupport,org.graalvm.nativeimage.objectfile,org.graalvm.nativeimage.pointsto"
NI_BASE_MODULES = "org.graalvm.nativeimage,org.graalvm.nativeimage.base,com.oracle.graal.graal_enterprise,com.oracle.svm.svm_enterprise"
JDK_MODULES = "java.naming,java.net.http,java.rmi,jdk.attach,jdk.charsets,jdk.crypto.ec,jdk.httpserver,jdk.localedata,jdk.jdwp.agent,jdk.security.auth"
ADD_MODULES = "$(NI_BUILDER_MODULES),$(NI_BASE_MODULES),$(JDK_MODULES)"

MODULE_JARS = "$$JAVA_HOME/lib/svm/bin/../../graalvm/svm-driver.jar:$$JAVA_HOME/lib/svm/bin/../builder/native-image-base.jar:$$JAVA_HOME/lib/svm/bin/../builder/espresso-svm.jar:$$JAVA_HOME/lib/svm/bin/../builder/objectfile.jar:$$JAVA_HOME/lib/svm/bin/../builder/pointsto.jar:$$JAVA_HOME/lib/svm/bin/../builder/svm-enterprise.jar:$$JAVA_HOME/lib/svm/bin/../builder/svm.jar:$$JAVA_HOME/lib/svm/bin/../builder/svm-configure.jar:$$JAVA_HOME/lib/svm/bin/../builder/svm-capnproto-runtime.jar:$$JAVA_HOME/lib/svm/bin/../builder/svm-foreign.jar:$$JAVA_HOME/lib/svm/bin/../library-support.jar"

NI_EXE = small_jdk/lib/svm/bin/native-image

all: clean native_image

small_jdk:
	jlink --output small_jdk --module-path "$(MODULE_JARS)" --add-modules "$(ADD_MODULES)"
	cp -r $$JAVA_HOME/lib/graalvm $$JAVA_HOME/lib/svm $$JAVA_HOME/lib/static $$JAVA_HOME/lib/truffle small_jdk/lib

Main.class: Main.java
	javac Main.java

native_image: Main.class small_jdk
	$(NI_EXE) Main -o main

clean:
	rm -rf small_jdk
	rm -f Main.class
	rm -f main
```

Main.java:
```java
public class Main {
    public static void main(String[] args) {
        System.out.println("Hello from Main");
    }
}
```

Running `make` on GraalVM CE 25.0.0, the following error is reported:
```
========================================================================================================================
GraalVM Native Image: Generating 'main' (executable)...
========================================================================================================================
[1/8] Initializing...
                                                                                    (0.0s @ 0.08GB)
Error: Substitution target for com.oracle.svm.core.posix.darwin.Target_java_util_prefs_FileSystemPreferences is not loaded. Use field `onlyWith` in the `TargetClass` annotation to make substitution only active when needed.
```

Running `make` on GraalVM CE 24.0.1 is OK.

Note that @JaroslavTulach was not possible to reproduce this error on Linux AMD64. Seems to affect only Mac (I have aarch64, but it probably also affects x64).

## Context
- Encountered in https://github.com/enso-org/enso/pull/14019#discussion_r2381732260
- The process how to create small JDK was recommended to us by @fniephaus in https://graalvm.slack.com/archives/CN9KSFB40/p1715117172381849?thread_ts=1715083564.880179&cid=CN9KSFB40
- Tracked as an issue in https://github.com/enso-org/enso/issues/14051