### PR TITLE
Use DebugScope.getName() for language top scope label

### DIFF
--- a/tools/src/com.oracle.truffle.tools.dap.test/src/com/oracle/truffle/tools/dap/test/SimpleLanguageDAPTest.java
+++ b/tools/src/com.oracle.truffle.tools.dap.test/src/com/oracle/truffle/tools/dap/test/SimpleLanguageDAPTest.java
@@ -622,6 +622,10 @@ public final class SimpleLanguageDAPTest {
         tester.finish();
     }
 
+    /**
+     * Asserts scope names in DAP responses, including the top scope label from the guest scope
+     * {@code toDisplayString} (Simple Language reports {@code "global"} for the top scope).
+     */
     @Test
     public void testScopes() throws Exception {
         tester = startDAPTester(true);
@@ -652,12 +656,12 @@ public final class SimpleLanguageDAPTest {
         // Ask for the local scope variables at the beginning of main:
         tester.sendMessage("{\"command\":\"scopes\",\"arguments\":{\"frameId\":1},\"type\":\"request\",\"seq\":7}");
         if (useBytecode) {
-            tester.compareReceivedMessages("{\"success\":true,\"body\":{\"scopes\":[{\"name\":\"Global\",\"variablesReference\":2,\"expensive\":true}]},\"type\":\"response\",\"request_seq\":7,\"command\":\"scopes\",\"seq\":13}");
+            tester.compareReceivedMessages("{\"success\":true,\"body\":{\"scopes\":[{\"name\":\"global\",\"variablesReference\":2,\"expensive\":true}]},\"type\":\"response\",\"request_seq\":7,\"command\":\"scopes\",\"seq\":13}");
             // The bytecode interpreter doesn't have a local scope, but we still need to request something to keep the sequence numbers in sync.
             tester.sendMessage("{\"command\":\"variables\",\"arguments\":{\"variablesReference\":2},\"type\":\"request\",\"seq\":8}");
             tester.getMessage();
         } else {
-            tester.compareReceivedMessages("{\"success\":true,\"body\":{\"scopes\":[{\"name\":\"Local\",\"variablesReference\":2,\"expensive\":false},{\"name\":\"Global\",\"variablesReference\":3,\"expensive\":true}]},\"type\":\"response\",\"request_seq\":7,\"command\":\"scopes\",\"seq\":13}");
+            tester.compareReceivedMessages("{\"success\":true,\"body\":{\"scopes\":[{\"name\":\"Local\",\"variablesReference\":2,\"expensive\":false},{\"name\":\"global\",\"variablesReference\":3,\"expensive\":true}]},\"type\":\"response\",\"request_seq\":7,\"command\":\"scopes\",\"seq\":13}");
             tester.sendMessage("{\"command\":\"variables\",\"arguments\":{\"variablesReference\":2},\"type\":\"request\",\"seq\":8}");
             tester.compareReceivedMessages("{\"success\":true,\"body\":{\"variables\":[]},\"type\":\"response\",\"request_seq\":8,\"command\":\"variables\",\"seq\":14}");
         }
@@ -676,7 +680,7 @@ public final class SimpleLanguageDAPTest {
         tester.compareReceivedMessages("{\"success\":true,\"body\":{\"stackFrames\":[{\"line\":5,\"name\":\"main\",\"column\":5,\"id\":1,\"source\":{\"sourceReference\":2,\"path\":\"" + testFilePath + "\",\"name\":\"SLTest.sl\"}}],\"totalFrames\":1},\"type\":\"response\",\"request_seq\":12,\"command\":\"stackTrace\",\"seq\":20}");
         // Ask for the local scope variables at line 5:
         tester.sendMessage("{\"command\":\"scopes\",\"arguments\":{\"frameId\":1},\"type\":\"request\",\"seq\":13}");
-        tester.compareReceivedMessages("{\"success\":true,\"body\":{\"scopes\":[{\"name\":\"" + (useBytecode ? "Block" : "Local") + "\",\"variablesReference\":2,\"expensive\":false},{\"name\":\"Global\",\"variablesReference\":3,\"expensive\":true}]},\"type\":\"response\",\"request_seq\":13,\"command\":\"scopes\",\"seq\":21}");
+        tester.compareReceivedMessages("{\"success\":true,\"body\":{\"scopes\":[{\"name\":\"" + (useBytecode ? "Block" : "Local") + "\",\"variablesReference\":2,\"expensive\":false},{\"name\":\"global\",\"variablesReference\":3,\"expensive\":true}]},\"type\":\"response\",\"request_seq\":13,\"command\":\"scopes\",\"seq\":21}");
         tester.sendMessage("{\"command\":\"variables\",\"arguments\":{\"variablesReference\":2},\"type\":\"request\",\"seq\":14}");
         tester.compareReceivedMessages("{\"success\":true,\"body\":{\"variables\":[{\"name\":\"a\",\"variablesReference\":0,\"type\":\"Number\",\"value\":\"10\"},{\"name\":\"b\",\"variablesReference\":0,\"type\":\"Number\",\"value\":\"2\"}]},\"type\":\"response\",\"request_seq\":14,\"command\":\"variables\",\"seq\":22}");
         // Step over:
@@ -693,14 +697,14 @@ public final class SimpleLanguageDAPTest {
         // Ask for the local scope variables at line 6:
         tester.sendMessage("{\"command\":\"scopes\",\"arguments\":{\"frameId\":1},\"type\":\"request\",\"seq\":18}");
         if (useBytecode) {
-            tester.compareReceivedMessages("{\"success\":true,\"body\":{\"scopes\":[{\"name\":\"Block\",\"variablesReference\":2,\"expensive\":false},{\"name\":\"Global\",\"variablesReference\":3,\"expensive\":true}]},\"type\":\"response\",\"request_seq\":18,\"command\":\"scopes\",\"seq\":28}");
+            tester.compareReceivedMessages("{\"success\":true,\"body\":{\"scopes\":[{\"name\":\"Block\",\"variablesReference\":2,\"expensive\":false},{\"name\":\"global\",\"variablesReference\":3,\"expensive\":true}]},\"type\":\"response\",\"request_seq\":18,\"command\":\"scopes\",\"seq\":28}");
             tester.sendMessage("{\"command\":\"variables\",\"arguments\":{\"variablesReference\":2},\"type\":\"request\",\"seq\":19}");
             tester.compareReceivedMessages("{\"success\":true,\"body\":{\"variables\":[{\"name\":\"a\",\"variablesReference\":0,\"type\":\"Number\",\"value\":\"10\"},{\"name\":\"b\",\"variablesReference\":0,\"type\":\"Number\",\"value\":\"2\"},{\"name\":\"c\",\"variablesReference\":0,\"type\":\"Number\",\"value\":\"12\"}]},\"type\":\"response\",\"request_seq\":19,\"command\":\"variables\",\"seq\":29}");
             // The bytecode interpreter doesn't have a second local scope, but we still need to request something to keep the sequence numbers in sync.
             tester.sendMessage("{\"command\":\"variables\",\"arguments\":{\"variablesReference\":3},\"type\":\"request\",\"seq\":20}");
             tester.getMessage();
         } else {
-            tester.compareReceivedMessages("{\"success\":true,\"body\":{\"scopes\":[{\"name\":\"Block\",\"variablesReference\":2,\"expensive\":false},{\"name\":\"Local\",\"variablesReference\":3,\"expensive\":false},{\"name\":\"Global\",\"variablesReference\":4,\"expensive\":true}]},\"type\":\"response\",\"request_seq\":18,\"command\":\"scopes\",\"seq\":28}");
+            tester.compareReceivedMessages("{\"success\":true,\"body\":{\"scopes\":[{\"name\":\"Block\",\"variablesReference\":2,\"expensive\":false},{\"name\":\"Local\",\"variablesReference\":3,\"expensive\":false},{\"name\":\"global\",\"variablesReference\":4,\"expensive\":true}]},\"type\":\"response\",\"request_seq\":18,\"command\":\"scopes\",\"seq\":28}");
             tester.sendMessage("{\"command\":\"variables\",\"arguments\":{\"variablesReference\":2},\"type\":\"request\",\"seq\":19}");
             tester.compareReceivedMessages("{\"success\":true,\"body\":{\"variables\":[{\"name\":\"c\",\"variablesReference\":0,\"type\":\"Number\",\"value\":\"12\"}]},\"type\":\"response\",\"request_seq\":19,\"command\":\"variables\",\"seq\":29}");
             tester.sendMessage("{\"command\":\"variables\",\"arguments\":{\"variablesReference\":3},\"type\":\"request\",\"seq\":20}");
@@ -818,7 +822,7 @@ public final class SimpleLanguageDAPTest {
         tester.sendMessage("{\"command\":\"stackTrace\",\"arguments\":{\"threadId\":1},\"type\":\"request\",\"seq\":15}");
         tester.compareReceivedMessages("{\"success\":true,\"body\":{\"stackFrames\":[{\"line\":13,\"name\":\"fn\",\"column\":2,\"id\":1,\"source\":{\"sourceReference\":2,\"path\":\"" + testFilePath + "\",\"name\":\"SLTest.sl\"}},{\"line\":6,\"name\":\"addThem\",\"column\":7,\"id\":2,\"source\":{\"sourceReference\":2,\"path\":\"" + testFilePath + "\",\"name\":\"SLTest.sl\"}},{\"line\":2,\"name\":\"main\",\"column\":7,\"id\":3,\"source\":{\"sourceReference\":2,\"path\":\"" + testFilePath + "\",\"name\":\"SLTest.sl\"}}],\"totalFrames\":3},\"type\":\"response\",\"request_seq\":15,\"command\":\"stackTrace\",\"seq\":27}");
         tester.sendMessage("{\"command\":\"scopes\",\"arguments\":{\"frameId\":1},\"type\":\"request\",\"seq\":16}");
-        tester.compareReceivedMessages("{\"success\":true,\"body\":{\"scopes\":[{\"name\":\"Local\",\"variablesReference\":4,\"expensive\":false},{\"name\":\"Global\",\"variablesReference\":5,\"expensive\":true}]},\"type\":\"response\",\"request_seq\":16,\"command\":\"scopes\",\"seq\":28}");
+        tester.compareReceivedMessages("{\"success\":true,\"body\":{\"scopes\":[{\"name\":\"Local\",\"variablesReference\":4,\"expensive\":false},{\"name\":\"global\",\"variablesReference\":5,\"expensive\":true}]},\"type\":\"response\",\"request_seq\":16,\"command\":\"scopes\",\"seq\":28}");
         tester.sendMessage("{\"command\":\"variables\",\"arguments\":{\"variablesReference\":4},\"type\":\"request\",\"seq\":17}");
         tester.compareReceivedMessages("{\"success\":true,\"body\":{\"variables\":[{\"name\":\"Return value\",\"variablesReference\":0,\"type\":\"Number\",\"value\":\"1\"},{\"name\":\"n\",\"variablesReference\":0,\"type\":\"Number\",\"value\":\"1\"}]},\"type\":\"response\",\"request_seq\":17,\"command\":\"variables\",\"seq\":29}");
         // change return value from 1 to 10_000_000_000 (it must be long because of SL)
@@ -836,7 +840,7 @@ public final class SimpleLanguageDAPTest {
         tester.sendMessage("{\"command\":\"stackTrace\",\"arguments\":{\"threadId\":1},\"type\":\"request\",\"seq\":21}");
         tester.compareReceivedMessages("{\"success\":true,\"body\":{\"stackFrames\":[{\"line\":6,\"name\":\"addThem\",\"column\":12,\"id\":1,\"source\":{\"sourceReference\":2,\"path\":\"" + testFilePath + "\",\"name\":\"SLTest.sl\"}},{\"line\":2,\"name\":\"main\",\"column\":7,\"id\":2,\"source\":{\"sourceReference\":2,\"path\":\"" + testFilePath + "\",\"name\":\"SLTest.sl\"}}],\"totalFrames\":2},\"type\":\"response\",\"request_seq\":21,\"command\":\"stackTrace\",\"seq\":35}");
         tester.sendMessage("{\"command\":\"scopes\",\"arguments\":{\"frameId\":1},\"type\":\"request\",\"seq\":22}");
-        tester.compareReceivedMessages("{\"success\":true,\"body\":{\"scopes\":[{\"name\":\"" + (useBytecode ? "Block" : "Local") + "\",\"variablesReference\":3,\"expensive\":false},{\"name\":\"Global\",\"variablesReference\":4,\"expensive\":true}]},\"type\":\"response\",\"request_seq\":22,\"command\":\"scopes\",\"seq\":36}");
+        tester.compareReceivedMessages("{\"success\":true,\"body\":{\"scopes\":[{\"name\":\"" + (useBytecode ? "Block" : "Local") + "\",\"variablesReference\":3,\"expensive\":false},{\"name\":\"global\",\"variablesReference\":4,\"expensive\":true}]},\"type\":\"response\",\"request_seq\":22,\"command\":\"scopes\",\"seq\":36}");
         tester.sendMessage("{\"command\":\"variables\",\"arguments\":{\"variablesReference\":3},\"type\":\"request\",\"seq\":23}");
         tester.compareReceivedMessages("{\"success\":true,\"body\":{\"variables\":[{\"name\":\"a\",\"variablesReference\":0,\"type\":\"Number\",\"value\":\"1\"},{\"name\":\"b\",\"variablesReference\":0,\"type\":\"Number\",\"value\":\"2\"}]},\"type\":\"response\",\"request_seq\":23,\"command\":\"variables\",\"seq\":37}");
         // at addThem:6, step into steps to the next line and check that `a` is 10_000_000_000
@@ -851,7 +855,7 @@ public final class SimpleLanguageDAPTest {
         tester.sendMessage("{\"command\":\"stackTrace\",\"arguments\":{\"threadId\":1},\"type\":\"request\",\"seq\":26}");
         tester.compareReceivedMessages("{\"success\":true,\"body\":{\"stackFrames\":[{\"line\":7,\"name\":\"addThem\",\"column\":3,\"id\":1,\"source\":{\"sourceReference\":2,\"path\":\"" + testFilePath + "\",\"name\":\"SLTest.sl\"}},{\"line\":2,\"name\":\"main\",\"column\":7,\"id\":2,\"source\":{\"sourceReference\":2,\"path\":\"" + testFilePath + "\",\"name\":\"SLTest.sl\"}}],\"totalFrames\":2},\"type\":\"response\",\"request_seq\":26,\"command\":\"stackTrace\",\"seq\":42}");
         tester.sendMessage("{\"command\":\"scopes\",\"arguments\":{\"frameId\":1},\"type\":\"request\",\"seq\":27}");
-        tester.compareReceivedMessages("{\"success\":true,\"body\":{\"scopes\":[{\"name\":\"" + (useBytecode ? "Block" : "Local") + "\",\"variablesReference\":3,\"expensive\":false},{\"name\":\"Global\",\"variablesReference\":4,\"expensive\":true}]},\"type\":\"response\",\"request_seq\":27,\"command\":\"scopes\",\"seq\":43}");
+        tester.compareReceivedMessages("{\"success\":true,\"body\":{\"scopes\":[{\"name\":\"" + (useBytecode ? "Block" : "Local") + "\",\"variablesReference\":3,\"expensive\":false},{\"name\":\"global\",\"variablesReference\":4,\"expensive\":true}]},\"type\":\"response\",\"request_seq\":27,\"command\":\"scopes\",\"seq\":43}");
         tester.sendMessage("{\"command\":\"variables\",\"arguments\":{\"variablesReference\":3},\"type\":\"request\",\"seq\":28}");
         tester.compareReceivedMessages("{\"success\":true,\"body\":{\"variables\":[{\"name\":\"a\",\"variablesReference\":0,\"type\":\"Number\",\"value\":\"10000000000\"},{\"name\":\"b\",\"variablesReference\":0,\"type\":\"Number\",\"value\":\"2\"}]},\"type\":\"response\",\"request_seq\":28,\"command\":\"variables\",\"seq\":44}");
         // at addThem:7
@@ -877,7 +881,7 @@ public final class SimpleLanguageDAPTest {
         tester.sendMessage("{\"command\":\"stackTrace\",\"arguments\":{\"threadId\":1},\"type\":\"request\",\"seq\":34}");
         tester.compareReceivedMessages("{\"success\":true,\"body\":{\"stackFrames\":[{\"line\":7,\"name\":\"addThem\",\"column\":12,\"id\":1,\"source\":{\"sourceReference\":2,\"path\":\"" + testFilePath + "\",\"name\":\"SLTest.sl\"}},{\"line\":2,\"name\":\"main\",\"column\":7,\"id\":2,\"source\":{\"sourceReference\":2,\"path\":\"" + testFilePath + "\",\"name\":\"SLTest.sl\"}}],\"totalFrames\":2},\"type\":\"response\",\"request_seq\":34,\"command\":\"stackTrace\",\"seq\":54}");
         tester.sendMessage("{\"command\":\"scopes\",\"arguments\":{\"frameId\":1},\"type\":\"request\",\"seq\":35}");
-        tester.compareReceivedMessages("{\"success\":true,\"body\":{\"scopes\":[{\"name\":\"" + (useBytecode ? "Block" : "Local") + "\",\"variablesReference\":3,\"expensive\":false},{\"name\":\"Global\",\"variablesReference\":4,\"expensive\":true}]},\"type\":\"response\",\"request_seq\":35,\"command\":\"scopes\",\"seq\":55}");
+        tester.compareReceivedMessages("{\"success\":true,\"body\":{\"scopes\":[{\"name\":\"" + (useBytecode ? "Block" : "Local") + "\",\"variablesReference\":3,\"expensive\":false},{\"name\":\"global\",\"variablesReference\":4,\"expensive\":true}]},\"type\":\"response\",\"request_seq\":35,\"command\":\"scopes\",\"seq\":55}");
         tester.sendMessage("{\"command\":\"variables\",\"arguments\":{\"variablesReference\":3},\"type\":\"request\",\"seq\":36}");
         tester.compareReceivedMessages("{\"success\":true,\"body\":{\"variables\":[{\"name\":\"a\",\"variablesReference\":0,\"type\":\"Number\",\"value\":\"10000000000\"},{\"name\":\"b\",\"variablesReference\":0,\"type\":\"Number\",\"value\":\"2\"}]},\"type\":\"response\",\"request_seq\":36,\"command\":\"variables\",\"seq\":56}");
         // Resume to finish:
@@ -1091,7 +1095,7 @@ public final class SimpleLanguageDAPTest {
         tester.sendMessage("{\"command\":\"stackTrace\",\"arguments\":{\"threadId\":1},\"type\":\"request\",\"seq\":7}");
         tester.compareReceivedMessages("{\"success\":true,\"body\":{\"stackFrames\":[{\"line\":16,\"name\":\"main\",\"column\":5,\"id\":1,\"source\":" + sourceJson + "}],\"totalFrames\":1},\"type\":\"response\",\"request_seq\":7,\"command\":\"stackTrace\",\"seq\":14}");
         tester.sendMessage("{\"command\":\"scopes\",\"arguments\":{\"frameId\":1},\"type\":\"request\",\"seq\":8}");
-        tester.compareReceivedMessages("{\"success\":true,\"body\":{\"scopes\":[{\"name\":\"" + (useBytecode ? "Block" : "Local") + "\",\"variablesReference\":2,\"expensive\":false},{\"name\":\"Global\",\"variablesReference\":3,\"expensive\":true}]},\"type\":\"response\",\"request_seq\":8,\"command\":\"scopes\",\"seq\":15}");
+        tester.compareReceivedMessages("{\"success\":true,\"body\":{\"scopes\":[{\"name\":\"" + (useBytecode ? "Block" : "Local") + "\",\"variablesReference\":2,\"expensive\":false},{\"name\":\"global\",\"variablesReference\":3,\"expensive\":true}]},\"type\":\"response\",\"request_seq\":8,\"command\":\"scopes\",\"seq\":15}");
         tester.sendMessage("{\"command\":\"variables\",\"arguments\":{\"variablesReference\":2},\"type\":\"request\",\"seq\":9}");
         tester.compareReceivedMessages("{\"success\":true,\"body\":{\"variables\":[{\"name\":\"n\",\"variablesReference\":0,\"type\":\"Number\",\"value\":\"1\"},"
                 + "{\"name\":\"m\",\"variablesReference\":0,\"type\":\"Number\",\"value\":\"4\"},"
@@ -1121,7 +1125,7 @@ public final class SimpleLanguageDAPTest {
         tester.sendMessage("{\"command\":\"stackTrace\",\"arguments\":{\"threadId\":1},\"type\":\"request\",\"seq\":16}");
         tester.compareReceivedMessages("{\"success\":true,\"body\":{\"stackFrames\":[{\"line\":16,\"name\":\"main\",\"column\":5,\"id\":1,\"source\":" + sourceJson + "}],\"totalFrames\":1},\"type\":\"response\",\"request_seq\":16,\"command\":\"stackTrace\",\"seq\":25}");
         tester.sendMessage("{\"command\":\"scopes\",\"arguments\":{\"frameId\":1},\"type\":\"request\",\"seq\":17}");
-        tester.compareReceivedMessages("{\"success\":true,\"body\":{\"scopes\":[{\"name\":\"" + (useBytecode ? "Block" : "Local") + "\",\"variablesReference\":2,\"expensive\":false},{\"name\":\"Global\",\"variablesReference\":3,\"expensive\":true}]},\"type\":\"response\",\"request_seq\":17,\"command\":\"scopes\",\"seq\":26}");
+        tester.compareReceivedMessages("{\"success\":true,\"body\":{\"scopes\":[{\"name\":\"" + (useBytecode ? "Block" : "Local") + "\",\"variablesReference\":2,\"expensive\":false},{\"name\":\"global\",\"variablesReference\":3,\"expensive\":true}]},\"type\":\"response\",\"request_seq\":17,\"command\":\"scopes\",\"seq\":26}");
         tester.sendMessage("{\"command\":\"variables\",\"arguments\":{\"variablesReference\":2},\"type\":\"request\",\"seq\":18}");
         tester.compareReceivedMessages("{\"success\":true,\"body\":{\"variables\":[{\"name\":\"n\",\"variablesReference\":0,\"type\":\"Number\",\"value\":\"0\"},"
                 + "{\"name\":\"m\",\"variablesReference\":0,\"type\":\"Number\",\"value\":\"1000\"},"

--- a/tools/src/com.oracle.truffle.tools.dap.test/src/com/oracle/truffle/tools/dap/test/StackFramesHandlerTest.java
+++ b/tools/src/com.oracle.truffle.tools.dap.test/src/com/oracle/truffle/tools/dap/test/StackFramesHandlerTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package com.oracle.truffle.tools.dap.test;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.oracle.truffle.tools.dap.server.StackFramesHandler;
+
+/**
+ * Unit tests for {@link com.oracle.truffle.tools.dap.server.StackFramesHandler}. Lives in this
+ * package so {@code mx unittest} can load the class (tests in {@code com.oracle.truffle.tools.dap.server}
+ * from the test module are not resolved by the harness).
+ */
+public class StackFramesHandlerTest {
+
+    @Test
+    public void topScopeDapNameNullAndBlankFallbackToGlobal() {
+        Assert.assertEquals(StackFramesHandler.DEFAULT_TOP_SCOPE_NAME, StackFramesHandler.topScopeDapName((String) null));
+        Assert.assertEquals(StackFramesHandler.DEFAULT_TOP_SCOPE_NAME, StackFramesHandler.topScopeDapName(""));
+        Assert.assertEquals(StackFramesHandler.DEFAULT_TOP_SCOPE_NAME, StackFramesHandler.topScopeDapName(" \t\r\n "));
+    }
+
+    @Test
+    public void topScopeDapNameTrimsWhitespace() {
+        Assert.assertEquals("Module", StackFramesHandler.topScopeDapName("  Module  "));
+        Assert.assertEquals("x", StackFramesHandler.topScopeDapName("\nx\t"));
+    }
+
+    @Test
+    public void topScopeDapNamePreservesGuestString() {
+        Assert.assertEquals("global", StackFramesHandler.topScopeDapName("global"));
+        Assert.assertEquals("DAP-Custom", StackFramesHandler.topScopeDapName("DAP-Custom"));
+    }
+}

--- a/tools/src/com.oracle.truffle.tools.dap/src/com/oracle/truffle/tools/dap/server/StackFramesHandler.java
+++ b/tools/src/com.oracle.truffle.tools.dap/src/com/oracle/truffle/tools/dap/server/StackFramesHandler.java
@@ -42,6 +42,9 @@ import java.util.List;
 
 public final class StackFramesHandler {
 
+    /** DAP variables-view label for a guest top scope when no usable guest name is available. */
+    public static final String DEFAULT_TOP_SCOPE_NAME = "Global";
+
     private final ExecutionContext context;
     private final DebuggerSession debuggerSession;
 
@@ -155,18 +158,32 @@ public final class StackFramesHandler {
     /**
      * Label for the guest language top scope in the DAP variables view. Prefer
      * {@link DebugScope#getName()} (guest {@code toDisplayString}) so languages can surface a
-     * meaningful name; fall back to {@code "Global"} if the name is unavailable or empty.
+     * meaningful name; fall back to {@value #DEFAULT_TOP_SCOPE_NAME} if the name is unavailable,
+     * empty, or blank after trimming, or if {@code getName()} throws.
      */
-    private static String topScopeDapName(DebugScope dscope) {
+    static String topScopeDapName(DebugScope dscope) {
         try {
-            String name = dscope.getName();
-            if (name != null && !name.isEmpty()) {
-                return name;
-            }
+            return topScopeDapName(dscope.getName());
         } catch (DebugException ignored) {
-            // Unusable guest scope name — keep the previous fixed label behavior.
+            // Unusable guest scope name - keep the previous fixed label behavior.
+            return DEFAULT_TOP_SCOPE_NAME;
         }
-        return "Global";
+    }
+
+    /**
+     * Maps a guest top-scope display string to the DAP scope name: trims whitespace and falls back
+     * to {@value #DEFAULT_TOP_SCOPE_NAME} for {@code null} or blank results.
+     * <p>
+     * Exposed as {@code public} so unit tests in {@code com.oracle.truffle.tools.dap.test} can run
+     * under {@code mx unittest} (that harness does not load test classes in this package from the
+     * test JAR). Production callers should use {@link #topScopeDapName(DebugScope)}.
+     */
+    public static String topScopeDapName(String guestName) {
+        if (guestName == null) {
+            return DEFAULT_TOP_SCOPE_NAME;
+        }
+        String trimmed = guestName.trim();
+        return trimmed.isEmpty() ? DEFAULT_TOP_SCOPE_NAME : trimmed;
     }
 
     public static Variable evaluateOnStackFrame(ThreadsHandler.SuspendedThreadInfo info, int frameId, String expression) {

--- a/tools/src/com.oracle.truffle.tools.dap/src/com/oracle/truffle/tools/dap/server/StackFramesHandler.java
+++ b/tools/src/com.oracle.truffle.tools.dap/src/com/oracle/truffle/tools/dap/server/StackFramesHandler.java
@@ -143,7 +143,7 @@ public final class StackFramesHandler {
             while (dscope != null) {
                 if (dscope.isFunctionScope() || dscope.getDeclaredValues().iterator().hasNext()) {
                     // provide only scopes that have some variables
-                    scopes.add(Scope.create("Global", info.getId(dscope), true));
+                    scopes.add(Scope.create(topScopeDapName(dscope), info.getId(dscope), true));
                 }
                 dscope = getParent(dscope);
             }
@@ -152,7 +152,24 @@ public final class StackFramesHandler {
         return null;
     }
 
-    public static Variable evaluateOnStackFrame(ThreadsHandler.SuspendedThreadInfo info, int frameId, String expression) throws DebugException {
+    /**
+     * Label for the guest language top scope in the DAP variables view. Prefer
+     * {@link DebugScope#getName()} (guest {@code toDisplayString}) so languages can surface a
+     * meaningful name; fall back to {@code "Global"} if the name is unavailable or empty.
+     */
+    private static String topScopeDapName(DebugScope dscope) {
+        try {
+            String name = dscope.getName();
+            if (name != null && !name.isEmpty()) {
+                return name;
+            }
+        } catch (DebugException ignored) {
+            // Unusable guest scope name — keep the previous fixed label behavior.
+        }
+        return "Global";
+    }
+
+    public static Variable evaluateOnStackFrame(ThreadsHandler.SuspendedThreadInfo info, int frameId, String expression) {
         FrameWrapper frameWrapper = info.getById(FrameWrapper.class, frameId);
         DebugStackFrame frame = frameWrapper != null ? frameWrapper.getFrame() : null;
         if (frame != null) {


### PR DESCRIPTION

### Summary
The Debug Adapter Protocol server always exposed Truffle’s language top scope (from `DebuggerSession.getTopScope`) under the fixed name **`"Global"`**, ignoring each language’s own scope display name.

This change uses **`DebugScope.getName()`** (which already reflects the guest scope’s `toDisplayString` via interop) when building the DAP `Scope` entry. If the name is missing, empty, or `getName()` fails with `DebugException`, the label falls back to **`"Global"`**, preserving previous behavior when a usable name is not available.

### Motivation
Guest languages can already provide a human-readable scope name through their scope object, but the DAP layer discarded it. Showing that name in the variables UI (e.g. namespace- or project-specific labels) improves clarity without changing how variables are resolved.

### Use Case
For [Clojure-on-Truffle–style languages](https://github.com/The-Alchemist/cloffle-clojure), “globals” are usually namespace def / Var bindings, not Java-style globals. The language already exposes that through `TruffleLanguage.getScope()`, and the guest scope object’s `toDisplayString` is a natural place to say which namespace you’re looking at (for example `Namespace: user` or `Namespace: my.app`).

Today the DAP server never showed that string: it always labeled that scope Global in the Variables view, so Clojure users saw a generic bucket name even when the implementation already knew the real namespace.

With this change, `DebugScope.getName()` (which is driven by that toDisplayString) becomes the DAP scope title when it’s non-empty, so the same breakpoint UI can show a namespace-specific label. If the name can’t be resolved, behavior stays Global, matching the old default.


### Risk / compatibility
**Low.** Clients still receive a string scope name; only the default label changes when `getName()` returns a non-empty value. Fallback remains `"Global"` on failure or empty name.B


