### PR TITLE
Extend wrapped JS function coverage in core runtime types

### DIFF
--- a/sdk/src/org.graalvm.webimage.api/src/org/graalvm/webimage/api/JSNumber.java
+++ b/sdk/src/org.graalvm.webimage.api/src/org/graalvm/webimage/api/JSNumber.java
@@ -119,4 +119,137 @@ public final class JSNumber extends JSValue {
     public int hashCode() {
         return javaDouble().hashCode();
     }
+
+    @JS.Coerce
+    @JS(value = "return isFinite(number);")
+    public native static boolean isFinite(JSNumber number);
+
+    @JS.Coerce
+    @JS(value = "return isFinite(number);")
+    public native static boolean isFinite(Number number);
+
+    @JS.Coerce
+    @JS(value = "return Number.isInteger(number);")
+    public native static boolean isInteger(JSNumber number);
+
+    @JS.Coerce
+    @JS(value = "return Number.isInteger(number);")
+    public native static boolean isInteger(Number number);
+
+    @JS.Coerce
+    @JS(value = "return isNaN(number);")
+    public native static boolean isNaN(JSValue number);
+
+    @JS.Coerce
+    @JS(value = "return isNaN(number);")
+    public native static boolean isNaN(Number number);
+
+    @JS.Coerce
+    @JS(value = "return Number.isSafeInteger(number);")
+    public native static boolean isSafeInteger(JSValue number);
+
+    @JS.Coerce
+    @JS(value = "return Number.isSafeInteger(number);")
+    public native static boolean isSafeInteger(Number number);
+
+    @JS.Coerce
+    @JS(value = "return parseFloat(number);")
+    public native static float parseFloat(Number number);
+
+    @JS.Coerce
+    @JS(value = "return parseFloat(number);")
+    public native static float parseFloat(String number);
+
+    @JS.Coerce
+    @JS(value = "return parseInt(number);")
+    public native static int parseInt(Number number);
+
+    @JS.Coerce
+    @JS(value = "return parseInt(number);")
+    public native static int parseInt(String number);
+
+    @JS.Coerce
+    @JS(value = "return parseInt(number, radix);")
+    public native static int parseInt(String number, int radix);
+
+    @JS.Coerce
+    @JS(value = "return Number.EPSILON;")
+    public native static double EPSILON();
+
+    @JS.Coerce
+    @JS(value = "return Number.MAX_SAFE_INTEGER;")
+    public native static double MAX_SAFE_INTEGER();
+
+    @JS.Coerce
+    @JS(value = "return Number.MAX_VALUE;")
+    public native static double MAX_VALUE();
+
+    @JS.Coerce
+    @JS(value = "return Number.MIN_SAFE_INTEGER;")
+    public native static double MIN_SAFE_INTEGER();
+
+    @JS.Coerce
+    @JS(value = "return Number.MIN_VALUE;")
+    public native static double MIN_VALUE();
+
+    @JS.Coerce
+    @JS(value = "return Number.NaN;")
+    public native static double NaN();
+
+    @JS.Coerce
+    @JS(value = "return Number.NEGATIVE_INFINITY;")
+    public native static double NEGATIVE_INFINITY();
+
+    @JS.Coerce
+    @JS(value = "return Number.POSITIVE_INFINITY;")
+    public native static double POSITIVE_INFINITY();
+
+    @JS.Coerce
+    @JS(value = "return this.toExponential();")
+    public native String toExponential();
+
+    @JS.Coerce
+    @JS(value = "return this.toExponential(fractionDigits);")
+    public native String toExponential(int fractionDigits);
+
+    @JS.Coerce
+    @JS(value = "return this.toFixed();")
+    public native String toFixed();
+
+    @JS.Coerce
+    @JS(value = "return this.toFixed(digits);")
+    public native String toFixed(int digits);
+
+    @JS.Coerce
+    @JS(value = "return this.toLocaleString();")
+    public native String toLocaleString();
+
+    @JS.Coerce
+    @JS(value = "return this.toLocaleString(locales);")
+    public native String toLocaleString(String locales);
+
+    @JS.Coerce
+    @JS(value = "return this.toLocaleString(locales, options);")
+    public native String toLocaleString(String locales, JSObject options);
+
+    @JS.Coerce
+    @JS(value = "return this.toPrecision();")
+    public native String toPrecision();
+
+    @JS.Coerce
+    @JS(value = "return this.toPrecision(precision);")
+    public native String toPrecision(int precision);
+
+    @Override
+    @JS.Coerce
+    @JS(value = "return this.toString();")
+    public native String toString();
+
+    @JS.Coerce
+    @JS(value = "return this.toString(radix);")
+    public native String toString(int radix);
+
+    @JS.Coerce
+    @JS(value = "return this.valueOf();")
+    public native double valueOf();
 }

--- a/sdk/src/org.graalvm.webimage.api/src/org/graalvm/webimage/api/JSObject.java
+++ b/sdk/src/org.graalvm.webimage.api/src/org/graalvm/webimage/api/JSObject.java
@@ -49,14 +49,14 @@ package org.graalvm.webimage.api;
  * wrapped into a <code>JSObject</code> instance. The <code>JSObject</code> allows the Java code to
  * access the fields of the underlying JavaScript object using the <code>get</code> and
  * <code>set</code> methods.
- *
+ * <p>
  * The Java {@link JSObject} instance that corresponds to the JavaScript object is called a <i>Java
  * mirror</i>. Vice versa, the JavaScript instance is a <i>JavaScript mirror</i> for that
  * {@link JSObject} instance.
  *
  *
  * <h3>Anonymous JavaScript objects</h3>
- *
+ * <p>
  * Here are a few examples of creating and modifying anonymous JavaScript objects:
  *
  * <pre>
@@ -68,7 +68,7 @@ package org.graalvm.webimage.api;
  * System.out.println(pair.get("x"));
  * System.out.println(pair.get("y"));
  * </pre>
- *
+ * <p>
  * In this example, using the {@code JSObject} methods, the user can access the <code>x</code> and
  * <code>y</code> fields.
  *
@@ -76,32 +76,32 @@ package org.graalvm.webimage.api;
  * pair.set("x", 5.4);
  * System.out.println(pair.get("x"));
  * </pre>
- *
+ * <p>
  * The code above sets a new value for the <code>x</code> field, and then prints the new value.
  *
  *
  * <h3>Anonymous JavaScript functions</h3>
- *
+ * <p>
  * A {@code JSObject} can be a Java-side wrapper for a JavaScript {@code Function} object. The
  * JavaScript {@code Function} value can be returned by the JavaScript code of the method annotated
  * with the {@link JS} annotation.
- *
+ * <p>
  * The Java program can then call the underlying function by calling the
  * {@link JSObject#call(Object, Object...)} method. If the underlying JavaScript object is not
  * callable, then calling {@code call} will result in an exception.
- *
+ * <p>
  * The {@code call} method has the following signature:
  *
  * <pre>
  * public Object call(Object thisArgument, Object... arguments);
  * </pre>
- *
+ * <p>
  * The {@code invoke} method has the following signature:
  *
  * <pre>
  * public Object invoke(Object... arguments);
  * </pre>
- *
+ * <p>
  * The difference is that the method {@code call} takes an object for specifying {@code this} of the
  * JavaScript function, while {@code invoke} uses the underlying {@code JSObject} as the value of
  * {@code this}.
@@ -130,13 +130,13 @@ package org.graalvm.webimage.api;
  *
  *
  * <h3>Declaring JavaScript classes in Java</h3>
- *
+ * <p>
  * The second purpose of {@link JSObject} is to declare JavaScript classes as classes in Java code,
  * in a way that makes the Java objects look-and-feel like native JavaScript objects. Users should
  * subclass the {@link JSObject} class when they need to define a JavaScript class whose fields and
  * methods can be accessed conveniently from Java, without the {@link JSObject#get(Object)} and
  * {@link JSObject#set(Object, Object)} methods.
- *
+ * <p>
  * Directly exposing a Java object to JavaScript code means that the JavaScript code is able to
  * manipulate the data within the object (e.g. mutate fields, add new fields, or redefine existing
  * fields), which is not allowed by default for regular Java classes. Extending {@link JSObject}
@@ -144,7 +144,7 @@ package org.graalvm.webimage.api;
  * One of the use-cases for these functionalities are JavaScript frameworks that redefine properties
  * of JavaScript objects with custom getters and setters, with the goal of enabling data-binding or
  * reactive updates.
- *
+ * <p>
  * In a subclass of {@link JSObject}, every JavaScript property directly corresponds to the Java
  * field of the same name. Consequently, all these properties point to native JavaScript values
  * rather than Java values, so bridge methods are generated that are called for each property access
@@ -154,7 +154,7 @@ package org.graalvm.webimage.api;
  * corresponding Java field. For this reason, the bridge methods also generate check-casts on every
  * access: if the JavaScript property that corresponds to the Java field does not contain a
  * compatible value, a {@link ClassCastException} is thrown.
- *
+ * <p>
  * There are several restrictions imposed on {@link JSObject} subclasses:
  * <ul>
  * <li>Only public and protected fields are allowed to ensure encapsulation.</li>
@@ -179,7 +179,7 @@ package org.graalvm.webimage.api;
  *     }
  * }
  * </pre>
- *
+ * <p>
  * The preceding Java class is effectively translated to the corresponding JavaScript class:
  *
  * <pre>
@@ -194,7 +194,7 @@ package org.graalvm.webimage.api;
  *     }
  * }
  * </pre>
- *
+ * <p>
  * The {@code Point} class can be used from Java as if it were a normal Java class:
  *
  * <pre>
@@ -203,7 +203,7 @@ package org.graalvm.webimage.api;
  * System.out.println(p.y);
  * System.out.println(p.absolute());
  * </pre>
- *
+ * <p>
  * All accesses to the fields {@code x} and {@code y} are rewritten to accesses on the corresponding
  * JavaScript properties. JavaScript code may assign values to these properties that violate the
  * type of the corresponding Java fields, but a subsequent Java read of such a field will result in
@@ -219,7 +219,7 @@ package org.graalvm.webimage.api;
  *
  *
  * <h3>Passing {@code JSObject} subclasses between JavaScript and Java</h3>
- *
+ * <p>
  * When an object of the {@link JSObject} subclass is passed from Java to JavaScript code using the
  * {@link JS} annotation, the object is converted from its Java representation to its JavaScript
  * representation. Changes in the JavaScript representation are reflected in the Java representation
@@ -236,7 +236,7 @@ package org.graalvm.webimage.api;
  * reset(p0, 0.0, 0.0);
  * System.out.println(p0.x + ", " + p0.y);
  * </pre>
- *
+ * <p>
  * A {@link Class} object that represents {@link JSObject} can also be passed to JavaScript code.
  * The {@link Class} object is wrapped in a proxy, which can be used inside a {@code new} expression
  * to instantiate the object of the corresponding class from JavaScript.
@@ -250,14 +250,14 @@ package org.graalvm.webimage.api;
  * Point p1 = create(Point.class, 1.25, 0.5);
  * System.out.println(p1.x + ", " + p1.y);
  * </pre>
- *
+ * <p>
  * Note that creating an object in JavaScript and passing it to Java several times does not
  * guarantee that the same mirror instance is returned each time -- each time a JavaScript object
  * becomes a Java mirror, a different instance of the mirror may be returned.
  *
  *
  * <h3>Importing existing JavaScript classes</h3>
- *
+ * <p>
  * The {@link JSObject} class allows access to properties of any JavaScript object using the
  * {@link JSObject#get(Object)} and {@link JSObject#set(Object, Object)} methods. In situations
  * where the programmer knows the relevant properties of a JavaScript object (for example, when
@@ -265,14 +265,14 @@ package org.graalvm.webimage.api;
  * "imported" to Java. To do this, the user declares a {@link JSObject} subclass that serves as a
  * facade to the JavaScript object. This subclass must be annotated with the {@link JS.Import}
  * annotation.
- *
+ * <p>
  * The name of the declared class Java must match the name of the JavaScript class that is being
  * imported. The package name of the Java class is not taken into account -- the same JavaScript
  * class can be imported multiple times from within separate packages.
- *
+ * <p>
  * The exposed JavaScript fields must be declared as {@code protected} or {@code public}. The
  * constructor parameters must match those of the JavaScript class, and its body must be empty.
- *
+ * <p>
  * Here is an example of a class declared in JavaScript:
  *
  * <pre>
@@ -283,7 +283,7 @@ package org.graalvm.webimage.api;
  *     }
  * }
  * </pre>
- *
+ * <p>
  * To import this class in Java code, we need the following declaration in Java:
  *
  * <pre>
@@ -296,19 +296,19 @@ package org.graalvm.webimage.api;
  *     }
  * }
  * </pre>
- *
+ * <p>
  * The fields declared in the {@code Rectangle} class are directly mapped to the properties of the
  * underlying JavaScript object. If the type of the property of the underlying JavaScript object
  * does not match the type of the field declared in Java, then a field-read in Java will throw a
  * {@link ClassCastException}.
- *
+ * <p>
  * The {@code Rectangle} class can be instantiated from Java as follows:
  *
  * <pre>
  * Rectangle r = new Rectangle(640, 480);
  * System.out.println(r.width + "x" + r.height);
  * </pre>
- *
+ * <p>
  * A JavaScript object whose {@code constructor} property matches the imported JavaScript class can
  * be converted to the declared Java class when the JavaScript code passes a value to Java. Here is
  * a code example that creates the {@code Rectangle} object in JavaScript, and passes it to Java:
@@ -317,13 +317,13 @@ package org.graalvm.webimage.api;
  * &#64;JS("return new Rectangle(width, height);")
  * Rectangle createRectangle(int width, int height);
  * </pre>
- *
+ * <p>
  * Another way to convert a JavaScript object to a Java facade is to call the
  * {@link JSObject#as(Class)} method to cast the {@link JSObject} instance to the proper subtype.
  *
  *
  * <h3>Exporting Java classes to JavaScript</h3>
- *
+ * <p>
  * The users can annotate the exported classes with the {@link JS.Export} annotation to denote that
  * the {@link JSObject} subclass should be made available to JavaScript code. Exported classes can
  * be accessed using the JavaScript VM-instance API, using the `exports` property.
@@ -344,7 +344,7 @@ package org.graalvm.webimage.api;
  *     }
  * }
  * </pre>
- *
+ * <p>
  * The exported class can then be used from JavaScript code as follows:
  *
  * <pre>
@@ -395,7 +395,7 @@ public class JSObject extends JSValue {
     /**
      * Sets the value of the key passed as the argument in the JavaScript object.
      *
-     * @param key the object under which the value should be placed in the JavaScript object
+     * @param key      the object under which the value should be placed in the JavaScript object
      * @param newValue the value that should be placed under the given key in the JavaScript object
      */
     @JS("this[key] = newValue;")
@@ -413,7 +413,7 @@ public class JSObject extends JSValue {
      * Invoke the underlying JavaScript function, if this object is callable.
      *
      * @param args The array of Java arguments, which is converted to JavaScript and passed to the
-     *            underlying JavaScript function
+     *             underlying JavaScript function
      * @return The result of the JavaScript function, converted to the corresponding Java value
      */
     @JS("return this.apply(this, conversion.extractJavaScriptArray(args[runtime.symbol.javaNative]));")
@@ -424,8 +424,8 @@ public class JSObject extends JSValue {
      * in the function, if this object is callable.
      *
      * @param thisArg The value for the binding of {@code this} inside the JavaScript function
-     * @param args The array of Java arguments, which is converted to JavaScript and passed to the
-     *            underlying JavaScript function
+     * @param args    The array of Java arguments, which is converted to JavaScript and passed to the
+     *                underlying JavaScript function
      * @return The result of the JavaScript function, converted to the corresponding Java value
      */
     @JS("return this.apply(thisArg, conversion.extractJavaScriptArray(args[runtime.symbol.javaNative]));")
@@ -547,4 +547,108 @@ public class JSObject extends JSValue {
     public boolean equalsJavaScript(JSObject that) {
         return referenceEquals(this, that).asBoolean();
     }
+
+    @JS.Coerce
+    @JS(value = "return Object.create(proto);")
+    public static native JSObject create(JSObject proto);
+
+    @JS.Coerce
+    @JS(value = "return Object.create(proto, properties);")
+    public static native JSObject create(JSObject proto, JSObject properties);
+
+    @JS.Coerce
+    @JS(value = "return Object.defineProperties(obj, prop);")
+    public static native JSObject defineProperties(JSObject obj, JSObject prop);
+
+    @JS.Coerce
+    @JS(value = "return Object.defineProperty(obj, prop, descriptor);")
+    public static native JSObject defineProperty(JSObject obj, JSString prop, JSObject descriptor);
+
+    @JS.Coerce
+    @JS(value = "return Object.defineProperty(obj, prop, descriptor);")
+    public static native JSObject defineProperty(JSObject obj, String prop, JSObject descriptor);
+
+    @JS.Coerce
+    @JS(value = "return Object.entries(obj);")
+    public static native JSObject entries(JSObject obj);
+
+    @JS.Coerce
+    @JS(value = "Object.freeze(obj);")
+    public static native void freeze(JSObject obj);
+
+    @JS.Coerce
+    @JS(value = "return Object.fromEntries(iterable);")
+    public static native JSObject fromEntries(JSObject iterable);
+
+    @JS.Coerce
+    @JS(value = "return Object.getOwnPropertyDescriptor(obj, prop);")
+    public static native JSObject getOwnPropertyDescriptor(JSObject obj, String prop);
+
+    @JS.Coerce
+    @JS(value = "return Object.getOwnPropertyNames(obj);")
+    public static native JSObject getOwnPropertyNames(JSObject obj);
+
+    @JS.Coerce
+    @JS(value = "return Object.groupBy(items, callback);")
+    public native static JSObject groupBy(JSObject items, JSValue callback);
+
+    @JS.Coerce
+    @JS(value = "return Object.hasOwn(obj, prop);")
+    public static native boolean hasOwn(JSObject obj, String prop);
+
+    @JS.Coerce
+    @JS(value = "return Object.is(value1, value2);")
+    public static native boolean is(JSValue value1, JSValue value2);
+
+    @JS.Coerce
+    @JS(value = "return Object.isExtensible(obj);")
+    public static native boolean isExtensible(JSObject obj);
+
+    @JS.Coerce
+    @JS(value = "return Object.isFrozen(obj);")
+    public static native boolean isFrozen(JSObject obj);
+
+    @JS.Coerce
+    @JS(value = "return Object.isSealed(obj);")
+    public static native boolean isSealed(JSObject obj);
+
+    @JS.Coerce
+    @JS(value = "return Object.keys(obj);")
+    public static native JSObject keys(JSObject obj);
+
+    @JS.Coerce
+    @JS(value = "return Object.preventExtensions(obj);")
+    public static native JSObject preventExtensions(JSObject obj);
+
+    @JS.Coerce
+    @JS(value = "return Object.seal(obj);")
+    public static native JSObject seal(JSObject obj);
+
+    @JS.Coerce
+    @JS(value = "return Object.setPrototypeOf(obj, proto);")
+    public static native JSObject setPrototypeOf(JSObject obj, JSObject proto);
+
+    @JS.Coerce
+    @JS(value = "return Object.values(obj);")
+    public static native JSObject values(JSObject obj);
+
+    @JS.Coerce
+    @JS(value = "return this.hasOwnProperty(prop);")
+    public native boolean hasOwnProperty(String prop);
+
+    @JS.Coerce
+    @JS(value = "return this.isPrototypeOf(object);")
+    public native boolean isPrototypeOf(JSObject object);
+
+    @JS.Coerce
+    @JS(value = "return this.propertyIsEnumerable(prop);")
+    public native boolean propertyIsEnumerable(String prop);
+
+    @JS.Coerce
+    @JS(value = "return this.toLocaleString();")
+    public native String toLocaleString();
+
+    @JS.Coerce
+    @JS(value = "return this.valueOf();")
+    public native JSValue valueOf();
 }

--- a/sdk/src/org.graalvm.webimage.api/src/org/graalvm/webimage/api/JSString.java
+++ b/sdk/src/org.graalvm.webimage.api/src/org/graalvm/webimage/api/JSString.java
@@ -82,4 +82,304 @@ public final class JSString extends JSValue {
     public int hashCode() {
         return javaString().hashCode();
     }
+
+    @JS.Coerce
+    @JS(value = "return String.fromCharCode();")
+    public static native JSString fromCharCode();
+
+    @JS.Coerce
+    @JS(value = "return String.fromCharCode(...codeUnits);")
+    public static native JSString fromCharCode(int... codeUnits);
+
+    @JS.Coerce
+    @JS(value = "return String.fromCodePoint();")
+    public static native JSString fromCodePoint();
+
+    @JS.Coerce
+    @JS(value = "return String.fromCodePoint(...codeUnits);")
+    public static native JSString fromCodePoint(int... codeUnits);
+
+    @JS(value = "return String.raw(template);")
+    public static native JSString raw(JSObject template);
+
+    @JS(value = """
+            const args = [];
+            for (let i = 0; i < substitutions.length; i++) {
+                args.push(substitutions[i]);
+            }
+            return String.raw(template, ...args);
+            """)
+    public static native JSString raw(JSObject template, Object... substitutions);
+
+    @JS.Coerce
+    @JS(value = "return this.at(index);")
+    public native JSString at(int index);
+
+    @JS.Coerce
+    @JS(value = "return this.charAt(index);")
+    public native JSString charAt(int index);
+
+    @JS.Coerce
+    @JS(value = "return this.charCodeAt(index);")
+    public native int charCodeAt(int index);
+
+    @JS.Coerce
+    @JS(value = "return this.codePointAt(index);")
+    public native int codePointAt(int index);
+
+    @JS.Coerce
+    @JS(value = "return this.concat.apply(this, strings);")
+    public native JSString concat(JSString... strings);
+
+    @JS.Coerce
+    @JS(value = "return this.endsWith(searchString);")
+    public native boolean endsWith(String searchString);
+
+    @JS.Coerce
+    @JS(value = "return this.endsWith(searchString, endPosition);")
+    public native boolean endsWith(String searchString, int endPosition);
+
+    @JS.Coerce
+    @JS(value = "return this.endsWith(searchString);")
+    public native boolean endsWith(JSString searchString);
+
+    @JS.Coerce
+    @JS(value = "return this.endsWith(searchString, endPosition);")
+    public native boolean endsWith(JSString searchString, int endPosition);
+
+    @JS.Coerce
+    @JS(value = "return this.includes(searchString);")
+    public native boolean includes(String searchString);
+
+    @JS.Coerce
+    @JS(value = "return this.includes(searchString, position);")
+    public native boolean includes(String searchString, int position);
+
+    @JS.Coerce
+    @JS(value = "return this.includes(searchString);")
+    public native boolean includes(JSString searchString);
+
+    @JS.Coerce
+    @JS(value = "return this.includes(searchString, position);")
+    public native boolean includes(JSString searchString, int position);
+
+    @JS.Coerce
+    @JS(value = "return this.indexOf(searchString);")
+    public native int indexOf(String searchString);
+
+    @JS.Coerce
+    @JS(value = "return this.indexOf(searchString, position);")
+    public native int indexOf(String searchString, int position);
+
+    @JS.Coerce
+    @JS(value = "return this.indexOf(searchString);")
+    public native int indexOf(JSString searchString);
+
+    @JS.Coerce
+    @JS(value = "return this.indexOf(searchString, position);")
+    public native int indexOf(JSString searchString, int position);
+
+    @JS.Coerce
+    @JS(value = "return this.isWellFormed();")
+    public native boolean isWellFormed();
+
+    @JS.Coerce
+    @JS(value = "return this.lastIndexOf(searchString);")
+    public native int lastIndexOf(String searchString);
+
+    @JS.Coerce
+    @JS(value = "return this.lastIndexOf(searchString, position);")
+    public native int lastIndexOf(String searchString, int position);
+
+    @JS.Coerce
+    @JS(value = "return this.lastIndexOf(searchString);")
+    public native int lastIndexOf(JSString searchString);
+
+    @JS.Coerce
+    @JS(value = "return this.lastIndexOf(searchString, position);")
+    public native int lastIndexOf(JSString searchString, int position);
+
+    @JS.Coerce
+    @JS(value = "return this.localeCompare(compareString);")
+    public native int localeCompare(String compareString);
+
+    @JS.Coerce
+    @JS(value = "return this.localeCompare(compareString, locales);")
+    public native int localeCompare(String compareString, String locales);
+
+    @JS.Coerce
+    @JS(value = "return this.localeCompare(compareString, locales, options);")
+    public native int localeCompare(String compareString, String locales, Object options);
+
+    @JS.Coerce
+    @JS(value = "return this.localeCompare(compareString);")
+    public native int localeCompare(JSString compareString);
+
+    @JS.Coerce
+    @JS(value = "return this.localeCompare(compareString, locales);")
+    public native int localeCompare(JSString compareString, JSString locales);
+
+    @JS.Coerce
+    @JS(value = "return this.localeCompare(compareString, locales, options);")
+    public native int localeCompare(JSString compareString, JSString locales, Object options);
+
+    @JS.Coerce
+    @JS(value = "return this.match(regexp);")
+    public native JSObject match(Object regexp);
+
+    @JS.Coerce
+    @JS(value = "return this.matchAll(regexp);")
+    public native JSObject matchAll(Object regexp);
+
+    @JS.Coerce
+    @JS(value = "return this.normalize();")
+    public native JSString normalize();
+
+    @JS.Coerce
+    @JS(value = "return this.normalize(form);")
+    public native JSString normalize(String form);
+
+    @JS.Coerce
+    @JS(value = "return this.padEnd(targetLength);")
+    public native JSString padEnd(int targetLength);
+
+    @JS.Coerce
+    @JS(value = "return this.padEnd(targetLength, padString);")
+    public native JSString padEnd(int targetLength, String padString);
+
+    @JS.Coerce
+    @JS(value = "return this.padEnd(targetLength, padString);")
+    public native JSString padEnd(int targetLength, JSString padString);
+
+    @JS.Coerce
+    @JS(value = "return this.padStart(targetLength);")
+    public native JSString padStart(int targetLength);
+
+    @JS.Coerce
+    @JS(value = "return this.padStart(targetLength, padString);")
+    public native JSString padStart(int targetLength, String padString);
+
+    @JS.Coerce
+    @JS(value = "return this.padStart(targetLength, padString);")
+    public native JSString padStart(int targetLength, JSString padString);
+
+    @JS.Coerce
+    @JS(value = "return this.repeat(count);")
+    public native JSString repeat(int count);
+
+    @JS.Coerce
+    @JS(value = "return this.replace(pattern, replacement);")
+    public native JSString replace(Object pattern, Object replacement);
+
+    @JS.Coerce
+    @JS(value = "return this.replaceAll(pattern, replacement);")
+    public native JSString replaceAll(Object pattern, Object replacement);
+
+    @JS.Coerce
+    @JS(value = "return this.search(regexp);")
+    public native int search(Object regexp);
+
+    @JS.Coerce
+    @JS(value = "return this.slice(indexStart);")
+    public native JSString slice(int indexStart);
+
+    @JS.Coerce
+    @JS(value = "return this.slice(indexStart, indexEnd);")
+    public native JSString slice(int indexStart, int indexEnd);
+
+    @JS.Coerce
+    @JS(value = "return this.split(separator);")
+    public native JSObject split(String separator);
+
+    @JS.Coerce
+    @JS(value = "return this.split(separator);")
+    public native JSObject split(JSObject separator);
+
+    @JS.Coerce
+    @JS(value = "return this.split(separator, limit);")
+    public native JSObject split(String separator, int limit);
+
+    @JS.Coerce
+    @JS(value = "return this.split(separator, limit);")
+    public native JSObject split(JSObject separator, int limit);
+
+    @JS.Coerce
+    @JS(value = "return this.startsWith(searchString);")
+    public native boolean startsWith(String searchString);
+
+    @JS.Coerce
+    @JS(value = "return this.startsWith(searchString);")
+    public native boolean startsWith(JSString searchString);
+
+    @JS.Coerce
+    @JS(value = "return this.startsWith(searchString, position);")
+    public native boolean startsWith(String searchString, int position);
+
+    @JS.Coerce
+    @JS(value = "return this.startsWith(searchString, position);")
+    public native boolean startsWith(JSString searchString, int position);
+
+    @JS.Coerce
+    @JS(value = "return this.toLocaleLowerCase();")
+    public native JSString toLocaleLowerCase();
+
+    @JS.Coerce
+    @JS(value = "return this.toLocaleLowerCase(locales);")
+    public native JSString toLocaleLowerCase(String locales);
+
+    @JS.Coerce
+    @JS(value = "return this.toLocaleLowerCase(locales);")
+    public native JSString toLocaleLowerCase(JSString locales);
+
+    @JS.Coerce
+    @JS(value = "return this.toLocaleUpperCase();")
+    public native JSString toLocaleUpperCase();
+
+    @JS.Coerce
+    @JS(value = "return this.toLocaleUpperCase(locales);")
+    public native JSString toLocaleUpperCase(String locales);
+
+    @JS.Coerce
+    @JS(value = "return this.toLocaleUpperCase(locales);")
+    public native JSString toLocaleUpperCase(JSString locales);
+
+    @JS.Coerce
+    @JS(value = "return this.toLowerCase();")
+    public native JSString toLowerCase();
+
+    @JS.Coerce
+    @JS(value = "return this.toUpperCase();")
+    public native JSString toUpperCase();
+
+    @JS.Coerce
+    @JS(value = "return this.toWellFormed();")
+    public native JSString toWellFormed();
+
+    @JS.Coerce
+    @JS(value = "return this.trim();")
+    public native JSString trim();
+
+    @JS.Coerce
+    @JS(value = "return this.trimEnd();")
+    public native JSString trimEnd();
+
+    @JS.Coerce
+    @JS(value = "return this.trimRight();")
+    public native JSString trimRight();
+
+    @JS.Coerce
+    @JS(value = "return this.trimStart();")
+    public native JSString trimStart();
+
+    @JS.Coerce
+    @JS(value = "return this.trimLeft();")
+    public native JSString trimLeft();
+
+    @JS.Coerce
+    @JS(value = "return this.valueOf();")
+    public native JSString valueOf();
+
+    @JS.Coerce
+    @JS(value = "return this.length;")
+    public native int length();
 }

--- a/sdk/src/org.graalvm.webimage.api/src/org/graalvm/webimage/api/JSSymbol.java
+++ b/sdk/src/org.graalvm.webimage.api/src/org/graalvm/webimage/api/JSSymbol.java
@@ -87,4 +87,83 @@ public final class JSSymbol extends JSValue {
     public int hashCode() {
         return javaString().hashCode();
     }
+
+    @JS(value = "return Symbol.for(key);")
+    public static native JSSymbol forKey(String key);
+
+    @JS.Coerce
+    @JS(value = "return Symbol.keyFor(sym);")
+    public static native JSValue keyFor(JSSymbol sym);
+
+    @JS.Coerce
+    @JS(value = "return Symbol.asyncDispose;")
+    public static native JSSymbol asyncDispose();
+
+    @JS.Coerce
+    @JS(value = "return Symbol.asyncIterator;")
+    public static native JSSymbol asyncIterator();
+
+    @JS.Coerce
+    @JS(value = "return Symbol.dispose;")
+    public static native JSSymbol dispose();
+
+    @JS.Coerce
+    @JS(value = "return Symbol.hasInstance;")
+    public static native JSSymbol hasInstance();
+
+    @JS.Coerce
+    @JS(value = "return Symbol.isConcatSpreadable;")
+    public static native JSSymbol isConcatSpreadable();
+
+    @JS.Coerce
+    @JS(value = "return Symbol.iterator;")
+    public static native JSSymbol iterator();
+
+    @JS.Coerce
+    @JS(value = "return Symbol.match;")
+    public static native JSSymbol match();
+
+    @JS.Coerce
+    @JS(value = "return Symbol.matchAll;")
+    public static native JSSymbol matchAll();
+
+    @JS.Coerce
+    @JS(value = "return Symbol.replace;")
+    public static native JSSymbol replace();
+
+    @JS.Coerce
+    @JS(value = "return Symbol.search;")
+    public static native JSSymbol search();
+
+    @JS.Coerce
+    @JS(value = "return Symbol.species;")
+    public static native JSSymbol species();
+
+    @JS.Coerce
+    @JS(value = "return Symbol.split;")
+    public static native JSSymbol split();
+
+    @JS.Coerce
+    @JS(value = "return Symbol.toPrimitive;")
+    public static native JSSymbol toPrimitive();
+
+    @JS.Coerce
+    @JS(value = "return Symbol.toStringTag;")
+    public static native JSSymbol toStringTag();
+
+    @JS.Coerce
+    @JS(value = "return Symbol.unscopables;")
+    public static native JSSymbol unscopables();
+
+    @JS.Coerce
+    @JS(value = "return sym.valueOf();")
+    public static native JSSymbol valueOf(Object sym);
+
+    @JS.Coerce
+    @JS(value = "return Symbol.for(a) === Symbol.for(b);")
+    public static native boolean isSameSymbol(String a, String b);
+
+    @JS.Coerce
+    @JS(value = "return sym.description;")
+    public static native String description(Object sym);
 }

--- a/sdk/src/org.graalvm.webimage.api/src/org/graalvm/webimage/api/JSValue.java
+++ b/sdk/src/org.graalvm.webimage.api/src/org/graalvm/webimage/api/JSValue.java
@@ -45,7 +45,7 @@ import java.math.BigInteger;
 
 /**
  * Java representation of a JavaScript value.
- *
+ * <p>
  * The subclasses of this class represent JavaScript's six primitive data types and the object data
  * type. The JavaScript {@code Null} data type does not have a special representation -- the
  * JavaScript {@code null} value is directly mapped to the Java {@code null} value.
@@ -53,6 +53,12 @@ import java.math.BigInteger;
 public abstract class JSValue {
 
     JSValue() {
+    }
+
+    @SuppressWarnings("unchecked")
+    public static <R> R checkedCoerce(Object value, Class<R> cls) {
+        if (value instanceof JSValue jsResult) return jsResult.as(cls);
+        return (R) value;
     }
 
     public static JSUndefined undefined() {

--- a/sdk/src/org.graalvm.webimage.api/src/org/graalvm/webimage/api/ThrownFromJavaScript.java
+++ b/sdk/src/org.graalvm.webimage.api/src/org/graalvm/webimage/api/ThrownFromJavaScript.java
@@ -45,10 +45,10 @@ package org.graalvm.webimage.api;
  * Represents the error value thrown in JavaScript.
  * <p>
  * Must not pass a {@link Throwable} instance, these should be thrown directly instead of being
- * wrapped in a {@link JSError}.
+ * wrapped in a {@link ThrownFromJavaScript}.
  */
 @SuppressWarnings("serial")
-public final class JSError extends RuntimeException {
+public final class ThrownFromJavaScript extends RuntimeException {
 
     private static final long serialVersionUID = -2343564169271174471L;
 
@@ -57,7 +57,7 @@ public final class JSError extends RuntimeException {
      */
     private final Object thrownObject;
 
-    public JSError(Object thrownObject) {
+    public ThrownFromJavaScript(Object thrownObject) {
         super(thrownObject.toString());
         this.thrownObject = thrownObject;
         assert !(thrownObject instanceof Throwable) : "Tried creating JSError for a throwable: " + thrownObject;

--- a/web-image/src/com.oracle.svm.webimage.jtt/src/com/oracle/svm/webimage/jtt/api/JSErrorsTest.java
+++ b/web-image/src/com.oracle.svm.webimage.jtt/src/com/oracle/svm/webimage/jtt/api/JSErrorsTest.java
@@ -26,7 +26,7 @@
 package com.oracle.svm.webimage.jtt.api;
 
 import org.graalvm.webimage.api.JS;
-import org.graalvm.webimage.api.JSError;
+import org.graalvm.webimage.api.ThrownFromJavaScript;
 
 public class JSErrorsTest {
     /**
@@ -43,7 +43,7 @@ public class JSErrorsTest {
     public static void main(String[] args) {
         try {
             typeError();
-        } catch (JSError e) {
+        } catch (ThrownFromJavaScript e) {
             System.out.println(e.getMessage());
         }
 

--- a/web-image/src/com.oracle.svm.webimage.jtt/src/com/oracle/svm/webimage/jtt/api/JavaProxyTest.java
+++ b/web-image/src/com.oracle.svm.webimage.jtt/src/com/oracle/svm/webimage/jtt/api/JavaProxyTest.java
@@ -28,7 +28,7 @@ package com.oracle.svm.webimage.jtt.api;
 import java.util.function.Function;
 
 import org.graalvm.webimage.api.JS;
-import org.graalvm.webimage.api.JSError;
+import org.graalvm.webimage.api.ThrownFromJavaScript;
 import org.graalvm.webimage.api.JSValue;
 
 import com.oracle.svm.core.NeverInline;
@@ -123,7 +123,7 @@ public class JavaProxyTest {
         try {
             r.run();
             System.out.println("ERROR: Expected JS error for " + name);
-        } catch (JSError jsError) {
+        } catch (ThrownFromJavaScript thrownFromJavaScript) {
             System.out.println("Caught JS error for " + name);
         }
     }

--- a/web-image/src/com.oracle.svm.webimage/src/com/oracle/svm/webimage/JSExceptionSupport.java
+++ b/web-image/src/com.oracle.svm.webimage/src/com/oracle/svm/webimage/JSExceptionSupport.java
@@ -28,7 +28,7 @@ package com.oracle.svm.webimage;
 import static com.oracle.svm.webimage.substitute.system.Target_java_lang_Throwable_Web.CAUSE_CAPTION;
 import static com.oracle.svm.webimage.substitute.system.Target_java_lang_Throwable_Web.SUPPRESSED_CAPTION;
 
-import org.graalvm.webimage.api.JSError;
+import org.graalvm.webimage.api.ThrownFromJavaScript;
 import org.graalvm.webimage.api.JSObject;
 import org.graalvm.webimage.api.JSString;
 import org.graalvm.webimage.api.JSValue;
@@ -121,8 +121,8 @@ public class JSExceptionSupport {
          * If the throwable is a JSError, the thrown JS object is implicitly a cause (if it is an
          * Error object). In that case, we also print the JS stack trace if available.
          */
-        if (SubstrateUtil.cast(t, Throwable.class) instanceof JSError jsError) {
-            Object thrownObject = jsError.getThrownObject();
+        if (SubstrateUtil.cast(t, Throwable.class) instanceof ThrownFromJavaScript thrownFromJavaScript) {
+            Object thrownObject = thrownFromJavaScript.getThrownObject();
             if (thrownObject instanceof JSObject jsObject && jsObject.get("stack") instanceof JSValue stack) {
                 s.println(prefix + "Caused by JS Error: " + t.getMessage());
                 if (stack instanceof JSString jsString) {

--- a/web-image/src/com.oracle.svm.webimage/src/com/oracle/svm/webimage/functionintrinsics/JSConversion.java
+++ b/web-image/src/com.oracle.svm.webimage/src/com/oracle/svm/webimage/functionintrinsics/JSConversion.java
@@ -33,7 +33,7 @@ import org.graalvm.nativeimage.Platforms;
 import org.graalvm.webimage.api.JS;
 import org.graalvm.webimage.api.JSBigInt;
 import org.graalvm.webimage.api.JSBoolean;
-import org.graalvm.webimage.api.JSError;
+import org.graalvm.webimage.api.ThrownFromJavaScript;
 import org.graalvm.webimage.api.JSNumber;
 import org.graalvm.webimage.api.JSObject;
 import org.graalvm.webimage.api.JSString;
@@ -674,11 +674,11 @@ public abstract class JSConversion {
      * Ensures that objects that are thrown in {@link JS}-annotated methods are a subclass of
      * {@link Throwable}. If a {@link Throwable} exception is thrown, it gets simply rethrown.
      * Otherwise, the exception object is converted to Java according ot the conversion rules
-     * specified by {@link JS} and wrapped into a {@link JSError}.
+     * specified by {@link JS} and wrapped into a {@link ThrownFromJavaScript}.
      *
      * @param excp thrown object. Due to JavaScript semantics this can be an arbitrary type.
-     * @throws Throwable the original {@link Throwable} or {@link JSError} which warps the converted
-     *             thrown JavaScript object
+     * @throws Throwable the original {@link Throwable} or {@link ThrownFromJavaScript} which warps
+     *             the converted thrown JavaScript object
      */
     public static void handleJSError(Object excp) throws Throwable {
         if (JSExceptionSupport.isThrowable(excp)) {
@@ -692,7 +692,7 @@ public abstract class JSConversion {
                 throw t;
             }
 
-            throw new JSError(obj);
+            throw new ThrownFromJavaScript(obj);
         }
     }
 }

--- a/web-image/src/com.oracle.svm.webimage/src/com/oracle/svm/webimage/wasmgc/WasmGCJSConversion.java
+++ b/web-image/src/com.oracle.svm.webimage/src/com/oracle/svm/webimage/wasmgc/WasmGCJSConversion.java
@@ -26,7 +26,7 @@
 package com.oracle.svm.webimage.wasmgc;
 
 import org.graalvm.nativeimage.Platforms;
-import org.graalvm.webimage.api.JSError;
+import org.graalvm.webimage.api.ThrownFromJavaScript;
 import org.graalvm.webimage.api.JSValue;
 
 import com.oracle.svm.core.feature.AutomaticallyRegisteredImageSingleton;
@@ -175,7 +175,7 @@ public class WasmGCJSConversion extends JSConversion {
             throw t;
         }
 
-        throw new JSError(thrownObject);
+        throw new ThrownFromJavaScript(thrownObject);
     }
 
     @Override


### PR DESCRIPTION
This pull request expands the set of host-accessible wrappers for internal JavaScript functions across key runtime types: `JSObject`, `JSNumber`, `JSString`, `JSSymbol`, and `JSValue`. These additions improve Java interop and simplify invocation of JavaScript behavior from host code.

Additionally, the class `JSError` has been renamed to `ThrownFromJavaScript` to better reflect its actual role. The original name implied alignment with the native JavaScript `Error` object, but the class more accurately represents any object thrown from JavaScript, regardless of its type.
