### PR TITLE
Fix mx unittest launch for configure tests

### DIFF
--- a/substratevm/mx.substratevm/mx_substratevm.py
+++ b/substratevm/mx.substratevm/mx_substratevm.py
@@ -3655,10 +3655,7 @@ class SVMInvariantsUnittestConfig(mx_compiler.GraalUnittestConfig):
 mx_unittest.register_unittest_config(SVMInvariantsUnittestConfig())
 
 
-class SVMDriverUnittestsConfig(mx_unittest.MxUnittestConfig):
-
-    def __init__(self):
-        super().__init__('svm-driver-unittest')
+class SVMUnittestsConfig(mx_unittest.MxUnittestConfig):
 
     def apply(self, config):
         vmArgs, mainClass, mainClassArgs = config
@@ -3678,7 +3675,8 @@ class SVMDriverUnittestsConfig(mx_unittest.MxUnittestConfig):
 
         return (vmArgs, mainClass, mainClassArgs)
 
-mx_unittest.register_unittest_config(SVMDriverUnittestsConfig())
+mx_unittest.register_unittest_config(SVMUnittestsConfig('svm-driver-unittest'))
+mx_unittest.register_unittest_config(SVMUnittestsConfig('svm-unittest'))
 
 
 @mx.command(suite, 'update-build-options-table', usage_msg='[--check] - Update or verify the BuildOptions.md table')

--- a/substratevm/mx.substratevm/suite.py
+++ b/substratevm/mx.substratevm/suite.py
@@ -2879,6 +2879,7 @@ suite = {
             "SVM",
             "SVM_CONFIGURE",
           ],
+          "unittestConfig" : "svm-unittest",
           "testDistribution" : True,
         },
 


### PR DESCRIPTION
## Summary

- Make the existing SVM unit-test launch configuration reusable.
- Apply it to `SVM_TESTS` so configure tests receive the required module exports and package opens.
- On current `master`, `mx unittest ResourceConfigurationTest` fails during JUnit discovery with an `IllegalAccessError`.

## Related Issues

- Found while testing #13195.

## Testing

- `mx build --dependencies=SVM_TESTS --build-logs=silent`
- `mx unittest ResourceConfigurationTest` (`OK (3 tests)`)
- `mx unittest com.oracle.svm.configure.test` (`OK (26 tests)`)
- `mx checkstyle`

## Documentation

- No documentation updates are needed because this only changes the local unit-test launch configuration.

## Contributor Checklist

- [x] I have read the contribution guide.
- [x] I have the right to contribute the submitted material under the project terms.
- [x] I have updated tests and documentation where appropriate.
- [x] If I used a coding assistant, I remain responsible for the entire contribution and have reviewed it accordingly.
