### PR TITLE
[GR-53498] Enable Native Image Layers on macOS/aarch64 and Linux/aarch64

### DIFF
--- a/substratevm/src/com.oracle.svm.core.graal.aarch64/src/com/oracle/svm/core/graal/aarch64/AArch64CGlobalDataLoadAddressOp.java
+++ b/substratevm/src/com.oracle.svm.core.graal.aarch64/src/com/oracle/svm/core/graal/aarch64/AArch64CGlobalDataLoadAddressOp.java
@@ -47,11 +47,17 @@ public final class AArch64CGlobalDataLoadAddressOp extends AArch64LIRInstruction
     @Def(REG) private AllocatableValue result;
 
     private final CGlobalDataInfo dataInfo;
+    private final int addend;
 
-    AArch64CGlobalDataLoadAddressOp(CGlobalDataInfo dataInfo, AllocatableValue result) {
+    AArch64CGlobalDataLoadAddressOp(CGlobalDataInfo dataInfo, AllocatableValue result, int addend) {
         super(TYPE);
         this.dataInfo = dataInfo;
         this.result = result;
+        this.addend = addend;
+    }
+
+    AArch64CGlobalDataLoadAddressOp(CGlobalDataInfo dataInfo, AllocatableValue result) {
+        this(dataInfo, result, 0);
     }
 
     @Override
@@ -67,6 +73,9 @@ public final class AArch64CGlobalDataLoadAddressOp extends AArch64LIRInstruction
         } else {
             // Data: load its address
             masm.adrpAdd(resultRegister);
+        }
+        if (addend != 0) {
+            masm.add(64, resultRegister, resultRegister, addend);
         }
     }
 }

--- a/substratevm/src/com.oracle.svm.core.graal.aarch64/src/com/oracle/svm/core/graal/aarch64/AArch64NativePatchConsumerFactory.java
+++ b/substratevm/src/com.oracle.svm.core.graal.aarch64/src/com/oracle/svm/core/graal/aarch64/AArch64NativePatchConsumerFactory.java
@@ -33,7 +33,6 @@ import com.oracle.svm.core.feature.AutomaticallyRegisteredImageSingleton;
 import com.oracle.svm.core.graal.code.NativeImagePatcher;
 import com.oracle.svm.core.graal.code.PatchConsumerFactory;
 import com.oracle.svm.shared.singletons.traits.BuiltinTraits.AllAccess;
-import com.oracle.svm.shared.singletons.traits.BuiltinTraits.Disallowed;
 import com.oracle.svm.shared.singletons.traits.BuiltinTraits.NoLayeredCallbacks;
 import com.oracle.svm.shared.singletons.traits.SingletonTraits;
 import com.oracle.svm.shared.util.VMError;
@@ -45,7 +44,7 @@ import jdk.graal.compiler.code.CompilationResult;
 
 @AutomaticallyRegisteredImageSingleton(PatchConsumerFactory.NativePatchConsumerFactory.class)
 @Platforms(Platform.AARCH64.class)
-@SingletonTraits(access = AllAccess.class, layeredCallbacks = NoLayeredCallbacks.class, other = Disallowed.class)
+@SingletonTraits(access = AllAccess.class, layeredCallbacks = NoLayeredCallbacks.class)
 final class AArch64NativePatchConsumerFactory extends PatchConsumerFactory.NativePatchConsumerFactory {
     @Override
     public Consumer<Assembler.CodeAnnotation> newConsumer(CompilationResult compilationResult) {

--- a/substratevm/src/com.oracle.svm.core.graal.aarch64/src/com/oracle/svm/core/graal/aarch64/AArch64ReservedRegisters.java
+++ b/substratevm/src/com.oracle.svm.core.graal.aarch64/src/com/oracle/svm/core/graal/aarch64/AArch64ReservedRegisters.java
@@ -29,14 +29,13 @@ import org.graalvm.nativeimage.Platforms;
 
 import com.oracle.svm.core.ReservedRegisters;
 import com.oracle.svm.shared.singletons.traits.BuiltinTraits.BuildtimeAccessOnly;
-import com.oracle.svm.shared.singletons.traits.BuiltinTraits.Disallowed;
 import com.oracle.svm.shared.singletons.traits.BuiltinTraits.NoLayeredCallbacks;
 import com.oracle.svm.shared.singletons.traits.SingletonTraits;
 
 import jdk.vm.ci.aarch64.AArch64;
 import jdk.vm.ci.code.Register;
 
-@SingletonTraits(access = BuildtimeAccessOnly.class, layeredCallbacks = NoLayeredCallbacks.class, other = Disallowed.class)
+@SingletonTraits(access = BuildtimeAccessOnly.class, layeredCallbacks = NoLayeredCallbacks.class)
 public final class AArch64ReservedRegisters extends ReservedRegisters {
 
     public static final Register THREAD_REGISTER = AArch64.r28;

--- a/substratevm/src/com.oracle.svm.core.graal.aarch64/src/com/oracle/svm/core/graal/aarch64/SubstrateAArch64Feature.java
+++ b/substratevm/src/com.oracle.svm.core.graal.aarch64/src/com/oracle/svm/core/graal/aarch64/SubstrateAArch64Feature.java
@@ -42,7 +42,6 @@ import com.oracle.svm.core.graal.code.SubstrateVectorArchitectureFactory;
 import com.oracle.svm.core.graal.meta.SubstrateRegisterConfig.ConfigKind;
 import com.oracle.svm.core.heap.ReferenceAccess;
 import com.oracle.svm.shared.singletons.traits.BuiltinTraits.BuildtimeAccessOnly;
-import com.oracle.svm.shared.singletons.traits.BuiltinTraits.Disallowed;
 import com.oracle.svm.shared.singletons.traits.BuiltinTraits.NoLayeredCallbacks;
 import com.oracle.svm.shared.singletons.traits.SingletonTraits;
 
@@ -90,7 +89,7 @@ class SubstrateAArch64Feature implements InternalFeature {
     }
 }
 
-@SingletonTraits(access = BuildtimeAccessOnly.class, layeredCallbacks = NoLayeredCallbacks.class, other = Disallowed.class)
+@SingletonTraits(access = BuildtimeAccessOnly.class, layeredCallbacks = NoLayeredCallbacks.class)
 class SubstrateAArch64RegisterConfigFactory implements SubstrateRegisterConfigFactory {
     @Override
     public RegisterConfig newRegisterFactory(ConfigKind config, MetaAccessProvider metaAccess, TargetDescription target, Boolean preserveFramePointer) {
@@ -98,7 +97,7 @@ class SubstrateAArch64RegisterConfigFactory implements SubstrateRegisterConfigFa
     }
 }
 
-@SingletonTraits(access = BuildtimeAccessOnly.class, layeredCallbacks = NoLayeredCallbacks.class, other = Disallowed.class)
+@SingletonTraits(access = BuildtimeAccessOnly.class, layeredCallbacks = NoLayeredCallbacks.class)
 class SubstrateAArch64BackendFactory extends SubstrateBackendFactory {
     @Override
     public SubstrateBackend newBackend(Providers newProviders) {
@@ -106,7 +105,7 @@ class SubstrateAArch64BackendFactory extends SubstrateBackendFactory {
     }
 }
 
-@SingletonTraits(access = BuildtimeAccessOnly.class, layeredCallbacks = NoLayeredCallbacks.class, other = Disallowed.class)
+@SingletonTraits(access = BuildtimeAccessOnly.class, layeredCallbacks = NoLayeredCallbacks.class)
 class SubstrateAArch64LoweringProviderFactory extends SubstrateVectorArchitectureFactory implements SubstrateLoweringProviderFactory {
 
     @Override

--- a/substratevm/src/com.oracle.svm.core.graal.aarch64/src/com/oracle/svm/core/graal/aarch64/SubstrateAArch64SuitesCreatorProvider.java
+++ b/substratevm/src/com.oracle.svm.core.graal.aarch64/src/com/oracle/svm/core/graal/aarch64/SubstrateAArch64SuitesCreatorProvider.java
@@ -27,13 +27,12 @@ package com.oracle.svm.core.graal.aarch64;
 
 import com.oracle.svm.core.graal.code.SubstrateSuitesCreatorProvider;
 import com.oracle.svm.shared.singletons.traits.BuiltinTraits.BuildtimeAccessOnly;
-import com.oracle.svm.shared.singletons.traits.BuiltinTraits.Disallowed;
 import com.oracle.svm.shared.singletons.traits.BuiltinTraits.NoLayeredCallbacks;
 import com.oracle.svm.shared.singletons.traits.SingletonTraits;
 
 import jdk.graal.compiler.core.phases.EconomyCompilerConfiguration;
 
-@SingletonTraits(access = BuildtimeAccessOnly.class, layeredCallbacks = NoLayeredCallbacks.class, other = Disallowed.class)
+@SingletonTraits(access = BuildtimeAccessOnly.class, layeredCallbacks = NoLayeredCallbacks.class)
 public class SubstrateAArch64SuitesCreatorProvider extends SubstrateSuitesCreatorProvider {
     public SubstrateAArch64SuitesCreatorProvider() {
         super(new AArch64SubstrateSuitesCreator(getHostedCompilerConfiguration()),

--- a/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/aarch64/AArch64DarwinUContextRegisterDumper.java
+++ b/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/aarch64/AArch64DarwinUContextRegisterDumper.java
@@ -37,9 +37,9 @@ import com.oracle.svm.core.graal.aarch64.AArch64ReservedRegisters;
 import com.oracle.svm.core.log.Log;
 import com.oracle.svm.core.posix.UContextRegisterDumper;
 import com.oracle.svm.core.posix.headers.Signal;
-import com.oracle.svm.shared.singletons.traits.BuiltinTraits.Disallowed;
 import com.oracle.svm.shared.singletons.traits.BuiltinTraits.RuntimeAccessOnly;
 import com.oracle.svm.shared.singletons.traits.BuiltinTraits.SingleLayer;
+import com.oracle.svm.shared.singletons.traits.SingletonLayeredInstallationKind.InitialLayerOnly;
 import com.oracle.svm.shared.singletons.traits.SingletonTraits;
 import com.oracle.svm.shared.util.VMError;
 
@@ -48,7 +48,7 @@ import org.graalvm.word.impl.Word;
 
 @AutomaticallyRegisteredImageSingleton(RegisterDumper.class)
 @Platforms(Platform.DARWIN_AARCH64.class)
-@SingletonTraits(access = RuntimeAccessOnly.class, layeredCallbacks = SingleLayer.class, other = Disallowed.class)
+@SingletonTraits(access = RuntimeAccessOnly.class, layeredCallbacks = SingleLayer.class, layeredInstallationKind = InitialLayerOnly.class)
 class AArch64DarwinUContextRegisterDumper implements UContextRegisterDumper {
     AArch64DarwinUContextRegisterDumper() {
         VMError.guarantee(AArch64.r27.equals(AArch64ReservedRegisters.HEAP_BASE_REGISTER));

--- a/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/aarch64/AArch64LinuxUContextRegisterDumper.java
+++ b/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/aarch64/AArch64LinuxUContextRegisterDumper.java
@@ -39,9 +39,9 @@ import com.oracle.svm.core.posix.UContextRegisterDumper;
 import com.oracle.svm.core.posix.headers.Signal.GregsPointer;
 import com.oracle.svm.core.posix.headers.Signal.mcontext_linux_aarch64_t;
 import com.oracle.svm.core.posix.headers.Signal.ucontext_t;
-import com.oracle.svm.shared.singletons.traits.BuiltinTraits.Disallowed;
 import com.oracle.svm.shared.singletons.traits.BuiltinTraits.RuntimeAccessOnly;
 import com.oracle.svm.shared.singletons.traits.BuiltinTraits.SingleLayer;
+import com.oracle.svm.shared.singletons.traits.SingletonLayeredInstallationKind.InitialLayerOnly;
 import com.oracle.svm.shared.singletons.traits.SingletonTraits;
 import com.oracle.svm.shared.util.VMError;
 
@@ -50,7 +50,7 @@ import org.graalvm.word.impl.Word;
 
 @AutomaticallyRegisteredImageSingleton(RegisterDumper.class)
 @Platforms(Platform.LINUX_AARCH64_BASE.class)
-@SingletonTraits(access = RuntimeAccessOnly.class, layeredCallbacks = SingleLayer.class, other = Disallowed.class)
+@SingletonTraits(access = RuntimeAccessOnly.class, layeredCallbacks = SingleLayer.class, layeredInstallationKind = InitialLayerOnly.class)
 class AArch64LinuxUContextRegisterDumper implements UContextRegisterDumper {
     AArch64LinuxUContextRegisterDumper() {
         VMError.guarantee(AArch64.r27.equals(AArch64ReservedRegisters.HEAP_BASE_REGISTER));

--- a/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/amd64/AMD64DarwinUContextRegisterDumper.java
+++ b/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/amd64/AMD64DarwinUContextRegisterDumper.java
@@ -39,9 +39,9 @@ import com.oracle.svm.core.log.Log;
 import com.oracle.svm.core.posix.UContextRegisterDumper;
 import com.oracle.svm.core.posix.headers.Signal;
 import com.oracle.svm.core.posix.headers.Signal.ucontext_t;
-import com.oracle.svm.shared.singletons.traits.BuiltinTraits.Disallowed;
 import com.oracle.svm.shared.singletons.traits.BuiltinTraits.RuntimeAccessOnly;
 import com.oracle.svm.shared.singletons.traits.BuiltinTraits.SingleLayer;
+import com.oracle.svm.shared.singletons.traits.SingletonLayeredInstallationKind.InitialLayerOnly;
 import com.oracle.svm.shared.singletons.traits.SingletonTraits;
 import com.oracle.svm.shared.util.VMError;
 
@@ -49,7 +49,7 @@ import jdk.vm.ci.amd64.AMD64;
 
 @AutomaticallyRegisteredImageSingleton(RegisterDumper.class)
 @Platforms(Platform.DARWIN_AMD64.class)
-@SingletonTraits(access = RuntimeAccessOnly.class, layeredCallbacks = SingleLayer.class, other = Disallowed.class)
+@SingletonTraits(access = RuntimeAccessOnly.class, layeredCallbacks = SingleLayer.class, layeredInstallationKind = InitialLayerOnly.class)
 class AMD64DarwinUContextRegisterDumper implements UContextRegisterDumper {
     AMD64DarwinUContextRegisterDumper() {
         VMError.guarantee(AMD64.r14.equals(AMD64ReservedRegisters.HEAP_BASE_REGISTER));

--- a/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/darwin/DarwinImageHeapProvider.java
+++ b/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/darwin/DarwinImageHeapProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,21 +24,172 @@
  */
 package com.oracle.svm.core.posix.darwin;
 
+import static com.oracle.svm.core.imagelayer.ImageLayerSection.SectionEntries.HEAP_BEGIN;
+import static com.oracle.svm.core.imagelayer.ImageLayerSection.SectionEntries.HEAP_END;
+import static com.oracle.svm.core.imagelayer.ImageLayerSection.SectionEntries.HEAP_WRITEABLE_BEGIN;
+import static com.oracle.svm.core.imagelayer.ImageLayerSection.SectionEntries.HEAP_WRITEABLE_END;
+import static com.oracle.svm.core.imagelayer.ImageLayerSection.SectionEntries.NEXT_SECTION;
+
+import org.graalvm.nativeimage.c.type.WordPointer;
 import org.graalvm.word.Pointer;
 import org.graalvm.word.UnsignedWord;
 
 import com.oracle.svm.guest.staging.Uninterruptible;
 import com.oracle.svm.core.c.function.CEntryPointErrors;
+import com.oracle.svm.core.code.DynamicMethodAddressResolutionHeapSupport;
+import com.oracle.svm.core.heap.Heap;
+import com.oracle.svm.core.imagelayer.ImageLayerBuildingSupport;
+import com.oracle.svm.core.imagelayer.ImageLayerSection;
 import com.oracle.svm.core.os.AbstractCopyingImageHeapProvider;
+import com.oracle.svm.core.os.LayeredImageHeapSupport;
+import com.oracle.svm.core.os.VirtualMemoryProvider;
+import com.oracle.svm.core.os.VirtualMemoryProvider.Access;
 import com.oracle.svm.core.posix.headers.darwin.DarwinVirtualMemory;
 import com.oracle.svm.shared.singletons.traits.BuiltinTraits.AllAccess;
-import com.oracle.svm.shared.singletons.traits.BuiltinTraits.Disallowed;
 import com.oracle.svm.shared.singletons.traits.BuiltinTraits.SingleLayer;
+import com.oracle.svm.shared.singletons.traits.SingletonLayeredInstallationKind.InitialLayerOnly;
 import com.oracle.svm.shared.singletons.traits.SingletonTraits;
+import com.oracle.svm.core.util.PointerUtils;
+import com.oracle.svm.core.util.UnsignedUtils;
 
-/** Creates image heaps on Darwin that are copy-on-write clones of the loaded image heap. */
-@SingletonTraits(access = AllAccess.class, layeredCallbacks = SingleLayer.class, other = Disallowed.class)
+import org.graalvm.word.impl.Word;
+
+/**
+ * Creates image heaps on Darwin that are copy-on-write clones of the loaded image heap. Supports
+ * both single-layer and layered image builds. For layered builds, each layer's image heap is
+ * individually copied and patched using the platform-independent {@link LayeredImageHeapSupport}.
+ */
+@SingletonTraits(access = AllAccess.class, layeredCallbacks = SingleLayer.class, layeredInstallationKind = InitialLayerOnly.class)
 public class DarwinImageHeapProvider extends AbstractCopyingImageHeapProvider {
+
+    @Override
+    @Uninterruptible(reason = "Called during isolate initialization.")
+    public int initialize(Pointer reservedAddressSpace, UnsignedWord reservedSize, WordPointer heapBaseOut, WordPointer imageHeapEndOut) {
+        if (!ImageLayerBuildingSupport.buildingImageLayer()) {
+            /* Non-layered: delegate to the standard copying path. */
+            return super.initialize(reservedAddressSpace, reservedSize, heapBaseOut, imageHeapEndOut);
+        }
+
+        /* Layered build: initialize each layer's image heap separately. */
+        Pointer selfReservedMemory = Word.nullPointer();
+        UnsignedWord requiredSize = getTotalRequiredAddressSpaceSize();
+        if (reservedAddressSpace.isNull()) {
+            UnsignedWord alignment = Word.unsigned(Heap.getHeap().getHeapBaseAlignment());
+            selfReservedMemory = VirtualMemoryProvider.get().reserve(requiredSize, alignment, false);
+            if (selfReservedMemory.isNull()) {
+                return CEntryPointErrors.RESERVE_ADDRESS_SPACE_FAILED;
+            }
+        } else if (reservedSize.belowThan(requiredSize)) {
+            return CEntryPointErrors.INSUFFICIENT_ADDRESS_SPACE;
+        }
+
+        Pointer heapBase;
+        Pointer selfReservedHeapBase;
+        if (DynamicMethodAddressResolutionHeapSupport.isEnabled()) {
+            UnsignedWord preHeapRequiredBytes = getPreHeapAlignedSizeForDynamicMethodAddressResolver();
+            if (selfReservedMemory.isNonNull()) {
+                selfReservedHeapBase = selfReservedMemory.add(preHeapRequiredBytes);
+                heapBase = selfReservedHeapBase;
+            } else {
+                heapBase = reservedAddressSpace.add(preHeapRequiredBytes);
+                selfReservedHeapBase = Word.nullPointer();
+            }
+
+            int error = DynamicMethodAddressResolutionHeapSupport.get().initialize();
+            if (error != CEntryPointErrors.NO_ERROR) {
+                freeImageHeap(selfReservedHeapBase);
+                return error;
+            }
+
+            error = DynamicMethodAddressResolutionHeapSupport.get().install(heapBase);
+            if (error != CEntryPointErrors.NO_ERROR) {
+                freeImageHeap(selfReservedHeapBase);
+                return error;
+            }
+        } else {
+            heapBase = selfReservedMemory.isNonNull() ? selfReservedMemory : reservedAddressSpace;
+            selfReservedHeapBase = selfReservedMemory;
+        }
+
+        /* Update heap base and image heap end. */
+        assert PointerUtils.isAMultiple(heapBase, Word.unsigned(Heap.getHeap().getHeapBaseAlignment()));
+        heapBaseOut.write(heapBase);
+
+        Pointer imageHeapEnd = getImageHeapEnd(heapBase);
+        assert PointerUtils.isAMultiple(imageHeapEnd, VirtualMemoryProvider.get().getGranularity());
+        imageHeapEndOut.write(imageHeapEnd);
+
+        Pointer imageHeapStart = getImageHeapBegin(heapBase);
+        int result = initializeLayeredImage(imageHeapStart, imageHeapEnd, selfReservedHeapBase);
+        if (result != CEntryPointErrors.NO_ERROR) {
+            freeImageHeap(selfReservedHeapBase);
+        }
+        return result;
+    }
+
+    /**
+     * Initialize a layered image by copying each layer's image heap using vm_copy and then
+     * applying cross-layer patches.
+     */
+    @Uninterruptible(reason = "Called during isolate initialization.")
+    private int initializeLayeredImage(Pointer imageHeapStart, Pointer imageHeapEnd, Pointer selfReservedHeapBase) {
+        UnsignedWord imageHeapAlignment = Word.unsigned(Heap.getHeap().getImageHeapAlignment());
+        assert PointerUtils.isAMultiple(imageHeapStart, imageHeapAlignment);
+
+        /* Apply cross-layer patches (code pointer relocation, heap ref patches, field updates). */
+        LayeredImageHeapSupport.patchLayeredImageHeap();
+
+        UnsignedWord pageSize = VirtualMemoryProvider.get().getGranularity();
+        Pointer currentSection = ImageLayerSection.getInitialLayerSection().get();
+        Pointer currentHeapStart = imageHeapStart;
+
+        while (currentSection.isNonNull()) {
+            Word heapBegin = currentSection.readWord(ImageLayerSection.getEntryOffset(HEAP_BEGIN));
+            Word heapEnd = currentSection.readWord(ImageLayerSection.getEntryOffset(HEAP_END));
+            Word heapWritableBegin = currentSection.readWord(ImageLayerSection.getEntryOffset(HEAP_WRITEABLE_BEGIN));
+            Word heapWritableEnd = currentSection.readWord(ImageLayerSection.getEntryOffset(HEAP_WRITEABLE_END));
+
+            /* Each layer's image heap starts at an aligned offset. */
+            currentHeapStart = PointerUtils.roundUp(currentHeapStart, imageHeapAlignment);
+
+            UnsignedWord imageHeapSize = getImageHeapSizeInFile(heapBegin, heapEnd);
+
+            /* Commit memory and copy this layer's image heap via vm_copy. */
+            int result = commitAndCopyMemory(heapBegin, imageHeapSize, currentHeapStart);
+            if (result != CEntryPointErrors.NO_ERROR) {
+                freeImageHeap(selfReservedHeapBase);
+                return result;
+            }
+
+            /* Protect read-only parts before the writable section. */
+            UnsignedWord writableBeginPageOffset = UnsignedUtils.roundDown(heapWritableBegin.subtract(heapBegin), pageSize);
+            if (writableBeginPageOffset.aboveThan(0)) {
+                if (VirtualMemoryProvider.get().protect(currentHeapStart, writableBeginPageOffset, Access.READ) != 0) {
+                    freeImageHeap(selfReservedHeapBase);
+                    return CEntryPointErrors.PROTECT_HEAP_FAILED;
+                }
+            }
+
+            /* Protect read-only parts after the writable section. */
+            UnsignedWord writableEndPageOffset = UnsignedUtils.roundUp(heapWritableEnd.subtract(heapBegin), pageSize);
+            if (writableEndPageOffset.belowThan(imageHeapSize)) {
+                Pointer afterWritableBoundary = currentHeapStart.add(writableEndPageOffset);
+                UnsignedWord afterWritableSize = imageHeapSize.subtract(writableEndPageOffset);
+                if (VirtualMemoryProvider.get().protect(afterWritableBoundary, afterWritableSize, Access.READ) != 0) {
+                    freeImageHeap(selfReservedHeapBase);
+                    return CEntryPointErrors.PROTECT_HEAP_FAILED;
+                }
+            }
+
+            currentHeapStart = currentHeapStart.add(imageHeapSize);
+
+            /* Advance to the next layer. */
+            currentSection = currentSection.readWord(ImageLayerSection.getEntryOffset(NEXT_SECTION));
+        }
+        assert imageHeapEnd.equal(currentHeapStart);
+        return CEntryPointErrors.NO_ERROR;
+    }
+
     @Override
     @Uninterruptible(reason = "Called during isolate initialization.")
     protected int copyMemory(Pointer loadedImageHeap, UnsignedWord imageHeapSize, Pointer newImageHeap) {

--- a/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/darwin/DarwinImageSingletonsFeature.java
+++ b/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/darwin/DarwinImageSingletonsFeature.java
@@ -31,11 +31,10 @@ import com.oracle.svm.core.feature.InternalFeature;
 import com.oracle.svm.core.imagelayer.ImageLayerBuildingSupport;
 import com.oracle.svm.core.os.ImageHeapProvider;
 import com.oracle.svm.shared.singletons.traits.BuiltinTraits.BuildtimeAccessOnly;
-import com.oracle.svm.shared.singletons.traits.BuiltinTraits.Disallowed;
 import com.oracle.svm.shared.singletons.traits.BuiltinTraits.SingleLayer;
 import com.oracle.svm.shared.singletons.traits.SingletonTraits;
 
-@SingletonTraits(access = BuildtimeAccessOnly.class, layeredCallbacks = SingleLayer.class, other = Disallowed.class)
+@SingletonTraits(access = BuildtimeAccessOnly.class, layeredCallbacks = SingleLayer.class)
 @AutomaticallyRegisteredFeature
 class DarwinImageSingletonsFeature implements InternalFeature {
     @Override

--- a/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/darwin/DarwinLibCSupport.java
+++ b/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/darwin/DarwinLibCSupport.java
@@ -30,11 +30,11 @@ import com.oracle.svm.core.headers.LibCSupport;
 import com.oracle.svm.core.posix.PosixLibCSupport;
 import com.oracle.svm.core.posix.headers.darwin.DarwinErrno;
 import com.oracle.svm.shared.singletons.traits.BuiltinTraits.AllAccess;
-import com.oracle.svm.shared.singletons.traits.BuiltinTraits.Disallowed;
 import com.oracle.svm.shared.singletons.traits.BuiltinTraits.SingleLayer;
+import com.oracle.svm.shared.singletons.traits.SingletonLayeredInstallationKind.InitialLayerOnly;
 import com.oracle.svm.shared.singletons.traits.SingletonTraits;
 
-@SingletonTraits(access = AllAccess.class, layeredCallbacks = SingleLayer.class, other = Disallowed.class)
+@SingletonTraits(access = AllAccess.class, layeredCallbacks = SingleLayer.class, layeredInstallationKind = InitialLayerOnly.class)
 @AutomaticallyRegisteredImageSingleton(LibCSupport.class)
 class DarwinLibCSupport extends PosixLibCSupport {
 

--- a/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/darwin/DarwinPhysicalMemorySupportImpl.java
+++ b/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/darwin/DarwinPhysicalMemorySupportImpl.java
@@ -36,14 +36,14 @@ import com.oracle.svm.core.heap.PhysicalMemory.PhysicalMemorySupport;
 import com.oracle.svm.core.log.Log;
 import com.oracle.svm.core.posix.headers.darwin.DarwinSysctl;
 import com.oracle.svm.core.posix.headers.darwin.Sysctl;
-import com.oracle.svm.shared.singletons.traits.BuiltinTraits.Disallowed;
-import com.oracle.svm.shared.singletons.traits.BuiltinTraits.NoLayeredCallbacks;
+import com.oracle.svm.shared.singletons.traits.BuiltinTraits.SingleLayer;
 import com.oracle.svm.shared.singletons.traits.BuiltinTraits.RuntimeAccessOnly;
+import com.oracle.svm.shared.singletons.traits.SingletonLayeredInstallationKind.InitialLayerOnly;
 import com.oracle.svm.shared.singletons.traits.SingletonTraits;
 import com.oracle.svm.shared.util.VMError;
 import org.graalvm.word.impl.Word;
 
-@SingletonTraits(access = RuntimeAccessOnly.class, layeredCallbacks = NoLayeredCallbacks.class, other = Disallowed.class)
+@SingletonTraits(access = RuntimeAccessOnly.class, layeredCallbacks = SingleLayer.class, layeredInstallationKind = InitialLayerOnly.class)
 @AutomaticallyRegisteredImageSingleton(PhysicalMemorySupport.class)
 class DarwinPhysicalMemorySupportImpl implements PhysicalMemorySupport {
 

--- a/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/darwin/DarwinStackOverflowSupport.java
+++ b/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/darwin/DarwinStackOverflowSupport.java
@@ -43,13 +43,13 @@ import com.oracle.svm.core.posix.headers.Pthread;
 import com.oracle.svm.core.posix.headers.darwin.DarwinPthread;
 import com.oracle.svm.core.stack.StackOverflowCheck;
 import com.oracle.svm.shared.singletons.traits.BuiltinTraits.AllAccess;
-import com.oracle.svm.shared.singletons.traits.BuiltinTraits.Disallowed;
 import com.oracle.svm.shared.singletons.traits.BuiltinTraits.SingleLayer;
+import com.oracle.svm.shared.singletons.traits.SingletonLayeredInstallationKind.InitialLayerOnly;
 import com.oracle.svm.shared.singletons.traits.SingletonTraits;
 import com.oracle.svm.shared.util.VMError;
 import org.graalvm.word.impl.Word;
 
-@SingletonTraits(access = AllAccess.class, layeredCallbacks = SingleLayer.class, other = Disallowed.class)
+@SingletonTraits(access = AllAccess.class, layeredCallbacks = SingleLayer.class, layeredInstallationKind = InitialLayerOnly.class)
 @AutomaticallyRegisteredImageSingleton(StackOverflowCheck.PlatformSupport.class)
 final class DarwinStackOverflowSupport implements StackOverflowCheck.PlatformSupport {
     @Override

--- a/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/darwin/DarwinVMLockSupport.java
+++ b/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/darwin/DarwinVMLockSupport.java
@@ -38,12 +38,12 @@ import com.oracle.svm.core.locks.VMSemaphore;
 import com.oracle.svm.core.posix.headers.darwin.DarwinVirtualMemory;
 import com.oracle.svm.core.posix.pthread.PthreadVMLockSupport;
 import com.oracle.svm.shared.singletons.traits.BuiltinTraits.AllAccess;
-import com.oracle.svm.shared.singletons.traits.BuiltinTraits.Disallowed;
-import com.oracle.svm.shared.singletons.traits.BuiltinTraits.NoLayeredCallbacks;
+import com.oracle.svm.shared.singletons.traits.BuiltinTraits.SingleLayer;
+import com.oracle.svm.shared.singletons.traits.SingletonLayeredInstallationKind.InitialLayerOnly;
 import com.oracle.svm.shared.singletons.traits.SingletonTraits;
 
 @AutomaticallyRegisteredImageSingleton(VMLockSupport.class)
-@SingletonTraits(access = AllAccess.class, layeredCallbacks = NoLayeredCallbacks.class, other = Disallowed.class)
+@SingletonTraits(access = AllAccess.class, layeredCallbacks = SingleLayer.class, layeredInstallationKind = InitialLayerOnly.class)
 final class DarwinVMLockSupport extends PthreadVMLockSupport {
 
     @Override

--- a/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/linux/LinuxImageHeapProvider.java
+++ b/substratevm/src/com.oracle.svm.core.posix/src/com/oracle/svm/core/posix/linux/LinuxImageHeapProvider.java
@@ -33,7 +33,6 @@ import static com.oracle.svm.core.Isolates.IMAGE_HEAP_WRITABLE_BEGIN;
 import static com.oracle.svm.core.Isolates.IMAGE_HEAP_WRITABLE_END;
 import static com.oracle.svm.core.Isolates.IMAGE_HEAP_WRITABLE_PATCHED_BEGIN;
 import static com.oracle.svm.core.Isolates.IMAGE_HEAP_WRITABLE_PATCHED_END;
-import static com.oracle.svm.core.imagelayer.ImageLayerSection.SectionEntries.CODE_START;
 import static com.oracle.svm.core.imagelayer.ImageLayerSection.SectionEntries.HEAP_BEGIN;
 import static com.oracle.svm.core.imagelayer.ImageLayerSection.SectionEntries.HEAP_END;
 import static com.oracle.svm.core.imagelayer.ImageLayerSection.SectionEntries.HEAP_RELOCATABLE_BEGIN;
@@ -43,7 +42,6 @@ import static com.oracle.svm.core.imagelayer.ImageLayerSection.SectionEntries.HE
 import static com.oracle.svm.core.imagelayer.ImageLayerSection.SectionEntries.HEAP_WRITEABLE_PATCHED_BEGIN;
 import static com.oracle.svm.core.imagelayer.ImageLayerSection.SectionEntries.HEAP_WRITEABLE_PATCHED_END;
 import static com.oracle.svm.core.imagelayer.ImageLayerSection.SectionEntries.NEXT_SECTION;
-import static com.oracle.svm.core.imagelayer.ImageLayerSection.SectionEntries.VARIABLY_SIZED_DATA;
 import static com.oracle.svm.core.posix.linux.ProcFSSupport.findMapping;
 import static com.oracle.svm.core.util.PointerUtils.roundDown;
 import static com.oracle.svm.core.util.UnsignedUtils.roundUp;
@@ -74,8 +72,8 @@ import com.oracle.svm.core.headers.LibC;
 import com.oracle.svm.core.heap.Heap;
 import com.oracle.svm.core.imagelayer.ImageLayerBuildingSupport;
 import com.oracle.svm.core.imagelayer.ImageLayerSection;
-import com.oracle.svm.core.jdk.UninterruptibleUtils;
 import com.oracle.svm.core.os.AbstractImageHeapProvider;
+import com.oracle.svm.core.os.LayeredImageHeapSupport;
 import com.oracle.svm.core.os.VirtualMemoryProvider;
 import com.oracle.svm.core.os.VirtualMemoryProvider.Access;
 import com.oracle.svm.core.posix.PosixUtils;
@@ -127,20 +125,12 @@ public class LinuxImageHeapProvider extends AbstractImageHeapProvider {
 
     private static final int MAX_PATHLEN = 4096;
 
-    private static final class ImageHeapPatchingState {
-        static final Word UNINITIALIZED = Word.zero();
-        static final Word IN_PROGRESS = Word.unsigned(1);
-        static final Word SUCCESSFUL = Word.unsigned(2);
-    }
-
-    private static final CGlobalData<Word> IMAGE_HEAP_PATCHING_STATE = CGlobalDataFactory.createWord(ImageHeapPatchingState.UNINITIALIZED);
-
     @Uninterruptible(reason = "Called during isolate initialization.")
     protected int initializeLayeredImage(Pointer imageHeapStart, Pointer imageHeapEnd, Pointer selfReservedHeapBase) {
         UnsignedWord imageHeapAlignment = unsigned(Heap.getHeap().getImageHeapAlignment());
         assert PointerUtils.isAMultiple(imageHeapStart, imageHeapAlignment);
 
-        patchLayeredImageHeap();
+        LayeredImageHeapSupport.patchLayeredImageHeap();
 
         int result = -1;
         int layerCount = 0;
@@ -183,190 +173,6 @@ public class LinuxImageHeapProvider extends AbstractImageHeapProvider {
         }
         assert imageHeapEnd == currentHeapStart;
         return result;
-    }
-
-    /**
-     * Apply patches to the image heap as specified by each layer. See {@link ImageLayerSection} and
-     * {@link ImageLayerSectionFeature} for the layout of the section that contains the patches and
-     * {@link LayeredDispatchTableFeature} where code patches are gathered.
-     */
-    @Uninterruptible(reason = "Thread state not yet set up.")
-    public static void patchLayeredImageHeap() {
-        Word heapPatchStateAddr = IMAGE_HEAP_PATCHING_STATE.get();
-        boolean firstIsolate = heapPatchStateAddr.logicCompareAndSwapWord(0, ImageHeapPatchingState.UNINITIALIZED, ImageHeapPatchingState.IN_PROGRESS, NamedLocationIdentity.OFF_HEAP_LOCATION);
-
-        if (!firstIsolate) {
-            // spin-wait for first isolate
-            Word state = heapPatchStateAddr.readWordVolatile(0, NamedLocationIdentity.OFF_HEAP_LOCATION);
-            while (state.equal(ImageHeapPatchingState.IN_PROGRESS)) {
-                PauseNode.pause();
-                state = heapPatchStateAddr.readWordVolatile(0, NamedLocationIdentity.OFF_HEAP_LOCATION);
-            }
-
-            /* Patching has already been successfully completed, nothing needs to be done. */
-            return;
-        }
-
-        Pointer layerSection = ImageLayerSection.getInitialLayerSection().get();
-        Pointer initialLayerImageHeap = layerSection.readWord(ImageLayerSection.getEntryOffset(HEAP_BEGIN));
-        Pointer codeBase = layerSection.readWord(ImageLayerSection.getEntryOffset(CODE_START));
-
-        int referenceSize = ConfigurationValues.getObjectLayout().getReferenceSize();
-        while (layerSection.isNonNull()) {
-            Pointer data = layerSection.add(ImageLayerSection.getEntryOffset(VARIABLY_SIZED_DATA));
-            int offset = 0;
-
-            offset = skipSingletonsTable(data, offset, referenceSize);
-
-            /* Patch code offsets to become relative to the code base. */
-            Pointer layerHeapRelocs = layerSection.readWord(ImageLayerSection.getEntryOffset(HEAP_RELOCATABLE_BEGIN));
-            Pointer layerCode = layerSection.readWord(ImageLayerSection.getEntryOffset(CODE_START));
-            /*
-             * Note that the code base can be above the layer's code section, in which case the
-             * subtraction underflows and the additions of code address computations overflow,
-             * giving the correct result.
-             */
-            Word layerCodeOffsetToBase = (Word) layerCode.subtract(codeBase);
-            offset = applyLayerCodePointerPatches(data, offset, layerHeapRelocs, layerCodeOffsetToBase);
-
-            /* Patch absolute addresses to become relative to the code base. */
-            Word negativeCodeBase = Word.<Word> zero().subtract(codeBase);
-            offset = applyLayerCodePointerPatches(data, offset, layerHeapRelocs, negativeCodeBase);
-
-            /* Patch references in the image heap. */
-            offset = applyLayerImageHeapRefPatches(data, offset, initialLayerImageHeap);
-
-            applyLayerImageHeapFieldUpdatePatches(data, offset, initialLayerImageHeap);
-
-            layerSection = layerSection.readWord(ImageLayerSection.getEntryOffset(NEXT_SECTION));
-        }
-
-        heapPatchStateAddr.writeWordVolatile(0, ImageHeapPatchingState.SUCCESSFUL);
-    }
-
-    @Uninterruptible(reason = "Thread state not yet set up.")
-    private static int skipSingletonsTable(Pointer data, int offset, int referenceSize) {
-        long singletonTableEntryCount = data.readLong(offset);
-        UnsignedWord singletonTableAlignedSize = roundUp(unsigned(singletonTableEntryCount * referenceSize), unsigned(Long.BYTES));
-        return offset + Long.BYTES + UnsignedUtils.safeToInt(singletonTableAlignedSize);
-    }
-
-    @Uninterruptible(reason = "Thread state not yet set up.")
-    private static int applyLayerCodePointerPatches(Pointer data, int startOffset, Pointer layerHeapRelocs, Word addend) {
-        int wordSize = ConfigurationValues.getTarget().wordSize;
-
-        int offset = startOffset;
-        long bitmapWordCountAsLong = data.readLong(offset);
-        int bitmapWordCount = UninterruptibleUtils.NumUtil.safeToInt(bitmapWordCountAsLong);
-        offset += Long.BYTES;
-        if (addend.equal(0)) {
-            /* Nothing to do. */
-            offset += bitmapWordCount * Long.BYTES;
-            return offset;
-        }
-
-        for (int i = 0; i < bitmapWordCount; i++) {
-            long bits = data.readLong(offset);
-            offset += Long.BYTES;
-            int j = 0; // index of a 1-bit
-            while (bits != 0) {
-                int ntz = UninterruptibleUtils.Long.countTrailingZeros(bits);
-                j += ntz;
-
-                int at = (i * 64 + j) * wordSize;
-                Word w = layerHeapRelocs.readWord(at);
-                w = w.add(addend);
-                layerHeapRelocs.writeWord(at, w);
-
-                /*
-                 * Note that we must not shift by ntz+1 here because it can be 64, which would be a
-                 * no-op according to the Java Language Specification, 15.19. Shift Operators.
-                 */
-                bits = (bits >>> ntz) >>> 1;
-                j++;
-            }
-        }
-        return offset;
-    }
-
-    /**
-     * See {@code CrossLayerConstantRegistryFeature#generateRelocationPatchArray} for more details
-     * about the layout.
-     */
-    @Uninterruptible(reason = "Thread state not yet set up.")
-    private static int applyLayerImageHeapRefPatches(Pointer patches, int startOffset, Pointer layerImageHeap) {
-        int referenceSize = ConfigurationValues.getObjectLayout().getReferenceSize();
-        int offset = startOffset;
-        long countAsLong = patches.readLong(offset);
-        int count = UninterruptibleUtils.NumUtil.safeToInt(countAsLong);
-        offset += Long.BYTES;
-        int endOffset = offset + count * Integer.BYTES;
-        while (offset < endOffset) {
-            int heapOffset = patches.readInt(offset);
-            int referenceEncoding = patches.readInt(offset + Integer.BYTES);
-            offset += 2 * Integer.BYTES;
-            if (referenceSize == 4) {
-                layerImageHeap.writeInt(heapOffset, referenceEncoding);
-            } else {
-                layerImageHeap.writeLong(heapOffset, referenceEncoding);
-            }
-        }
-        return endOffset;
-    }
-
-    /**
-     * See {@code CrossLayerUpdaterFeature#generateUpdatePatchArray} for more details about the
-     * layout.
-     */
-    @Uninterruptible(reason = "Thread state not yet set up.")
-    private static int applyLayerImageHeapFieldUpdatePatches(Pointer patches, int startOffset, Pointer layerImageHeap) {
-        long countAsLong = patches.readLong(startOffset);
-        if (countAsLong == 0) {
-            // empty - nothing to do
-            return startOffset + Long.BYTES;
-        }
-
-        int headerSize = patches.readInt(startOffset + Long.BYTES);
-
-        int headerOffset = startOffset + Long.BYTES + Integer.BYTES;
-        int headerEndOffset = headerOffset + headerSize;
-
-        // calculate entry offset start
-        int entryOffset = headerEndOffset;
-
-        /* Now update values. */
-        while (headerOffset < headerEndOffset) {
-            // read appropriate slot of header
-            int valueSize = patches.readInt(headerOffset);
-            headerOffset += Integer.BYTES;
-            int numEntries = patches.readInt(headerOffset);
-            headerOffset += Integer.BYTES;
-            for (int j = 0; j < numEntries; j++) {
-                int heapOffset = patches.readInt(entryOffset);
-                entryOffset += Integer.BYTES;
-                switch (valueSize) {
-                    case 1 -> {
-                        byte value = patches.readByte(entryOffset);
-                        layerImageHeap.writeByte(heapOffset, value);
-                        entryOffset += Byte.BYTES;
-                    }
-                    case 4 -> {
-                        int value = patches.readInt(entryOffset);
-                        layerImageHeap.writeInt(heapOffset, value);
-                        entryOffset += Integer.BYTES;
-                    }
-                    case 8 -> {
-                        long value = patches.readLong(entryOffset);
-                        layerImageHeap.writeLong(heapOffset, value);
-                        entryOffset += Long.BYTES;
-                    }
-                    default -> throw VMError.shouldNotReachHereAtRuntime();
-                }
-            }
-        }
-
-        VMError.guarantee((startOffset + Long.BYTES + Integer.BYTES + countAsLong) == entryOffset);
-        return entryOffset;
     }
 
     @Override

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/aarch64/AArch64CPUFeatureAccess.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/aarch64/AArch64CPUFeatureAccess.java
@@ -37,7 +37,6 @@ import com.oracle.svm.guest.staging.Uninterruptible;
 import com.oracle.svm.core.UnmanagedMemoryUtil;
 import com.oracle.svm.core.graal.stackvalue.UnsafeStackValue;
 import com.oracle.svm.shared.singletons.traits.BuiltinTraits.AllAccess;
-import com.oracle.svm.shared.singletons.traits.BuiltinTraits.Disallowed;
 import com.oracle.svm.shared.singletons.traits.BuiltinTraits.NoLayeredCallbacks;
 import com.oracle.svm.shared.singletons.traits.SingletonTraits;
 import com.oracle.svm.shared.util.VMError;
@@ -46,7 +45,7 @@ import jdk.graal.compiler.nodes.spi.LoweringProvider;
 import jdk.vm.ci.aarch64.AArch64;
 import jdk.vm.ci.code.Architecture;
 
-@SingletonTraits(access = AllAccess.class, layeredCallbacks = NoLayeredCallbacks.class, other = Disallowed.class)
+@SingletonTraits(access = AllAccess.class, layeredCallbacks = NoLayeredCallbacks.class)
 public class AArch64CPUFeatureAccess extends CPUFeatureAccessImpl {
 
     @Platforms(Platform.HOSTED_ONLY.class)

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/os/LayeredImageHeapSupport.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/os/LayeredImageHeapSupport.java
@@ -1,0 +1,258 @@
+/*
+ * Copyright (c) 2025, 2025, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package com.oracle.svm.core.os;
+
+import static com.oracle.svm.core.imagelayer.ImageLayerSection.SectionEntries.CODE_START;
+import static com.oracle.svm.core.imagelayer.ImageLayerSection.SectionEntries.HEAP_BEGIN;
+import static com.oracle.svm.core.imagelayer.ImageLayerSection.SectionEntries.HEAP_RELOCATABLE_BEGIN;
+import static com.oracle.svm.core.imagelayer.ImageLayerSection.SectionEntries.HEAP_RELOCATABLE_END;
+import static com.oracle.svm.core.imagelayer.ImageLayerSection.SectionEntries.HEAP_WRITEABLE_PATCHED_BEGIN;
+import static com.oracle.svm.core.imagelayer.ImageLayerSection.SectionEntries.HEAP_WRITEABLE_PATCHED_END;
+import static com.oracle.svm.core.imagelayer.ImageLayerSection.SectionEntries.NEXT_SECTION;
+import static com.oracle.svm.core.imagelayer.ImageLayerSection.SectionEntries.VARIABLY_SIZED_DATA;
+import static com.oracle.svm.core.util.UnsignedUtils.roundUp;
+import static jdk.graal.compiler.word.Word.unsigned;
+
+import org.graalvm.word.Pointer;
+import org.graalvm.word.UnsignedWord;
+
+import com.oracle.svm.guest.staging.Uninterruptible;
+import com.oracle.svm.core.c.CGlobalData;
+import com.oracle.svm.core.c.CGlobalDataFactory;
+import com.oracle.svm.core.config.ConfigurationValues;
+import com.oracle.svm.core.imagelayer.ImageLayerSection;
+import com.oracle.svm.core.jdk.UninterruptibleUtils;
+import com.oracle.svm.core.util.UnsignedUtils;
+import com.oracle.svm.shared.util.VMError;
+
+import jdk.graal.compiler.nodes.NamedLocationIdentity;
+import jdk.graal.compiler.nodes.PauseNode;
+import org.graalvm.word.impl.Word;
+
+/**
+ * Platform-independent support for patching layered image heaps at runtime. The patching operations
+ * (code pointer relocation, heap reference patching, field update patching) are pure memory
+ * operations with no OS-specific dependencies.
+ *
+ * Both {@code LinuxImageHeapProvider} and {@code DarwinImageHeapProvider} delegate to this class
+ * for layered image heap patching.
+ */
+public final class LayeredImageHeapSupport {
+
+    private static final class ImageHeapPatchingState {
+        static final Word UNINITIALIZED = Word.zero();
+        static final Word IN_PROGRESS = Word.unsigned(1);
+        static final Word SUCCESSFUL = Word.unsigned(2);
+    }
+
+    private static final CGlobalData<Word> IMAGE_HEAP_PATCHING_STATE = CGlobalDataFactory.createWord(ImageHeapPatchingState.UNINITIALIZED);
+
+    /**
+     * Apply patches to the image heap as specified by each layer. This method is thread-safe: the
+     * first isolate to call it performs the patching while subsequent callers spin-wait until
+     * patching is complete.
+     *
+     * See {@code ImageLayerSectionFeature} for the layout of the section that contains the patches
+     * and {@code LayeredDispatchTableFeature} where code patches are gathered.
+     */
+    @Uninterruptible(reason = "Thread state not yet set up.")
+    public static void patchLayeredImageHeap() {
+        Word heapPatchStateAddr = IMAGE_HEAP_PATCHING_STATE.get();
+        boolean firstIsolate = heapPatchStateAddr.logicCompareAndSwapWord(0, ImageHeapPatchingState.UNINITIALIZED, ImageHeapPatchingState.IN_PROGRESS, NamedLocationIdentity.OFF_HEAP_LOCATION);
+
+        if (!firstIsolate) {
+            // spin-wait for first isolate
+            Word state = heapPatchStateAddr.readWordVolatile(0, NamedLocationIdentity.OFF_HEAP_LOCATION);
+            while (state.equal(ImageHeapPatchingState.IN_PROGRESS)) {
+                PauseNode.pause();
+                state = heapPatchStateAddr.readWordVolatile(0, NamedLocationIdentity.OFF_HEAP_LOCATION);
+            }
+
+            /* Patching has already been successfully completed, nothing needs to be done. */
+            return;
+        }
+
+        Pointer layerSection = ImageLayerSection.getInitialLayerSection().get();
+        Pointer initialLayerImageHeap = layerSection.readWord(ImageLayerSection.getEntryOffset(HEAP_BEGIN));
+        Pointer codeBase = layerSection.readWord(ImageLayerSection.getEntryOffset(CODE_START));
+
+        int referenceSize = ConfigurationValues.getObjectLayout().getReferenceSize();
+        while (layerSection.isNonNull()) {
+            Pointer data = layerSection.add(ImageLayerSection.getEntryOffset(VARIABLY_SIZED_DATA));
+            int offset = 0;
+
+            offset = skipSingletonsTable(data, offset, referenceSize);
+
+            /* Patch code offsets to become relative to the code base. */
+            Pointer layerHeapRelocs = layerSection.readWord(ImageLayerSection.getEntryOffset(HEAP_RELOCATABLE_BEGIN));
+            Pointer layerCode = layerSection.readWord(ImageLayerSection.getEntryOffset(CODE_START));
+            /*
+             * Note that the code base can be above the layer's code section, in which case the
+             * subtraction underflows and the additions of code address computations overflow,
+             * giving the correct result.
+             */
+            Word layerCodeOffsetToBase = (Word) layerCode.subtract(codeBase);
+            offset = applyLayerCodePointerPatches(data, offset, layerHeapRelocs, layerCodeOffsetToBase);
+
+            /* Patch absolute addresses to become relative to the code base. */
+            Word negativeCodeBase = Word.<Word> zero().subtract(codeBase);
+            offset = applyLayerCodePointerPatches(data, offset, layerHeapRelocs, negativeCodeBase);
+
+            /* Patch references in the image heap. */
+            offset = applyLayerImageHeapRefPatches(data, offset, initialLayerImageHeap);
+
+            applyLayerImageHeapFieldUpdatePatches(data, offset, initialLayerImageHeap);
+
+            layerSection = layerSection.readWord(ImageLayerSection.getEntryOffset(NEXT_SECTION));
+        }
+
+        heapPatchStateAddr.writeWordVolatile(0, ImageHeapPatchingState.SUCCESSFUL);
+    }
+
+    @Uninterruptible(reason = "Thread state not yet set up.")
+    private static int skipSingletonsTable(Pointer data, int offset, int referenceSize) {
+        long singletonTableEntryCount = data.readLong(offset);
+        UnsignedWord singletonTableAlignedSize = roundUp(unsigned(singletonTableEntryCount * referenceSize), unsigned(Long.BYTES));
+        return offset + Long.BYTES + UnsignedUtils.safeToInt(singletonTableAlignedSize);
+    }
+
+    @Uninterruptible(reason = "Thread state not yet set up.")
+    private static int applyLayerCodePointerPatches(Pointer data, int startOffset, Pointer layerHeapRelocs, Word addend) {
+        int wordSize = ConfigurationValues.getTarget().wordSize;
+
+        int offset = startOffset;
+        long bitmapWordCountAsLong = data.readLong(offset);
+        int bitmapWordCount = UninterruptibleUtils.NumUtil.safeToInt(bitmapWordCountAsLong);
+        offset += Long.BYTES;
+        if (addend.equal(0)) {
+            /* Nothing to do. */
+            offset += bitmapWordCount * Long.BYTES;
+            return offset;
+        }
+
+        for (int i = 0; i < bitmapWordCount; i++) {
+            long bits = data.readLong(offset);
+            offset += Long.BYTES;
+            int j = 0; // index of a 1-bit
+            while (bits != 0) {
+                int ntz = UninterruptibleUtils.Long.countTrailingZeros(bits);
+                j += ntz;
+
+                int at = (i * 64 + j) * wordSize;
+                Word w = layerHeapRelocs.readWord(at);
+                w = w.add(addend);
+                layerHeapRelocs.writeWord(at, w);
+
+                /*
+                 * Note that we must not shift by ntz+1 here because it can be 64, which would be a
+                 * no-op according to the Java Language Specification, 15.19. Shift Operators.
+                 */
+                bits = (bits >>> ntz) >>> 1;
+                j++;
+            }
+        }
+        return offset;
+    }
+
+    /**
+     * See {@code CrossLayerConstantRegistryFeature#generateRelocationPatchArray} for more details
+     * about the layout.
+     */
+    @Uninterruptible(reason = "Thread state not yet set up.")
+    private static int applyLayerImageHeapRefPatches(Pointer patches, int startOffset, Pointer layerImageHeap) {
+        int referenceSize = ConfigurationValues.getObjectLayout().getReferenceSize();
+        int offset = startOffset;
+        long countAsLong = patches.readLong(offset);
+        int count = UninterruptibleUtils.NumUtil.safeToInt(countAsLong);
+        offset += Long.BYTES;
+        int endOffset = offset + count * Integer.BYTES;
+        while (offset < endOffset) {
+            int heapOffset = patches.readInt(offset);
+            int referenceEncoding = patches.readInt(offset + Integer.BYTES);
+            offset += 2 * Integer.BYTES;
+            if (referenceSize == 4) {
+                layerImageHeap.writeInt(heapOffset, referenceEncoding);
+            } else {
+                layerImageHeap.writeLong(heapOffset, referenceEncoding);
+            }
+        }
+        return endOffset;
+    }
+
+    /**
+     * See {@code CrossLayerUpdaterFeature#generateUpdatePatchArray} for more details about the
+     * layout.
+     */
+    @Uninterruptible(reason = "Thread state not yet set up.")
+    private static int applyLayerImageHeapFieldUpdatePatches(Pointer patches, int startOffset, Pointer layerImageHeap) {
+        long countAsLong = patches.readLong(startOffset);
+        if (countAsLong == 0) {
+            // empty - nothing to do
+            return startOffset + Long.BYTES;
+        }
+
+        int headerSize = patches.readInt(startOffset + Long.BYTES);
+
+        int headerOffset = startOffset + Long.BYTES + Integer.BYTES;
+        int headerEndOffset = headerOffset + headerSize;
+
+        // calculate entry offset start
+        int entryOffset = headerEndOffset;
+
+        /* Now update values. */
+        while (headerOffset < headerEndOffset) {
+            // read appropriate slot of header
+            int valueSize = patches.readInt(headerOffset);
+            headerOffset += Integer.BYTES;
+            int numEntries = patches.readInt(headerOffset);
+            headerOffset += Integer.BYTES;
+            for (int j = 0; j < numEntries; j++) {
+                int heapOffset = patches.readInt(entryOffset);
+                entryOffset += Integer.BYTES;
+                switch (valueSize) {
+                    case 1 -> {
+                        byte value = patches.readByte(entryOffset);
+                        layerImageHeap.writeByte(heapOffset, value);
+                        entryOffset += Byte.BYTES;
+                    }
+                    case 4 -> {
+                        int value = patches.readInt(entryOffset);
+                        layerImageHeap.writeInt(heapOffset, value);
+                        entryOffset += Integer.BYTES;
+                    }
+                    case 8 -> {
+                        long value = patches.readLong(entryOffset);
+                        layerImageHeap.writeLong(heapOffset, value);
+                        entryOffset += Long.BYTES;
+                    }
+                    default -> throw VMError.shouldNotReachHereAtRuntime();
+                }
+            }
+        }
+
+        VMError.guarantee((startOffset + Long.BYTES + Integer.BYTES + countAsLong) == entryOffset);
+        return entryOffset;
+    }
+}

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/c/codegen/CCompilerInvoker.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/c/codegen/CCompilerInvoker.java
@@ -290,7 +290,7 @@ public abstract class CCompilerInvoker {
 
     }
 
-    @SingletonTraits(access = BuildtimeAccessOnly.class, layeredCallbacks = NoLayeredCallbacks.class, other = Disallowed.class)
+    @SingletonTraits(access = BuildtimeAccessOnly.class, layeredCallbacks = NoLayeredCallbacks.class)
     private static class DarwinCCompilerInvoker extends CCompilerInvoker {
 
         DarwinCCompilerInvoker(Path tempDirectory) {

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/image/AbstractImage.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/image/AbstractImage.java
@@ -57,7 +57,12 @@ public abstract class AbstractImage {
         IMAGE_LAYER(false, true) {
             @Override
             protected String getFilenameSuffix() {
-                return ".so";
+                return switch (ObjectFile.getNativeFormat()) {
+                    case ELF -> ".so";
+                    case MACH_O -> ".dylib";
+                    case PECOFF -> ".dll";
+                    default -> throw new AssertionError("Unreachable");
+                };
             }
         },
         SHARED_LIBRARY(false) {

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/image/CCLinkerInvocation.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/image/CCLinkerInvocation.java
@@ -485,6 +485,7 @@ public abstract class CCLinkerInvocation implements LinkerInvocation {
                 case STATIC_EXECUTABLE:
                     // checked in the definition of --static
                     throw VMError.shouldNotReachHereUnexpectedInput(imageKind);
+                case IMAGE_LAYER:
                 case SHARED_LIBRARY:
                     cmd.add("-shared");
                     if (Platform.includedIn(Platform.DARWIN.class)) {

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/image/LIRNativeImageCodeCache.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/image/LIRNativeImageCodeCache.java
@@ -273,6 +273,14 @@ public class LIRNativeImageCodeCache extends NativeImageCodeCache {
                             continue;
                         }
 
+                        if (callee.isCompiledInPriorLayer()) {
+                            /*
+                             * Cross-layer calls are resolved via relocations at link/load time,
+                             * not via trampolines in the current layer's code area.
+                             */
+                            continue;
+                        }
+
                         int calleeStart = curOffsetMap.get(callee);
 
                         int maxDistance;

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/imagelayer/HostedImageLayerBuildingSupport.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/imagelayer/HostedImageLayerBuildingSupport.java
@@ -324,9 +324,9 @@ public final class HostedImageLayerBuildingSupport extends ImageLayerBuildingSup
         return false;
     }
 
-    /** Currently layered images are only supported on {@link LINUX_AMD64}. */
+    /** Layered images are supported on Linux AMD64/AARCH64 and Darwin AARCH64. */
     private static boolean supportedPlatform(Platform platform) {
-        return platform instanceof LINUX_AMD64;
+        return platform instanceof LINUX_AMD64 || platform instanceof Platform.LINUX_AARCH64 || platform instanceof Platform.DARWIN_AARCH64;
     }
 
     public static HostedImageLayerBuildingSupport initialize(HostedOptionValues values, ImageClassLoader imageClassLoader, Path builderTempDir) {


### PR DESCRIPTION
## Summary

Native Image Layers were previously restricted to Linux AMD64. This PR extends layer support to **macOS/aarch64** and **Linux/aarch64**.

### AArch64 backend changes
- Add `forceIndirectCall()` to `shouldEmitIndirectCall()`, matching the AMD64 backend
- Handle cross-layer method calls in `emitIndirectForeignCallAddress()` via `DynamicImageLayerInfo` (both delayed and prior-layer methods)
- Implement `createLoadMethodPointerConstant()` for extension layers (previously threw `VMError.unimplemented`)
- Add addend constructor to `AArch64CGlobalDataLoadAddressOp` for prior-layer method offset calculation
- Skip cross-layer callees in `LIRNativeImageCodeCache.addDirectCallTrampolines()`

### Darwin platform changes
- Extend `DarwinImageHeapProvider` with full layered image heap initialization using `vm_copy()` per layer section, with read-only page protection
- Extract platform-independent patching code from `LinuxImageHeapProvider` into new shared `LayeredImageHeapSupport` class
- Update all Darwin singleton annotations from `Disallowed` to appropriate layered kinds (`InitialLayerOnly` / `Independent`)
- Make `IMAGE_LAYER` file suffix format-aware (`.dylib` on macOS, `.so` on Linux)
- Add `IMAGE_LAYER` case to `DarwinCCLinkerInvocation`

### Platform gate
- Add `DARWIN_AARCH64` and `LINUX_AARCH64` to `HostedImageLayerBuildingSupport.supportedPlatform()`

## Test plan

- [x] Base layer creation (`-H:LayerCreate`) produces valid `.dylib` on macOS/aarch64
- [x] Extension layer creation (`-H:LayerUse`) produces thin executable that links against base layer
- [x] Extension layer binary runs correctly, resolving system properties and printing output
- [x] Cross-layer method calls (safepoint slowpaths, etc.) resolved via indirect calls through `CGlobalData` addresses
- [x] No regressions on existing Linux AMD64 layer path (patching code extracted to shared class, behavior unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)