### PR TITLE
[Web Image] Fix unhandled UNSTRUCTURED_LOCKING and an order-dependent single-abstract-method failure

### DIFF
--- a/web-image/src/com.oracle.svm.hosted.webimage.test/src/com/oracle/svm/hosted/webimage/test/WebImageUnitTests.java
+++ b/web-image/src/com.oracle.svm.hosted.webimage.test/src/com/oracle/svm/hosted/webimage/test/WebImageUnitTests.java
@@ -29,6 +29,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 
+import com.oracle.svm.hosted.webimage.test.unit.ImplicitExceptionsSupportMethodTest;
 import com.oracle.svm.hosted.webimage.test.unit.MoveResolverTest;
 import com.oracle.svm.hosted.webimage.test.unit.WasmActiveDataTest;
 
@@ -36,6 +37,7 @@ import junit.framework.TestSuite;
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
+                ImplicitExceptionsSupportMethodTest.class,
                 MoveResolverTest.class,
                 WasmActiveDataTest.class
 })

--- a/web-image/src/com.oracle.svm.hosted.webimage.test/src/com/oracle/svm/hosted/webimage/test/unit/ImplicitExceptionsSupportMethodTest.java
+++ b/web-image/src/com.oracle.svm.hosted.webimage.test/src/com/oracle/svm/hosted/webimage/test/unit/ImplicitExceptionsSupportMethodTest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2026, 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package com.oracle.svm.hosted.webimage.test.unit;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import com.oracle.svm.hosted.webimage.codegen.WebImageImplicitExceptionsFeature;
+import com.oracle.svm.webimage.functionintrinsics.ImplicitExceptions;
+
+import jdk.graal.compiler.nodes.extended.BytecodeExceptionNode.BytecodeExceptionKind;
+
+/**
+ * Checks that every {@link BytecodeExceptionKind} has a usable support method in
+ * {@link ImplicitExceptions}.
+ * <p>
+ * {@link WebImageImplicitExceptionsFeature#getSupportMethodName} throws for unmapped kinds, and
+ * mismatched arities are only detected once a
+ * {@link jdk.graal.compiler.nodes.extended.BytecodeExceptionNode} of that kind actually shows up in
+ * the analyzed graphs. Both failure modes therefore only surface for applications that happen to
+ * contain the offending node, which is how the unmapped
+ * {@link BytecodeExceptionKind#UNSTRUCTURED_LOCKING} went unnoticed. Going over the enum here
+ * catches a new or changed kind at test time instead.
+ * <p>
+ * The methods are only inspected reflectively, never invoked, so that
+ * {@link ImplicitExceptions}'s class initializer (which registers foreign calls) does not have to
+ * run outside of an image build.
+ */
+@RunWith(Parameterized.class)
+public class ImplicitExceptionsSupportMethodTest {
+
+    @Parameterized.Parameters(name = "{0}")
+    public static BytecodeExceptionKind[] data() {
+        return BytecodeExceptionKind.values();
+    }
+
+    @Parameterized.Parameter public BytecodeExceptionKind kind;
+
+    @Test
+    public void supportMethodIsUsable() {
+        String methodName = WebImageImplicitExceptionsFeature.getSupportMethodName(kind);
+        Assert.assertNotNull("No support method name for " + kind, methodName);
+
+        List<Method> candidates = new ArrayList<>();
+        for (Method method : ImplicitExceptions.class.getDeclaredMethods()) {
+            if (method.getName().equals(methodName)) {
+                candidates.add(method);
+            }
+        }
+
+        Assert.assertEquals(ImplicitExceptions.class.getName() + "." + methodName + " for " + kind + " must exist exactly once", 1, candidates.size());
+
+        Method supportMethod = candidates.get(0);
+        Assert.assertTrue(supportMethod + " must be public", Modifier.isPublic(supportMethod.getModifiers()));
+        Assert.assertTrue(supportMethod + " must be static", Modifier.isStatic(supportMethod.getModifiers()));
+        Assert.assertTrue(supportMethod + " must return a Throwable for " + kind, Throwable.class.isAssignableFrom(supportMethod.getReturnType()));
+        Assert.assertEquals(supportMethod + " must take the arguments of " + kind, kind.getNumArguments(), supportMethod.getParameterCount());
+    }
+}

--- a/web-image/src/com.oracle.svm.hosted.webimage/src/com/oracle/svm/hosted/webimage/codegen/WebImageImplicitExceptionsFeature.java
+++ b/web-image/src/com.oracle.svm.hosted.webimage/src/com/oracle/svm/hosted/webimage/codegen/WebImageImplicitExceptionsFeature.java
@@ -91,6 +91,7 @@ public final class WebImageImplicitExceptionsFeature implements InternalFeature 
             case ILLEGAL_ARGUMENT_EXCEPTION_ARGUMENT_IS_NOT_AN_ARRAY -> "createNewArgumentIsNotArrayException";
             case ASSERTION_ERROR_OBJECT -> "createNewAssertionErrorObject";
             case ASSERTION_ERROR_NULLARY -> "createNewAssertionErrorNullary";
+            case UNSTRUCTURED_LOCKING -> "createNewIllegalMonitorStateException";
 
             default -> throw GraalError.shouldNotReachHereUnexpectedValue(exceptionKind);
         };

--- a/web-image/src/com.oracle.svm.hosted.webimage/src/com/oracle/svm/hosted/webimage/util/ReflectUtil.java
+++ b/web-image/src/com.oracle.svm.hosted.webimage/src/com/oracle/svm/hosted/webimage/util/ReflectUtil.java
@@ -25,6 +25,7 @@
 
 package com.oracle.svm.hosted.webimage.util;
 
+import java.lang.reflect.Method;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.Optional;
@@ -57,11 +58,18 @@ public class ReflectUtil {
     private static synchronized UnmodifiableEconomicSet<String> getObjectMethodDescriptors(MetaAccessProvider metaAccess) {
         if (objectMethodDescriptors == null) {
             EconomicSet<String> descriptors = EconomicSet.create();
-            for (ResolvedJavaMethod declaredMethod : metaAccess.lookupJavaType(Object.class).getDeclaredMethods(false)) {
-                if (declaredMethod.isPublic()) {
-                    descriptors.add(fullDescriptor(declaredMethod));
-                }
+            /*
+             * Reflection on the host java.lang.Object rather than
+             * ResolvedJavaType.getDeclaredMethods, because that returns an empty array for a type
+             * that is not linked yet and is never allowed to force linking. This set is computed
+             * once and cached for the rest of the build, so picking up an empty result would
+             * silently disable the java.lang.Object filter below for every later query, and which
+             * query lands here first depends on the order the parallel analysis happens to run in.
+             */
+            for (Method declaredMethod : Object.class.getMethods()) {
+                descriptors.add(fullDescriptor(metaAccess.lookupJavaMethod(declaredMethod)));
             }
+            GraalError.guarantee(!descriptors.isEmpty(), "Found no public methods on java.lang.Object");
             objectMethodDescriptors = descriptors;
         }
 

--- a/web-image/src/com.oracle.svm.webimage/src/com/oracle/svm/webimage/functionintrinsics/ImplicitExceptions.java
+++ b/web-image/src/com.oracle.svm.webimage/src/com/oracle/svm/webimage/functionintrinsics/ImplicitExceptions.java
@@ -104,6 +104,11 @@ public class ImplicitExceptions {
     }
 
     @NeverInline("outlining for smaller code size")
+    public static IllegalMonitorStateException createNewIllegalMonitorStateException() {
+        return new IllegalMonitorStateException("Unstructured locking encountered. Native Image enforces structured locking (JVMS 2.11.10)");
+    }
+
+    @NeverInline("outlining for smaller code size")
     public static ArithmeticException createNewArithmeticException() {
         return new ArithmeticException();
     }


### PR DESCRIPTION
## Summary

Two independent Web Image build failures, both found compiling ktfmt (the Kotlin
formatter, which embeds the Kotlin compiler frontend and IntelliJ's
intellij-core) with `--tool:svm-wasm`.

**Unhandled `UNSTRUCTURED_LOCKING`.**
`WebImageImplicitExceptionsFeature.getSupportMethodName` maps thirteen
`BytecodeExceptionKind`s to support methods in Web Image's `ImplicitExceptions`
and falls through to `shouldNotReachHere` for `UNSTRUCTURED_LOCKING`, so an image
whose reachable graph produces such a node cannot be built at all. This adds the
missing nullary creator, following the shape of the other kinds that carry a
fixed message (`createNewNegativeLengthException`,
`createNewArgumentIsNotArrayException`), and maps the kind to it.

A nullary creator rather than one taking the message: the regular SVM backend
maps this kind to `CREATE_ILLEGAL_MONITOR_STATE_EXCEPTION`, which takes a
`String`, and `NonSnippetLowerings` appends `getExceptionMessage()` as a constant
argument during lowering. Web Image's feature compares `node.getArguments()`
against the support method's parameter count directly with no such append, so a
one-parameter creator would fail the arity check.

**`java.lang.Object` filter silently disabled by initialization order.**
`ReflectUtil.singleAbstractMethodForInterface` skips abstract methods matching a
public `java.lang.Object` method, per JLS 9.8, so a `@FunctionalInterface` may
legally redeclare `hashCode()`. It built that filter set from
`ResolvedJavaType.getDeclaredMethods(false)`, which returns an empty array for a
type that is not linked yet and is never allowed to force linking
(`AnalysisType.getDeclaredMethods` guarantees `!forceLink`). The result is cached
in a static field for the rest of the build, so an empty result silently disables
the filter for every later query.

The symptom is a failed guarantee ("Incorrect single abstract method logic")
naming an interface that is a legitimate functional interface — IntelliJ's
`RefHashMap.Key` declares `get()` and `hashCode()`. It is order dependent: two
identical builds of the same application named two different interfaces,
`RefHashMap$Key` and `ConcurrentRefHashMap$KeyReference`, because which query
happens to populate the cache first depends on the parallel analysis.

Building the set by reflecting over the host `java.lang.Object` removes the
linkage dependency entirely, and a guarantee makes an empty set loud rather than
silently wrong.

## Related Issues

- Fixes #14193 (unhandled `UNSTRUCTURED_LOCKING`)
- Fixes #14192 (single abstract method failure). Note the cause given in that
  report is wrong — the `Object`-method filter already exists and is correct; it
  is the cached empty set that disables it. Corrected in a comment on the issue.
- Doesnt fix #14194

## Testing

No automated test is included, and I would appreciate direction on where one
belongs.

I did write a unit test against `singleAbstractMethodForInterface` and then
removed it: called with host JVMCI types it returns empty for every interface,
because `GuestAnnotationAccess` cannot read `@FunctionalInterface` off them, so
it asserted nothing. It also would not have caught the original bug, which
depends on analysis ordering rather than on the shape of the interface. A
meaningful regression test looks like a real image build, and I would rather
follow your lead than guess at the harness.

Verified manually:

- `mx build` in the `web-image` suite, against labsjdk
  `ce-25.0.4+7-jvmci-25.2-b20` (the `labsjdk-ce-latest` pin in `common.json`),
  Linux x64.
- Compiled ktfmt 0.64 with `--tool:svm-wasm` through the built `native-image`.
  Before: analysis fails on #14192; with only that fixed, code generation fails
  on #14193. After both: the build completes and produces a 33MB WasmGC module
  (12,320 types and 57,270 methods reachable).
- Ran the resulting module under Node 22 to confirm it instantiates and its
  exported entry point is reachable.
- Re-ran the ktfmt build repeatedly to confirm the order-dependent failure no
  longer appears.

Scope note: the module builds and boots but cannot yet do useful work, because
`AtomicReferenceFieldUpdater.newUpdater` throws at run time under Web Image.
That is unrelated to either fix here, reproduces on a released 25.2.4 with a
15-line example, and is filed separately — nothing in this PR is intended to
address it.

## Documentation

No documentation updates. Both changes are internal to the Web Image builder and
alter no documented behaviour, option, or API.

## Contributor Checklist

- [x] I have read the contribution guide.
- [x] I have the right to contribute the submitted material under the project terms.
- [ ] I have updated tests and documentation where appropriate.
- [x] If I used a coding assistant, I remain responsible for the entire contribution and have reviewed it accordingly.