### PR TITLE
Fix resource bundle registration for java.xml.crypto TransformService

### DIFF
--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/xml/JavaxXmlClassAndResourcesLoaderFeature.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/xml/JavaxXmlClassAndResourcesLoaderFeature.java
@@ -33,6 +33,7 @@ import static com.oracle.svm.hosted.xml.XMLParsersRegistration.SAXParserClasses;
 import static com.oracle.svm.hosted.xml.XMLParsersRegistration.SchemaDVFactoryClasses;
 import static com.oracle.svm.hosted.xml.XMLParsersRegistration.StAXParserClasses;
 import static com.oracle.svm.hosted.xml.XMLParsersRegistration.TransformerClassesAndResources;
+import static com.oracle.svm.hosted.xml.XMLParsersRegistration.XMLCryptoTransformServiceClassesAndResources;
 
 import org.graalvm.nativeimage.hosted.FieldValueTransformer;
 
@@ -62,6 +63,10 @@ public class JavaxXmlClassAndResourcesLoaderFeature extends JNIRegistrationUtil 
 
         access.registerReachabilityHandler(new TransformerClassesAndResources()::registerConfigs,
                         method(access, "javax.xml.transform.FactoryFinder", "find", Class.class, String.class));
+
+        // TransformService of java.xml.crypto module
+        access.registerReachabilityHandler(new XMLCryptoTransformServiceClassesAndResources()::registerConfigs,
+                        method(access, "com.sun.org.apache.xml.internal.security.utils.I18n", "init", String.class, String.class));
 
         access.registerReachabilityHandler(new DOMImplementationRegistryClasses()::registerConfigs,
                         method(access, "org.w3c.dom.bootstrap.DOMImplementationRegistry", "newInstance"));

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/xml/XMLParsersRegistration.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/xml/XMLParsersRegistration.java
@@ -153,4 +153,23 @@ public abstract class XMLParsersRegistration extends JNIRegistrationUtil {
             return Collections.singletonList("com.sun.org.apache.xalan.internal.xsltc.trax.TransformerFactoryImpl");
         }
     }
+
+    static class XMLCryptoTransformServiceClassesAndResources extends XMLParsersRegistration {
+
+        @Override
+        void registerResources() {
+            /*
+             * To allow register new resource bundle classes during analysis phase
+             */
+            ClassInitializationSupport classInitializationSupport = (ClassInitializationSupport) ImageSingletons.lookup(RuntimeClassInitializationSupport.class);
+            classInitializationSupport.withUnsealedConfiguration(() -> {
+                ResourcesRegistry.singleton().addResourceBundles(AccessCondition.unconditional(), false, "com.sun.org.apache.xml.internal.security/resource/xmlsecurity");
+            });
+        }
+
+        @Override
+        List<String> xmlParserClasses() {
+            return Collections.emptyList();
+        }
+    }
 }


### PR DESCRIPTION
This fix proposes to add the required resource bundle when `TransformService.getInstance()` from the `java.xml.crypto` module is reachable. Thoughts?

Testing:
- [x] Passes the reproducer from the issue. I've also tested this with a "larger" app on a 25u backport.

Closes: #12641