### PR TITLE
FIX: Record fast accessor method dependency

### DIFF
--- a/compiler/src/jdk.graal.compiler.test/src/jdk/graal/compiler/core/test/inlining/InliningTest.java
+++ b/compiler/src/jdk.graal.compiler.test/src/jdk/graal/compiler/core/test/inlining/InliningTest.java
@@ -69,6 +69,29 @@ import jdk.vm.ci.meta.TriState;
 
 public class InliningTest extends GraalCompilerTest {
 
+    private static final class FastAccessor {
+        private final int value;
+
+        FastAccessor(int value) {
+            this.value = value;
+        }
+
+        int getValue() {
+            return value;
+        }
+    }
+
+    public static int fastAccessorSnippet(FastAccessor accessor) {
+        return accessor.getValue();
+    }
+
+    @Test
+    public void testFastAccessorRecordsMethodDependency() {
+        StructuredGraph graph = assertInlined(getGraph("fastAccessorSnippet", false));
+        ResolvedJavaMethod accessor = getResolvedJavaMethod(FastAccessor.class, "getValue");
+        Assert.assertTrue("fast-inlined accessor must be recorded for class redefinition", graph.getMethods().contains(accessor));
+    }
+
     @Test
     public void testInvokeStaticInlining() {
         assertInlined(getGraph("invokeStaticSnippet", false));

--- a/compiler/src/jdk.graal.compiler/src/jdk/graal/compiler/java/BytecodeParser.java
+++ b/compiler/src/jdk.graal.compiler/src/jdk/graal/compiler/java/BytecodeParser.java
@@ -2684,6 +2684,8 @@ public abstract class BytecodeParser extends CoreProvidersDelegate implements Gr
                     ValueNode receiver = invocationPluginReceiver.init(targetMethod, args).get(true);
                     ResolvedJavaField resolvedField = (ResolvedJavaField) field;
                     try (DebugCloseable context = openNodeContext(targetMethod, 1)) {
+                        // A nested BytecodeParser would record this dependency in build().
+                        graph.recordMethod(targetMethod);
                         genGetField(resolvedField, receiver);
                         notifyBeforeInline(targetMethod);
                         String reason = "inline accessor method (bytecode parsing)";


### PR DESCRIPTION
### Summary

Record accessor methods handled by BytecodeParser.tryFastInlineAccessor in the graph’s method dependency list.

### Problem

The fast accessor inlining path emits a field load directly instead of creating a nested BytecodeParser. As a result, it bypasses the graph.recordMethod(method) call normally performed by BytecodeParser.build().

When JVMTI class redefinition or retransformation is enabled, HotSpot converts the recorded methods into evol_method dependencies. Without the accessor in this list, retransformation of its declaring class does not invalidate compiled
callers containing its inlined body.

This can leave stale compiled code active. The issue was reproduced using Mockito’s inline mock maker:

1. Compile and inline a simple getter into a hot caller.
2. Retransform the getter’s declaring class while creating a mock.
3. Direct calls observe the transformed implementation, but the compiled caller continues executing the original inlined field read.

### Fix

Call graph.recordMethod(targetMethod) when the fast accessor path successfully inlines a getter. This restores the dependency that would have been recorded by the nested parser.

Add a regression test verifying that a fast-inlined accessor is present in StructuredGraph.getMethods().

### Testing

- New regression test fails before the fix and passes afterward.
- Full InliningTest: 37 tests passed, 2 ignored.
- Checkstyle passed for both modified files.
- Mockito/JUnit reproducer passed 10 consecutive runs with the rebuilt libgraal.
- Post-fix LogCompilation output includes both:

<dependency type='evol_method' x0='...Victim getValue ()Ljava/lang/String;'/>
<dependency type='evol_method' x0='...Caller call (...)'/>

### Contributor Checklist

- [x] I have read the contribution guide.
- [x] I have the right to contribute the submitted material under the project terms.
- [x] I have updated tests and documentation where appropriate.
- [x] If I used a coding assistant, I remain responsible for the entire contribution and have reviewed it accordingly.
