### PR TITLE
Register FillerArray as unsafe allocated

### DIFF
--- a/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/GenScavengeGCFeature.java
+++ b/substratevm/src/com.oracle.svm.core.genscavenge/src/com/oracle/svm/core/genscavenge/GenScavengeGCFeature.java
@@ -28,6 +28,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
+import com.oracle.svm.core.heap.FillerArray;
 import org.graalvm.nativeimage.ImageSingletons;
 import org.graalvm.nativeimage.hosted.Feature;
 import org.graalvm.nativeimage.impl.PinnedObjectSupport;
@@ -154,6 +155,9 @@ class GenScavengeGCFeature implements InternalFeature {
             // If building libgraal, set system property showing gc algorithm
             SystemPropertiesSupport.singleton().setLibGraalRuntimeProperty("gc", Heap.getHeap().getGC().getName());
         }
+
+        /* GC needs a custom filler array class. */
+        access.registerAsUnsafeAllocated(FillerArray.class);
 
         // Needed for the barrier set.
         access.registerAsUsed(Object[].class);


### PR DESCRIPTION
## Summary

Register `FillerArray` class as unsafe allocated before the static analysis is executed during the native image build. Currently comparisons using `FillerArray.class` (e.g., in `HeapDumpWriter#isFillerObject'`) are not compiled into the native image. 
For example `HeapDumpWriter#isFillerObject` (`return obj.getClass() == FillerArray.class || obj.getClass() == FillerObject.class;`) results in code where only `obj.getClass() == FillerObject.class` is checked.

`isFillerObject` gets inlined into `HeapDumpWriter$DumpObjectsVisitor#visitObject` when building a native image using `mx native-image -g -H:+SourceLevelDebug --enable-monitoring=heapdump HelloWorld`. Therefore the annotated and shorted disassembly of `visitObject` is listed below.
```
HeapDumpWriter$DumpObjectsVisitor#visitObject(Object obj)

# stack overflow check
0000555555605d00:   sub     $0x18,%rsp
0000555555605d04:   cmp     0x8(%r15),%rsp
0000555555605d08:   jbe     0x555555605e4a <_ZN63com.oracle.svm.core.heap.dump.HeapDumpWriter$DumpObjectsVisitor11visitObjectEJvP16java.lang.Object+330>     # jump to throw StackOverflowError
0000555555605d0e:   nop     
0000555555605d0f:   nop     

# inlined isFillerObject(obj) call
1407                          return obj.getClass() == FillerArray.class || obj.getClass() == FillerObject.class;
0000555555605d10:   nop     
0000555555605d11:   nop     
0000555555605d12:   cmp     %r14,%rsi
0000555555605d15:   je      0x555555605e4f <_ZN63com.oracle.svm.core.heap.dump.HeapDumpWriter$DumpObjectsVisitor11visitObjectEJvP16java.lang.Object+335>     # jump to throw NullPointerException
0000555555605d1b:   nop     
0000555555605d1c:   mov     $0xfffffffffffffff8,%rax
0000555555605d23:   and     (%rsi),%rax
0000555555605d26:   movabs  $0x80848,%rcx        # 0x80848 is the FillerObject.class object
0000555555605d30:   cmp     %rax,%rcx
0000555555605d33:   je      0x555555605db7 <_ZN63com.oracle.svm.core.heap.dump.HeapDumpWriter$DumpObjectsVisitor11visitObjectEJvP16java.lang.Object+183>     # jump to true branch with early return

# rest of visitObject
1395                          if (isLarge(obj)) {
0000555555605d39:   nop     
1411                          return getObjectSize(obj).aboveThan(LARGE_OBJECT_THRESHOLD);
# ...

# true branch with early return
1392                              return;
0000555555605db7:   nop     
0000555555605db8:   nop     
0000555555605db9:   cmpl    $0x0,0x10(%r15)
0000555555605dbe:   xchg    %ax,%ax
0000555555605dc0:   jle     0x555555605e37 <_ZN63com.oracle.svm.core.heap.dump.HeapDumpWriter$DumpObjectsVisitor11visitObjectEJvP16java.lang.Object+311>
0000555555605dc6:   add     $0x18,%rsp
0000555555605dca:   ret     
0000555555605dcb:   mov     0x8(%rsp),%rsi
0000555555605dd0:   mov     0x10(%rsp),%rdi

# else branch of if (isLarge(obj))
1401                              writeObject(obj);
0000555555605dd5:   nop     
0000555555605dd6:   mov     0x10(%rdi),%rdi
0000555555605dda:   nopw    0x0(%rax,%rax,1)

# Safepoint and Exception calls
1390                          if (isFillerObject(obj)) {
0000555555605e37:   call    0x555555666d40 <_ZN44com.oracle.svm.core.thread.SafepointSlowpath43enterSlowPathSafepointCheckCalleeSavedCCONVEJvv>
0000555555605e3c:   jmp     0x555555605dc6 <_ZN63com.oracle.svm.core.heap.dump.HeapDumpWriter$DumpObjectsVisitor11visitObjectEJvP16java.lang.Object+198>
0000555555605e3e:   xchg    %ax,%ax
1403                      }
0000555555605e40:   call    0x555555666d40 <_ZN44com.oracle.svm.core.thread.SafepointSlowpath43enterSlowPathSafepointCheckCalleeSavedCCONVEJvv>
0000555555605e45:   jmp     0x555555605db2 <_ZN63com.oracle.svm.core.heap.dump.HeapDumpWriter$DumpObjectsVisitor11visitObjectEJvP16java.lang.Object+178>
1390                          if (isFillerObject(obj)) {
0000555555605e4a:   call    0x5555555fbc60 <_ZN57com.oracle.svm.core.graal.snippets.StackOverflowCheckImpl29throwCachedStackOverflowErrorEJvv>
1407                          return obj.getClass() == FillerArray.class || obj.getClass() == FillerObject.class;
0000555555605e4f:   call    0x555555659020 <_ZN47com.oracle.svm.core.snippets.ImplicitExceptions31throwCachedNullPointerExceptionEJvv>
1401                              writeObject(obj);
0000555555605e54:   call    0x555555659020 <_ZN47com.oracle.svm.core.snippets.ImplicitExceptions31throwCachedNullPointerExceptionEJvv>
0000555555605e59:   nop     
```

## Related Issues

- No related issues.

## Testing

- Built native images and looked if the comparison was compiled.

Disassembly of `HeapDumpWriter$DumpObjectsVisitor#visitObject` with the changes
```
HeapDumpWriter$DumpObjectsVisitor#visitObject(Object obj)

# stack overflowcheck
0000555555605d00:   sub     $0x18,%rsp
0000555555605d04:   cmp     0x8(%r15),%rsp
0000555555605d08:   jbe     0x555555605e47 <_ZN63com.oracle.svm.core.heap.dump.HeapDumpWriter$DumpObjectsVisitor11visitObjectEJvP16java.lang.Object+327>     # jump to throw StackOverflowError
0000555555605d0e:   nop     
0000555555605d0f:   nop 

# inlined isFillerObject(obj) call
1407                          return obj.getClass() == FillerArray.class || obj.getClass() == FillerObject.class;
0000555555605d10:   nop     
0000555555605d11:   nop     
0000555555605d12:   cmp     %r14,%rsi
0000555555605d15:   je      0x555555605e4c <_ZN63com.oracle.svm.core.heap.dump.HeapDumpWriter$DumpObjectsVisitor11visitObjectEJvP16java.lang.Object+332>     # jump to throw NullPointerException
0000555555605d1b:   nop     
0000555555605d1c:   mov     $0xfffffffffffffff8,%rax
0000555555605d23:   and     (%rsi),%rax
0000555555605d26:   movabs  $0x80848,%rcx        # 0x80848 is the FillerObject.class object
0000555555605d30:   cmp     %rax,%rcx
0000555555605d33:   jne     0x555555605d4b <_ZN63com.oracle.svm.core.heap.dump.HeapDumpWriter$DumpObjectsVisitor11visitObjectEJvP16java.lang.Object+75>    # jump to second comparison of or

# true branch with early return
1392                              return;
0000555555605d35:   nop     
0000555555605d36:   nop     
0000555555605d37:   cmpl    $0x0,0x10(%r15)
0000555555605d3c:   nopl    0x0(%rax)
0000555555605d40:   jle     0x555555605e34 <_ZN63com.oracle.svm.core.heap.dump.HeapDumpWriter$DumpObjectsVisitor11visitObjectEJvP16java.lang.Object+308>
0000555555605d46:   add     $0x18,%rsp
0000555555605d4a:   ret     

# second comparison of or
0000555555605d4b:   movabs  $0x87860,%rcx        # 0x87860 is the FillerArray.class object
0000555555605d55:   cmp     %rax,%rcx
0000555555605d58:   je      0x555555605d35 <_ZN63com.oracle.svm.core.heap.dump.HeapDumpWriter$DumpObjectsVisitor11visitObjectEJvP16java.lang.Object+53>     # jump to true branch with early return

# rest of visitObject
1395                          if (isLarge(obj)) {
0000555555605d5a:   nop     
1411                          return getObjectSize(obj).aboveThan(LARGE_OBJECT_THRESHOLD);
# ...

# Safepoint and exception calls
1390                          if (isFillerObject(obj)) {
0000555555605e34:   call    0x555555666d40 <_ZN44com.oracle.svm.core.thread.SafepointSlowpath43enterSlowPathSafepointCheckCalleeSavedCCONVEJvv>
0000555555605e39:   jmp     0x555555605d46 <_ZN63com.oracle.svm.core.heap.dump.HeapDumpWriter$DumpObjectsVisitor11visitObjectEJvP16java.lang.Object+70>
0000555555605e3e:   xchg    %ax,%ax
1403                      }
0000555555605e40:   call    0x555555666d40 <_ZN44com.oracle.svm.core.thread.SafepointSlowpath43enterSlowPathSafepointCheckCalleeSavedCCONVEJvv>
0000555555605e45:   jmp     0x555555605dc7 <_ZN63com.oracle.svm.core.heap.dump.HeapDumpWriter$DumpObjectsVisitor11visitObjectEJvP16java.lang.Object+199>
1390                          if (isFillerObject(obj)) {
0000555555605e47:   call    0x5555555fbc60 <_ZN57com.oracle.svm.core.graal.snippets.StackOverflowCheckImpl29throwCachedStackOverflowErrorEJvv>
1407                          return obj.getClass() == FillerArray.class || obj.getClass() == FillerObject.class;
0000555555605e4c:   call    0x555555659020 <_ZN47com.oracle.svm.core.snippets.ImplicitExceptions31throwCachedNullPointerExceptionEJvv>
1401                              writeObject(obj);
0000555555605e51:   call    0x555555659020 <_ZN47com.oracle.svm.core.snippets.ImplicitExceptions31throwCachedNullPointerExceptionEJvv>
0000555555605e56:   nop
``

## Documentation

- No documentation updates needed.

## Contributor Checklist

- [x] I have read the contribution guide.
- [x] I have the right to contribute the submitted material under the project terms.
- [x] I have updated tests and documentation where appropriate.
- [x] If I used a coding assistant, I remain responsible for the entire contribution and have reviewed it accordingly.
