### PR TITLE
Fix checkByteArrayIllegal loop condition in ObjectState

### DIFF
--- a/compiler/src/jdk.graal.compiler/src/jdk/graal/compiler/virtual/phases/ea/ObjectState.java
+++ b/compiler/src/jdk.graal.compiler/src/jdk/graal/compiler/virtual/phases/ea/ObjectState.java
@@ -129,7 +129,7 @@ public class ObjectState {
         ValueNode value = values[i];
         int totalBytes = value.getStackKind().getByteCount();
         // Stamps erase the actual kind of a value. totalBytes is therefore not reliable.
-        while (j < values.length && values[i].isIllegalConstant()) {
+        while (j < values.length && values[j].isIllegalConstant()) {
             j++;
         }
         assert j - i <= totalBytes : Assertions.errorMessage(i, j, totalBytes, values, valuePos);


### PR DESCRIPTION
## Summary
Fixes the loop in `ObjectState.checkByteArrayIllegal` that skips trailing illegal constants after a primitive in a byte array. The loop variable is `j`, but the condition incorrectly used `values[i]`, so the loop did not advance correctly when multiple illegal slots follow the primitive.

## Testing
- Compiler change only; assertion logic fix aligned with existing comments (`totalBytes` / stamps caveat).