### PR TITLE
Emit declarative element segments for ref.func references in WasmGC

### DIFF
--- a/web-image/src/com.oracle.svm.hosted.webimage/src/com/oracle/svm/hosted/webimage/wasm/ast/WasmModule.java
+++ b/web-image/src/com.oracle.svm.hosted.webimage/src/com/oracle/svm/hosted/webimage/wasm/ast/WasmModule.java
@@ -28,9 +28,11 @@ package com.oracle.svm.hosted.webimage.wasm.ast;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.SequencedMap;
+import java.util.Set;
 
 import com.oracle.svm.hosted.webimage.wasm.ast.id.WasmId;
 import com.oracle.svm.hosted.webimage.wasmgc.ast.RecursiveGroup;
@@ -64,6 +66,16 @@ public class WasmModule {
     protected List<Data> dataSegments = new ArrayList<>();
 
     protected final ActiveData activeData = new ActiveData();
+
+    /**
+     * Functions that need to be declared in a declarative element segment.
+     * <p>
+     * Per the WebAssembly spec, any function referenced by {@code ref.func} outside of an
+     * active/passive element segment must be declared in a declarative element segment.
+     * This is required for validation by strict validators like {@code wasm-tools validate}
+     * and {@code wasmtime}.
+     */
+    protected final Set<WasmId.Func> declarativeFuncRefs = new LinkedHashSet<>();
 
     protected StartFunction startFunction = null;
 
@@ -159,6 +171,17 @@ public class WasmModule {
 
     public void addActiveData(long offset, byte[] data) {
         activeData.addData(offset, data);
+    }
+
+    /**
+     * Declares a function reference for a declarative element segment.
+     */
+    public void addDeclarativeFuncRef(WasmId.Func func) {
+        declarativeFuncRefs.add(func);
+    }
+
+    public Set<WasmId.Func> getDeclarativeFuncRefs() {
+        return Collections.unmodifiableSet(declarativeFuncRefs);
     }
 
     public void constructActiveDataSegments() {

--- a/web-image/src/com.oracle.svm.hosted.webimage/src/com/oracle/svm/hosted/webimage/wasm/ast/visitors/WasmPrinter.java
+++ b/web-image/src/com.oracle.svm.hosted.webimage/src/com/oracle/svm/hosted/webimage/wasm/ast/visitors/WasmPrinter.java
@@ -27,6 +27,8 @@ package com.oracle.svm.hosted.webimage.wasm.ast.visitors;
 
 import java.io.IOException;
 import java.io.Writer;
+import java.util.LinkedHashSet;
+import java.util.Set;
 
 import com.oracle.svm.hosted.webimage.options.WebImageOptions;
 import com.oracle.svm.hosted.webimage.wasm.WebImageWasmOptions;
@@ -375,15 +377,79 @@ public class WasmPrinter extends WasmVisitor {
     @Override
     @SuppressWarnings("try")
     public void visitModule(WasmModule m) {
+        collectDeclarativeFuncRefs(m);
+
         parenOpen("module");
         space();
         try (var ignored = new Indenter()) {
             super.visitModule(m);
+            emitDeclarativeFuncRefs(m);
         }
         newline();
 
         print(')');
         newline();
+    }
+
+    /**
+     * Emits declarative element segments for all functions referenced by {@code ref.func}.
+     * <p>
+     * In WAT: {@code (elem declare func $f1 $f2 ...)}
+     */
+    private void emitDeclarativeFuncRefs(WasmModule m) {
+        Set<WasmId.Func> funcRefs = m.getDeclarativeFuncRefs();
+        if (funcRefs.isEmpty()) {
+            return;
+        }
+
+        newline();
+        newline();
+        printComment("Declarative element segment for ref.func declarations");
+        newline();
+        parenOpen("elem declare func");
+        for (WasmId.Func func : funcRefs) {
+            space();
+            printId(func);
+        }
+        parenClose();
+    }
+
+    /**
+     * Scans all functions and globals for {@code ref.func} instructions and registers them
+     * as declarative function references in the module.
+     * <p>
+     * Per the WebAssembly spec, functions referenced by {@code ref.func} outside of active
+     * or passive element segments must be declared in a declarative element segment
+     * ({@code (elem declare func ...)}).
+     */
+    private void collectDeclarativeFuncRefs(WasmModule m) {
+        Set<WasmId.Func> funcRefs = new LinkedHashSet<>();
+
+        // Collect from function bodies
+        RefFuncCollector collector = new RefFuncCollector(funcRefs);
+        for (Function func : m.getFunctions()) {
+            collector.visitFunction(func);
+        }
+
+        // Collect from global initializers
+        for (Global global : m.getGlobals().sequencedValues()) {
+            collector.visitInstruction(global.init);
+        }
+
+        // Collect from table element initializers
+        for (Table table : m.getTables()) {
+            if (table.elements != null) {
+                for (Instruction elem : table.elements) {
+                    collector.visitInstruction(elem);
+                }
+            }
+        }
+
+        // Functions already in active table elements don't need declarative declaration,
+        // but including them is harmless and simpler than filtering.
+        for (WasmId.Func func : funcRefs) {
+            m.addDeclarativeFuncRef(func);
+        }
     }
 
     @Override
@@ -1482,5 +1548,23 @@ public class WasmPrinter extends WasmVisitor {
             super.visitAnyExternConversion(inst);
         }
         newline();
+    }
+
+    /**
+     * Visitor that collects all function IDs referenced by {@code ref.func} instructions.
+     */
+    private static class RefFuncCollector extends WasmVisitor {
+
+        private final Set<WasmId.Func> funcRefs;
+
+        RefFuncCollector(Set<WasmId.Func> funcRefs) {
+            this.funcRefs = funcRefs;
+        }
+
+        @Override
+        public void visitRefFunc(Instruction.RefFunc inst) {
+            funcRefs.add(inst.func);
+            super.visitRefFunc(inst);
+        }
     }
 }


### PR DESCRIPTION
## Summary

The WebAssembly spec requires that functions referenced by `ref.func` outside of active/passive element segments must be declared in a declarative element segment (`elem declare func ...`). The WasmGC backend uses `ref.func` in heap initialization code (DynamicHub `newInstance` and `clone` function pointers) but never emits the required declarations.

This causes validation failures with strict validators:
- `wasm-tools validate` reports "undeclared function reference"
- `wasmtime` rejects modules assembled by `wasm-tools parse`
- Binaryen's `wasm-as` silently adds declarations, masking the issue

### Changes

- Add `declarativeFuncRefs` set to `WasmModule` to track functions needing declarative element segments
- Add `RefFuncCollector` visitor in `WasmPrinter` that scans all function bodies, globals, and table initializers for `ref.func` instructions
- Emit `(elem declare func ...)` in the WAT output with all collected references

The fix is general — it handles any current or future `ref.func` usage automatically, not just the heap initialization paths.

## Test plan

- [ ] Existing WasmGC tests pass (no behavioral change — Binaryen already handled this implicitly)
- [ ] `wasm-tools validate --features all` passes on WasmGC output
- [ ] `wasm-tools parse` successfully assembles WasmGC WAT to binary