### PR TITLE
Backport [GR-71287]  Reduce image size when using JFR.

### DIFF
--- a/substratevm/mx.substratevm/suite.py
+++ b/substratevm/mx.substratevm/suite.py
@@ -400,6 +400,8 @@ suite = {
                     "jdk.jfr.internal",
                     "jdk.jfr.internal.event",
                     "jdk.jfr.internal.jfc",
+                    "jdk.jfr.internal.settings",
+                    "jdk.jfr.internal.tracing",
                 ],
                 "jdk.internal.vm.ci": [
                     "jdk.vm.ci.meta",

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/Target_jdk_jfr_internal_settings_MethodSetting.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/Target_jdk_jfr_internal_settings_MethodSetting.java
@@ -26,16 +26,19 @@
 
 package com.oracle.svm.core.jfr;
 
-import com.oracle.svm.core.annotate.Substitute;
-import com.oracle.svm.core.annotate.TargetClass;
-import jdk.jfr.internal.PlatformEventType;
 import java.util.List;
 
+import com.oracle.svm.core.annotate.Substitute;
+import com.oracle.svm.core.annotate.TargetClass;
+
+import jdk.jfr.internal.PlatformEventType;
+import jdk.jfr.internal.settings.MethodSetting;
+
 @SuppressWarnings({"unused", "static-method"}) //
-@TargetClass(className = "jdk.jfr.internal.settings.MethodSetting")
+@TargetClass(value = MethodSetting.class)
 public final class Target_jdk_jfr_internal_settings_MethodSetting {
     @Substitute
-    protected void apply(PlatformEventType eventType, List<String> filters) {
+    private void apply(PlatformEventType eventType, List<String> filters) {
         SubstrateJVM.getLogging().logJfrSettingWarning("Method timing and tracing is not supported yet.");
     }
 }

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/Target_jdk_jfr_internal_tracing_PlatformTracer.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/Target_jdk_jfr_internal_tracing_PlatformTracer.java
@@ -29,7 +29,13 @@ package com.oracle.svm.core.jfr;
 import com.oracle.svm.core.annotate.Substitute;
 import com.oracle.svm.core.annotate.TargetClass;
 
-@TargetClass(className = "jdk.jfr.internal.tracing.PlatformTracer")
+import jdk.jfr.internal.tracing.PlatformTracer;
+
+/**
+ * This class is not supported at the moment. So, we completely replace it with an empty
+ * implementation to reduce the image size.
+ */
 @Substitute
+@TargetClass(value = PlatformTracer.class)
 public final class Target_jdk_jfr_internal_tracing_PlatformTracer {
 }

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/logging/JfrLogging.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jfr/logging/JfrLogging.java
@@ -62,7 +62,6 @@ public class JfrLogging {
     public void logJfrSettingWarning(String message) {
         int tagSetId = SubstrateUtil.cast(LogTag.JFR_SETTING, Target_jdk_jfr_internal_LogTag.class).id;
         log(tagSetId, JfrLogConfiguration.JfrLogLevel.WARNING.level, message);
-
     }
 
     public void log(int tagSetId, int level, String message) {


### PR DESCRIPTION
This backports https://github.com/oracle/graal/pull/12514

This should be relatively low risk since it substitutes out code that Native Image JFR does not yet support.
Tested with mx native-unittest.