### PR TITLE
[GR-67556][Native Image] Preserve module-qualified resource bundles in Native Image metadata

### DIFF
--- a/docs/reference-manual/native-image/ReachabilityMetadata.md
+++ b/docs/reference-manual/native-image/ReachabilityMetadata.md
@@ -740,6 +740,8 @@ To request a bundle from a specific module:
 }
 ```
 
+Use `"module": "ALL-UNNAMED"` to restrict bundle lookup to the class path instead of allowing the same bundle name to resolve from named modules.
+
 Resource bundles are included for all locales that are [included into the image](#locales).
 
 ### Locales

--- a/docs/reference-manual/native-image/assets/resource-config-schema-v1.1.0.json
+++ b/docs/reference-manual/native-image/assets/resource-config-schema-v1.1.0.json
@@ -120,6 +120,10 @@
             "additionalProperties": false,
             "type": "object"
           },
+          "module": {
+            "type": "string",
+            "title": "Module containing the resource bundle"
+          },
           "name": {
             "type": "string",
             "title": "Fully qualified name of the resource bundle"

--- a/sdk/src/org.graalvm.nativeimage/src/org/graalvm/nativeimage/hosted/RuntimeResourceAccess.java
+++ b/sdk/src/org.graalvm.nativeimage/src/org/graalvm/nativeimage/hosted/RuntimeResourceAccess.java
@@ -108,7 +108,7 @@ public final class RuntimeResourceAccess {
         deprecationFlag.printDeprecationWarning();
         Objects.requireNonNull(locales);
         RuntimeResourceSupport.singleton().addResourceBundles(AccessCondition.unconditional(),
-                        withModuleName(module, baseBundleName), Arrays.asList(locales));
+                        moduleName(module), baseBundleName, Arrays.asList(locales));
     }
 
     /**
@@ -123,13 +123,12 @@ public final class RuntimeResourceAccess {
     public static void addResourceBundle(Module module, String bundleName) {
         deprecationFlag.printDeprecationWarning();
         RuntimeResourceSupport.singleton().addResourceBundles(AccessCondition.unconditional(),
-                        false, withModuleName(module, bundleName));
+                        false, moduleName(module), bundleName);
     }
 
-    private static String withModuleName(Module module, String str) {
+    private static String moduleName(Module module) {
         Objects.requireNonNull(module);
-        Objects.requireNonNull(str);
-        return module.isNamed() ? module.getName() + ":" + str : str;
+        return module.isNamed() ? module.getName() : null;
     }
 
     private RuntimeResourceAccess() {

--- a/sdk/src/org.graalvm.nativeimage/src/org/graalvm/nativeimage/hosted/RuntimeResourceAccess.java
+++ b/sdk/src/org.graalvm.nativeimage/src/org/graalvm/nativeimage/hosted/RuntimeResourceAccess.java
@@ -60,6 +60,7 @@ import org.graalvm.nativeimage.impl.RuntimeResourceSupport;
 public final class RuntimeResourceAccess {
 
     private static final APIDeprecationSupport deprecationFlag = ImageSingletons.lookup(APIDeprecationSupport.class);
+    private static final String ALL_UNNAMED_MODULE = "ALL-UNNAMED";
 
     /**
      * Make Java resource {@code resourcePath} from {@code module} available at run time. If the
@@ -106,9 +107,10 @@ public final class RuntimeResourceAccess {
      */
     public static void addResourceBundle(Module module, String baseBundleName, Locale[] locales) {
         deprecationFlag.printDeprecationWarning();
+        Objects.requireNonNull(baseBundleName);
         Objects.requireNonNull(locales);
         RuntimeResourceSupport.singleton().addResourceBundles(AccessCondition.unconditional(),
-                        moduleName(module), baseBundleName, Arrays.asList(locales));
+                        bundleModuleName(module), baseBundleName, Arrays.asList(locales));
     }
 
     /**
@@ -122,13 +124,14 @@ public final class RuntimeResourceAccess {
      */
     public static void addResourceBundle(Module module, String bundleName) {
         deprecationFlag.printDeprecationWarning();
+        Objects.requireNonNull(bundleName);
         RuntimeResourceSupport.singleton().addResourceBundles(AccessCondition.unconditional(),
-                        false, moduleName(module), bundleName);
+                        false, bundleModuleName(module), bundleName);
     }
 
-    private static String moduleName(Module module) {
+    private static String bundleModuleName(Module module) {
         Objects.requireNonNull(module);
-        return module.isNamed() ? module.getName() : null;
+        return module.isNamed() ? module.getName() : ALL_UNNAMED_MODULE;
     }
 
     private RuntimeResourceAccess() {

--- a/sdk/src/org.graalvm.nativeimage/src/org/graalvm/nativeimage/impl/RuntimeResourceSupport.java
+++ b/sdk/src/org.graalvm.nativeimage/src/org/graalvm/nativeimage/impl/RuntimeResourceSupport.java
@@ -61,7 +61,15 @@ public interface RuntimeResourceSupport<C> {
 
     void addResourceBundles(C condition, boolean preserved, String name);
 
+    default void addResourceBundles(C condition, boolean preserved, String moduleName, String name) {
+        addResourceBundles(condition, preserved, qualifyBundleName(moduleName, name));
+    }
+
     void addResourceBundles(C condition, String basename, Collection<Locale> locales);
+
+    default void addResourceBundles(C condition, String moduleName, String basename, Collection<Locale> locales) {
+        addResourceBundles(condition, qualifyBundleName(moduleName, basename), locales);
+    }
 
     /* Following functions are used only from features */
     void addCondition(AccessCondition condition, Module module, String resourcePath);
@@ -78,4 +86,9 @@ public interface RuntimeResourceSupport<C> {
     }
 
     void injectResource(Module module, String resourcePath, byte[] resourceContent, Object origin);
+
+    /* Adapter for legacy string-based bundle registration APIs. */
+    private static String qualifyBundleName(String moduleName, String bundleName) {
+        return moduleName != null && !moduleName.isEmpty() ? moduleName + ":" + bundleName : bundleName;
+    }
 }

--- a/substratevm/mx.substratevm/mx_substratevm.py
+++ b/substratevm/mx.substratevm/mx_substratevm.py
@@ -556,6 +556,13 @@ def svm_gate_body(args, tasks):
     with Task('hosted jvm unittests', tasks, tags=[GraalTags.native_unittests]) as t:
         if t:
             jvm_unittest(['--record-results', '--print-failed', 'failed.txt',
+                          '--add-exports=jdk.internal.vm.ci/jdk.vm.ci.meta=ALL-UNNAMED',
+                          '--add-exports=jdk.internal.vm.ci/jdk.vm.ci.meta.annotation=ALL-UNNAMED',
+                          '--add-exports=jdk.internal.vm.ci/jdk.vm.ci.meta.annotation=jdk.graal.compiler.vmaccess',
+                          '--add-exports=jdk.internal.vm.ci/jdk.vm.ci.code=ALL-UNNAMED',
+                          '--add-exports=jdk.graal.compiler/jdk.graal.compiler.util.json=ALL-UNNAMED',
+                          '--add-exports=org.graalvm.nativeimage/org.graalvm.nativeimage.impl=ALL-UNNAMED',
+                          '--add-opens=org.graalvm.nativeimage/org.graalvm.nativeimage.impl=ALL-UNNAMED',
                           'com.oracle.svm.hosted.jdk.localization'])
 
     with Task('conditional configuration tests', tasks, tags=[GraalTags.condconfig]) as t:

--- a/substratevm/mx.substratevm/mx_substratevm.py
+++ b/substratevm/mx.substratevm/mx_substratevm.py
@@ -553,6 +553,11 @@ def svm_gate_body(args, tasks):
                 with native_image_context(IMAGE_ASSERTION_FLAGS) as native_image:
                     java_desktop_integration_task(native_image, args.extra_image_builder_arguments)
 
+    with Task('hosted jvm unittests', tasks, tags=[GraalTags.native_unittests]) as t:
+        if t:
+            jvm_unittest(['--record-results', '--print-failed', 'failed.txt',
+                          'com.oracle.svm.hosted.jdk.localization'])
+
     with Task('conditional configuration tests', tasks, tags=[GraalTags.condconfig]) as t:
         if t:
             with native_image_context(IMAGE_ASSERTION_FLAGS) as native_image:

--- a/substratevm/mx.substratevm/suite.py
+++ b/substratevm/mx.substratevm/suite.py
@@ -1324,6 +1324,31 @@ suite = {
             "jacoco" : "exclude",
         },
 
+        "com.oracle.svm.hosted.test": {
+            "subDir": "src",
+            "sourceDirs": ["src"],
+            "dependencies": [
+                "mx:JUNIT_TOOL",
+                "sdk:NATIVEIMAGE",
+                "com.oracle.svm.hosted",
+            ],
+            "requiresConcealed": {
+                "jdk.internal.vm.ci": [
+                    "jdk.vm.ci.meta",
+                    "jdk.vm.ci.meta.annotation",
+                ],
+            },
+            "checkstyle": "com.oracle.svm.test",
+            "workingSets": "SVM",
+            "annotationProcessors": [
+                "compiler:GRAAL_PROCESSOR",
+                "SVM_PROCESSOR",
+            ],
+            "javaCompliance" : "24+",
+            "testProject": True,
+            "jacoco" : "exclude",
+        },
+
         "com.oracle.svm.tutorial" : {
             "subDir": "src",
             "sourceDirs" : ["src"],
@@ -2796,6 +2821,21 @@ suite = {
             "com.oracle.svm.test.debug",
             "com.oracle.svm.test.debug.missing.classes",
             "SVM_TEST_RESOURCE_WITH_SPACE",
+          ],
+          "distDependencies": [
+            "mx:JUNIT_TOOL",
+            "sdk:NATIVEIMAGE",
+            "SVM",
+            "SVM_CONFIGURE",
+          ],
+          "testDistribution" : True,
+        },
+
+        "SVM_HOSTED_TESTS" : {
+          "subDir": "src",
+          "relpath" : True,
+          "dependencies" : [
+            "com.oracle.svm.hosted.test",
           ],
           "distDependencies": [
             "mx:JUNIT_TOOL",

--- a/substratevm/src/com.oracle.svm.configure.test/src/com/oracle/svm/configure/test/config/ResourceConfigurationTest.java
+++ b/substratevm/src/com.oracle.svm.configure.test/src/com/oracle/svm/configure/test/config/ResourceConfigurationTest.java
@@ -29,6 +29,7 @@ import java.io.IOException;
 import java.io.PipedReader;
 import java.io.PipedWriter;
 import java.io.StringReader;
+import java.io.StringWriter;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.EnumSet;
@@ -93,7 +94,54 @@ public class ResourceConfigurationTest {
             List<String> addedResources = new LinkedList<>();
             List<String> ignoredResources = new LinkedList<>();
 
-            ResourceConfigurationParser<UnresolvedAccessCondition> rcp = createParser(newTestRegistry(addedResources, ignoredResources));
+            ResourcesRegistry<UnresolvedAccessCondition> registry = new ResourcesRegistry<>() {
+
+                @Override
+                public void addResources(UnresolvedAccessCondition condition, String pattern, Object origin) {
+                    addedResources.add(pattern);
+                }
+
+                @Override
+                public void addGlob(UnresolvedAccessCondition condition, String module, String glob, Object origin) {
+                    throw new AssertionError("Unused function.");
+                }
+
+                @Override
+                public void addResourceEntry(Module module, String resourcePath, Object origin) {
+                    throw new AssertionError("Unused function.");
+                }
+
+                @Override
+                public void injectResource(Module module, String resourcePath, byte[] resourceContent, Object origin) {
+                }
+
+                @Override
+                public void ignoreResources(UnresolvedAccessCondition condition, String pattern, Object origin) {
+                    ignoredResources.add(pattern);
+                }
+
+                @Override
+                public void addResourceBundles(UnresolvedAccessCondition condition, boolean preserved, String name) {
+                }
+
+                @Override
+                public void addResourceBundles(UnresolvedAccessCondition condition, String basename, Collection<Locale> locales) {
+
+                }
+
+                @Override
+                public void addCondition(AccessCondition accessCondition, Module module, String resourcePath) {
+
+                }
+
+                @Override
+                public void addClassBasedResourceBundle(UnresolvedAccessCondition condition, String basename, String className) {
+
+                }
+            };
+
+            ResourceConfigurationParser<UnresolvedAccessCondition> rcp = ResourceConfigurationParser.create(false, AccessConditionResolver.identityResolver(), registry,
+                            EnumSet.of(ConfigurationParserOption.STRICT_CONFIGURATION));
             writerThread.start();
             rcp.parseAndRegister(pr);
 
@@ -116,6 +164,178 @@ public class ResourceConfigurationTest {
         parser.parseAndRegister(new StringReader(config));
 
         Assert.assertEquals(List.of("\\QMETA-INF/services/com.alibaba.csp.sentinel.cluster.TokenService\\E"), ignoredResources);
+    }
+
+    @Test
+    public void moduleQualifiedBundlesRoundTripInLegacyConfig() throws IOException {
+        String json = """
+                        {
+                          "resources": {
+                            "includes": []
+                          },
+                          "bundles": [
+                            {
+                              "module": "first.module",
+                              "name": "com.example.Messages",
+                              "locales": ["en-US"]
+                            },
+                            {
+                              "module": "second.module",
+                              "name": "com.example.Messages",
+                              "classNames": ["com.example.MessagesBundle"]
+                            }
+                          ],
+                          "globs": []
+                        }
+                        """;
+
+        ResourceConfiguration rc = new ResourceConfiguration();
+        rc.createParser(false, EnumSet.of(ConfigurationParserOption.STRICT_CONFIGURATION)).parseAndRegister(new StringReader(json));
+
+        UnresolvedAccessCondition condition = UnresolvedAccessCondition.unconditional();
+        Assert.assertTrue(rc.anyBundleMatches(condition, "first.module", "com.example.Messages"));
+        Assert.assertTrue(rc.anyBundleMatches(condition, "second.module", "com.example.Messages"));
+        Assert.assertFalse(rc.anyBundleMatches(condition, "com.example.Messages"));
+
+        String printed = printLegacyJson(rc);
+        Assert.assertTrue(printed.contains("\"module\":\"first.module\""));
+        Assert.assertTrue(printed.contains("\"module\":\"second.module\""));
+        Assert.assertTrue(printed.contains("\"name\":\"com.example.Messages\""));
+        Assert.assertTrue(printed.contains("\"classNames\":[\"com.example.MessagesBundle\"]"));
+        Assert.assertTrue(printed.contains("\"locales\":[\"en-US\"]"));
+    }
+
+    @Test
+    public void moduleQualifiedBundlesUseQualifiedNamesForLegacyRegistryCallbacks() throws IOException {
+        String json = """
+                        {
+                          "bundles": [
+                            {
+                              "module": "first.module",
+                              "name": "com.example.Messages",
+                              "locales": ["en-US"]
+                            },
+                            {
+                              "module": "second.module",
+                              "name": "com.example.Messages",
+                              "classNames": ["com.example.MessagesBundle"]
+                            },
+                            {
+                              "module": "third.module",
+                              "name": "com.example.Messages"
+                            }
+                          ]
+                        }
+                        """;
+
+        List<String> localizedBundles = new LinkedList<>();
+        List<String> classBasedBundles = new LinkedList<>();
+        List<String> allLocaleBundles = new LinkedList<>();
+
+        ResourcesRegistry<UnresolvedAccessCondition> registry = new ResourcesRegistry<>() {
+            @Override
+            public void addResources(UnresolvedAccessCondition condition, String pattern, Object origin) {
+                throw new AssertionError("Unused function.");
+            }
+
+            @Override
+            public void addGlob(UnresolvedAccessCondition condition, String module, String glob, Object origin) {
+                throw new AssertionError("Unused function.");
+            }
+
+            @Override
+            public void addResourceEntry(Module module, String resourcePath, Object origin) {
+                throw new AssertionError("Unused function.");
+            }
+
+            @Override
+            public void injectResource(Module module, String resourcePath, byte[] resourceContent, Object origin) {
+            }
+
+            @Override
+            public void ignoreResources(UnresolvedAccessCondition condition, String pattern, Object origin) {
+                throw new AssertionError("Unused function.");
+            }
+
+            @Override
+            public void addResourceBundles(UnresolvedAccessCondition condition, boolean preserved, String name) {
+                allLocaleBundles.add(name);
+            }
+
+            @Override
+            public void addResourceBundles(UnresolvedAccessCondition condition, String basename, Collection<Locale> locales) {
+                localizedBundles.add(basename);
+            }
+
+            @Override
+            public void addCondition(AccessCondition accessCondition, Module module, String resourcePath) {
+            }
+
+            @Override
+            public void addClassBasedResourceBundle(UnresolvedAccessCondition condition, String basename, String className) {
+                classBasedBundles.add(basename + "=" + className);
+            }
+        };
+
+        ResourceConfigurationParser<UnresolvedAccessCondition> parser = ResourceConfigurationParser.create(false, AccessConditionResolver.identityResolver(), registry,
+                        EnumSet.of(ConfigurationParserOption.STRICT_CONFIGURATION));
+        parser.parseAndRegister(new StringReader(json));
+
+        Assert.assertEquals(List.of("first.module:com.example.Messages"), localizedBundles);
+        Assert.assertEquals(List.of("second.module:com.example.Messages=com.example.MessagesBundle"), classBasedBundles);
+        Assert.assertEquals(List.of("third.module:com.example.Messages"), allLocaleBundles);
+    }
+
+    @Test
+    public void moduleQualifiedBundlesRemainDistinctInCombinedConfig() throws IOException {
+        String json = """
+                        {
+                          "resources": [
+                            {
+                              "module": "first.module",
+                              "bundle": "com.example.Messages"
+                            },
+                            {
+                              "module": "second.module",
+                              "bundle": "com.example.Messages"
+                            }
+                          ]
+                        }
+                        """;
+
+        ResourceConfiguration rc = new ResourceConfiguration();
+        rc.createParser(true, EnumSet.of(ConfigurationParserOption.STRICT_CONFIGURATION)).parseAndRegister(new StringReader(json));
+
+        UnresolvedAccessCondition condition = UnresolvedAccessCondition.unconditional();
+        Assert.assertTrue(rc.anyBundleMatches(condition, "first.module", "com.example.Messages"));
+        Assert.assertTrue(rc.anyBundleMatches(condition, "second.module", "com.example.Messages"));
+        Assert.assertFalse(rc.anyBundleMatches(condition, "com.example.Messages"));
+        Assert.assertTrue(rc.supportsCombinedFile());
+
+        String printed = printJson(rc);
+        Assert.assertTrue(printed.contains("\"module\":\"first.module\""));
+        Assert.assertTrue(printed.contains("\"module\":\"second.module\""));
+        Assert.assertTrue(printed.contains("\"bundle\":\"com.example.Messages\""));
+    }
+
+    private static String printLegacyJson(ResourceConfiguration rc) {
+        StringWriter out = new StringWriter();
+        try (JsonWriter writer = new JsonWriter(out)) {
+            rc.printLegacyJson(writer);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+        return out.toString();
+    }
+
+    private static String printJson(ResourceConfiguration rc) {
+        StringWriter out = new StringWriter();
+        try (JsonWriter writer = new JsonWriter(out)) {
+            rc.printJson(writer);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+        return out.toString();
     }
 
     private static ResourceConfigurationParser<UnresolvedAccessCondition> createParser(ResourcesRegistry<UnresolvedAccessCondition> registry) {

--- a/substratevm/src/com.oracle.svm.configure/src/com/oracle/svm/configure/ResourceConfigurationParser.java
+++ b/substratevm/src/com.oracle.svm.configure/src/com/oracle/svm/configure/ResourceConfigurationParser.java
@@ -73,11 +73,14 @@ public abstract class ResourceConfigurationParser<C> extends ConditionalConfigur
         String bundleNameAttribute = inResourcesSection ? BUNDLE_KEY : NAME_KEY;
         checkAttributes(resource, "bundle descriptor object", Collections.singletonList(bundleNameAttribute), Arrays.asList(MODULE_KEY, "locales", "classNames", "condition"));
         String basename = asString(resource.get(bundleNameAttribute));
+        String moduleName = asNullableString(resource.get(MODULE_KEY), MODULE_KEY);
+        if (moduleName != null && moduleName.isEmpty()) {
+            moduleName = null;
+        }
         TypeResult<C> resolvedAccessCondition = conditionResolver.resolveCondition(parseCondition(resource));
         if (!resolvedAccessCondition.isPresent()) {
             return;
         }
-        // TODO GR-67556 - Add full support for MODULE_KEY in ResourceBundle configurations
         Object locales = resource.get("locales");
         if (locales != null) {
             List<Locale> asList = asList(locales, "Attribute 'locales' must be a list of locales")
@@ -85,7 +88,7 @@ public abstract class ResourceConfigurationParser<C> extends ConditionalConfigur
                             .map(ResourceConfigurationParser::parseLocale)
                             .collect(Collectors.toList());
             if (!asList.isEmpty()) {
-                registry.addResourceBundles(resolvedAccessCondition.get(), basename, asList);
+                registry.addResourceBundles(resolvedAccessCondition.get(), moduleName, basename, asList);
             }
 
         }
@@ -94,12 +97,12 @@ public abstract class ResourceConfigurationParser<C> extends ConditionalConfigur
             List<Object> asList = asList(classNames, "Attribute 'classNames' must be a list of classes");
             for (Object o : asList) {
                 String className = asString(o);
-                registry.addClassBasedResourceBundle(resolvedAccessCondition.get(), basename, className);
+                registry.addClassBasedResourceBundle(resolvedAccessCondition.get(), moduleName, basename, className);
             }
         }
         if (locales == null && classNames == null) {
             /* If nothing more precise is specified, register in every included locale */
-            registry.addResourceBundles(resolvedAccessCondition.get(), false, basename);
+            registry.addResourceBundles(resolvedAccessCondition.get(), false, moduleName, basename);
         }
     }
 

--- a/substratevm/src/com.oracle.svm.configure/src/com/oracle/svm/configure/ResourcesRegistry.java
+++ b/substratevm/src/com.oracle.svm.configure/src/com/oracle/svm/configure/ResourcesRegistry.java
@@ -40,6 +40,10 @@ public interface ResourcesRegistry<C> extends RuntimeResourceSupport<C> {
 
     void addClassBasedResourceBundle(C condition, String basename, String className);
 
+    default void addClassBasedResourceBundle(C condition, String moduleName, String basename, String className) {
+        addClassBasedResourceBundle(condition, qualifyBundleName(moduleName, basename), className);
+    }
+
     /**
      * Although the interface-methods below are already defined in the super-interface
      * {@link RuntimeResourceSupport} they are also needed here for legacy code that accesses them
@@ -57,5 +61,19 @@ public interface ResourcesRegistry<C> extends RuntimeResourceSupport<C> {
     void addResourceBundles(C condition, boolean preserved, String name);
 
     @Override
+    default void addResourceBundles(C condition, boolean preserved, String moduleName, String name) {
+        RuntimeResourceSupport.super.addResourceBundles(condition, preserved, moduleName, name);
+    }
+
+    @Override
     void addResourceBundles(C condition, String basename, Collection<Locale> locales);
+
+    @Override
+    default void addResourceBundles(C condition, String moduleName, String basename, Collection<Locale> locales) {
+        RuntimeResourceSupport.super.addResourceBundles(condition, moduleName, basename, locales);
+    }
+
+    private static String qualifyBundleName(String moduleName, String bundleName) {
+        return moduleName != null && !moduleName.isEmpty() ? moduleName + ":" + bundleName : bundleName;
+    }
 }

--- a/substratevm/src/com.oracle.svm.configure/src/com/oracle/svm/configure/config/ResourceConfiguration.java
+++ b/substratevm/src/com.oracle.svm.configure/src/com/oracle/svm/configure/config/ResourceConfiguration.java
@@ -350,7 +350,7 @@ public final class ResourceConfiguration extends ConfigurationBase<ResourceConfi
 
     private BundleConfiguration getOrCreateBundleConfig(UnresolvedAccessCondition condition, String moduleName, String baseName) {
         ConditionalElement<BundleIdentity> key = new ConditionalElement<>(condition, new BundleIdentity(moduleName, baseName));
-        return bundles.computeIfAbsent(key, cond -> new BundleConfiguration(condition, moduleName, baseName));
+        return bundles.computeIfAbsent(key, entry -> new BundleConfiguration(entry.condition(), entry.element().module(), entry.element().baseName()));
     }
 
     public boolean anyResourceMatches(String s) {

--- a/substratevm/src/com.oracle.svm.configure/src/com/oracle/svm/configure/config/ResourceConfiguration.java
+++ b/substratevm/src/com.oracle.svm.configure/src/com/oracle/svm/configure/config/ResourceConfiguration.java
@@ -104,13 +104,28 @@ public final class ResourceConfiguration extends ConfigurationBase<ResourceConfi
         }
 
         @Override
+        public void addResourceBundles(UnresolvedAccessCondition condition, boolean preserved, String moduleName, String baseName) {
+            configuration.addBundle(condition, moduleName, baseName);
+        }
+
+        @Override
         public void addResourceBundles(UnresolvedAccessCondition condition, String basename, Collection<Locale> locales) {
             configuration.addBundle(condition, basename, locales);
         }
 
         @Override
+        public void addResourceBundles(UnresolvedAccessCondition condition, String moduleName, String basename, Collection<Locale> locales) {
+            configuration.addBundle(condition, moduleName, basename, locales);
+        }
+
+        @Override
         public void addClassBasedResourceBundle(UnresolvedAccessCondition condition, String basename, String className) {
             configuration.addClassResourceBundle(condition, basename, className);
+        }
+
+        @Override
+        public void addClassBasedResourceBundle(UnresolvedAccessCondition condition, String moduleName, String basename, String className) {
+            configuration.addClassResourceBundle(condition, moduleName, basename, className);
         }
     }
 
@@ -146,10 +161,17 @@ public final class ResourceConfiguration extends ConfigurationBase<ResourceConfi
         }
     }
 
+    public record BundleIdentity(String module, String baseName) {
+        public static Comparator<BundleIdentity> comparator() {
+            Comparator<String> stringComparator = Comparator.nullsFirst(Comparator.naturalOrder());
+            return Comparator.comparing(BundleIdentity::module, stringComparator).thenComparing(BundleIdentity::baseName, stringComparator);
+        }
+    }
+
     private final Set<ConditionalElement<String>> addedResources = Collections.newSetFromMap(new ConcurrentHashMap<>());
     private final Set<ConditionalElement<ResourceEntry>> addedGlobs = Collections.newSetFromMap(new ConcurrentHashMap<>());
     private final ConcurrentMap<ConditionalElement<String>, Pattern> ignoredResources = new ConcurrentHashMap<>();
-    private final ConcurrentMap<ConditionalElement<String>, BundleConfiguration> bundles = new ConcurrentHashMap<>();
+    private final ConcurrentMap<ConditionalElement<BundleIdentity>, BundleConfiguration> bundles = new ConcurrentHashMap<>();
 
     public ResourceConfiguration() {
     }
@@ -158,7 +180,7 @@ public final class ResourceConfiguration extends ConfigurationBase<ResourceConfi
         addedGlobs.addAll(other.addedGlobs);
         other.addedResources.forEach(this::classifyAndAddPattern);
         ignoredResources.putAll(other.ignoredResources);
-        for (Map.Entry<ConditionalElement<String>, BundleConfiguration> entry : other.bundles.entrySet()) {
+        for (Map.Entry<ConditionalElement<BundleIdentity>, BundleConfiguration> entry : other.bundles.entrySet()) {
             bundles.put(entry.getKey(), new BundleConfiguration(entry.getValue()));
         }
     }
@@ -210,7 +232,7 @@ public final class ResourceConfiguration extends ConfigurationBase<ResourceConfi
         for (Map.Entry<ConditionalElement<String>, Pattern> entry : other.ignoredResources.entrySet()) {
             ignoredResources.put(new ConditionalElement<>(condition, entry.getKey().element()), entry.getValue());
         }
-        for (Map.Entry<ConditionalElement<String>, BundleConfiguration> entry : other.bundles.entrySet()) {
+        for (Map.Entry<ConditionalElement<BundleIdentity>, BundleConfiguration> entry : other.bundles.entrySet()) {
             bundles.put(new ConditionalElement<>(condition, entry.getKey().element()), new BundleConfiguration(entry.getValue()));
         }
     }
@@ -300,23 +322,35 @@ public final class ResourceConfiguration extends ConfigurationBase<ResourceConfi
     }
 
     public void addBundle(UnresolvedAccessCondition condition, String basename, Collection<Locale> locales) {
-        BundleConfiguration config = getOrCreateBundleConfig(condition, basename);
+        addBundle(condition, null, basename, locales);
+    }
+
+    public void addBundle(UnresolvedAccessCondition condition, String moduleName, String basename, Collection<Locale> locales) {
+        BundleConfiguration config = getOrCreateBundleConfig(condition, moduleName, basename);
         for (Locale locale : locales) {
             config.locales.add(locale.toLanguageTag());
         }
     }
 
     public void addBundle(UnresolvedAccessCondition condition, String baseName) {
-        getOrCreateBundleConfig(condition, baseName);
+        addBundle(condition, null, baseName);
+    }
+
+    public void addBundle(UnresolvedAccessCondition condition, String moduleName, String baseName) {
+        getOrCreateBundleConfig(condition, moduleName, baseName);
     }
 
     private void addClassResourceBundle(UnresolvedAccessCondition condition, String basename, String className) {
-        getOrCreateBundleConfig(condition, basename).classNames.add(className);
+        addClassResourceBundle(condition, null, basename, className);
     }
 
-    private BundleConfiguration getOrCreateBundleConfig(UnresolvedAccessCondition condition, String baseName) {
-        ConditionalElement<String> key = new ConditionalElement<>(condition, baseName);
-        return bundles.computeIfAbsent(key, _ -> new BundleConfiguration(condition, baseName));
+    private void addClassResourceBundle(UnresolvedAccessCondition condition, String moduleName, String basename, String className) {
+        getOrCreateBundleConfig(condition, moduleName, basename).classNames.add(className);
+    }
+
+    private BundleConfiguration getOrCreateBundleConfig(UnresolvedAccessCondition condition, String moduleName, String baseName) {
+        ConditionalElement<BundleIdentity> key = new ConditionalElement<>(condition, new BundleIdentity(moduleName, baseName));
+        return bundles.computeIfAbsent(key, cond -> new BundleConfiguration(condition, moduleName, baseName));
     }
 
     public boolean anyResourceMatches(String s) {
@@ -340,7 +374,11 @@ public final class ResourceConfiguration extends ConfigurationBase<ResourceConfi
     }
 
     public boolean anyBundleMatches(UnresolvedAccessCondition condition, String bundleName) {
-        return bundles.containsKey(new ConditionalElement<>(condition, bundleName));
+        return anyBundleMatches(condition, null, bundleName);
+    }
+
+    public boolean anyBundleMatches(UnresolvedAccessCondition condition, String moduleName, String bundleName) {
+        return bundles.containsKey(new ConditionalElement<>(condition, new BundleIdentity(moduleName, bundleName)));
     }
 
     @Override
@@ -350,7 +388,7 @@ public final class ResourceConfiguration extends ConfigurationBase<ResourceConfi
             if (!addedGlobs.isEmpty()) {
                 writer.appendSeparator();
             }
-            JsonPrinter.printCollection(writer, bundles.keySet(), ConditionalElement.comparator(String::compareTo), (p, w) -> printResourceBundle(bundles.get(p), w, true), false, true);
+            JsonPrinter.printCollection(writer, bundles.keySet(), ConditionalElement.comparator(BundleIdentity.comparator()), (p, w) -> printResourceBundle(bundles.get(p), w, true), false, true);
         }
     }
 
@@ -379,7 +417,7 @@ public final class ResourceConfiguration extends ConfigurationBase<ResourceConfi
 
     void printBundlesJson(JsonWriter writer) throws IOException {
         writer.quote(BUNDLES_KEY).appendFieldSeparator();
-        JsonPrinter.printCollection(writer, bundles.keySet(), ConditionalElement.comparator(), (p, w) -> printResourceBundle(bundles.get(p), w, false));
+        JsonPrinter.printCollection(writer, bundles.keySet(), ConditionalElement.comparator(BundleIdentity.comparator()), (p, w) -> printResourceBundle(bundles.get(p), w, false));
     }
 
     void printGlobsJson(JsonWriter writer) throws IOException {
@@ -450,7 +488,7 @@ public final class ResourceConfiguration extends ConfigurationBase<ResourceConfi
     public interface Predicate {
         boolean testIncludedResource(ConditionalElement<String> condition);
 
-        boolean testIncludedBundle(ConditionalElement<String> condition, BundleConfiguration bundleConfiguration);
+        boolean testIncludedBundle(ConditionalElement<BundleIdentity> condition, BundleConfiguration bundleConfiguration);
 
         boolean testIncludedGlob(ConditionalElement<ResourceEntry> entry);
     }

--- a/substratevm/src/com.oracle.svm.configure/src/com/oracle/svm/configure/config/conditional/ConditionalConfigurationPredicate.java
+++ b/substratevm/src/com.oracle.svm.configure/src/com/oracle/svm/configure/config/conditional/ConditionalConfigurationPredicate.java
@@ -73,7 +73,7 @@ public class ConditionalConfigurationPredicate implements TypeConfiguration.Pred
     }
 
     @Override
-    public boolean testIncludedBundle(ConditionalElement<String> condition, ResourceConfiguration.BundleConfiguration bundleConfiguration) {
+    public boolean testIncludedBundle(ConditionalElement<ResourceConfiguration.BundleIdentity> condition, ResourceConfiguration.BundleConfiguration bundleConfiguration) {
         return !filter.includes(condition.condition().getTypeName());
     }
 

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/configure/ConfigurationFiles.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/configure/ConfigurationFiles.java
@@ -108,12 +108,12 @@ public final class ConfigurationFiles {
 
         @OptionMigrationMessage("Use a resource-config.json in your META-INF/native-image/<groupID>/<artifactID> directory instead.")//
         @Option(help = "Files describing Java resources to be included in the image according to the schema at " +
-                        "https://github.com/oracle/graal/blob/master/docs/reference-manual/native-image/assets/resource-config-schema-v1.0.0.json", type = OptionType.User)//
+                        "https://github.com/oracle/graal/blob/master/docs/reference-manual/native-image/assets/resource-config-schema-v1.1.0.json", type = OptionType.User)//
         @BundleMember(role = BundleMember.Role.Input)//
         public static final HostedOptionKey<AccumulatingLocatableMultiOptionValue.Paths> ResourceConfigurationFiles = new HostedOptionKey<>(
                         AccumulatingLocatableMultiOptionValue.Paths.buildWithCommaDelimiter());
         @Option(help = "Resources describing Java resources to be included in the image according to the schema at " +
-                        "https://github.com/oracle/graal/blob/master/docs/reference-manual/native-image/assets/resource-config-schema-v1.0.0.json", type = OptionType.User)//
+                        "https://github.com/oracle/graal/blob/master/docs/reference-manual/native-image/assets/resource-config-schema-v1.1.0.json", type = OptionType.User)//
         public static final HostedOptionKey<AccumulatingLocatableMultiOptionValue.Strings> ResourceConfigurationResources = new HostedOptionKey<>(
                         AccumulatingLocatableMultiOptionValue.Strings.buildWithCommaDelimiter());
 

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/localization/LocalizationSupport.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/localization/LocalizationSupport.java
@@ -78,6 +78,7 @@ import sun.util.resources.Bundles;
  */
 @SingletonTraits(access = AllAccess.class, layeredCallbacks = NoLayeredCallbacks.class, layeredInstallationKind = Duplicable.class, other = PartiallyLayerAware.class)
 public class LocalizationSupport {
+    static final String ALL_UNNAMED_MODULE = "ALL-UNNAMED";
 
     public final Map<String, Charset> charsets = new HashMap<>();
 
@@ -119,21 +120,29 @@ public class LocalizationSupport {
 
     @Platforms(Platform.HOSTED_ONLY.class)
     public void prepareBundle(String bundleName, ResourceBundle bundle, Function<String, Optional<Module>> findModule, Locale locale, boolean jdkBundle) {
+        String[] bundleNameWithModule = StringUtil.split(bundleName, ":", 2);
+        String moduleName = bundleNameWithModule.length < 2 ? null : bundleNameWithModule[0];
+        String baseName = bundleNameWithModule.length < 2 ? bundleName : bundleNameWithModule[1];
+        prepareBundle(moduleName, baseName, bundle, findModule, locale, jdkBundle);
+    }
+
+    @Platforms(Platform.HOSTED_ONLY.class)
+    public void prepareBundle(String moduleName, String bundleName, ResourceBundle bundle, Function<String, Optional<Module>> findModule, Locale locale, boolean jdkBundle) {
         /*
          * Class-based bundle lookup happens on every query, but we don't need to register the
          * constructor for a property resource bundle since the class lookup will fail.
          */
-        registerRequiredReflectionAndResourcesForBundle(bundleName, Set.of(locale), jdkBundle);
+        registerRequiredReflectionAndResourcesForBundle(moduleName, bundleName, Set.of(locale), jdkBundle, findModule);
         if (!(bundle instanceof PropertyResourceBundle)) {
             registerNullaryConstructor(bundle.getClass());
         }
 
         /* Property-based bundle lookup happens only if class-based lookup fails */
         if (bundle instanceof PropertyResourceBundle) {
-            String[] bundleNameWithModule = StringUtil.split(bundleName, ":", 2);
             String resourceName;
-            String origin = "Added for PropertyResourceBundle: " + bundleName;
-            if (bundleNameWithModule.length < 2) {
+            String debugName = qualifyBundleName(moduleName, bundleName);
+            String origin = "Added for PropertyResourceBundle: " + debugName;
+            if (moduleName == null || moduleName.isEmpty()) {
                 resourceName = toSlashSeparated(control.toBundleName(bundleName, locale)).concat(".properties");
 
                 Map<String, EconomicSet<Module>> packageToModules = ImageSingletons.lookup(ClassLoaderSupport.class).getPackageToModules();
@@ -146,10 +155,13 @@ public class LocalizationSupport {
                 if (modules.isEmpty()) {
                     ImageSingletons.lookup(RuntimeResourceSupport.class).addResource(null, resourceName, origin);
                 }
+            } else if (ALL_UNNAMED_MODULE.equals(moduleName)) {
+                resourceName = toSlashSeparated(control.toBundleName(bundleName, locale)).concat(".properties");
+                ImageSingletons.lookup(RuntimeResourceSupport.class).addResource(null, resourceName, origin);
             } else {
                 if (findModule != null) {
-                    resourceName = toSlashSeparated(control.toBundleName(bundleNameWithModule[1], locale)).concat(".properties");
-                    Optional<Module> module = findModule.apply(bundleNameWithModule[0]);
+                    resourceName = toSlashSeparated(control.toBundleName(bundleName, locale)).concat(".properties");
+                    Optional<Module> module = findModule.apply(moduleName);
                     String finalResourceName = resourceName;
                     module.ifPresent(m -> ImageSingletons.lookup(RuntimeResourceSupport.class).addResource(m, finalResourceName, origin));
                 }
@@ -168,6 +180,11 @@ public class LocalizationSupport {
     }
 
     public void registerRequiredReflectionAndResourcesForBundle(String baseName, Collection<Locale> wantedLocales, boolean jdkBundle) {
+        registerRequiredReflectionAndResourcesForBundle(null, baseName, wantedLocales, jdkBundle, null);
+    }
+
+    public void registerRequiredReflectionAndResourcesForBundle(String moduleName, String baseName, Collection<Locale> wantedLocales, boolean jdkBundle,
+                    Function<String, Optional<Module>> findModule) {
         if (!jdkBundle) {
             int i = baseName.lastIndexOf('.');
             if (i > 0) {
@@ -178,11 +195,16 @@ public class LocalizationSupport {
         }
 
         for (Locale locale : wantedLocales) {
-            registerRequiredReflectionAndResourcesForBundleAndLocale(baseName, locale, jdkBundle);
+            registerRequiredReflectionAndResourcesForBundleAndLocale(moduleName, baseName, locale, jdkBundle, findModule);
         }
     }
 
     public void registerRequiredReflectionAndResourcesForBundleAndLocale(String baseName, Locale baseLocale, boolean jdkBundle) {
+        registerRequiredReflectionAndResourcesForBundleAndLocale(null, baseName, baseLocale, jdkBundle, null);
+    }
+
+    public void registerRequiredReflectionAndResourcesForBundleAndLocale(String moduleName, String baseName, Locale baseLocale, boolean jdkBundle,
+                    Function<String, Optional<Module>> findModule) {
         /*
          * Bundles in the sun.(text|util).resources.cldr packages are loaded with an alternative
          * strategy which tries parent aliases defined in CLDRBaseLocaleDataMetaInfo.parentLocales.
@@ -190,6 +212,7 @@ public class LocalizationSupport {
         List<Locale> candidateLocales = jdkBundle
                         ? getJDKBundleCandidateLocales(baseName, baseLocale)
                         : control.getCandidateLocales(baseName, baseLocale);
+        Module module = resolveNamedModule(moduleName, findModule);
 
         for (Locale locale : candidateLocales) {
             String bundleWithLocale = jdkBundle ? strategy.toBundleName(baseName, locale) : control.toBundleName(baseName, locale);
@@ -198,7 +221,7 @@ public class LocalizationSupport {
             if (bundleClass != null) {
                 registerNullaryConstructor(bundleClass);
             }
-            Resources.currentLayer().registerNegativeQuery(bundleWithLocale.replace('.', '/') + ".properties");
+            Resources.currentLayer().registerNegativeQuery(module, bundleWithLocale.replace('.', '/') + ".properties");
 
             if (jdkBundle) {
                 String otherBundleName = Bundles.toOtherBundleName(baseName, bundleWithLocale, locale);
@@ -293,13 +316,19 @@ public class LocalizationSupport {
             return true;
         }
         if (MetadataTracer.enabled()) {
-            MetadataTracer.singleton().traceResourceBundle(module != null && module.isNamed() ? module.getName() : null, baseName);
+            String moduleName = module == null ? null : module.isNamed() ? module.getName() : ALL_UNNAMED_MODULE;
+            MetadataTracer.singleton().traceResourceBundle(moduleName, baseName);
         }
         if (module != null && module.isNamed()) {
             /* Module-specific registrations are keyed separately from legacy unqualified ones. */
             RuntimeDynamicAccessMetadata registeredModuleBundle = registeredBundles.get(qualifyBundleName(module.getName(), baseName));
             if (registeredModuleBundle != null) {
                 return registeredModuleBundle.satisfied();
+            }
+        } else if (module != null) {
+            RuntimeDynamicAccessMetadata registeredUnnamedBundle = registeredBundles.get(qualifyBundleName(ALL_UNNAMED_MODULE, baseName));
+            if (registeredUnnamedBundle != null) {
+                return registeredUnnamedBundle.satisfied();
             }
         }
         RuntimeDynamicAccessMetadata registeredBundle = registeredBundles.get(baseName);
@@ -311,6 +340,13 @@ public class LocalizationSupport {
 
     private static String qualifyBundleName(String moduleName, String baseName) {
         return moduleName != null && !moduleName.isEmpty() ? moduleName + ":" + baseName : baseName;
+    }
+
+    private static Module resolveNamedModule(String moduleName, Function<String, Optional<Module>> findModule) {
+        if (moduleName == null || moduleName.isEmpty() || ALL_UNNAMED_MODULE.equals(moduleName) || findModule == null) {
+            return null;
+        }
+        return findModule.apply(moduleName).orElse(null);
     }
 
     private static EconomicSet<String> getLanguageTags(EconomicSet<Locale> locales) {

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/localization/LocalizationSupport.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/localization/LocalizationSupport.java
@@ -278,18 +278,39 @@ public class LocalizationSupport {
         registeredBundles.put(baseName, RuntimeDynamicAccessMetadata.addCondition(registeredBundles.get(baseName), condition, false));
     }
 
+    @Platforms(Platform.HOSTED_ONLY.class)
+    public void registerBundleLookup(AccessCondition condition, String moduleName, String baseName) {
+        registerBundleLookup(condition, qualifyBundleName(moduleName, baseName));
+    }
+
     public boolean isRegisteredBundleLookup(String baseName, Locale locale, Object controlOrStrategy) {
+        return isRegisteredBundleLookup(null, baseName, locale, controlOrStrategy);
+    }
+
+    public boolean isRegisteredBundleLookup(Module module, String baseName, Locale locale, Object controlOrStrategy) {
         if (baseName == null || locale == null || controlOrStrategy == null) {
             /* Those cases will throw a NullPointerException before any lookup */
             return true;
         }
         if (MetadataTracer.enabled()) {
-            MetadataTracer.singleton().traceResourceBundle(baseName);
+            MetadataTracer.singleton().traceResourceBundle(module != null && module.isNamed() ? module.getName() : null, baseName);
         }
-        if (registeredBundles.containsKey(baseName)) {
-            return registeredBundles.get(baseName).satisfied();
+        if (module != null && module.isNamed()) {
+            /* Module-specific registrations are keyed separately from legacy unqualified ones. */
+            RuntimeDynamicAccessMetadata registeredModuleBundle = registeredBundles.get(qualifyBundleName(module.getName(), baseName));
+            if (registeredModuleBundle != null) {
+                return registeredModuleBundle.satisfied();
+            }
+        }
+        RuntimeDynamicAccessMetadata registeredBundle = registeredBundles.get(baseName);
+        if (registeredBundle != null) {
+            return registeredBundle.satisfied();
         }
         return false;
+    }
+
+    private static String qualifyBundleName(String moduleName, String baseName) {
+        return moduleName != null && !moduleName.isEmpty() ? moduleName + ":" + baseName : baseName;
     }
 
     private static EconomicSet<String> getLanguageTags(EconomicSet<Locale> locales) {

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/localization/substitutions/Target_java_util_ResourceBundle.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/jdk/localization/substitutions/Target_java_util_ResourceBundle.java
@@ -63,7 +63,7 @@ final class Target_java_util_ResourceBundle {
 
         // get resource bundles for a named module only if loader is the module's class loader
         if (callerModule.isNamed() && loader == getLoader(callerModule)) {
-            if (ResourceBundleMissingRegistrationSupport.shouldReport(caller, baseName, locale, control)) {
+            if (ResourceBundleMissingRegistrationSupport.shouldReport(caller, callerModule, baseName, locale, control)) {
                 MissingResourceRegistrationUtils.reportResourceBundleAccess(callerModule, baseName);
             }
             return MissingRegistrationUtils.runIgnoringMissingRegistrations(new Supplier<ResourceBundle>() {
@@ -82,7 +82,7 @@ final class Target_java_util_ResourceBundle {
                         ? loader.getUnnamedModule()
                         : BootLoader.getUnnamedModule();
 
-        if (ResourceBundleMissingRegistrationSupport.shouldReport(caller, baseName, locale, control)) {
+        if (ResourceBundleMissingRegistrationSupport.shouldReport(caller, unnamedModule, baseName, locale, control)) {
             MissingResourceRegistrationUtils.reportResourceBundleAccess(unnamedModule, baseName);
         }
         return MissingRegistrationUtils.runIgnoringMissingRegistrations(new Supplier<ResourceBundle>() {
@@ -101,11 +101,7 @@ final class Target_java_util_ResourceBundle {
                     Control control) {
         Objects.requireNonNull(module);
         Module callerModule = getCallerModule(caller);
-        /*
-         * TODO GR-67556 - Implement proper module-aware LocalizationSupport bundle registration to
-         * ensure we show MissingResourceRegistrationError in all relevant situations.
-         */
-        if (ResourceBundleMissingRegistrationSupport.shouldReport(caller, baseName, locale, control)) {
+        if (ResourceBundleMissingRegistrationSupport.shouldReport(caller, module, baseName, locale, control)) {
             MissingResourceRegistrationUtils.reportResourceBundleAccess(module, baseName);
         }
         return MissingRegistrationUtils.runIgnoringMissingRegistrations(() -> getBundleImpl(callerModule, module, baseName, locale, control));
@@ -133,8 +129,8 @@ final class ResourceBundleMissingRegistrationSupport {
     private ResourceBundleMissingRegistrationSupport() {
     }
 
-    static boolean shouldReport(Class<?> caller, String baseName, Locale locale, Control control) {
-        return !isRuntimeLoaded(caller) && !ImageSingletons.lookup(LocalizationSupport.class).isRegisteredBundleLookup(baseName, locale, control);
+    static boolean shouldReport(Class<?> caller, Module module, String baseName, Locale locale, Control control) {
+        return !isRuntimeLoaded(caller) && !ImageSingletons.lookup(LocalizationSupport.class).isRegisteredBundleLookup(module, baseName, locale, control);
     }
 
     private static boolean isRuntimeLoaded(Class<?> clazz) {

--- a/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/metadata/MetadataTracer.java
+++ b/substratevm/src/com.oracle.svm.core/src/com/oracle/svm/core/metadata/MetadataTracer.java
@@ -338,13 +338,21 @@ public final class MetadataTracer {
      * Marks the given resource bundle within the given locale as reachable.
      */
     public void traceResourceBundle(String baseName) {
+        traceResourceBundle(null, baseName);
+    }
+
+    /**
+     * Marks the given resource bundle within the given module as reachable.
+     */
+    public void traceResourceBundle(String moduleName, String baseName) {
         assert enabledAtRunTime();
         ConfigurationSet configurationSet = getConfigurationSetForTracing();
         if (configurationSet != null) {
             UnresolvedAccessCondition condition = traceCondition();
             if (condition != null) {
-                debug("resource bundle registered", baseName);
-                configurationSet.getResourceConfiguration().addBundle(condition, baseName, List.of());
+                String debugName = moduleName != null ? moduleName + ":" + baseName : baseName;
+                debug("resource bundle registered", debugName);
+                configurationSet.getResourceConfiguration().addBundle(condition, moduleName, baseName, List.of());
             }
         }
     }

--- a/substratevm/src/com.oracle.svm.hosted.test/src/com/oracle/svm/hosted/jdk/localization/LocalizationFeatureTest.java
+++ b/substratevm/src/com.oracle.svm.hosted.test/src/com/oracle/svm/hosted/jdk/localization/LocalizationFeatureTest.java
@@ -1,0 +1,303 @@
+/*
+ * Copyright (c) 2025, 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package com.oracle.svm.hosted.jdk.localization;
+
+import java.lang.reflect.Field;
+import java.nio.charset.StandardCharsets;
+import java.util.Collection;
+import java.util.List;
+import java.util.ListResourceBundle;
+import java.util.Locale;
+import java.util.Optional;
+import java.util.ResourceBundle;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.graalvm.collections.EconomicMap;
+import org.graalvm.collections.EconomicSet;
+import org.graalvm.nativeimage.ImageSingletons;
+import org.graalvm.nativeimage.dynamicaccess.AccessCondition;
+import org.graalvm.nativeimage.hosted.RuntimeResourceAccess;
+import org.graalvm.nativeimage.impl.APIDeprecationSupport;
+import org.graalvm.nativeimage.impl.ImageSingletonsSupport;
+import org.graalvm.nativeimage.impl.RuntimeResourceSupport;
+import org.graalvm.nativeimage.impl.TypeReachabilityCondition;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import com.oracle.svm.core.configure.RuntimeDynamicAccessMetadata;
+import com.oracle.svm.core.jdk.localization.LocalizationSupport;
+import com.oracle.svm.core.util.UserError;
+import com.oracle.svm.hosted.InternalResourceAccess;
+import com.oracle.svm.shared.option.HostedOptionValues;
+
+import jdk.graal.compiler.options.OptionKey;
+import jdk.graal.compiler.options.OptionValues;
+
+public class LocalizationFeatureTest {
+    private static boolean installedImageSingletonsSupport;
+
+    @BeforeClass
+    public static void installImageSingletonsSupport() {
+        installedImageSingletonsSupport = TestImageSingletonsSupport.installIfMissing();
+    }
+
+    @AfterClass
+    public static void restoreImageSingletonsSupport() {
+        if (installedImageSingletonsSupport) {
+            TestImageSingletonsSupport.uninstallForTests();
+        }
+    }
+
+    @Test
+    public void allUnnamedModuleSelectorDoesNotRequireResolution() {
+        String moduleName = LocalizationFeature.validateBundleModuleName(LocalizationFeature.ALL_UNNAMED_MODULE, "com.example.Messages", ignored -> {
+            throw new AssertionError("ALL-UNNAMED should not be resolved as a named module.");
+        });
+        Assert.assertEquals(LocalizationFeature.ALL_UNNAMED_MODULE, moduleName);
+    }
+
+    @Test
+    public void missingNamedModuleIsRejected() {
+        UserError.UserException error = Assert.assertThrows(UserError.UserException.class,
+                        () -> LocalizationFeature.validateBundleModuleName(
+                                        "missing.module",
+                                        "com.example.Messages",
+                                        ignored -> Optional.empty()));
+        Assert.assertTrue(error.getMessage().contains("missing.module"));
+        Assert.assertTrue(error.getMessage().contains("com.example.Messages"));
+    }
+
+    @Test
+    public void allUnnamedBundleRegistrationsRemainDistinctFromUnqualifiedLookups() {
+        LocalizationSupport support = new LocalizationSupport(EconomicSet.create(), StandardCharsets.UTF_8);
+        support.registerBundleLookup(AccessCondition.unconditional(), LocalizationFeature.ALL_UNNAMED_MODULE, "com.example.Messages");
+
+        EconomicMap<String, RuntimeDynamicAccessMetadata> registeredBundles = registeredBundles(support);
+        Assert.assertNull(registeredBundles.get("com.example.Messages"));
+        Assert.assertNotNull(registeredBundles.get(LocalizationFeature.ALL_UNNAMED_MODULE + ":com.example.Messages"));
+    }
+
+    @Test
+    public void namedBundleRegistrationsRemainModuleQualified() {
+        LocalizationSupport support = new LocalizationSupport(EconomicSet.create(), StandardCharsets.UTF_8);
+        Module javaBase = Object.class.getModule();
+        support.registerBundleLookup(AccessCondition.unconditional(), javaBase.getName(), "com.example.Messages");
+
+        EconomicMap<String, RuntimeDynamicAccessMetadata> registeredBundles = registeredBundles(support);
+        Assert.assertNotNull(registeredBundles.get(javaBase.getName() + ":com.example.Messages"));
+        Assert.assertNull(registeredBundles.get("com.example.Messages"));
+    }
+
+    @Test
+    public void allUnnamedBundleRegistrationsOnlySatisfyUnnamedModuleLookups() {
+        LocalizationSupport support = new LocalizationSupport(EconomicSet.create(), StandardCharsets.UTF_8);
+        support.registerBundleLookup(AccessCondition.unconditional(), LocalizationFeature.ALL_UNNAMED_MODULE, "com.example.Messages");
+
+        ResourceBundle.Control control = ResourceBundle.Control.getControl(ResourceBundle.Control.FORMAT_DEFAULT);
+        Module unnamedModule = LocalizationFeatureTest.class.getClassLoader().getUnnamedModule();
+
+        Assert.assertTrue(support.isRegisteredBundleLookup(unnamedModule, "com.example.Messages", Locale.ROOT, control));
+        Assert.assertFalse(support.isRegisteredBundleLookup(Object.class.getModule(), "com.example.Messages", Locale.ROOT, control));
+    }
+
+    @Test
+    public void runtimeResourceAccessUsesAllUnnamedForUnnamedModules() {
+        RecordingRuntimeResourceSupport runtimeResources = recordingRuntimeResourceSupport();
+        runtimeResources.reset();
+
+        RuntimeResourceAccess.addResourceBundle(LocalizationFeatureTest.class.getModule(), "com.example.Messages", new Locale[]{Locale.ROOT});
+
+        Assert.assertEquals(LocalizationFeature.ALL_UNNAMED_MODULE + ":com.example.Messages", runtimeResources.registeredBundleName);
+        Assert.assertEquals(List.of(Locale.ROOT), runtimeResources.registeredLocales);
+    }
+
+    @Test
+    public void resourceAccessBundleRegistrationUsesAllUnnamedForClasspathBundles() {
+        RecordingRuntimeResourceSupport runtimeResources = recordingRuntimeResourceSupport();
+        runtimeResources.reset();
+
+        ResourceBundle bundle = ResourceBundle.getBundle(ClasspathBundle.class.getName(), Locale.ROOT, LocalizationFeatureTest.class.getClassLoader());
+        InternalResourceAccess.singleton().registerResourceBundle(AccessCondition.unconditional(), bundle);
+
+        Assert.assertEquals(ClasspathBundle.class.getName(), bundle.getBaseBundleName());
+        Assert.assertEquals(LocalizationFeature.ALL_UNNAMED_MODULE + ":" + ClasspathBundle.class.getName(), runtimeResources.registeredBundleName);
+        Assert.assertNull(runtimeResources.registeredLocales);
+    }
+
+    @Test
+    public void namedModuleMismatchIsRejectedForBundleClass() {
+        UserError.UserException error = Assert.assertThrows(UserError.UserException.class,
+                        () -> LocalizationFeature.validateBundleClassModule("java.logging", "com.example.Messages", "java.lang.String", String.class));
+        Assert.assertTrue(error.getMessage().contains("java.logging"));
+        Assert.assertTrue(error.getMessage().contains("java.base"));
+        Assert.assertTrue(error.getMessage().contains("java.lang.String"));
+    }
+
+    @Test
+    public void allUnnamedSelectorRejectsNamedBundleClasses() {
+        UserError.UserException error = Assert.assertThrows(UserError.UserException.class,
+                        () -> LocalizationFeature.validateBundleClassModule(LocalizationFeature.ALL_UNNAMED_MODULE, "com.example.Messages", "java.lang.String", String.class));
+        Assert.assertTrue(error.getMessage().contains(LocalizationFeature.ALL_UNNAMED_MODULE));
+        Assert.assertTrue(error.getMessage().contains("java.base"));
+    }
+
+    @Test
+    public void runtimeCheckedConditionsAreRequiredForBundleLookupMetadata() {
+        LocalizationSupport support = new LocalizationSupport(EconomicSet.create(), StandardCharsets.UTF_8);
+        TypeReachabilityCondition condition = TypeReachabilityCondition.create(String.class, false);
+
+        Throwable error = Assert.assertThrows(Throwable.class,
+                        () -> support.registerBundleLookup(condition, "java.base", "com.example.Messages"));
+        Assert.assertTrue(error.getMessage().contains("runtime conditions"));
+    }
+
+    @SuppressWarnings("unchecked")
+    private static EconomicMap<String, RuntimeDynamicAccessMetadata> registeredBundles(LocalizationSupport support) {
+        try {
+            Field field = LocalizationSupport.class.getDeclaredField("registeredBundles");
+            field.setAccessible(true);
+            return (EconomicMap<String, RuntimeDynamicAccessMetadata>) field.get(support);
+        } catch (ReflectiveOperationException ex) {
+            throw new AssertionError(ex);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private static RecordingRuntimeResourceSupport recordingRuntimeResourceSupport() {
+        return (RecordingRuntimeResourceSupport) ImageSingletons.lookup(RuntimeResourceSupport.class);
+    }
+
+    public static final class ClasspathBundle extends ListResourceBundle {
+        @Override
+        protected Object[][] getContents() {
+            return new Object[][]{
+                            {"key", "value"}
+            };
+        }
+    }
+
+    private static final class RecordingRuntimeResourceSupport implements RuntimeResourceSupport<AccessCondition> {
+        private String registeredBundleName;
+        private List<Locale> registeredLocales;
+
+        void reset() {
+            registeredBundleName = null;
+            registeredLocales = null;
+        }
+
+        @Override
+        public void addResources(AccessCondition condition, String pattern, Object origin) {
+            throw new AssertionError("Unused function.");
+        }
+
+        @Override
+        public void addGlob(AccessCondition condition, String module, String glob, Object origin) {
+            throw new AssertionError("Unused function.");
+        }
+
+        @Override
+        public void ignoreResources(AccessCondition condition, String pattern, Object origin) {
+            throw new AssertionError("Unused function.");
+        }
+
+        @Override
+        public void addResourceBundles(AccessCondition condition, boolean preserved, String name) {
+            registeredBundleName = name;
+            registeredLocales = null;
+        }
+
+        @Override
+        public void addResourceBundles(AccessCondition condition, String basename, Collection<Locale> locales) {
+            registeredBundleName = basename;
+            registeredLocales = List.copyOf(locales);
+        }
+
+        @Override
+        public void addCondition(AccessCondition condition, Module module, String resourcePath) {
+            throw new AssertionError("Unused function.");
+        }
+
+        @Override
+        public void addResourceEntry(Module module, String resourcePath, Object origin) {
+            throw new AssertionError("Unused function.");
+        }
+
+        @Override
+        public void injectResource(Module module, String resourcePath, byte[] resourceContent, Object origin) {
+            throw new AssertionError("Unused function.");
+        }
+    }
+
+    private static final class TestImageSingletonsSupport extends ImageSingletonsSupport {
+        private final ConcurrentHashMap<Class<?>, Object> singletons = new ConcurrentHashMap<>();
+
+        static boolean installIfMissing() {
+            if (isInstalled()) {
+                return false;
+            }
+            TestImageSingletonsSupport support = new TestImageSingletonsSupport();
+            EconomicMap<OptionKey<?>, Object> values = OptionValues.newOptionMap();
+            support.add(HostedOptionValues.class, new HostedOptionValues(values));
+            support.add(APIDeprecationSupport.class, new APIDeprecationSupport(false));
+            addTestSingleton(support, RuntimeResourceSupport.class, new RecordingRuntimeResourceSupport());
+            installSupport(support);
+            return true;
+        }
+
+        @SuppressWarnings({"rawtypes", "unchecked"})
+        private static void addTestSingleton(TestImageSingletonsSupport support, Class<?> key, Object value) {
+            support.add((Class) key, value);
+        }
+
+        static void uninstallForTests() {
+            try {
+                Field supportField = ImageSingletonsSupport.class.getDeclaredField("support");
+                supportField.setAccessible(true);
+                supportField.set(null, null);
+            } catch (ReflectiveOperationException ex) {
+                throw new AssertionError(ex);
+            }
+        }
+
+        @Override
+        public <T> void add(Class<T> key, T value) {
+            singletons.put(key, value);
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public <T> T lookup(Class<T> key) {
+            return (T) singletons.get(key);
+        }
+
+        @Override
+        public boolean contains(Class<?> key) {
+            return singletons.containsKey(key);
+        }
+    }
+}

--- a/substratevm/src/com.oracle.svm.hosted.test/src/com/oracle/svm/hosted/jdk/localization/LocalizationFeatureTest.java
+++ b/substratevm/src/com.oracle.svm.hosted.test/src/com/oracle/svm/hosted/jdk/localization/LocalizationFeatureTest.java
@@ -75,8 +75,8 @@ public class LocalizationFeatureTest {
 
     @Test
     public void allUnnamedModuleSelectorDoesNotRequireResolution() {
-        String moduleName = LocalizationFeature.validateBundleModuleName(LocalizationFeature.ALL_UNNAMED_MODULE, "com.example.Messages", ignored -> {
-            throw new AssertionError("ALL-UNNAMED should not be resolved as a named module.");
+        String moduleName = LocalizationFeature.validateBundleModuleName(LocalizationFeature.ALL_UNNAMED_MODULE, "com.example.Messages", moduleToResolve -> {
+            throw new AssertionError("ALL-UNNAMED should not be resolved as a named module: " + moduleToResolve);
         });
         Assert.assertEquals(LocalizationFeature.ALL_UNNAMED_MODULE, moduleName);
     }
@@ -87,7 +87,10 @@ public class LocalizationFeatureTest {
                         () -> LocalizationFeature.validateBundleModuleName(
                                         "missing.module",
                                         "com.example.Messages",
-                                        ignored -> Optional.empty()));
+                                        moduleToResolve -> {
+                                            Assert.assertEquals("missing.module", moduleToResolve);
+                                            return Optional.empty();
+                                        }));
         Assert.assertTrue(error.getMessage().contains("missing.module"));
         Assert.assertTrue(error.getMessage().contains("com.example.Messages"));
     }

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/InternalResourceAccess.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/InternalResourceAccess.java
@@ -36,6 +36,8 @@ import org.graalvm.nativeimage.dynamicaccess.ResourceAccess;
 
 public final class InternalResourceAccess implements ResourceAccess {
 
+    private static final String ALL_UNNAMED_MODULE = "ALL-UNNAMED";
+
     private final RuntimeResourceSupport<AccessCondition> rrsInstance;
     private static InternalResourceAccess instance;
 
@@ -71,12 +73,16 @@ public final class InternalResourceAccess implements ResourceAccess {
             }
 
             Method m = ReflectionUtil.lookupMethod(cache.getClass(), "getModule");
-            Module modul = ReflectionUtil.invokeMethod(m, cache);
+            Module module = ReflectionUtil.invokeMethod(m, cache);
 
             Method m2 = ReflectionUtil.lookupMethod(cache.getClass(), "getName");
             String name = ReflectionUtil.invokeMethod(m2, cache);
 
-            rrsInstance.addResourceBundles(condition, false, modul != null && modul.isNamed() ? modul.getName() : null, name);
+            rrsInstance.addResourceBundles(condition, false, bundleModuleName(module), name);
         }
+    }
+
+    private static String bundleModuleName(Module module) {
+        return module != null && module.isNamed() ? module.getName() : ALL_UNNAMED_MODULE;
     }
 }

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/InternalResourceAccess.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/InternalResourceAccess.java
@@ -76,8 +76,7 @@ public final class InternalResourceAccess implements ResourceAccess {
             Method m2 = ReflectionUtil.lookupMethod(cache.getClass(), "getName");
             String name = ReflectionUtil.invokeMethod(m2, cache);
 
-            String finalBundleName = (modul != null && modul.isNamed()) ? modul.getName() + ":" + name : name;
-            rrsInstance.addResourceBundles(condition, false, finalBundleName);
+            rrsInstance.addResourceBundles(condition, false, modul != null && modul.isNamed() ? modul.getName() : null, name);
         }
     }
 }

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/ResourcesFeature.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/ResourcesFeature.java
@@ -312,6 +312,12 @@ public class ResourcesFeature implements InternalFeature {
         }
 
         @Override
+        public void addResourceBundles(AccessCondition condition, boolean preserved, String moduleName, String name) {
+            abortIfSealed();
+            registerConditionalConfiguration(condition, (cnd) -> ImageSingletons.lookup(LocalizationFeature.class).prepareBundle(cnd, moduleName, name));
+        }
+
+        @Override
         public void addClassBasedResourceBundle(AccessCondition condition, String basename, String className) {
             abortIfSealed();
             registerConditionalConfiguration(condition, _ -> ImageSingletons.lookup(LocalizationFeature.class).prepareClassResourceBundle(basename, className));
@@ -320,13 +326,19 @@ public class ResourcesFeature implements InternalFeature {
         @Override
         public void addClassBasedResourceBundle(AccessCondition condition, String moduleName, String basename, String className) {
             abortIfSealed();
-            registerConditionalConfiguration(condition, _ -> ImageSingletons.lookup(LocalizationFeature.class).prepareClassResourceBundle(condition, moduleName, basename, className));
+            registerConditionalConfiguration(condition, cnd -> ImageSingletons.lookup(LocalizationFeature.class).prepareClassResourceBundle(cnd, moduleName, basename, className));
         }
 
         @Override
         public void addResourceBundles(AccessCondition condition, String basename, Collection<Locale> locales) {
             abortIfSealed();
             registerConditionalConfiguration(condition, (cnd) -> ImageSingletons.lookup(LocalizationFeature.class).prepareBundle(cnd, basename, locales));
+        }
+
+        @Override
+        public void addResourceBundles(AccessCondition condition, String moduleName, String basename, Collection<Locale> locales) {
+            abortIfSealed();
+            registerConditionalConfiguration(condition, (cnd) -> ImageSingletons.lookup(LocalizationFeature.class).prepareBundle(cnd, moduleName, basename, locales));
         }
 
         /*

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/ResourcesFeature.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/ResourcesFeature.java
@@ -318,6 +318,12 @@ public class ResourcesFeature implements InternalFeature {
         }
 
         @Override
+        public void addClassBasedResourceBundle(AccessCondition condition, String moduleName, String basename, String className) {
+            abortIfSealed();
+            registerConditionalConfiguration(condition, _ -> ImageSingletons.lookup(LocalizationFeature.class).prepareClassResourceBundle(condition, moduleName, basename, className));
+        }
+
+        @Override
         public void addResourceBundles(AccessCondition condition, String basename, Collection<Locale> locales) {
             abortIfSealed();
             registerConditionalConfiguration(condition, (cnd) -> ImageSingletons.lookup(LocalizationFeature.class).prepareBundle(cnd, basename, locales));

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/jdk/localization/LocalizationFeature.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/jdk/localization/LocalizationFeature.java
@@ -34,6 +34,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.MissingResourceException;
+import java.util.Optional;
 import java.util.ResourceBundle;
 import java.util.ServiceLoader;
 import java.util.Set;
@@ -108,6 +109,7 @@ import sun.util.resources.ParallelListResourceBundle;
 @AutomaticallyRegisteredFeature
 @SingletonTraits(access = BuildtimeAccessOnly.class, layeredCallbacks = NoLayeredCallbacks.class, other = PartiallyLayerAware.class)
 public class LocalizationFeature implements InternalFeature {
+    static final String ALL_UNNAMED_MODULE = "ALL-UNNAMED";
 
     /**
      * Locales required by default in Java.
@@ -475,6 +477,7 @@ public class LocalizationFeature implements InternalFeature {
 
     @Platforms(Platform.HOSTED_ONLY.class)
     public void prepareClassResourceBundle(AccessCondition condition, String moduleName, String basename, String className) {
+        String resolvedModuleName = validateBundleModuleName(moduleName, basename, this.imageClassLoader::findModule);
         if (moduleName == null || moduleName.isEmpty()) {
             prepareClassResourceBundle(basename, className);
             return;
@@ -485,15 +488,26 @@ public class LocalizationFeature implements InternalFeature {
             return;
         }
         UserError.guarantee(ResourceBundle.class.isAssignableFrom(bundleClass), "%s is not a subclass of ResourceBundle", bundleClass.getName());
-        trace("Adding class based resource bundle: " + moduleName + ":" + className + " " + bundleClass);
-        support.registerBundleLookup(condition, moduleName, basename);
-        support.registerRequiredReflectionAndResourcesForBundle(basename, Set.of(), false);
+        validateBundleClassModule(resolvedModuleName, basename, className, bundleClass);
+        trace("Adding class based resource bundle: " + resolvedModuleName + ":" + className + " " + bundleClass);
+        support.registerBundleLookup(condition, resolvedModuleName, basename);
+        support.registerRequiredReflectionAndResourcesForBundle(
+                        resolvedModuleName,
+                        basename,
+                        Set.of(),
+                        false,
+                        this.imageClassLoader::findModule);
         support.prepareClassResourceBundle(basename, bundleClass);
     }
 
     @Platforms(Platform.HOSTED_ONLY.class)
     public void prepareBundle(AccessCondition condition, String baseName) {
         prepareBundle(condition, baseName, allLocales);
+    }
+
+    @Platforms(Platform.HOSTED_ONLY.class)
+    public void prepareBundle(AccessCondition condition, String moduleName, String baseName) {
+        prepareBundle(condition, moduleName, baseName, allLocales);
     }
 
     private static final String[] RESOURCE_EXTENSION_PREFIXES = new String[]{
@@ -505,7 +519,7 @@ public class LocalizationFeature implements InternalFeature {
 
     @Platforms(Platform.HOSTED_ONLY.class)
     public void prepareBundle(AccessCondition condition, String baseName, Iterable<Locale> wantedLocales) {
-        prepareBundleInternal(condition, baseName, wantedLocales);
+        prepareBundleInternal(condition, null, baseName, wantedLocales);
 
         String alternativeBundleName = null;
         for (String resourceExtensionPrefix : RESOURCE_EXTENSION_PREFIXES) {
@@ -515,26 +529,44 @@ public class LocalizationFeature implements InternalFeature {
             }
         }
         if (alternativeBundleName != null) {
-            prepareBundleInternal(condition, alternativeBundleName, wantedLocales);
+            prepareBundleInternal(condition, null, alternativeBundleName, wantedLocales);
         }
     }
 
-    private void prepareBundleInternal(AccessCondition condition, String baseName, Iterable<Locale> wantedLocales) {
+    @Platforms(Platform.HOSTED_ONLY.class)
+    public void prepareBundle(AccessCondition condition, String moduleName, String baseName, Iterable<Locale> wantedLocales) {
+        prepareBundleInternal(condition, moduleName, baseName, wantedLocales);
+
+        String alternativeBundleName = null;
+        for (String resourceExtensionPrefix : RESOURCE_EXTENSION_PREFIXES) {
+            if (baseName.startsWith(resourceExtensionPrefix) && !baseName.startsWith(resourceExtensionPrefix + ".ext")) {
+                alternativeBundleName = baseName.replace(resourceExtensionPrefix, resourceExtensionPrefix + ".ext");
+                break;
+            }
+        }
+        if (alternativeBundleName != null) {
+            prepareBundleInternal(condition, moduleName, alternativeBundleName, wantedLocales);
+        }
+    }
+
+    private void prepareBundleInternal(AccessCondition condition, String moduleName, String baseName, Iterable<Locale> wantedLocales) {
+        String resolvedModuleName = validateBundleModuleName(moduleName, baseName, this.imageClassLoader::findModule);
         boolean somethingFound = false;
+        String bundleSpec = qualifyBundleName(resolvedModuleName, baseName);
         for (Locale locale : wantedLocales) {
-            support.registerBundleLookup(condition, baseName);
+            support.registerBundleLookup(condition, resolvedModuleName, baseName);
             List<ResourceBundle> resourceBundle;
             try {
-                resourceBundle = ImageSingletons.lookup(ClassLoaderSupport.class).getResourceBundle(baseName, locale);
+                resourceBundle = ImageSingletons.lookup(ClassLoaderSupport.class).getResourceBundle(bundleSpec, locale);
             } catch (MissingResourceException mre) {
                 for (Locale candidateLocale : support.control.getCandidateLocales(baseName, locale)) {
-                    prepareNegativeBundle(condition, baseName, candidateLocale, false);
+                    prepareNegativeBundle(condition, resolvedModuleName, baseName, candidateLocale, false);
                 }
                 continue;
             }
             somethingFound |= !resourceBundle.isEmpty();
             for (ResourceBundle bundle : resourceBundle) {
-                prepareBundle(condition, baseName, bundle, locale, false);
+                prepareBundle(condition, resolvedModuleName, baseName, bundle, locale, false);
             }
         }
 
@@ -545,6 +577,7 @@ public class LocalizationFeature implements InternalFeature {
              */
             Class<?> clazz = findClassByName.apply(baseName);
             if (clazz != null && ResourceBundle.class.isAssignableFrom(clazz)) {
+                validateBundleClassModule(resolvedModuleName, baseName, baseName, clazz);
                 trace("Found non-compliant class-based bundle " + clazz);
                 try {
                     support.prepareNonCompliant(clazz);
@@ -563,13 +596,13 @@ public class LocalizationFeature implements InternalFeature {
                             "If the bundle is part of a module, verify the bundle name is a fully qualified class name. Otherwise " +
                             "verify the bundle path is accessible in the classpath.";
             trace(errorMessage);
-            prepareNegativeBundle(condition, baseName, Locale.ROOT, false);
+            prepareNegativeBundle(condition, resolvedModuleName, baseName, Locale.ROOT, false);
             for (Locale locale : wantedLocales) {
-                prepareNegativeBundle(condition, baseName, Locale.of(locale.getLanguage()), false);
+                prepareNegativeBundle(condition, resolvedModuleName, baseName, Locale.of(locale.getLanguage()), false);
             }
             for (Locale locale : wantedLocales) {
                 if (!locale.getCountry().isEmpty()) {
-                    prepareNegativeBundle(condition, baseName, locale, false);
+                    prepareNegativeBundle(condition, resolvedModuleName, baseName, locale, false);
                 }
             }
         }
@@ -577,18 +610,24 @@ public class LocalizationFeature implements InternalFeature {
 
     @Platforms(Platform.HOSTED_ONLY.class)
     protected void prepareNegativeBundle(AccessCondition condition, String baseName, Locale locale, boolean jdkBundle) {
-        support.registerBundleLookup(condition, baseName);
-        support.registerRequiredReflectionAndResourcesForBundleAndLocale(baseName, locale, jdkBundle);
+        prepareNegativeBundle(condition, null, baseName, locale, jdkBundle);
+    }
+
+    @Platforms(Platform.HOSTED_ONLY.class)
+    protected void prepareNegativeBundle(AccessCondition condition, String moduleName, String baseName, Locale locale, boolean jdkBundle) {
+        support.registerBundleLookup(condition, moduleName, baseName);
+        support.registerRequiredReflectionAndResourcesForBundleAndLocale(moduleName, baseName, locale, jdkBundle, this.imageClassLoader::findModule);
     }
 
     @Platforms(Platform.HOSTED_ONLY.class)
     protected void prepareJDKBundle(ResourceBundle bundle, Locale locale) {
         String baseName = bundle.getBaseBundleName();
-        prepareBundle(AccessCondition.unconditional(), baseName, bundle, locale, true);
+        prepareBundle(AccessCondition.unconditional(), null, baseName, bundle, locale, true);
     }
 
     @Platforms(Platform.HOSTED_ONLY.class)
-    private void prepareBundle(AccessCondition condition, String bundleName, ResourceBundle bundle, Locale locale, boolean jdkBundle) {
+    private void prepareBundle(AccessCondition condition, String moduleName, String baseName, ResourceBundle bundle, Locale locale, boolean jdkBundle) {
+        String bundleName = qualifyBundleName(moduleName, baseName);
         trace("Adding bundle " + bundleName + ", locale " + locale + " with condition " + condition);
         /*
          * Ensure that the bundle contents are loaded. We need to walk the whole bundle parent chain
@@ -596,14 +635,59 @@ public class LocalizationFeature implements InternalFeature {
          */
         for (ResourceBundle cur = bundle; cur != null; cur = SharedSecrets.getJavaUtilResourceBundleAccess().getParent(cur)) {
             /* Register all bundles with their corresponding locales */
-            support.prepareBundle(bundleName, cur, this.imageClassLoader::findModule, cur.getLocale(), jdkBundle);
+            support.prepareBundle(moduleName, baseName, cur, this.imageClassLoader::findModule, cur.getLocale(), jdkBundle);
         }
 
         /*
          * Finally, register the requested bundle with requested locale (Requested might be more
          * specific than the actual bundle locale
          */
-        support.prepareBundle(bundleName, bundle, this.imageClassLoader::findModule, locale, jdkBundle);
+        support.prepareBundle(moduleName, baseName, bundle, this.imageClassLoader::findModule, locale, jdkBundle);
+    }
+
+    private static String qualifyBundleName(String moduleName, String baseName) {
+        return moduleName != null && !moduleName.isEmpty() ? moduleName + ":" + baseName : baseName;
+    }
+
+    static String validateBundleModuleName(String moduleName, String baseName, Function<String, Optional<Module>> findModule) {
+        if (moduleName == null || moduleName.isEmpty()) {
+            return null;
+        }
+        if (ALL_UNNAMED_MODULE.equals(moduleName)) {
+            return moduleName;
+        }
+        if (findModule.apply(moduleName).isEmpty()) {
+            throw UserError.abort(
+                            "Resource bundle '%s' was configured with module '%s', but that module is not present on the image classpath or module path.",
+                            baseName,
+                            moduleName);
+        }
+        return moduleName;
+    }
+
+    static void validateBundleClassModule(String moduleName, String bundleName, String className, Class<?> bundleClass) {
+        if (moduleName == null || moduleName.isEmpty()) {
+            return;
+        }
+        Module actualModule = bundleClass.getModule();
+        if (ALL_UNNAMED_MODULE.equals(moduleName)) {
+            throwIfModuleMismatch(!actualModule.isNamed(), bundleName, className, moduleName, actualModule);
+            return;
+        }
+        throwIfModuleMismatch(actualModule.isNamed() && moduleName.equals(actualModule.getName()), bundleName, className, moduleName, actualModule);
+    }
+
+    private static void throwIfModuleMismatch(boolean valid, String bundleName, String className, String expectedModuleName, Module actualModule) {
+        if (valid) {
+            return;
+        }
+        String actualModuleName = actualModule.isNamed() ? actualModule.getName() : ALL_UNNAMED_MODULE;
+        throw UserError.abort(
+                        "Resource bundle '%s' was configured with module '%s', but class '%s' belongs to module '%s'.",
+                        bundleName,
+                        expectedModuleName,
+                        className,
+                        actualModuleName);
     }
 
     @Platforms(Platform.HOSTED_ONLY.class)

--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/jdk/localization/LocalizationFeature.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/jdk/localization/LocalizationFeature.java
@@ -474,6 +474,24 @@ public class LocalizationFeature implements InternalFeature {
     }
 
     @Platforms(Platform.HOSTED_ONLY.class)
+    public void prepareClassResourceBundle(AccessCondition condition, String moduleName, String basename, String className) {
+        if (moduleName == null || moduleName.isEmpty()) {
+            prepareClassResourceBundle(basename, className);
+            return;
+        }
+        Class<?> bundleClass = findClassByName.apply(className);
+        if (bundleClass == null) {
+            /* Unknown classes are ignored */
+            return;
+        }
+        UserError.guarantee(ResourceBundle.class.isAssignableFrom(bundleClass), "%s is not a subclass of ResourceBundle", bundleClass.getName());
+        trace("Adding class based resource bundle: " + moduleName + ":" + className + " " + bundleClass);
+        support.registerBundleLookup(condition, moduleName, basename);
+        support.registerRequiredReflectionAndResourcesForBundle(basename, Set.of(), false);
+        support.prepareClassResourceBundle(basename, bundleClass);
+    }
+
+    @Platforms(Platform.HOSTED_ONLY.class)
     public void prepareBundle(AccessCondition condition, String baseName) {
         prepareBundle(condition, baseName, allLocales);
     }


### PR DESCRIPTION
Fixes #13194

## Summary

Implements the GR-67556 TODOs for module-aware resource bundle handling in Native Image.

## What changed

- preserve the optional 'module' qualifier in resource bundle metadata
- keep bundles with the same base name but different modules distinct
- make runtime registration and lookup with module
- use "bundle Identifier" record instead of plain String as a key

## Validation

- `mx build`
- `mx unittest ResourceConfigurationTest`

Tested new and old approach (with module and without). Both work. 