### PR TITLE
[GR-70360] Fix JFR memory leak in Java event TLBs

### DIFF
--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/JfrThreadLocal.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/JfrThreadLocal.java
@@ -217,7 +217,7 @@ public class JfrThreadLocal implements ThreadListener {
     @Uninterruptible(reason = "Locking without transition requires that the whole critical section is uninterruptible.")
     private static void flushToGlobalMemoryAndRetireBuffer(JfrBuffer buffer) {
         assert VMOperation.isInProgressAtSafepoint();
-        if (buffer.isNull()) {
+        if (buffer.isNull() || JfrBufferAccess.isRetired(buffer)) {
             return;
         }
 


### PR DESCRIPTION
This PR fixes a native memory leak in JFR. The problem was reported originally by @joggeli34
 here https://github.com/oracle/graal/issues/12253

The problem is that JFR Java event buffers are not being retired/reinstated correctly. Instead of these buffers being reused between recordings, they are leaked. The reason for the leak is because we prematurely reset the `javaBuffer` thread local when stopping a recording. This is is bad because we need to reuse this thread local to reinstate the buffer in the next recording when a new Java `EventWriter` is created. Instead, a new buffer gets created and the retired one is lost.

This results in a leak of the size [(pageSize > 8 * 1024 ? pageSize : 8 * 1024)](https://github.com/openjdk/jdk/blob/jdk-26%2B18/src/jdk.jfr/share/classes/jdk/jfr/internal/Options.java#L67) * THREAD_COUNT  per new recording. 

The leak only happens when a recording is stopped and a new recording is started while the same threads are still running. This is the scenario when Java event buffers would be retired/reinstated.  
The leak was discovered by @joggeli34 because they are using [Pyroscope](https://github.com/grafana/pyroscope-java) which starts/stops new recordings every 10s. This frequent new recording creation exacerbates the leak. 

I used NMT to investigate this by adding more fine grained JFR NMT categories. Notice that committed memory in  category JFR1 increases overtime.
<img width="307" height="140" alt="image" src="https://github.com/user-attachments/assets/1e30725c-df35-4417-abe9-b0e23cf494d7" />
<img width="307" height="140" alt="image" src="https://github.com/user-attachments/assets/f48e9519-a2ec-426a-ab99-9d714d546495" />
<img width="307" height="140" alt="image" src="https://github.com/user-attachments/assets/8bd0c015-8233-4555-ad8f-b710164765c4" />
<img width="307" height="140" alt="image" src="https://github.com/user-attachments/assets/6c1c1cfb-cad1-436e-8f9c-eb4ff5ae4d45" />


After the fix, the memory usage does not increase. 

This bug fix should be backported to GraalVM for JDK 25.
