### PR TITLE
Fix native-image metadata docs and schema links

### DIFF
--- a/docs/reference-manual/native-image/Compatibility.md
+++ b/docs/reference-manual/native-image/Compatibility.md
@@ -27,7 +27,7 @@ We recommend to check [Native Image Basics](NativeImageBasics.md) for a detailed
 To be suitable for closed-world assumption, the following Java features generally require metadata to pass to `native-image` at build time. 
 This metadata ensures that a native image uses the minimum amount of space necessary.
 
-The compatibility of Native Image with the most popular Java libraries was recently enhanced by publishing [shared reachability metadata on GitHub](https://github.com/oracle/graalvm-reachability). The users can share the burden of maintaining metadata for third-party dependencies and reuse it.
+The compatibility of Native Image with the most popular Java libraries was recently enhanced by publishing [shared reachability metadata on GitHub](https://github.com/oracle/graalvm-reachability-metadata). Users can share the burden of maintaining metadata for third-party dependencies and reuse it.
 See [Reachability Metadata](ReachabilityMetadata.md) to learn more.
 
 ## Features Incompatible with Closed-World Assumption
@@ -109,4 +109,4 @@ Find a list of options for the `native-image` builder [here](BuildOptions.md).
 
 * [Class Initialization in Native Image](ClassInitialization.md)
 * [Reachability Metadata](ReachabilityMetadata.md)
-* [GraalVM Reachability Metadata Repository](https://github.com/oracle/graalvm-reachability)
+* [GraalVM Reachability Metadata Repository](https://github.com/oracle/graalvm-reachability-metadata)

--- a/docs/reference-manual/native-image/assets/dynamic-access-metadata-schema-v1.0.0.json
+++ b/docs/reference-manual/native-image/assets/dynamic-access-metadata-schema-v1.0.0.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2019-09/schema",
-  "$id": "https://github.com/oracle/graal/blob/master/docs/reference-manual/native-image/assets/dynamic-access-metadata-v1.0.0.json",
+  "$id": "https://github.com/oracle/graal/blob/master/docs/reference-manual/native-image/assets/dynamic-access-metadata-schema-v1.0.0.json",
   "title": "JSON schema for library support metadata used by the Dynamic Access tab of the GraalVM Native Image Build Report",
   "version": "1.0.0",
   "type": "array",

--- a/docs/reference-manual/native-image/assets/embedded-resources-schema-v1.1.0.json
+++ b/docs/reference-manual/native-image/assets/embedded-resources-schema-v1.1.0.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2019-09/schema",
-  "$id": "https://github.com/oracle/graal/blob/master/docs/reference-manual/native-image/assets/embedded-resources-schema-v1.0.0.json",
+  "$id": "https://github.com/oracle/graal/blob/master/docs/reference-manual/native-image/assets/embedded-resources-schema-v1.1.0.json",
   "default": [],
   "items": {
     "properties": {

--- a/docs/reference-manual/native-image/contribute/Contributing.md
+++ b/docs/reference-manual/native-image/contribute/Contributing.md
@@ -17,6 +17,6 @@ There are two common ways to contribute:
 
 If you want to contribute changes to Native Image core, you must adhere to the project's standards of quality. For more information, see [Native Image Code Style](CodeStyle.md).
 
-If you would like to ensure complete compatibility of your library with Native Image, consider contributing your library metadata to the [GraalVM Reachability Metadata Repository](https://github.com/oracle/graalvm-reachability-metadata). 
-Follow [contributing rules](https://github.com/oracle/graalvm-reachability-metadata/blob/master/CONTRIBUTING.md) for this repository. 
+If you would like to ensure complete compatibility of your library with Native Image, consider contributing your library metadata to the [GraalVM Reachability Metadata Repository](https://github.com/oracle/graalvm-reachability-metadata).
+Follow [contributing rules](https://github.com/oracle/graalvm-reachability-metadata/blob/master/docs/CONTRIBUTING.md) for this repository.
 Using this open source repository, users can share the burden of maintaining metadata for third-party dependencies.


### PR DESCRIPTION
## Summary
- fix stale Native Image documentation links to the Reachability Metadata repository
- correct schema $id values for dynamic-access-metadata and embedded-resources assets