### PR TITLE
Fix `endsWith()` to the correct version `endswith()` in mx_sdk_vm_impl.py

### DIFF
--- a/sdk/mx.sdk/mx_sdk_vm_impl.py
+++ b/sdk/mx.sdk/mx_sdk_vm_impl.py
@@ -2994,7 +2994,7 @@ def graalvm_version(version_type):
         if version_type == 'vendor':
             graalvm_suffix = ''
             if java_pre:
-                graalvm_suffix += '.' if graalvm_version.endsWith('dev') else '-'
+                graalvm_suffix += '.' if graalvm_version.endswith('dev') else '-'
                 graalvm_suffix += java_pre
         else:
             assert version_type == 'base-dir', version_type


### PR DESCRIPTION
Apparently, the PR [[GR-70588] Include the GraalVM version rather than the Java version in the vendor version and basedir name](https://github.com/oracle/graal/pull/12319) (i.e. [commit 270badf98ef4bb](https://github.com/oracle/graal/commit/270badf98ef4bba9d0aa753248d1399e11a27628)) introduced a Python typo because it used `endsWith()` instead of  `endswith()`. This lets my builds fail.

It's strange that thiy typo hasn't been caught by any tests