### PR TITLE
Add extract-sbom command to native-image-utils tool

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -194,6 +194,8 @@ jobs:
       if: ${{ matrix.env.TOOLS_JDK_VERSION != '' }}
       run: |
         ${MX_PATH}/mx --java-home= fetch-jdk --jdk-id labsjdk-ce-${TOOLS_JDK_VERSION} --to jdk-dl --alias ${TOOLS_JAVA_HOME_LOCATION}
+    - name: Install libelf.h
+      run: sudo apt update && sudo apt-get install -y libelf-dev
     - name: Update dependency cache
       if: ${{ env.MX_RUNS_DEBUG == 'true' || env.MX_RUNS_STYLE == 'true' }}
       run: sudo apt update

--- a/substratevm/mx.substratevm/mx_substratevm.py
+++ b/substratevm/mx.substratevm/mx_substratevm.py
@@ -2266,6 +2266,7 @@ mx_sdk_vm.register_graalvm_component(mx_sdk_vm.GraalVmJreComponent(
             build_args=svm_experimental_options([
                 '-H:-ParseRuntimeOptions',
                 '-H:+TreatAllTypeReachableConditionsAsTypeReached',
+                '--features=com.oracle.svm.configure.command.sbom.SbomExtractFeature',
             ]),
             extra_jvm_args=_native_image_utils_extra_jvm_args(),
             home_finder=False,

--- a/substratevm/mx.substratevm/suite.py
+++ b/substratevm/mx.substratevm/suite.py
@@ -945,6 +945,28 @@ suite = {
             "jacoco" : "exclude",
         },
 
+        "com.oracle.svm.native.extractsbom": {
+            "subDir": "src",
+            "native": "static_lib",
+            "deliverable" : "extract_sbom",
+            "os_arch": {
+                "linux": {
+                    "<others>": {
+                        "cflags": ["-g", "-Wall", "-fPIC" ],
+                    },
+                },
+                "<others>": {
+                    "<others>": {
+                        "ignore": "only supported on linux",
+                    },
+                },
+            },
+            "multitarget": {
+                "libc": ["glibc", "default"],
+            },
+            "jacoco" : "exclude",
+        },
+
         "com.oracle.svm.native.reporterchelper": {
             "subDir": "src",
             "native": "shared_lib",
@@ -2395,6 +2417,7 @@ suite = {
                             "dependency:com.oracle.svm.native.libchelper/*",
                             "dependency:com.oracle.svm.native.jvm.posix/*",
                             "dependency:com.oracle.svm.native.libcontainer/*",
+                            "dependency:com.oracle.svm.native.extractsbom/*",
                             "file:debug/include",
                             "file:src/com.oracle.svm.core/src/com/oracle/svm/core/gc/shared/include",
                         ],

--- a/substratevm/src/com.oracle.svm.configure/src/com/oracle/svm/configure/ConfigurationTool.java
+++ b/substratevm/src/com.oracle.svm.configure/src/com/oracle/svm/configure/ConfigurationTool.java
@@ -31,6 +31,7 @@ import java.util.Iterator;
 import java.util.Map;
 
 import com.oracle.svm.configure.command.ConfigurationCommand;
+import com.oracle.svm.configure.command.ConfigurationCommandExtractSbom;
 import com.oracle.svm.configure.command.ConfigurationCommandFileCommand;
 import com.oracle.svm.configure.command.ConfigurationGenerateCommand;
 import com.oracle.svm.configure.command.ConfigurationGenerateConditionalsCommand;
@@ -58,6 +59,7 @@ public class ConfigurationTool {
         ConfigurationCommand processTraceCommand = new ConfigurationProcessTraceCommand();
         ConfigurationCommand generateFiltersCommand = new ConfigurationGenerateFiltersCommand();
         ConfigurationCommand conditionalsCommand = new ConfigurationGenerateConditionalsCommand();
+        ConfigurationCommand sbomExtractCommand = new ConfigurationCommandExtractSbom();
 
         commands.put(helpCommand.getName(), helpCommand);
         commands.put(generateCommand.getName(), generateCommand);
@@ -65,6 +67,7 @@ public class ConfigurationTool {
         commands.put(processTraceCommand.getName(), processTraceCommand);
         commands.put(conditionalsCommand.getName(), conditionalsCommand);
         commands.put(generateFiltersCommand.getName(), generateFiltersCommand);
+        commands.put(sbomExtractCommand.getName(), sbomExtractCommand);
     }
 
     public static Collection<ConfigurationCommand> getCommands() {

--- a/substratevm/src/com.oracle.svm.configure/src/com/oracle/svm/configure/command/ConfigurationCommandExtractSbom.java
+++ b/substratevm/src/com.oracle.svm.configure/src/com/oracle/svm/configure/command/ConfigurationCommandExtractSbom.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2023, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package com.oracle.svm.configure.command;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Iterator;
+
+import com.oracle.svm.configure.ConfigurationUsageException;
+import com.oracle.svm.configure.command.sbom.SbomExtractLibrary;
+
+public final class ConfigurationCommandExtractSbom extends ConfigurationCommand {
+
+    private static final String IMAGE_PATH_OPT = "--image-path";
+    private static final String EXTRACT_CMD = "extract-sbom";
+
+    @Override
+    public String getName() {
+        return EXTRACT_CMD;
+    }
+
+    @Override
+    public void apply(Iterator<String> argumentsIterator) throws IOException {
+        Path imagePath = null;
+        while (argumentsIterator.hasNext()) {
+            String[] optionValue = argumentsIterator.next().split(OPTION_VALUE_SEP, OPTION_VALUE_LENGTH);
+            String option = optionValue[OPTION_INDEX];
+            String value = (optionValue.length > 1) ? optionValue[VALUE_INDEX] : null;
+            switch (option) {
+                case IMAGE_PATH_OPT:
+                    imagePath = requirePath(option, value);
+                    break;
+            }
+        }
+        if (imagePath == null) {
+            throw new ConfigurationUsageException("Argument must be provided for: " + IMAGE_PATH_OPT);
+        }
+        if (!Files.exists(imagePath)) {
+            throw new ConfigurationUsageException("Binary does not exist or is not readable: " + imagePath);
+        }
+        int exitCode = SbomExtractLibrary.extractSbom(imagePath);
+        if (exitCode != 0) {
+            throw new RuntimeException("Failed to extract SBOM. See previous messages for defails.");
+        }
+    }
+
+    @Override
+    public String getUsage() {
+        return String.format("native-image-utils %s %s=<native-binary>", EXTRACT_CMD, IMAGE_PATH_OPT);
+    }
+
+    @Override
+    protected String getDescription0() {
+        return """
+                                      extracts an embedded SBOM from a native image binary.
+                            --image-path=<path>
+                                                  the path to the binary where the SBOM is embedded.
+                        """.replace("\n", System.lineSeparator());
+    }
+}

--- a/substratevm/src/com.oracle.svm.configure/src/com/oracle/svm/configure/command/sbom/SbomExtractFeature.java
+++ b/substratevm/src/com.oracle.svm.configure/src/com/oracle/svm/configure/command/sbom/SbomExtractFeature.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2026, 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package com.oracle.svm.configure.command.sbom;
+
+import org.graalvm.nativeimage.hosted.Feature;
+
+import com.oracle.svm.shared.singletons.traits.BuiltinTraits.BuildtimeAccessOnly;
+import com.oracle.svm.shared.singletons.traits.BuiltinTraits.NoLayeredCallbacks;
+import com.oracle.svm.shared.singletons.traits.SingletonTraits;
+
+/**
+ * Marker feature used at build-time to add linking for the extract_sbom static library.
+ */
+@SingletonTraits(access = BuildtimeAccessOnly.class, layeredCallbacks = NoLayeredCallbacks.class)
+public class SbomExtractFeature implements Feature {
+    @Override
+    public void afterRegistration(AfterRegistrationAccess access) {
+        // Nothing. This is only a hook to enable the extract_sbom.a library at build time
+    }
+}

--- a/substratevm/src/com.oracle.svm.configure/src/com/oracle/svm/configure/command/sbom/SbomExtractLibrary.java
+++ b/substratevm/src/com.oracle.svm.configure/src/com/oracle/svm/configure/command/sbom/SbomExtractLibrary.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2026, 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package com.oracle.svm.configure.command.sbom;
+
+import java.nio.file.Path;
+import java.util.List;
+
+import org.graalvm.nativeimage.ImageSingletons;
+import org.graalvm.nativeimage.Platform;
+import org.graalvm.nativeimage.Platforms;
+import org.graalvm.nativeimage.c.CContext;
+import org.graalvm.nativeimage.c.function.CFunction;
+import org.graalvm.nativeimage.c.function.CFunction.Transition;
+import org.graalvm.nativeimage.c.function.CLibrary;
+import org.graalvm.nativeimage.c.type.CCharPointer;
+import org.graalvm.nativeimage.c.type.CTypeConversion;
+import org.graalvm.nativeimage.c.type.CTypeConversion.CCharPointerHolder;
+
+/**
+ * Provides Java-level access to the native {@code libextract_sbom} implementation.
+ */
+@CContext(SbomExtractLibraryDirectives.class)
+@CLibrary(value = "extract_sbom", requireStatic = true)
+public class SbomExtractLibrary {
+
+    public static int extractSbom(Path executable) {
+        CCharPointerHolder exe = CTypeConversion.toCString(executable.toAbsolutePath().toString());
+        return extractSbomNative(exe.get());
+    }
+
+    @CFunction(value = "extract_sbom", transition = Transition.NO_TRANSITION)
+    private static native int extractSbomNative(CCharPointer executable);
+
+}
+
+@Platforms(Platform.HOSTED_ONLY.class)
+class SbomExtractLibraryDirectives implements CContext.Directives {
+    /**
+     * True if {@link SbomExtractLibrary} should be linked.
+     */
+    @Override
+    public boolean isInConfiguration() {
+        return Platform.includedIn(Platform.LINUX.class) && ImageSingletons.contains(SbomExtractFeature.class);
+    }
+
+    @Override
+    public List<String> getLibraries() {
+        return List.of("elf");
+    }
+}

--- a/substratevm/src/com.oracle.svm.native.extractsbom/src/extract_sbom.c
+++ b/substratevm/src/com.oracle.svm.native.extractsbom/src/extract_sbom.c
@@ -1,0 +1,322 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <libelf.h>
+#include <gelf.h>
+#include <zlib.h>
+
+typedef struct {
+    const char *name;
+    GElf_Sym sym;
+    size_t section_index;
+} elf_symbol;
+
+#ifdef DEBUG
+
+#define LOG_DEBUG(format, type, param)   \
+{                                        \
+   fprintf(stderr, format, (type)param); \
+}
+
+#else
+
+#define LOG_DEBUG(format, type, param)
+
+#endif
+
+static elf_symbol *read_symbols(Elf *elf, size_t *symcount) {
+    Elf_Scn *scn = NULL;
+    GElf_Shdr shdr;
+    Elf_Data *data;
+    Elf_Data *str_data;
+    elf_symbol *symbol_table = NULL;
+    size_t symbol_count = 0;
+
+    // Find the .dynsym section
+    while ((scn = elf_nextscn(elf, scn)) != NULL) {
+        if (gelf_getshdr(scn, &shdr) != &shdr) {
+            continue;
+        }
+
+        if (shdr.sh_type == SHT_DYNSYM) {
+            break;
+        }
+    }
+
+    if (!scn) {
+        fprintf(stderr, "No dynamic symbol table found\n");
+        return NULL;
+    }
+
+    // Get the symbol table data
+    data = elf_getdata(scn, NULL);
+    if (!data) {
+        fprintf(stderr, "Failed to get symbol table data\n");
+        return NULL;
+    }
+
+    // Get the string table
+    Elf_Scn *str_scn = elf_getscn(elf, shdr.sh_link);
+    if (!str_scn) {
+        fprintf(stderr, "Failed to get string table section\n");
+        return NULL;
+    }
+
+    str_data = elf_getdata(str_scn, NULL);
+    if (!str_data) {
+        fprintf(stderr, "Failed to get string table data\n");
+        return NULL;
+    }
+
+    // Calculate number of symbols
+    symbol_count = shdr.sh_size / shdr.sh_entsize;
+
+    if (symbol_count == 0) {
+        fprintf(stderr, "No dynamic symbols found\n");
+        return NULL;
+    }
+
+    // Allocate symbol table
+    symbol_table = (elf_symbol *) malloc(symbol_count * sizeof(elf_symbol));
+    if (!symbol_table) {
+        fprintf(stderr, "Failed to allocate memory for symbol table\n");
+        return NULL;
+    }
+
+    // Read all symbols
+    for (size_t i = 0; i < symbol_count; i++) {
+        GElf_Sym sym;
+        if (gelf_getsym(data, i, &sym) != &sym) {
+            free(symbol_table);
+            fprintf(stderr, "Failed to read symbol at index %zu\n", i);
+            return NULL;
+        }
+
+        symbol_table[i].sym = sym;
+        symbol_table[i].section_index = sym.st_shndx;
+        symbol_table[i].name = (const char *)str_data->d_buf + sym.st_name;
+    }
+
+    *symcount = symbol_count;
+    return symbol_table;
+}
+
+static elf_symbol *find_symbol(elf_symbol *symbol_table, size_t symcount, const char *name) {
+    for (size_t i = 0; i < symcount; i++) {
+        if (symbol_table[i].name && strcmp(symbol_table[i].name, name) == 0) {
+            return &symbol_table[i];
+        }
+    }
+    return NULL;
+}
+
+static int get_section_data_at_offset(Elf *elf, elf_symbol *sym, uint64_t offset,
+                                       size_t size, unsigned char **out_data) {
+    Elf_Scn *section;
+    GElf_Shdr shdr;
+    Elf_Data *section_data;
+
+    section = elf_getscn(elf, sym->section_index);
+    if (!section || gelf_getshdr(section, &shdr) != &shdr) {
+        fprintf(stderr, "Failed to get section\n");
+        return 1;
+    }
+
+    section_data = elf_getdata(section, NULL);
+    if (!section_data) {
+        fprintf(stderr, "Failed to get section data\n");
+        return 1;
+    }
+
+    if (offset + size > section_data->d_size) {
+        fprintf(stderr, "Not enough data to read %zu bytes at offset %lu\n", size, offset);
+        return 1;
+    }
+
+    *out_data = (unsigned char *)section_data->d_buf + offset;
+    return 0;
+}
+
+#define CHUNK_SIZE 16384
+
+// inflate data in 'source' with len 'source_len' to the buffer pointed to by
+// 'dest'. The output length will be set in 'dest_len'.
+static int inflate_gzip(const unsigned char *source, uint64_t source_len,
+                        unsigned char **dest, uint64_t *dest_len) {
+    z_stream strm;
+    int ret;
+    size_t output_size = 0;
+    size_t output_capacity = CHUNK_SIZE;
+    unsigned char *output = malloc(output_capacity);
+    unsigned char out_buffer[CHUNK_SIZE];
+
+    if (!output) {
+        fprintf(stderr, "Failed to allocate memory\n");
+        return 1;
+    }
+
+    // Initialize zlib stream
+    strm.zalloc = Z_NULL;
+    strm.zfree = Z_NULL;
+    strm.opaque = Z_NULL;
+    strm.avail_in = 0;
+    strm.next_in = Z_NULL;
+
+    // Initialize for gzip format (windowBits = 15 + 16 for gzip)
+    ret = inflateInit2(&strm, 15 + 16);
+    if (ret != Z_OK) {
+        fprintf(stderr, "Failed to initialize zlib: %d\n", ret);
+        free(output);
+        return 1;
+    }
+
+    // Set input
+    strm.avail_in = source_len;
+    strm.next_in = (unsigned char *)source;
+
+    // Decompress until end of stream
+    do {
+        strm.avail_out = CHUNK_SIZE;
+        strm.next_out = out_buffer;
+
+        ret = inflate(&strm, Z_NO_FLUSH);
+
+        switch (ret) {
+            case Z_NEED_DICT:
+            case Z_DATA_ERROR:
+            case Z_MEM_ERROR:
+                fprintf(stderr, "Decompression error: %d\n", ret);
+                inflateEnd(&strm);
+                free(output);
+                return 1;
+        }
+
+        size_t have = CHUNK_SIZE - strm.avail_out;
+
+        // Resize output buffer if needed
+        if (output_size + have > output_capacity) {
+            output_capacity *= 2;
+            unsigned char *new_output = realloc(output, output_capacity);
+            if (!new_output) {
+                fprintf(stderr, "Failed to reallocate memory\n");
+                inflateEnd(&strm);
+                free(output);
+                return 1;
+            }
+            output = new_output;
+        }
+
+        // Copy decompressed data to output
+        memcpy(output + output_size, out_buffer, have);
+        output_size += have;
+
+    } while (strm.avail_out == 0);
+
+    // Cleanup
+    inflateEnd(&strm);
+
+    if (ret != Z_STREAM_END) {
+        fprintf(stderr, "Incomplete decompression\n");
+        free(output);
+        return 1;
+    }
+
+    *dest = output;
+    *dest_len = output_size;
+
+    return 0;
+}
+
+#undef CHUNK_SIZE
+
+// Retrieves an embedded SBOM (gzip compressed) from a binary (executable or
+// shared library). The executable parameter is the path to the binary. The
+// SBOM is streamed to stdout
+int extract_sbom(const char* executable) {
+    int fd;
+    Elf *elf;
+    elf_symbol *symbol_table = NULL;
+    elf_symbol *sbom_sym, *sbom_size_sym;
+    size_t symcount;
+    unsigned char *length_data, *compressed_data, *decompressed_data = NULL;
+    uint64_t sbom_length, sbom_offset, decompressed_len;
+    GElf_Shdr shdr;
+    int ret = 1;
+
+    if (elf_version(EV_CURRENT) == EV_NONE) {
+        fprintf(stderr, "Failed to initialize libelf: %s\n", elf_errmsg(-1));
+        return 1;
+    }
+
+    fd = open(executable, O_RDONLY);
+    if (fd < 0) {
+        fprintf(stderr, "Failed to open file '%s'\n", executable);
+        return 1;
+    }
+
+    elf = elf_begin(fd, ELF_C_READ, NULL);
+    if (!elf || elf_kind(elf) != ELF_K_ELF) {
+        fprintf(stderr, "Failed to open ELF file '%s'\n", executable);
+        goto cleanup;
+    }
+
+    symbol_table = read_symbols(elf, &symcount);
+    if (!symbol_table) {
+        goto cleanup;
+    }
+
+    sbom_sym = find_symbol(symbol_table, symcount, "sbom");
+    sbom_size_sym = find_symbol(symbol_table, symcount, "sbom_length");
+    if (!sbom_sym || !sbom_size_sym) {
+        fprintf(stderr, "Required symbols 'sbom' or 'sbom_length' not found\n");
+        goto cleanup;
+    }
+
+    // Read sbom_length value (8 bytes)
+    Elf_Scn *size_section = elf_getscn(elf, sbom_size_sym->section_index);
+    if (!size_section || gelf_getshdr(size_section, &shdr) != &shdr) {
+        fprintf(stderr, "Failed to get sbom_length section\n");
+        goto cleanup;
+    }
+
+    uint64_t size_offset = sbom_size_sym->sym.st_value - shdr.sh_addr;
+    if (get_section_data_at_offset(elf, sbom_size_sym, size_offset, 8, &length_data) != 0) {
+        goto cleanup;
+    }
+    memcpy(&sbom_length, length_data, 8);
+
+    // Read compressed SBOM data
+    Elf_Scn *sbom_section = elf_getscn(elf, sbom_sym->section_index);
+    if (!sbom_section || gelf_getshdr(sbom_section, &shdr) != &shdr) {
+        fprintf(stderr, "Failed to get sbom section\n");
+        goto cleanup;
+    }
+
+    sbom_offset = sbom_sym->sym.st_value - shdr.sh_addr;
+    if (get_section_data_at_offset(elf, sbom_sym, sbom_offset, sbom_length, &compressed_data) != 0) {
+        goto cleanup;
+    }
+
+    LOG_DEBUG("sbom address: 0x%lx\n", unsigned long, sbom_sym->sym.st_value);
+    LOG_DEBUG("sbom_length: %lu bytes\n", unsigned long, sbom_length);
+
+    // Decompress and output
+    if (inflate_gzip(compressed_data, sbom_length, &decompressed_data, &decompressed_len) != 0) {
+        fprintf(stderr, "Failed to decompress data\n");
+        goto cleanup;
+    }
+
+    fwrite(decompressed_data, decompressed_len, 1, stdout);
+    LOG_DEBUG("Successfully extracted %lu bytes of compressed data\n", unsigned long, sbom_length);
+    ret = 0;
+
+cleanup:
+    free(decompressed_data);
+    free(symbol_table);
+    if (elf) elf_end(elf);
+    if (fd >= 0) close(fd);
+    return ret;
+}
+


### PR DESCRIPTION
## Summary

This tool relies on a native library, `libextract_sbom.a`, produced by the build, which is currently Linux only and allows for `extract-sbom` command added to the `native-image-utils` tool. It can be used to read the gzip compressed SBOM bytes from another native image.

## Related Issues

Implementation of https://github.com/oracle/graal/issues/13374

## Testing

- [x] SBOM extraction on a native image produced with Oracle GraalVM
- [x] SBOM extraction on a patched build of Mandrel 25 which embeds a Quarkus SBOM.

## Basic Usage:

1. Build GraalVM (with native-image-utils). E.g. by adding: `--native=...,native-image-utils --components="Native Image Configure Tool,...`
3. `$GRAALVM_HOME/bin/native-image-utils extract-sbom --image-path=/path/to/binary-with-sbom-embedded`


**Assisted-by:** Claude, Model: Sonnet 4.5