### PR TITLE
Fix Groovy substitutions for Apache Groovy /5.x compatibility

### DIFF
--- a/substratevm/src/com.oracle.svm.polyglot/src/com/oracle/svm/polyglot/groovy/GroovySubstitutions.java
+++ b/substratevm/src/com.oracle.svm.polyglot/src/com/oracle/svm/polyglot/groovy/GroovySubstitutions.java
@@ -43,12 +43,13 @@ final class GroovyIndyInterfaceFeature implements Feature {
 
     @Override
     public boolean isInConfiguration(IsInConfigurationAccess access) {
-        return access.findClassByName("org.codehaus.groovy.vmplugin.v7.IndyInterface") != null;
+        return access.findClassByName("org.codehaus.groovy.vmplugin.v8.IndyInterface") != null ||
+                access.findClassByName("org.codehaus.groovy.vmplugin.v7.IndyInterface") != null;
     }
 }
 
-@TargetClass(className = "org.codehaus.groovy.vmplugin.v7.IndyInterface", onlyWith = com.oracle.svm.polyglot.groovy.GroovyIndyInterfaceFeature.IsEnabled.class)
-final class Target_org_codehaus_groovy_vmplugin_v7_IndyInterface_invalidateSwitchPoints {
+@TargetClass(className = "org.codehaus.groovy.vmplugin.v8.IndyInterface", onlyWith = com.oracle.svm.polyglot.groovy.GroovyIndyInterfaceFeature.IsEnabled.class)
+final class Target_org_codehaus_groovy_vmplugin_v8_IndyInterface_invalidateSwitchPoints {
     @Substitute
     protected static void invalidateSwitchPoints() {
         throw new Error("IndyInterface.invalidateSwitchPoints() is not supported.");


### PR DESCRIPTION
### Problem

Native Image builds fail when Apache Groovy  5.x is present on the classpath with the following error during the initialization phase:
```
Error: Could not find target method: protected static void 
com.oracle.svm.polyglot.groovy.Target_org_codehaus_groovy_vmplugin_v7_IndyInterface_invalidateSwitchPoints.invalidateSwitchPoints()
```

This affects projects using:
- Apache Groovy 5.x (`org.apache.groovy:groovy`)
- Micronaut

Reported in issue #10200.

### Investigation & Root Cause

Through investigation of the Groovy source code and GraalVM substitution mechanism, we identified the following:

#### 1. Architecture Change in Groovy /5.x

Groovy changes:

**Old Groovy :**
- `org.codehaus.groovy.vmplugin.v7.IndyInterface` contains `invalidateSwitchPoints()` method

**New Groovy (5.x):**
- `org.codehaus.groovy.vmplugin.v8.IndyInterface` is the primary interface (contains `invalidateSwitchPoints()`)
- `org.codehaus.groovy.vmplugin.v7.IndyInterface` exists only as a **deprecated bridge class** for backward compatibility
- v7 **no longer contains** `invalidateSwitchPoints()` - it only delegates to v8

**Evidence from Groovy source code:**

v7/IndyInterface (Groovy 5.x):
```java
@Deprecated
public class IndyInterface {
    // All methods delegate to v8:
    public static CallSite bootstrap(...) {
        return org.codehaus.groovy.vmplugin.v8.IndyInterface.bootstrap(...);
    }
    
    // NO invalidateSwitchPoints() method!
}
```

v8/IndyInterface (Groovy 5.x):
```java
public class IndyInterface {
    protected static void invalidateSwitchPoints() {  // ← Method is HERE now
        if (LOG_ENABLED) {
            LOG.info("invalidating switch point");
        }
        synchronized (IndyInterface.class) {
            SwitchPoint old = switchPoint;
            switchPoint = new SwitchPoint();
            SwitchPoint.invalidateAll(new SwitchPoint[]{old});
        }
    }
}
```

#### 2. Current GraalVM Substitution Issue

The existing `GroovyIndyInterfaceFeature` has :

**Only targets v7**
```java
@Override
public boolean isInConfiguration(IsInConfigurationAccess access) {
    return access.findClassByName("org.codehaus.groovy.vmplugin.v7.IndyInterface") != null;
}
```
- Doesn't check for v8 at all
- Assumes the method exists in v7

### Solution

This PR updates the Groovy substitutions to handle both v7 and v8:

### Changes Made

- Updated `isInConfiguration()` to detect both v7 and v8 IndyInterface classes

### Related Issues

Fixes #10200