### PR TITLE
Fix incorrect OtherContextException wrapper when the exception comes back to its creator context

### DIFF
--- a/truffle/src/com.oracle.truffle.api.instrumentation.test/src/com/oracle/truffle/api/instrumentation/test/TruffleContextTest.java
+++ b/truffle/src/com.oracle.truffle.api.instrumentation.test/src/com/oracle/truffle/api/instrumentation/test/TruffleContextTest.java
@@ -614,6 +614,31 @@ public class TruffleContextTest extends AbstractPolyglotTest {
         innerContext.close();
     }
 
+    @Test
+    public void testInnerContextRethrowsOuterContextError() throws InteropException {
+        EvalContextTestException outerException = new EvalContextTestException();
+        EvalContextRethrowingObject innerObject = new EvalContextRethrowingObject(outerException);
+        AtomicReference<AbstractTruffleException> innerCaughtException = new AtomicReference<>();
+        setupLanguageThatReturns(() -> innerObject);
+
+        TruffleContext innerContext = languageEnv.newInnerContextBuilder().initializeCreatorContext(true).build();
+        outerException.expectedContext = languageEnv.getContext();
+        innerObject.expectedContext = innerContext;
+        innerObject.innerCaughtException = innerCaughtException;
+
+        Object result = innerContext.evalInternal(null, newTruffleSource());
+        assertNotEquals("must be wrapped", innerObject, result);
+        try {
+            InteropLibrary.getUncached().execute(result, outerException);
+            fail();
+        } catch (AbstractTruffleException e) {
+            assertSame(outerException, e);
+        }
+        assertNotNull(innerCaughtException.get());
+        assertEquals(1, innerObject.executeCount);
+        innerContext.close();
+    }
+
     @SuppressWarnings("serial")
     @ExportLibrary(InteropLibrary.class)
     static class EvalContextTestException extends AbstractTruffleException {
@@ -655,6 +680,45 @@ public class TruffleContextTest extends AbstractPolyglotTest {
             }
             executeCount++;
             return this;
+        }
+    }
+
+    @ExportLibrary(InteropLibrary.class)
+    static class EvalContextRethrowingObject implements TruffleObject {
+
+        final EvalContextTestException outerException;
+        TruffleContext expectedContext;
+        AtomicReference<AbstractTruffleException> innerCaughtException;
+        int executeCount;
+
+        EvalContextRethrowingObject(EvalContextTestException outerException) {
+            this.outerException = outerException;
+        }
+
+        @ExportMessage
+        @TruffleBoundary
+        final boolean isExecutable() {
+            assertTrue(expectedContext.isEntered());
+            return true;
+        }
+
+        @ExportMessage
+        @TruffleBoundary
+        final Object execute(Object[] args) {
+            assertTrue(expectedContext.isEntered());
+            assertEquals(1, args.length);
+            executeCount++;
+            try {
+                InteropLibrary.getUncached().throwException(args[0]);
+                fail();
+            } catch (AbstractTruffleException e) {
+                Assert.assertNotSame(outerException, e);
+                innerCaughtException.set(e);
+                throw e;
+            } catch (InteropException e) {
+                throw CompilerDirectives.shouldNotReachHere(e);
+            }
+            return null;
         }
     }
 

--- a/truffle/src/com.oracle.truffle.api/src/com/oracle/truffle/api/TruffleContext.java
+++ b/truffle/src/com.oracle.truffle.api/src/com/oracle/truffle/api/TruffleContext.java
@@ -1274,7 +1274,7 @@ public final class TruffleContext implements AutoCloseable {
 
         /**
          * Specifies a {@link Runnable} that will be executed when some operation on the new context
-         * attenmpted while the context is already {@link TruffleContext#close()} closed}. However,
+         * attempted while the context is already {@link TruffleContext#close() closed}. However,
          * the runnable will only be executed if the outer context is not closed.
          *
          * The purpose of the runnable is to allow throwing a custom guest exception before the

--- a/truffle/src/com.oracle.truffle.polyglot/src/com/oracle/truffle/polyglot/OtherContextGuestObject.java
+++ b/truffle/src/com.oracle.truffle.polyglot/src/com/oracle/truffle/polyglot/OtherContextGuestObject.java
@@ -338,13 +338,13 @@ final class OtherContextGuestObject implements TruffleObject {
         }
 
         @TruffleBoundary
-        OtherContextException(PolyglotContextImpl thisContext, Exception delegate, PolyglotContextImpl delegateContext) {
+        OtherContextException(PolyglotContextImpl receiverContext, Exception delegate, PolyglotContextImpl delegateContext) {
             super(delegate.getMessage());
             assert !(delegate instanceof OtherContextException) : "recursive host foreign value found";
-            assert thisContext != null && delegateContext != null : "Must have associated contexts.";
-            assert thisContext != delegateContext : "no need for foreign value if contexts match";
+            assert receiverContext != null && delegateContext != null : "Must have associated contexts.";
+            assert receiverContext != delegateContext : "no need for foreign value if contexts match";
             this.delegate = delegate;
-            this.receiverContext = thisContext;
+            this.receiverContext = receiverContext;
             this.delegateContext = delegateContext;
         }
 

--- a/truffle/src/com.oracle.truffle.polyglot/src/com/oracle/truffle/polyglot/OtherContextGuestObject.java
+++ b/truffle/src/com.oracle.truffle.polyglot/src/com/oracle/truffle/polyglot/OtherContextGuestObject.java
@@ -181,10 +181,16 @@ final class OtherContextGuestObject implements TruffleObject {
     @TruffleBoundary
     static <T extends Throwable> RuntimeException migrateException(PolyglotContextImpl receiverContext, Throwable e, PolyglotContextImpl valueContext) throws T {
         if (e instanceof OtherContextException) {
+            // Same logic as in migrateValue()
             OtherContextException other = (OtherContextException) e;
             if (other.receiverContext == receiverContext && other.delegateContext == valueContext) {
+                // reuse wrapper it is already wrapped
                 throw other;
+            } else if (other.receiverContext == valueContext && other.delegateContext == receiverContext) {
+                // unpack foreign value it belongs to that context
+                throw (T) other.delegate;
             } else {
+                // Preserve original context of the delegate when forwarding through third context
                 throw new OtherContextException(receiverContext, other.delegate, other.delegateContext);
             }
         } else if (InteropLibrary.getUncached().isException(e)) {

--- a/truffle/src/com.oracle.truffle.polyglot/src/com/oracle/truffle/polyglot/PolyglotContextImpl.java
+++ b/truffle/src/com.oracle.truffle.polyglot/src/com/oracle/truffle/polyglot/PolyglotContextImpl.java
@@ -1720,6 +1720,7 @@ final class PolyglotContextImpl implements com.oracle.truffle.polyglot.PolyglotI
         // guaranteed by migrateValue
         assert value instanceof TruffleObject;
         if (value instanceof OtherContextGuestObject) {
+            // Same logic as in migrateException()
             OtherContextGuestObject otherValue = (OtherContextGuestObject) value;
             if (otherValue.receiverContext == this && otherValue.delegateContext == valueContext) {
                 // reuse wrapper it is already wrapped


### PR DESCRIPTION
## Summary

Fixes https://github.com/oracle/graal/issues/13453

## Testing

I wrote a test for this in `truffle/src/com.oracle.truffle.api.instrumentation.test/src/com/oracle/truffle/api/instrumentation/test/TruffleContextTest.java` with the help of Codex. It passes with the fix and fails without.

I also have tests in TruffleRuby for this: https://github.com/truffleruby/truffleruby/pull/4235/changes
I confirm this PR fixes https://github.com/oracle/graal/issues/13453, as in those tests fail without and pass with this PR.

## Documentation

No documentation updates are needed.

## Contributor Checklist

- [x] I have read the contribution guide.
- [x] I have the right to contribute the submitted material under the project terms.
- [x] I have updated tests and documentation where appropriate.
- [x] If I used a coding assistant, I remain responsible for the entire contribution and have reviewed it accordingly.
