### PR TITLE
Fix rendering of the build options table in BuildOptions.md

### DIFF
--- a/docs/reference-manual/native-image/BuildOptions.md
+++ b/docs/reference-manual/native-image/BuildOptions.md
@@ -37,6 +37,7 @@ Use reachability metadata instead.
 These deprecated URL protocol options are omitted from the generated table; see [URL Protocols in Native Image](URLProtocols.md).
 
 <!-- BEGIN: build-options-table -->
+
 | Command | Type | Description | Default | Usage |
 |---------|------|-------------|---------|-------|
 | `--add-exports` | String | value <module>/<package>=<target-module>(,<target-module>)* updates <module> to export <package> to <target-module>, regardless of module declaration. <target-module> can be ALL-UNNAMED to export to all unnamed modules. | None | `--add-exports=add-exports` |
@@ -109,6 +110,7 @@ These deprecated URL protocol options are omitted from the generated table; see 
 | `-cp` | Path | class search path of directories and zip/jar files |  | `-cp <class search path of directories and zip/jar files>` |
 | `-p` | Path | module path |  | `-p <module path>` |
 | `@argument` | String | one or more argument files containing options |  | `@argument files` |
+
 <!-- END: build-options-table -->
 
 ## List of Useful Options

--- a/substratevm/mx.substratevm/mx_substratevm_docs.py
+++ b/substratevm/mx.substratevm/mx_substratevm_docs.py
@@ -259,9 +259,12 @@ def update_build_options_table():
         # Extract table content from generated markdown
         table_content = _extract_table_from_markdown(generated_content)
 
-        # Replace content between markers
+        # Replace content between markers. The blank lines around the table are
+        # required: kramdown (used by the GraalVM website) only recognizes a table
+        # that starts after a block boundary, so a table directly following the
+        # HTML comment marker would be rendered as a paragraph.
         new_content = (content[:begin_idx + len(begin_marker)] +
-                   '\n' + table_content + '\n' +
+                   '\n\n' + table_content + '\n\n' +
                    content[end_idx:])
 
     # Write updated content


### PR DESCRIPTION
The build options table on https://www.graalvm.org/latest/reference-manual/native-image/overview/Options/ is currently rendered as a single paragraph of raw `|`-separated text instead of a table (the `---------` separator row even shows up as em-dashes).

### Cause

kramdown, the Markdown parser used by the GraalVM website, only recognizes a table that starts after a block boundary (`after_block_boundary?` in kramdown's table parser). In `BuildOptions.md`, the table directly follows the `<!-- BEGIN: build-options-table -->` HTML comment without a blank line, so kramdown treats the whole table as a paragraph.

Verified locally with kramdown 2.5.2 (both the default and the GFM parser): the current file yields one `<table>` on the page (the system properties table), the fixed file yields two.

### Fix

- `docs/reference-manual/native-image/BuildOptions.md`: add a blank line after the `BEGIN` marker and before the `END` marker.
- `substratevm/mx.substratevm/mx_substratevm_docs.py`: make `mx update-build-options-table` emit those blank lines so that regenerating the table does not reintroduce the problem. `verify_build_options_table` strips the content between the markers before comparing, so the check is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QCkkfwM4p6DgUYzCXio6dj
