### PR TITLE
Update ASM to 9.8

### DIFF
--- a/espresso/mx.espresso/suite.py
+++ b/espresso/mx.espresso/suite.py
@@ -461,7 +461,7 @@ suite = {
             "javaCompliance" : "17+",
             "spotbugs" : "false",
             "shadedDependencies" : [
-                "truffle:ASM_9.7.1",
+                "truffle:ASM_9.8",
             ],
             "class" : "ShadedLibraryProject",
             "shade" : {

--- a/truffle/mx.truffle/suite.py
+++ b/truffle/mx.truffle/suite.py
@@ -109,38 +109,38 @@ suite = {
       "license": ["MIT"],
     },
 
-    "ASM_9.7.1": {
-      "digest": "sha512:4767b01603dad5c79cc1e2b5f3722f72b1059d928f184f446ba11badeb1b381b3a3a9a801cc43d25d396df950b09d19597c73173c411b1da890de808b94f1f50",
-      "sourceDigest": "sha512:d7c0de5912d04949a3d06cad366ff35a877da2682d9c74579625d62686032ea9349aff6102b17f92e9ec7eb4e9b1cd906b649c6a3ac798bfb9e31e5425de009d",
+    "ASM_9.8": {
+      "digest": "sha512:cbd250b9c698a48a835e655f5f5262952cc6dd1a434ec0bc3429a9de41f2ce08fcd3c4f569daa7d50321ca6ad1d32e131e4199aa4fe54bce9e9691b37e45060e",
+      "sourceDigest": "sha512:329663d73f165c7e006a20dd24bb6f5b4ac1079097d83c91770fd9fc537655a384c4cc40e5835f800d6453d393b6adbcd51c6eab6fe90cd8e1e8e87b9b513cc4",
       "maven": {
         "groupId": "org.ow2.asm",
         "artifactId": "asm",
-        "version": "9.7.1",
+        "version": "9.8",
       },
       "license": "BSD-new",
     },
 
-    "ASM_TREE_9.7.1": {
-      "digest": "sha512:e55008c392fdd35e95d3404766b12dd4b46e13d5c362fcd0ab42a65751a82737eaf0ebc857691d1916190d34407adfde4437615d69c278785416fd911e00978d",
+    "ASM_TREE_9.8": {
+      "digest": "sha512:4493f573d9f0cfc8837db9be25a8b61a825a06aafc0e02f0363875584ff184a5a14600e53793c09866300859e44f153faffd0e050de4a7fba1a63b5fb010a9a7",
       "sourceDigest": "sha512:3cea80bc7b55679dfa3d2065c6cb6951007cc7817082e9fcf4c5e3cdc073c22eddf7c7899cff60b1092049ec9038e8d3aa9a8828ef731739bda8b5afcec30e86",
       "maven": {
         "groupId": "org.ow2.asm",
         "artifactId": "asm-tree",
-        "version": "9.7.1",
+        "version": "9.8",
       },
-      "dependencies" : ["ASM_9.7.1"],
+      "dependencies" : ["ASM_9.8"],
       "license": "BSD-new",
     },
 
-    "ASM_COMMONS_9.7.1": {
-      "digest": "sha512:81daf5765e387e6aeec5d45c4b9e4e1b471fb4f350931e5a214845c7c657a2142768f6902765e49c0ce2c595962e5d008883cba2e4a40c4bdce8f2e92518d2db",
+    "ASM_COMMONS_9.8": {
+      "digest": "sha512:d2add10e25416b701bd84651b42161e090df2f32940de5e06e0e2a41c6106734db2fe5136f661d8a8af55e80dc958bc7b385a1004f0ebe550828dfa1e9d70d41",
       "sourceDigest": "sha512:dea8a2f871024210980821dc06c6796a3fca58293f650614275a086aaf9e2f45066a128f434dadabb85162c52796e99c863a6838e851ec02d6d97c603ed5a6d9",
       "maven": {
         "groupId": "org.ow2.asm",
         "artifactId": "asm-commons",
-        "version": "9.7.1",
+        "version": "9.8",
       },
-      "dependencies" : ["ASM_9.7.1", "ASM_TREE_9.7.1"],
+      "dependencies" : ["ASM_9.8", "ASM_TREE_9.8"],
       "license": "BSD-new",
     },
 
@@ -1452,9 +1452,9 @@ suite = {
       "javaCompliance" : "17+",
       "spotbugsIgnoresGenerated" : True,
       "shadedDependencies" : [
-        "truffle:ASM_9.7.1",
-        "truffle:ASM_TREE_9.7.1",
-        "truffle:ASM_COMMONS_9.7.1",
+        "truffle:ASM_9.8",
+        "truffle:ASM_TREE_9.8",
+        "truffle:ASM_COMMONS_9.8",
       ],
       "class" : "ShadedLibraryProject",
       "shade" : {

--- a/vm/THIRD_PARTY_LICENSE_CE.txt
+++ b/vm/THIRD_PARTY_LICENSE_CE.txt
@@ -1669,7 +1669,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ================================================================================
 
-ASM 9.7.1
+ASM 9.8
 
 https://gitlab.ow2.org/asm/asm/blob/master/LICENSE.txt
 


### PR DESCRIPTION
Updates ASM to 9.8 to be in sync with `mx-suite` and `graalvm-community-jdk25u` repositories regarding ASM version.

Notice, the latest ASM version is 9.9.1 that supports Java 26, but this PR syncs ASM to 9.8 for consistency with [mx suite](https://github.com/graalvm/mx/blob/6934051ffc792c8f5b9a6fd35aeb3e257ad67a3f/mx.mx/suite.py#L46-L91).

This PR is the same as in previously closed PR #12965 but no longer related to previous issue #12723 which was fixed in `graalvm-community-jdk25u`.
The only purpose of this PR is to keep versions in sync between repositories, but not particular functionality issues.
If there are any reasons to keep ASM 9.7.1 in `oracle/graal` repository - let me know and we can close this PR in this case.