### PR TITLE
Generatioanl Shenandoah fix: Skip card mark for off-heap stores

### DIFF
--- a/compiler/src/jdk.graal.compiler.test/src/jdk/graal/compiler/hotspot/test/ShenandoahOopHandleBarrierTest.java
+++ b/compiler/src/jdk.graal.compiler.test/src/jdk/graal/compiler/hotspot/test/ShenandoahOopHandleBarrierTest.java
@@ -1,0 +1,174 @@
+/*
+ * Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package jdk.graal.compiler.hotspot.test;
+
+import java.util.ListIterator;
+
+import org.junit.Assert;
+import org.junit.Assume;
+import org.junit.Test;
+
+import jdk.graal.compiler.api.test.ModuleSupport;
+import jdk.graal.compiler.core.common.memory.BarrierType;
+import jdk.graal.compiler.core.test.TestPhase;
+import jdk.graal.compiler.hotspot.HotSpotGraalRuntime.HotSpotGC;
+import jdk.graal.compiler.hotspot.replacements.HotSpotReplacementsUtil;
+import jdk.graal.compiler.nodeinfo.NodeSize;
+import jdk.graal.compiler.nodes.StructuredGraph;
+import jdk.graal.compiler.nodes.gc.ObjectWriteBarrierNode;
+import jdk.graal.compiler.nodes.gc.shenandoah.ShenandoahCardBarrierNode;
+import jdk.graal.compiler.nodes.gc.shenandoah.ShenandoahSATBBarrierNode;
+import jdk.graal.compiler.nodes.memory.WriteNode;
+import jdk.graal.compiler.options.OptionValues;
+import jdk.graal.compiler.phases.BasePhase;
+import jdk.graal.compiler.phases.common.WriteBarrierAdditionPhase;
+import jdk.graal.compiler.phases.tiers.LowTierContext;
+import jdk.graal.compiler.phases.tiers.Suites;
+
+/**
+ * Tests the barriers emitted by Shenandoah for a store into the contents of an {@code OopHandle},
+ * which lives in a native OopStorage rather than in the Java heap.
+ *
+ * <p>
+ * Such a store requires the SATB pre barrier but must <em>not</em> be card marked: the card address
+ * is computed as {@code card_table_base + (store_address >> card_shift)}, which for a non-heap
+ * address lands outside the card table. HotSpot draws the same distinction via
+ * {@code ShenandoahBarrierSet::need_card_barrier} (gated on {@code IN_HEAP}) and its
+ * {@code oop_store_in_heap} / {@code oop_store_not_in_heap} split.
+ *
+ * <p>
+ * The store under test is the one emitted by the {@code Thread.setScopedValueCache} invocation
+ * plugin, reached by compiling {@code java.lang.ScopedValue$Cache.put}. That method conveniently
+ * contains both kinds of oop store: the off-heap handle write, and ordinary in-heap array element
+ * writes which must keep their card barrier.
+ */
+public class ShenandoahOopHandleBarrierTest extends HotSpotGraalCompilerTest {
+
+    private boolean sawOopHandleWrite;
+    private boolean sawInHeapObjectWrite;
+
+    public static class Holder {
+        Object field;
+    }
+
+    public static void heapFieldStoreSnippet(Holder h, Object value) {
+        h.field = value;
+    }
+
+    /**
+     * An ordinary in-heap oop store must keep its card barrier. Guards against the off-heap fix
+     * suppressing card marks too broadly.
+     */
+    @Test
+    public void testInHeapFieldWriteIsCardMarked() {
+        Assume.assumeTrue("Shenandoah specific test", runtime().getGarbageCollector() == HotSpotGC.Shenandoah);
+        test("heapFieldStoreSnippet", new Holder(), "value");
+        Assert.assertTrue("expected to see an in-heap oop store", sawInHeapObjectWrite);
+    }
+
+    /**
+     * A store into the contents of an {@code OopHandle} must keep the SATB pre barrier but must not
+     * be card marked.
+     */
+    @Test
+    public void testScopedValueCacheHandleWrite() {
+        Assume.assumeTrue("Shenandoah specific test", runtime().getGarbageCollector() == HotSpotGC.Shenandoah);
+        ModuleSupport.exportAndOpenAllPackagesToUnnamed("java.base");
+
+        // Compiles the graph produced by the Thread.setScopedValueCache invocation plugin, which
+        // writes the Object[] into the JavaThread::_scopedValueCache OopHandle.
+        compileAndInstallSubstitution(Thread.class, "setScopedValueCache");
+
+        Assert.assertTrue("expected to compile a write to the scoped value cache OopHandle",
+                        sawOopHandleWrite);
+    }
+
+    private void verifyBarriers(StructuredGraph graph) {
+        for (WriteNode write : graph.getNodes().filter(WriteNode.class)) {
+            boolean isOopHandle = write.getLocationIdentity() instanceof HotSpotReplacementsUtil.OopHandleLocationIdentity;
+            if (isOopHandle) {
+                sawOopHandleWrite = true;
+
+                Assert.assertEquals("OopHandle oop store should use a write barrier type",
+                                BarrierType.FIELD, write.getBarrierType());
+
+                // The SATB pre barrier is still required for an off-heap oop store.
+                Assert.assertTrue("OopHandle oop store must keep its SATB pre barrier",
+                                hasBarrierFor(graph, ShenandoahSATBBarrierNode.class, write));
+
+                // The card barrier must not be applied to a non-heap address.
+                Assert.assertFalse("OopHandle oop store must not be card marked",
+                                hasBarrierFor(graph, ShenandoahCardBarrierNode.class, write));
+            } else if (write.getBarrierType() == BarrierType.FIELD || write.getBarrierType() == BarrierType.ARRAY) {
+                // Ordinary in-heap oop stores must still be card marked.
+                sawInHeapObjectWrite = true;
+                Assert.assertTrue("in-heap oop store must be card marked: " + write,
+                                hasBarrierFor(graph, ShenandoahCardBarrierNode.class, write));
+            }
+        }
+    }
+
+    /**
+     * Determines whether {@code graph} contains a barrier of the given type operating on the same
+     * address as {@code write}. Matching on the address rather than on graph adjacency keeps this
+     * robust against unrelated nodes being scheduled between the write and its barriers.
+     */
+    private static boolean hasBarrierFor(StructuredGraph graph, Class<? extends ObjectWriteBarrierNode> barrierClass, WriteNode write) {
+        for (ObjectWriteBarrierNode barrier : graph.getNodes().filter(barrierClass)) {
+            if (barrier.getAddress() == write.getAddress()) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /*
+     * Check the state of the barriers immediately after insertion. Shenandoah inserts barriers in
+     * the low tier (LOW_TIER_BARRIER_ADDITION), unlike the card table collectors which use the mid
+     * tier.
+     */
+    @Override
+    protected Suites createSuites(OptionValues opts) {
+        Suites ret = super.createSuites(opts);
+        ListIterator<BasePhase<? super LowTierContext>> iter = ret.getLowTier().findPhase(WriteBarrierAdditionPhase.class, true);
+        iter.add(new TestPhase() {
+            @Override
+            protected void run(StructuredGraph graph) {
+                verifyBarriers(graph);
+            }
+
+            @Override
+            public float codeSizeIncrease() {
+                return NodeSize.IGNORE_SIZE_CONTRACT_FACTOR;
+            }
+
+            @Override
+            public CharSequence getName() {
+                return "VerifyShenandoahOopHandleBarriersPhase";
+            }
+        });
+        return ret;
+    }
+}

--- a/compiler/src/jdk.graal.compiler/src/jdk/graal/compiler/hotspot/HotSpotShenandoahBarrierSet.java
+++ b/compiler/src/jdk.graal.compiler/src/jdk/graal/compiler/hotspot/HotSpotShenandoahBarrierSet.java
@@ -73,8 +73,22 @@ public class HotSpotShenandoahBarrierSet extends ShenandoahBarrierSet {
     }
 
     @Override
+    protected boolean isInHeap(LocationIdentity location) {
+        /*
+         * The contents of an OopHandle reside in a native OopStorage, not in the Java heap, so such
+         * a store must not be card marked. Compare HotSpotZBarrierSet, where the equivalent
+         * distinction is carried down to the LIR generators as StoreKind.Native.
+         */
+        return !(location instanceof HotSpotReplacementsUtil.OopHandleLocationIdentity);
+    }
+
+    @Override
     public BarrierType writeBarrierType(LocationIdentity location) {
         if (location instanceof HotSpotReplacementsUtil.OopHandleLocationIdentity) {
+            /*
+             * Off-heap oop store: the SATB pre barrier is required, the card barrier is not. The
+             * card barrier is suppressed by isInHeap above.
+             */
             return BarrierType.FIELD;
         }
         return BarrierType.NONE;

--- a/compiler/src/jdk.graal.compiler/src/jdk/graal/compiler/hotspot/aarch64/shenandoah/AArch64HotSpotShenandoahCardBarrierOp.java
+++ b/compiler/src/jdk.graal.compiler/src/jdk/graal/compiler/hotspot/aarch64/shenandoah/AArch64HotSpotShenandoahCardBarrierOp.java
@@ -100,7 +100,8 @@ public class AArch64HotSpotShenandoahCardBarrierOp extends AArch64LIRInstruction
             if (HotSpotReplacementsUtil.useCondCardMark(config)) {
                 Label alreadyDirty = new Label();
                 masm.ldr(8, rscratch2, cardAddr);
-                masm.cbz(8, rscratch2, alreadyDirty);
+                // cbz only has 32-bit and 64-bit forms; the byte loaded above is zero extended.
+                masm.cbz(32, rscratch2, alreadyDirty);
                 masm.str(8, zr, cardAddr);
                 masm.bind(alreadyDirty);
             } else {

--- a/compiler/src/jdk.graal.compiler/src/jdk/graal/compiler/nodes/gc/shenandoah/ShenandoahBarrierSet.java
+++ b/compiler/src/jdk.graal.compiler/src/jdk/graal/compiler/nodes/gc/shenandoah/ShenandoahBarrierSet.java
@@ -212,7 +212,7 @@ public class ShenandoahBarrierSet extends BarrierSet {
                          */
                         addShenandoahSATBBarrier(node, node.getAddress(), writtenValue, expectedValue, graph);
                     }
-                    if (!init && useCardBarrier && !StampTool.isPointerAlwaysNull(writtenValue)) {
+                    if (!init && useCardBarrier && isInHeap(node.getLocationIdentity()) && !StampTool.isPointerAlwaysNull(writtenValue)) {
                         graph.addAfterFixed(node, graph.add(new ShenandoahCardBarrierNode(node.getAddress())));
                     }
                 }
@@ -338,5 +338,24 @@ public class ShenandoahBarrierSet extends BarrierSet {
             return BarrierType.READ;
         }
         return null;
+    }
+
+    /**
+     * Determines whether a write to {@code location} targets memory inside the Java heap.
+     *
+     * <p>
+     * The card marking post barrier computes a card address as
+     * {@code card_table_base + (store_address >> card_shift)}, which is only meaningful for heap
+     * addresses. Off-heap oop stores - for example a store into the contents of an
+     * {@code OopHandle} residing in a native OopStorage - must therefore not be card marked, since
+     * doing so writes a byte at an essentially arbitrary address outside the card table. This
+     * mirrors HotSpot, which gates the card barrier on the {@code IN_HEAP} decorator via
+     * {@code ShenandoahBarrierSet::need_card_barrier} and splits {@code oop_store_in_heap} from
+     * {@code oop_store_not_in_heap}. Note that the SATB pre barrier is still required for off-heap
+     * oop stores, so this predicate only affects the card barrier.
+     */
+    @SuppressWarnings("unused")
+    protected boolean isInHeap(LocationIdentity location) {
+        return true;
     }
 }


### PR DESCRIPTION
Generational Shenandoah crashed with SIGSEGV/SIGBUS in Graal-compiled code when storing an oop into the contents of an OopHandle, such as the store performed by the Thread.setScopedValueCache intrinsic.

`HotSpotShenandoahBarrierSet.writeBarrierType()` answers `BarrierType.FIELD` for an `OopHandleLocationIdentity` so that the SATB pre barrier is emitted, but `ShenandoahBarrierSet.addWriteBarriers()` then also attached a **card barrier unconditionally**. An OopHandle's contents live in a native OopStorage rather than in the Java heap, so computing `card_table_base + (address >> card_shift)` lands outside the card table and the card write corrupts unrelated memory or faults.

Gate the card barrier on a new overridable `isInHeap()` predicate, mirroring HotSpot, which gates on the `IN_HEAP` decorator via `ShenandoahBarrierSet::need_card_barrier` and splits `oop_store_in_heap` from `oop_store_not_in_heap`. The SATB pre barrier is retained. G1 was unaffected because it does not override `writeBarrierType(LocationIdentity)` and so emits no barrier at all here; ZGC was unaffected because it carries the distinction down to its LIR generators as `StoreKind.Native`.

Also pass 32 rather than 8 as the `cbz` operand size in the AArch64 card barrier op. `cbz` has no 8-bit form and asserted on every conditional card mark. With assertions disabled the encoder falls back to a 32-bit `cbz`, which is accidentally correct because the preceding `ldrb` zero extends, so this is benign in a product build but makes the path impossible to exercise in an assertion-enabled build.  It is a prerequisite for the in-heap case of the test added here.

Added `ShenandoahOopHandleBarrierTest`, which asserts that an `OopHandle` oop store keeps its SATB pre barrier and is not card marked, and that an ordinary in-heap oop store still is.

Testing (aarch64, jargraal): a ScopedValue stress reproducer driving first-time ScopedValue.get() calls on freshly created threads crashes within a second unpatched; patched it survives 271M virtual-thread and 1.8M platform-thread iterations, including under `-XX:+ShenandoahVerify`, which also validates remembered set integrity. The new test fails without the `isInHeap()` gate ("OopHandle oop store must not be card marked") and passes with it.

## Contributor Checklist

- [x] I have read the contribution guide.
- [x] I have the right to contribute the submitted material under the project terms.
- [x] I have updated tests and documentation where appropriate.
- [x] If I used a coding assistant, I remain responsible for the entire contribution and have reviewed it accordingly.
