### PR TITLE
fix(riscv64): implement fixed-parameter and return-saving calling convention

### DIFF
--- a/substratevm/src/com.oracle.svm.core.graal.riscv64/src/com/oracle/svm/core/graal/riscv64/SubstrateRISCV64RegisterConfig.java
+++ b/substratevm/src/com.oracle.svm.core.graal.riscv64/src/com/oracle/svm/core/graal/riscv64/SubstrateRISCV64RegisterConfig.java
@@ -69,6 +69,7 @@ import static jdk.vm.ci.riscv64.RISCV64.x24;
 import static jdk.vm.ci.riscv64.RISCV64.x25;
 import static jdk.vm.ci.riscv64.RISCV64.x26;
 import static jdk.vm.ci.riscv64.RISCV64.x27;
+import static jdk.vm.ci.riscv64.RISCV64.x28;
 import static jdk.vm.ci.riscv64.RISCV64.x3;
 import static jdk.vm.ci.riscv64.RISCV64.x8;
 import static jdk.vm.ci.riscv64.RISCV64.x9;
@@ -76,10 +77,12 @@ import static jdk.vm.ci.riscv64.RISCV64.x9;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.graalvm.collections.EconomicSet;
 import org.graalvm.nativeimage.Platform;
 
 import com.oracle.svm.core.ReservedRegisters;
 import com.oracle.svm.core.config.ObjectLayout;
+import com.oracle.svm.core.graal.code.AssignedLocation;
 import com.oracle.svm.core.graal.code.SubstrateCallingConvention;
 import com.oracle.svm.core.graal.code.SubstrateCallingConventionKind;
 import com.oracle.svm.core.graal.code.SubstrateCallingConventionType;
@@ -219,16 +222,34 @@ public class SubstrateRISCV64RegisterConfig implements SubstrateRegisterConfig {
     @Override
     public CallingConvention getCallingConvention(Type t, JavaType returnType, JavaType[] parameterTypes, ValueKindFactory<?> valueKindFactory) {
         SubstrateCallingConventionType type = (SubstrateCallingConventionType) t;
-        if (type.fixedParameterAssignment != null || type.returnSaving != null) {
-            throw unsupportedFeature("Fixed parameter assignments and return saving are not yet supported on this platform.");
-        }
-
         boolean isEntryPoint = type.nativeABI() && !type.outgoing;
 
         AllocatableValue[] locations = new AllocatableValue[parameterTypes.length];
+        JavaKind[] kinds = new JavaKind[locations.length];
 
-        int currentGeneral = 0;
-        int currentFP = 0;
+        /*
+         * When a call uses a return buffer, the first parameter is a placeholder pointing to the
+         * buffer where the (multi-register) return values are saved. The callee ignores it, but the
+         * calling convention must still assign it a location. We park it in x28 (t3), mirroring the
+         * AArch64 backend's use of r8.
+         */
+        int firstActualArgument = 0;
+        if (type.usesReturnBuffer()) {
+            VMError.guarantee(type.fixedParameterAssignment != null);
+            VMError.guarantee(type.fixedParameterAssignment[0].isPlaceholder());
+            firstActualArgument = 1;
+            JavaKind kind = ObjectLayout.getCallSignatureKind(isEntryPoint, parameterTypes[0], metaAccess, target);
+            kinds[0] = kind;
+            ValueKind<?> paramValueKind = valueKindFactory.getValueKind(isEntryPoint ? kind : kind.getStackKind());
+            locations[0] = x28.asValue(paramValueKind);
+
+            for (int i = 1; i < type.fixedParameterAssignment.length; i++) {
+                AssignedLocation storage = type.fixedParameterAssignment[i];
+                if (storage.assignsToRegister()) {
+                    assert !storage.register().equals(x28);
+                }
+            }
+        }
 
         /*
          * We have to reserve a slot between return address and outgoing parameters for the
@@ -237,54 +258,86 @@ public class SubstrateRISCV64RegisterConfig implements SubstrateRegisterConfig {
          */
         int currentStackOffset = (type.nativeABI() ? nativeParamsStackOffset : target.wordSize);
 
-        JavaKind[] kinds = new JavaKind[locations.length];
-        for (int i = 0; i < parameterTypes.length; i++) {
-            JavaKind kind = ObjectLayout.getCallSignatureKind(isEntryPoint, parameterTypes[i], metaAccess, target);
-            kinds[i] = kind;
+        if (!type.customABI()) {
+            int currentGeneral = 0;
+            int currentFP = 0;
 
-            Register register = null;
-            if (type.kind == SubstrateCallingConventionKind.ForwardReturnValue) {
-                VMError.guarantee(i == 0, "Method with calling convention ForwardReturnValue cannot have more than one parameter");
-                register = getReturnRegister(kind);
-            } else {
-                switch (kind) {
-                    case Byte:
-                    case Boolean:
-                    case Short:
-                    case Char:
-                    case Int:
-                    case Long:
-                    case Object:
-                        if (currentGeneral < generalParameterRegs.size()) {
-                            register = generalParameterRegs.get(currentGeneral++);
-                        }
-                        break;
-                    case Float:
-                    case Double:
-                        if (currentFP < fpParameterRegs.size()) {
-                            register = fpParameterRegs.get(currentFP++);
-                        }
-                        break;
-                    default:
-                        throw shouldNotReachHereUnexpectedInput(kind); // ExcludeFromJacocoGeneratedReport
-                }
+            for (int i = firstActualArgument; i < parameterTypes.length; i++) {
+                JavaKind kind = ObjectLayout.getCallSignatureKind(isEntryPoint, parameterTypes[i], metaAccess, target);
+                kinds[i] = kind;
 
-            }
-            if (register != null) {
-                boolean useJavaKind = isEntryPoint && Platform.includedIn(Platform.LINUX.class);
-                locations[i] = register.asValue(valueKindFactory.getValueKind(useJavaKind ? kind : kind.getStackKind()));
-            } else {
-                if (type.nativeABI()) {
-                    if (Platform.includedIn(Platform.LINUX.class)) {
-                        ValueKind<?> valueKind = valueKindFactory.getValueKind(type.outgoing ? kind.getStackKind() : kind);
-                        int alignment = Math.max(kind.getByteCount(), target.wordSize);
-                        locations[i] = StackSlot.get(valueKind, currentStackOffset, !type.outgoing);
-                        currentStackOffset = currentStackOffset + alignment;
-                    } else {
-                        throw VMError.unsupportedPlatform(); // ExcludeFromJacocoGeneratedReport
-                    }
+                Register register = null;
+                if (type.kind == SubstrateCallingConventionKind.ForwardReturnValue) {
+                    VMError.guarantee(i == 0, "Method with calling convention ForwardReturnValue cannot have more than one parameter");
+                    register = getReturnRegister(kind);
                 } else {
-                    currentStackOffset = javaStackParameterAssignment(valueKindFactory, locations, i, kind, currentStackOffset, type.outgoing);
+                    switch (kind) {
+                        case Byte:
+                        case Boolean:
+                        case Short:
+                        case Char:
+                        case Int:
+                        case Long:
+                        case Object:
+                            if (currentGeneral < generalParameterRegs.size()) {
+                                register = generalParameterRegs.get(currentGeneral++);
+                            }
+                            break;
+                        case Float:
+                        case Double:
+                            if (currentFP < fpParameterRegs.size()) {
+                                register = fpParameterRegs.get(currentFP++);
+                            }
+                            break;
+                        default:
+                            throw shouldNotReachHereUnexpectedInput(kind); // ExcludeFromJacocoGeneratedReport
+                    }
+
+                }
+                if (register != null) {
+                    boolean useJavaKind = isEntryPoint && Platform.includedIn(Platform.LINUX.class);
+                    locations[i] = register.asValue(valueKindFactory.getValueKind(useJavaKind ? kind : kind.getStackKind()));
+                } else {
+                    if (type.nativeABI()) {
+                        if (Platform.includedIn(Platform.LINUX.class)) {
+                            ValueKind<?> valueKind = valueKindFactory.getValueKind(type.outgoing ? kind.getStackKind() : kind);
+                            int alignment = Math.max(kind.getByteCount(), target.wordSize);
+                            locations[i] = StackSlot.get(valueKind, currentStackOffset, !type.outgoing);
+                            currentStackOffset = currentStackOffset + alignment;
+                        } else {
+                            throw VMError.unsupportedPlatform(); // ExcludeFromJacocoGeneratedReport
+                        }
+                    } else {
+                        currentStackOffset = javaStackParameterAssignment(valueKindFactory, locations, i, kind, currentStackOffset, type.outgoing);
+                    }
+                }
+            }
+        } else {
+            EconomicSet<Register> usedRegisters = EconomicSet.create();
+            VMError.guarantee(parameterTypes.length == type.fixedParameterAssignment.length, "Parameters/assignments size mismatch.");
+
+            for (int i = firstActualArgument; i < locations.length; i++) {
+                JavaKind kind = ObjectLayout.getCallSignatureKind(isEntryPoint, parameterTypes[i], metaAccess, target);
+                kinds[i] = kind;
+
+                ValueKind<?> paramValueKind = valueKindFactory.getValueKind(isEntryPoint ? kind : kind.getStackKind());
+
+                AssignedLocation storage = type.fixedParameterAssignment[i];
+                if (storage.assignsToRegister()) {
+                    if (kind == JavaKind.Void || kind == JavaKind.Illegal) {
+                        throw unsupportedFeature("Unsupported storage/kind pair - Storage: " + storage + " ; Kind: " + kind);
+                    }
+                    Register reg = storage.register();
+                    VMError.guarantee(target.arch.canStoreValue(reg.getRegisterCategory(), paramValueKind.getPlatformKind()), "Cannot assign value to register.");
+                    locations[i] = reg.asValue(paramValueKind);
+                    VMError.guarantee(!usedRegisters.contains(reg), "Register was already used.");
+                    usedRegisters.add(reg);
+                } else if (storage.assignsToStack()) {
+                    assert currentStackOffset <= storage.stackOffset() : "currentStackOffset=" + currentStackOffset + ", stackOffset=" + storage.stackOffset();
+                    locations[i] = StackSlot.get(valueKindFactory.getValueKind(kind), storage.stackOffset(), !type.outgoing);
+                    currentStackOffset = storage.stackOffset();
+                } else {
+                    throw VMError.shouldNotReachHere("Placeholder assignment.");
                 }
             }
         }

--- a/substratevm/src/com.oracle.svm.core.graal.riscv64/src/com/oracle/svm/core/graal/riscv64/SubstrateRISCV64RegisterConfig.java
+++ b/substratevm/src/com.oracle.svm.core.graal.riscv64/src/com/oracle/svm/core/graal/riscv64/SubstrateRISCV64RegisterConfig.java
@@ -219,6 +219,21 @@ public class SubstrateRISCV64RegisterConfig implements SubstrateRegisterConfig {
         return currentStackOffset + alignment;
     }
 
+    /**
+     * The Linux calling convention expects stack arguments to be aligned to at least 8 bytes, but
+     * any unused padding bits have unspecified values.
+     *
+     * For more details, see <a
+     * href=https://github.com/riscv-non-isa/riscv-elf-psabi-doc/blob/master/riscv-cc.adoc>the
+     * RISC-V calling convention</a>.
+     */
+    private int linuxNativeStackParameterAssignment(ValueKindFactory<?> valueKindFactory, AllocatableValue[] locations, int index, JavaKind kind, int currentStackOffset, boolean isOutgoing) {
+        ValueKind<?> valueKind = valueKindFactory.getValueKind(isOutgoing ? kind.getStackKind() : kind);
+        int alignment = Math.max(kind.getByteCount(), target.wordSize);
+        locations[index] = StackSlot.get(valueKind, currentStackOffset, !isOutgoing);
+        return currentStackOffset + alignment;
+    }
+
     @Override
     public CallingConvention getCallingConvention(Type t, JavaType returnType, JavaType[] parameterTypes, ValueKindFactory<?> valueKindFactory) {
         SubstrateCallingConventionType type = (SubstrateCallingConventionType) t;
@@ -300,10 +315,7 @@ public class SubstrateRISCV64RegisterConfig implements SubstrateRegisterConfig {
                 } else {
                     if (type.nativeABI()) {
                         if (Platform.includedIn(Platform.LINUX.class)) {
-                            ValueKind<?> valueKind = valueKindFactory.getValueKind(type.outgoing ? kind.getStackKind() : kind);
-                            int alignment = Math.max(kind.getByteCount(), target.wordSize);
-                            locations[i] = StackSlot.get(valueKind, currentStackOffset, !type.outgoing);
-                            currentStackOffset = currentStackOffset + alignment;
+                            currentStackOffset = linuxNativeStackParameterAssignment(valueKindFactory, locations, i, kind, currentStackOffset, type.outgoing);
                         } else {
                             throw VMError.unsupportedPlatform(); // ExcludeFromJacocoGeneratedReport
                         }

--- a/substratevm/src/com.oracle.svm.core.graal.riscv64/src/com/oracle/svm/core/graal/riscv64/SubstrateRISCV64RegisterConfig.java
+++ b/substratevm/src/com.oracle.svm.core.graal.riscv64/src/com/oracle/svm/core/graal/riscv64/SubstrateRISCV64RegisterConfig.java
@@ -355,7 +355,17 @@ public class SubstrateRISCV64RegisterConfig implements SubstrateRegisterConfig {
         }
 
         JavaKind returnKind = returnType == null ? JavaKind.Void : ObjectLayout.getCallSignatureKind(isEntryPoint, returnType, metaAccess, target);
-        AllocatableValue returnLocation = returnKind == JavaKind.Void ? Value.ILLEGAL : getReturnRegister(returnKind).asValue(valueKindFactory.getValueKind(returnKind.getStackKind()));
+        AllocatableValue returnLocation = Value.ILLEGAL;
+        if (returnKind != JavaKind.Void) {
+            ValueKind<?> returnValueKind = valueKindFactory.getValueKind(returnKind.getStackKind());
+            if (type.customABI() && type.returnSaving.length == 1 && type.returnSaving[0].assignsToRegister()) {
+                Register register = type.returnSaving[0].register();
+                VMError.guarantee(target.arch.canStoreValue(register.getRegisterCategory(), returnValueKind.getPlatformKind()), "Cannot assign return value to register.");
+                returnLocation = register.asValue(returnValueKind);
+            } else {
+                returnLocation = getReturnRegister(returnKind).asValue(returnValueKind);
+            }
+        }
         return new SubstrateCallingConvention(type, kinds, currentStackOffset, returnLocation, locations);
     }
 


### PR DESCRIPTION
## Summary

Master restored the LLVM backend with a riscv64 target, but `SubstrateRISCV64RegisterConfig.getCallingConvention` still throws "Fixed parameter assignments and return saving are not yet supported on this platform" for custom-ABI calls. The first foreign call during image generation (`throwNewNullPointerException`) trips it, so native-image cannot get past "Compiling methods" on riscv64.

This implements the fixed-parameter-assignment and return-saving path for riscv64, mirroring the existing AArch64 register config: the return-buffer placeholder parameter is parked in x28 (t3) where AArch64 uses r8, and custom-ABI parameters are assigned to their fixed register/stack locations. The standard-ABI path is unchanged in behaviour, only moved under the `!type.customABI()` branch.

## Related Issues

Part of reviving the riscv64 LLVM backend, discussed in #13351.

## Testing

Built substratevm for linux-riscv64 on a Banana Pi F3 (SpaceMiT K1) and ran native-image on a HelloWorld with `--tool:llvm-backend --no-fallback`. Before this change the build aborted in `getCallingConvention` at the first foreign call; after it, the build proceeds through all method compilation. The image does not yet link on riscv64 due to a separate, independent issue (the in-process object reader still uses the LLVM 13 bytedeco preset against LLVM 20.1.4 objects, discussed in #13351).

## Documentation

No documentation changes needed.

## Contributor Checklist

- [x] I have read the contribution guide.
- [x] I have the right to contribute the submitted material under the project terms.
- [x] I have updated tests and documentation where appropriate.
- [ ] If I used a coding assistant, I remain responsible for the entire contribution and have reviewed it accordingly.
