### PR TITLE
[GR-79516] Add GC-agnostic garbage collector tests

### DIFF
--- a/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/GCAtomicReferenceTest.java
+++ b/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/GCAtomicReferenceTest.java
@@ -1,0 +1,261 @@
+/*
+ * Copyright (c) 2026, 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package com.oracle.svm.test;
+
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.VarHandle;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.atomic.AtomicReferenceArray;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Tests atomic operations on reference fields while the garbage collector is active.
+ *
+ * Ordinary reference stores and atomic ones (compare-and-set, get-and-set) are handled by different
+ * code in the VM: an atomic operation has to both perform the hardware atomic instruction and do the
+ * GC bookkeeping, without breaking either. That combination is easy to get subtly wrong, and when a
+ * collector moves objects at the same time it gets harder still, because the value sitting in the
+ * field may be the old location of an object that has just been moved. A buggy implementation can
+ * then make a compare-and-set fail when it should have succeeded, or leave a stale reference behind.
+ *
+ * Each test therefore performs a lot of atomic reference traffic while allocating and collecting, and
+ * verifies afterwards that the values are exactly what the atomic operations should have produced.
+ * The tests work with any garbage collector and use only standard Java APIs.
+ */
+public class GCAtomicReferenceTest {
+
+    /** Written to a volatile field so the compiler cannot delete the allocations. */
+    private static volatile Object sink;
+
+    private static void allocateGarbage() {
+        sink = new byte[16 * 1024];
+        sink = null;
+    }
+
+    /** A value object that remembers which iteration created it. */
+    private static final class Value {
+        private final int id;
+
+        Value(int id) {
+            this.id = id;
+        }
+    }
+
+    /** Target of the {@link VarHandle} test below. */
+    private static final class Holder {
+        @SuppressWarnings("unused") private volatile Value field;
+    }
+
+    /**
+     * Repeatedly replaces the contents of an {@link AtomicReference} with
+     * {@code compareAndSet}, allocating and collecting along the way.
+     *
+     * Every step must succeed, because the test is single-threaded and always passes the value it
+     * just read as the expected value. A failed compare-and-set here would therefore mean the VM
+     * reported a mismatch that cannot exist in the program itself, which is exactly the symptom of a
+     * GC that moved the referenced object without the atomic operation accounting for it.
+     */
+    @Test
+    public void testCompareAndSetAlwaysSucceedsWhileCollecting() {
+        final int iterations = 20_000;
+        AtomicReference<Value> ref = new AtomicReference<>(new Value(0));
+
+        for (int i = 1; i <= iterations; i++) {
+            Value expected = ref.get();
+            Value updated = new Value(i);
+            boolean ok = ref.compareAndSet(expected, updated);
+            Assert.assertTrue("compareAndSet failed at iteration " + i + " although the value had not changed", ok);
+
+            if (i % 100 == 0) {
+                allocateGarbage();
+                System.gc();
+            }
+        }
+
+        Assert.assertEquals("the reference does not hold the last value written", iterations, ref.get().id);
+    }
+
+    /**
+     * Checks {@code compareAndSet} in the case where it is supposed to fail: the expected value does
+     * not match what the field holds. The operation must return false and must leave the field
+     * untouched.
+     *
+     * This is the mirror image of the previous test. Together they show that the implementation
+     * neither invents failures nor accepts mismatches.
+     */
+    @Test
+    public void testCompareAndSetFailsOnMismatchAndLeavesValueIntact() {
+        Value actual = new Value(1);
+        Value wrongExpectation = new Value(2);
+        Value replacement = new Value(3);
+        AtomicReference<Value> ref = new AtomicReference<>(actual);
+
+        allocateGarbage();
+        System.gc();
+
+        boolean ok = ref.compareAndSet(wrongExpectation, replacement);
+        Assert.assertFalse("compareAndSet must fail when the expected value does not match", ok);
+        Assert.assertSame("a failed compareAndSet must not modify the reference", actual, ref.get());
+    }
+
+    /**
+     * Exercises {@code getAndSet}, which unconditionally installs a new value and returns the old
+     * one. Because the test knows the exact sequence of values, the returned value must always be the
+     * one from the previous step; anything else means a reference was lost or duplicated.
+     */
+    @Test
+    public void testGetAndSetReturnsPreviousValueWhileCollecting() {
+        final int iterations = 20_000;
+        AtomicReference<Value> ref = new AtomicReference<>(new Value(0));
+
+        for (int i = 1; i <= iterations; i++) {
+            Value previous = ref.getAndSet(new Value(i));
+            Assert.assertEquals("getAndSet returned the wrong previous value at iteration " + i, i - 1, previous.id);
+
+            if (i % 100 == 0) {
+                allocateGarbage();
+                System.gc();
+            }
+        }
+
+        Assert.assertEquals("the reference does not hold the last value written", iterations, ref.get().id);
+    }
+
+    /**
+     * Repeats the compare-and-set test through a {@link VarHandle} on a normal object field, rather
+     * than through {@link AtomicReference}. This reaches the same VM machinery by a different route,
+     * which is worth covering separately because the two are compiled differently.
+     */
+    @Test
+    public void testVarHandleCompareAndSetOnFieldWhileCollecting() throws ReflectiveOperationException {
+        VarHandle handle = MethodHandles.privateLookupIn(Holder.class, MethodHandles.lookup())
+                        .findVarHandle(Holder.class, "field", Value.class);
+
+        final int iterations = 10_000;
+        Holder holder = new Holder();
+        handle.set(holder, new Value(0));
+
+        for (int i = 1; i <= iterations; i++) {
+            Value expected = (Value) handle.get(holder);
+            boolean ok = handle.compareAndSet(holder, expected, new Value(i));
+            Assert.assertTrue("VarHandle compareAndSet failed at iteration " + i, ok);
+
+            if (i % 100 == 0) {
+                allocateGarbage();
+                System.gc();
+            }
+        }
+
+        Value finalValue = (Value) handle.get(holder);
+        Assert.assertEquals("the field does not hold the last value written", iterations, finalValue.id);
+    }
+
+    /**
+     * Same operations again, but on the many slots of an {@link AtomicReferenceArray}. Array elements
+     * are addressed differently from object fields, so this covers an additional code path, and using
+     * many slots increases the chance of catching a collector that mishandles one of them.
+     */
+    @Test
+    public void testAtomicReferenceArraySlotsStayConsistent() {
+        final int slots = 512;
+        final int rounds = 40;
+        AtomicReferenceArray<Value> array = new AtomicReferenceArray<>(slots);
+        for (int i = 0; i < slots; i++) {
+            array.set(i, new Value(i));
+        }
+
+        for (int round = 1; round <= rounds; round++) {
+            for (int i = 0; i < slots; i++) {
+                Value expected = array.get(i);
+                boolean ok = array.compareAndSet(i, expected, new Value(round * slots + i));
+                Assert.assertTrue("compareAndSet failed for slot " + i + " in round " + round, ok);
+            }
+            allocateGarbage();
+            System.gc();
+        }
+
+        int base = rounds * slots;
+        for (int i = 0; i < slots; i++) {
+            Assert.assertEquals("slot " + i + " does not hold the last value written", base + i, array.get(i).id);
+        }
+    }
+
+    /**
+     * The multi-threaded version: several threads hammer the same {@link AtomicReference} with
+     * compare-and-set while collections happen.
+     *
+     * With real concurrency an individual compare-and-set is allowed to fail, because another thread
+     * may have won the race, so the test does not check individual attempts. Instead each thread
+     * retries until it succeeds and counts its own successes, and at the end the total number of
+     * successful updates must match the counter stored in the reference. If the VM ever let two
+     * threads believe they both won, or lost an update, the two numbers would disagree.
+     */
+    @Test
+    public void testConcurrentCompareAndSetDoesNotLoseUpdates() throws InterruptedException {
+        final int threads = 4;
+        final int updatesPerThread = 5_000;
+        AtomicReference<Value> ref = new AtomicReference<>(new Value(0));
+        CountDownLatch start = new CountDownLatch(1);
+        CountDownLatch done = new CountDownLatch(threads);
+
+        for (int t = 0; t < threads; t++) {
+            Thread worker = new Thread(() -> {
+                try {
+                    start.await();
+                    for (int i = 0; i < updatesPerThread; i++) {
+                        /* Retry until this thread wins the race; each success increments the id by one. */
+                        while (true) {
+                            Value expected = ref.get();
+                            if (ref.compareAndSet(expected, new Value(expected.id + 1))) {
+                                break;
+                            }
+                        }
+                    }
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                } finally {
+                    done.countDown();
+                }
+            });
+            worker.setDaemon(true);
+            worker.start();
+        }
+
+        start.countDown();
+        /* Keep the collector busy while the threads are competing. */
+        for (int i = 0; i < 50 && done.getCount() > 0; i++) {
+            allocateGarbage();
+            System.gc();
+            Thread.sleep(5);
+        }
+        Assert.assertTrue("worker threads did not finish in time", done.await(60, TimeUnit.SECONDS));
+
+        Assert.assertEquals("updates were lost or double-counted", threads * updatesPerThread, ref.get().id);
+    }
+}

--- a/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/GCObjectGraphTest.java
+++ b/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/GCObjectGraphTest.java
@@ -1,0 +1,259 @@
+/*
+ * Copyright (c) 2026, 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package com.oracle.svm.test;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Tests that the garbage collector never damages the object graph.
+ *
+ * A collector may move objects around in memory and must then update every reference that pointed to
+ * them. If it misses one, or updates one incorrectly, the program is left with a reference to the
+ * wrong place. The symptom is usually a crash or nonsense data much later, far away from the real
+ * bug, which makes it hard to find. These tests make the damage visible immediately: they build data
+ * structures with known contents, force collections, and then check that every field, every array
+ * element and every map entry still holds exactly what it held before.
+ *
+ * The tests are written for any garbage collector: they only use {@link System#gc()} and allocation
+ * to provoke collections, and they make no assumption about when a collection happens.
+ */
+public class GCObjectGraphTest {
+
+    /** How much garbage to allocate per step, to keep the collector busy. */
+    private static final int GARBAGE_CHUNK = 32 * 1024;
+
+    /** Written to a volatile field so the compiler cannot delete the allocations. */
+    private static volatile Object sink;
+
+    private static void allocateGarbage(int chunks) {
+        for (int i = 0; i < chunks; i++) {
+            sink = new byte[GARBAGE_CHUNK];
+        }
+        sink = null;
+    }
+
+    /** Requests several collections, allocating in between so that collectors make progress. */
+    private static void collectRepeatedly(int rounds) {
+        for (int i = 0; i < rounds; i++) {
+            allocateGarbage(8);
+            System.gc();
+        }
+    }
+
+    /** A node in a linked chain. Each node stores its own index so it can be verified later. */
+    private static final class Node {
+        private final int index;
+        private Node next;
+
+        Node(int index) {
+            this.index = index;
+        }
+    }
+
+    /**
+     * Builds a long chain of objects, collects, then walks the whole chain.
+     *
+     * Each node is checked twice: that it appears in the right position (its stored index matches how
+     * far along the chain we are) and that the chain has exactly the expected length. If the GC moved
+     * a node but failed to update the {@code next} field pointing at it, the walk would go off to the
+     * wrong object and one of these checks would fail.
+     */
+    @Test
+    public void testLinkedChainSurvivesGC() {
+        final int length = 10_000;
+        Node head = new Node(0);
+        Node current = head;
+        for (int i = 1; i < length; i++) {
+            current.next = new Node(i);
+            current = current.next;
+        }
+
+        collectRepeatedly(5);
+
+        int position = 0;
+        for (Node n = head; n != null; n = n.next) {
+            Assert.assertEquals("node at position " + position + " has the wrong index after GC", position, n.index);
+            position++;
+        }
+        Assert.assertEquals("the chain lost or gained nodes during GC", length, position);
+    }
+
+    /**
+     * Same idea as the chain test, but for references stored in an array instead of in object fields,
+     * because a collector updates those through a different code path.
+     *
+     * The array is filled with strings whose contents are known from their position, so a reference
+     * that ends up pointing at the wrong object is detected immediately.
+     */
+    @Test
+    public void testObjectArrayContentsSurviveGC() {
+        final int size = 20_000;
+        String[] array = new String[size];
+        for (int i = 0; i < size; i++) {
+            array[i] = "element-" + i;
+        }
+
+        collectRepeatedly(5);
+
+        for (int i = 0; i < size; i++) {
+            Assert.assertEquals("array slot " + i + " changed during GC", "element-" + i, array[i]);
+        }
+    }
+
+    /**
+     * Checks a real-world data structure rather than a hand-built one. A {@link HashMap} stores its
+     * entries in an internal array of entry objects that themselves reference keys and values, so a
+     * single missed reference update usually makes lookups fail.
+     *
+     * After collecting, every key must still find its value, and the map must still report the same
+     * size.
+     */
+    @Test
+    public void testHashMapContentsSurviveGC() {
+        final int entries = 5_000;
+        Map<String, Integer> map = new HashMap<>();
+        for (int i = 0; i < entries; i++) {
+            map.put("key-" + i, i);
+        }
+
+        collectRepeatedly(5);
+
+        Assert.assertEquals("the map changed size during GC", entries, map.size());
+        for (int i = 0; i < entries; i++) {
+            Assert.assertEquals("lookup of key-" + i + " failed after GC", Integer.valueOf(i), map.get("key-" + i));
+        }
+    }
+
+    /**
+     * Exercises the case where the program keeps changing references while the collector is running.
+     *
+     * Every time a reference field is overwritten, the GC has to be told about it; that is what a
+     * write barrier does. This test overwrites many references, interleaved with allocation and
+     * collections, and then verifies that the surviving objects are exactly the ones that were last
+     * written. A broken or missing write barrier typically shows up here as a stale or corrupted
+     * entry.
+     */
+    @Test
+    public void testReferenceUpdatesDuringGCAreTracked() {
+        final int slots = 2_000;
+        final int rounds = 10;
+        Node[] holder = new Node[slots];
+
+        for (int round = 0; round < rounds; round++) {
+            /* Overwrite every slot with a freshly allocated node, dropping the previous one. */
+            for (int i = 0; i < slots; i++) {
+                holder[i] = new Node(round * slots + i);
+            }
+            allocateGarbage(4);
+            System.gc();
+        }
+
+        /* Only the nodes written in the final round may still be referenced. */
+        int base = (rounds - 1) * slots;
+        for (int i = 0; i < slots; i++) {
+            Assert.assertNotNull("slot " + i + " unexpectedly became null", holder[i]);
+            Assert.assertEquals("slot " + i + " does not hold the last value written to it", base + i, holder[i].index);
+        }
+    }
+
+    /**
+     * Builds a structure where objects reference each other in a cycle, then drops it entirely.
+     *
+     * Cycles are worth testing because a collector that freed memory by counting references would
+     * never reclaim them. The point here is simply that the program keeps running correctly and the
+     * still-live structure stays intact while the abandoned cycles are collected.
+     */
+    @Test
+    public void testCyclicGarbageIsCollectedAndLiveDataSurvives() {
+        /* This list is kept alive for the whole test and must stay valid. */
+        List<Node> live = new ArrayList<>();
+        for (int i = 0; i < 100; i++) {
+            live.add(new Node(i));
+        }
+
+        for (int round = 0; round < 20; round++) {
+            createCycle();
+            System.gc();
+        }
+
+        Assert.assertEquals("the live list changed size", 100, live.size());
+        for (int i = 0; i < live.size(); i++) {
+            Assert.assertEquals("live element " + i + " was damaged", i, live.get(i).index);
+        }
+    }
+
+    /**
+     * Creates two nodes that point at each other and then returns, so the pair is unreachable but
+     * still referenced from within itself.
+     */
+    private static void createCycle() {
+        Node a = new Node(-1);
+        Node b = new Node(-2);
+        a.next = b;
+        b.next = a;
+    }
+
+    /**
+     * A stress test with a mixture of object sizes and lifetimes, closer to how a real program
+     * behaves than the focused tests above.
+     *
+     * Most allocations are immediately abandoned, while every hundredth object is kept. At the end,
+     * the kept objects are verified. Collectors often treat large and small objects differently, so
+     * mixing sizes covers more of the allocation paths.
+     */
+    @Test
+    public void testMixedAllocationStressKeepsSurvivorsIntact() {
+        final int iterations = 50_000;
+        List<Object> survivors = new ArrayList<>();
+
+        for (int i = 0; i < iterations; i++) {
+            /* Vary the size so that both small objects and larger arrays are exercised. */
+            int size = (i % 50 == 0) ? 8 * 1024 : 32;
+            byte[] data = new byte[size];
+            /* Write a recognizable value so corruption can be detected later. */
+            data[0] = (byte) i;
+            if (i % 100 == 0) {
+                survivors.add(data);
+            } else {
+                sink = data;
+            }
+        }
+        sink = null;
+        System.gc();
+
+        Assert.assertEquals("unexpected number of survivors", iterations / 100, survivors.size());
+        for (int i = 0; i < survivors.size(); i++) {
+            byte[] data = (byte[]) survivors.get(i);
+            int originalIteration = i * 100;
+            Assert.assertEquals("survivor " + i + " has corrupted contents", (byte) originalIteration, data[0]);
+        }
+    }
+}

--- a/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/GCReferenceTest.java
+++ b/substratevm/src/com.oracle.svm.test/src/com/oracle/svm/test/GCReferenceTest.java
@@ -1,0 +1,261 @@
+/*
+ * Copyright (c) 2026, 2026, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package com.oracle.svm.test;
+
+import java.lang.ref.Cleaner;
+import java.lang.ref.PhantomReference;
+import java.lang.ref.Reference;
+import java.lang.ref.ReferenceQueue;
+import java.lang.ref.SoftReference;
+import java.lang.ref.WeakReference;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.function.BooleanSupplier;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Tests that the garbage collector handles {@link java.lang.ref} reference objects correctly.
+ *
+ * In short: an object that nobody uses any more must be collected, and the reference objects that
+ * were watching it must be updated (cleared) and reported (enqueued). An object that is still in
+ * use must never be collected.
+ *
+ * These tests work with any garbage collector. They only use standard Java to trigger collections
+ * ({@link System#gc()} plus allocating garbage), never GC-specific flags or internal APIs. Because
+ * no collector promises to collect an object at an exact moment, tests that need a collection call
+ * {@link #awaitGC}, which keeps retrying until a deadline instead of assuming that one
+ * {@link System#gc()} call is enough. That also keeps the tests correct for concurrent collectors,
+ * which finish their work in the background.
+ *
+ * Object finalization is deliberately not tested here, because Native Image does not run finalizers.
+ */
+public class GCReferenceTest {
+
+    /** How long a test is willing to wait for the GC to do its work before failing. */
+    private static final long TIMEOUT_MS = 30_000;
+
+    /** How much garbage to allocate between collection attempts, to create memory pressure. */
+    private static final int GARBAGE_CHUNK = 64 * 1024;
+
+    /** A simple test object. The id only exists to make failure messages readable. */
+    private static final class Payload {
+        private final int id;
+
+        Payload(int id) {
+            this.id = id;
+        }
+
+        @Override
+        public String toString() {
+            return "Payload(" + id + ")";
+        }
+    }
+
+    /**
+     * Keeps asking for a garbage collection until {@code condition} becomes true, then returns. If
+     * the condition is still false when the timeout expires, the test fails.
+     *
+     * Why the loop is necessary: a single {@link System#gc()} is only a hint. Some collectors need
+     * allocation to happen before they start a cycle, and a concurrent collector does its work on
+     * background threads, so the result may only be visible a little later. Allocating garbage and
+     * sleeping briefly on each attempt covers both cases.
+     */
+    private static void awaitGC(BooleanSupplier condition, String message) {
+        long deadline = System.currentTimeMillis() + TIMEOUT_MS;
+        int attempts = 0;
+        while (System.currentTimeMillis() < deadline) {
+            if (condition.getAsBoolean()) {
+                return;
+            }
+            attempts++;
+            System.gc();
+            consume(new byte[GARBAGE_CHUNK]);
+            try {
+                Thread.sleep(10);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new AssertionError("interrupted while waiting for GC", e);
+            }
+        }
+        Assert.fail(message + " (still not satisfied after " + attempts + " GC attempts in " + TIMEOUT_MS + "ms)");
+    }
+
+    /** Written to a volatile field so the compiler cannot delete the allocation above. */
+    private static volatile Object sink;
+
+    private static void consume(Object o) {
+        sink = o;
+        sink = null;
+    }
+
+    /*
+     * The two helpers below create the object being watched inside their own method. That matters:
+     * when the helper returns, the only strong reference to the object is gone, so the object really
+     * is unreachable. If the object were created in the test method instead, the test method's own
+     * local variable could keep it alive and the test would pass for the wrong reason.
+     */
+
+    private static WeakReference<Payload> newWeak(ReferenceQueue<Payload> queue) {
+        Payload referent = new Payload(1);
+        return new WeakReference<>(referent, queue);
+    }
+
+    private static PhantomReference<Payload> newPhantom(ReferenceQueue<Payload> queue) {
+        Payload referent = new Payload(2);
+        return new PhantomReference<>(referent, queue);
+    }
+
+    /**
+     * Checks the most basic weak-reference promise: once the only way to reach an object is through a
+     * {@link WeakReference}, the GC is allowed to collect it, and afterwards the reference must read
+     * as empty ({@code get()} returns null).
+     */
+    @Test
+    public void testWeakReferenceIsCleared() {
+        WeakReference<Payload> ref = newWeak(null);
+        awaitGC(() -> ref.refersTo(null), "weak reference was not cleared");
+        Assert.assertNull("get() must return null once the reference is cleared", ref.get());
+    }
+
+    /**
+     * Checks the notification half of weak references: if the reference was registered with a
+     * {@link ReferenceQueue}, the GC must not only clear it but also put it on that queue, so the
+     * program can find out that the object is gone.
+     */
+    @Test
+    public void testWeakReferenceIsEnqueued() throws InterruptedException {
+        ReferenceQueue<Payload> queue = new ReferenceQueue<>();
+        WeakReference<Payload> ref = newWeak(queue);
+        awaitGC(() -> ref.refersTo(null), "weak reference was not cleared");
+
+        Reference<? extends Payload> dequeued = queue.remove(TIMEOUT_MS);
+        Assert.assertSame("the cleared reference must be enqueued", ref, dequeued);
+    }
+
+    /**
+     * Same idea as the weak-reference queue test, but for {@link PhantomReference}, which the GC
+     * handles in a later phase. Note that {@code get()} on a phantom reference always returns null
+     * by design, so whether the object is still reachable is checked with
+     * {@link Reference#refersTo} instead.
+     */
+    @Test
+    public void testPhantomReferenceIsEnqueued() throws InterruptedException {
+        ReferenceQueue<Payload> queue = new ReferenceQueue<>();
+        PhantomReference<Payload> ref = newPhantom(queue);
+        Assert.assertNull("PhantomReference.get() must always return null", ref.get());
+
+        awaitGC(() -> ref.refersTo(null), "phantom reference was not cleared");
+        Reference<? extends Payload> dequeued = queue.remove(TIMEOUT_MS);
+        Assert.assertSame("the phantom reference must be enqueued", ref, dequeued);
+    }
+
+    /**
+     * The opposite direction, and the more dangerous one to get wrong: an object that the program is
+     * still holding on to must survive, no matter how many collections happen. If a GC wrongly
+     * decided this object was garbage, the program would later read a dangling reference.
+     *
+     * The test runs many collections with allocation in between and then checks that neither the
+     * weak nor the soft reference to the still-used object was cleared.
+     */
+    @Test
+    public void testStronglyReachableReferentIsNotCleared() {
+        Payload strong = new Payload(3);
+        WeakReference<Payload> weak = new WeakReference<>(strong);
+        SoftReference<Payload> soft = new SoftReference<>(strong);
+
+        for (int i = 0; i < 20; i++) {
+            System.gc();
+            consume(new byte[GARBAGE_CHUNK]);
+        }
+
+        Assert.assertFalse("a strongly reachable weak referent must not be cleared", weak.refersTo(null));
+        Assert.assertSame("weak.get() must still return the referent", strong, weak.get());
+        Assert.assertFalse("a strongly reachable soft referent must not be cleared", soft.refersTo(null));
+        Assert.assertSame("soft.get() must still return the referent", strong, soft.get());
+
+        /* Using 'strong' here guarantees it stayed reachable for the whole test. */
+        Assert.assertEquals("Payload(3)", strong.toString());
+    }
+
+    /**
+     * A sanity check on the queue itself: a queue that the GC has not put anything into must stay
+     * empty. {@code poll()} returns null immediately and {@code remove(timeout)} times out.
+     */
+    @Test
+    public void testEmptyReferenceQueuePollsNull() throws InterruptedException {
+        ReferenceQueue<Payload> queue = new ReferenceQueue<>();
+        Assert.assertNull("poll() on an empty queue must return null", queue.poll());
+        Assert.assertNull("remove(timeout) on an empty queue must time out", queue.remove(50));
+    }
+
+    /**
+     * Checks {@link Cleaner}, the modern replacement for finalizers: a cleanup action registered for
+     * an object must actually run once that object becomes unreachable. This goes through the same
+     * GC reference-processing machinery as the tests above, but via the API that real code uses to
+     * release resources.
+     */
+    @Test
+    public void testCleanerRunsAfterObjectBecomesUnreachable() throws InterruptedException {
+        Cleaner cleaner = Cleaner.create();
+        CountDownLatch cleaned = new CountDownLatch(1);
+        registerCleanable(cleaner, cleaned);
+
+        awaitGC(() -> cleaned.getCount() == 0, "cleaner action did not run");
+        Assert.assertTrue("cleaner action must have run", cleaned.await(TIMEOUT_MS, TimeUnit.MILLISECONDS));
+    }
+
+    /**
+     * Registers the cleanup action. The action counts down a latch and deliberately does not
+     * mention the watched object: a cleanup action that referred to its own object would keep that
+     * object alive forever and the cleanup would never run.
+     */
+    private static void registerCleanable(Cleaner cleaner, CountDownLatch cleaned) {
+        Payload referent = new Payload(4);
+        cleaner.register(referent, cleaned::countDown);
+    }
+
+    /**
+     * Scales the first test up from one reference to a thousand. A GC that only processed some of the
+     * references it found would pass the single-reference test but fail here, so this checks that
+     * every single one is cleared.
+     */
+    @Test
+    public void testManyWeakReferencesAreAllCleared() {
+        final int count = 1000;
+        List<WeakReference<Payload>> refs = new ArrayList<>(count);
+        for (int i = 0; i < count; i++) {
+            refs.add(newWeak(null));
+        }
+
+        awaitGC(() -> refs.stream().allMatch(r -> r.refersTo(null)), "not all weak references were cleared");
+
+        long remaining = refs.stream().filter(r -> !r.refersTo(null)).count();
+        Assert.assertEquals("all weak references must be cleared", 0, remaining);
+    }
+}


### PR DESCRIPTION
Please, review this PR to add add three test classes to `com.oracle.svm.test` to verify garbage collector correctness in Native Image.

Before this change, the GC-related tests in `com.oracle.svm.test` covered JFR event emission (`jfr/TestGCEvents`, `jfr/TestGCHeapSummaryEvent`, `jfr/TestGarbageCollectionEvents` and friends), the JMX management interface (`jmx/JmxTest`, via `GarbageCollectorMXBean` and `MemoryMXBean`) and native memory accounting (`nmt/NativeMemoryTrackingTests`). Those verify that GC information is reported, not that the collector behaves correctly: for example `JmxTest` asserts `getCollectionCount() >= 0`, which holds even if collection is completely broken. Nothing verified that references are cleared and enqueued, that the object graph is intact after a collection, or that atomic reference updates behave correctly while collecting.

The new tests close that gap:

- **`GCReferenceTest`** (7 tests) — weak and phantom references must be cleared and enqueued once their referent becomes unreachable; a strongly reachable referent must *never* be cleared; a `Cleaner` action must run. Also scales to 1000 references to catch a collector that only processes some of the references it discovers.

- **`GCObjectGraphTest`** (6 tests) — linked chains (10k nodes), object arrays (20k elements) and `HashMap` contents (5k entries) must be unchanged after collections; reference fields must hold the last value written to them; cyclic garbage must not disturb live data. This is where a missing or incorrect reference update after the collector moves an object becomes visible immediately, instead of as an unrelated crash much later.

- **`GCAtomicReferenceTest`** (6 tests) — compare-and-set and get-and-set on reference fields must behave correctly while collections happen, via `AtomicReference`, `VarHandle`, `AtomicReferenceArray`, and from four concurrent threads. Atomic reference updates combine a hardware atomic with GC bookkeeping, so they are covered separately from plain stores. Notably, a single-threaded compare-and-set must always succeed; a spurious failure would mean the VM reported a mismatch that cannot exist in the program.

The tests are deliberately **GC-agnostic**: collections are provoked only with `System.gc()` and allocation pressure — never with GC-specific options, VM internals or the WhiteBox API — so they are valid for any current or future Native Image collector, including concurrent ones. Assertions that depend on a collection having happened retry until a timeout rather than assuming a single `System.gc()` suffices, which keeps them correct for a collector that finishes its work on background threads.

## Testing

- `mx --primary-suite=substratevm native-unittest com.oracle.svm.test.GCReferenceTest com.oracle.svm.test.GCObjectGraphTest com.oracle.svm.test.GCAtomicReferenceTest` → `OK (19 tests)`, exit 0.
- Full suite: `mx --primary-suite=substratevm native-unittest` → `OK (280 tests)`, exit 0. The new classes are picked up automatically by the harness; no regressions.
- `mx --primary-suite=substratevm --components=ni,nju build` → clean, including checkstyle.
- Platform tested: `linux-aarch64` with the default (Serial) GC. Not yet run on `linux-amd64` or other platforms; the tests contain no platform- or collector-specific code.

## Documentation

No documentation updates needed — this change only adds tests. The intent of each test, and the specific bug class it is designed to catch, is documented in Javadoc on the test classes and methods.

## Contributor Checklist

- [x] I have read the contribution guide.
- [x] I have the right to contribute the submitted material under the project terms.
- [x] I have updated tests and documentation where appropriate.
- [x] If I used a coding assistant, I remain responsible for the entire contribution and have reviewed it accordingly.

