### PR TITLE
Improve linkage diagnostic for unlinked methods

### DIFF
--- a/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/code/CompileQueue.java
+++ b/substratevm/src/com.oracle.svm.hosted/src/com/oracle/svm/hosted/code/CompileQueue.java
@@ -73,6 +73,7 @@ import com.oracle.svm.core.meta.MethodRef;
 import com.oracle.svm.core.meta.SubstrateMethodOffsetConstant;
 import com.oracle.svm.core.meta.SubstrateMethodPointerConstant;
 import com.oracle.svm.core.util.InterruptImageBuilding;
+import com.oracle.svm.core.util.UserError;
 import com.oracle.svm.hosted.FeatureHandler;
 import com.oracle.svm.hosted.NativeImageGenerator;
 import com.oracle.svm.hosted.NativeImageOptions;
@@ -1497,6 +1498,7 @@ public class CompileQueue {
         if (customFunction != null) {
             return customFunction.compile(debug, method, compilationIdentifier, reason, runtimeConfig);
         }
+        reportUnlinkedMethodWithoutCompilationGraph(method);
         try {
             return defaultCompileFunction(debug, method, compilationIdentifier, reason, runtimeConfig, false);
         } catch (RuntimeException | Error t) {
@@ -1517,6 +1519,20 @@ public class CompileQueue {
                     throw t;
                 }
 
+            }
+        }
+    }
+
+    private static void reportUnlinkedMethodWithoutCompilationGraph(HostedMethod method) {
+        if (method.compilationInfo.getCompilationGraph() == null && !method.getDeclaringClass().isLinked()) {
+            try {
+                method.getDeclaringClass().link();
+            } catch (LinkageError error) {
+                throw UserError.abort(error,
+                                "The method %s cannot be compiled because its declaring class %s could not be linked. " +
+                                                "Linking failed with %s. This may indicate that a required dependency is missing from the image classpath. " +
+                                                "Add the dependency that provides the missing class and check its transitive dependencies.",
+                                method.format("%H.%n(%p)"), method.getDeclaringClass().toJavaName(), error);
             }
         }
     }


### PR DESCRIPTION
## Summary

- Improve Native Image diagnostics when a method must be compiled without a compilation graph because its declaring class is not linked.
- Retry linking the declaring class before compilation.
- Report a clear error containing the original `LinkageError` when linking fails, including guidance to check missing and transitive dependencies.
- Preserve the existing compilation fallback behavior and missing-graph invariant.

## Related Issues

- https://github.com/oracle/graal/issues/14010

## Testing

- Ran `mx build` in the `substratevm` suite.
- Ran `mx checkstyle`.
- Ran `mx unittest com.oracle.svm.hosted.test` (`OK (4 tests)`).
- Reproduced the original issue with the Apache POI demo and verified that the missing Batik dependency is reported with the improved diagnostic.
- Verified that the dependency-complete demo successfully produces a native executable.

## Documentation

- No documentation updates are needed for this implementation-only diagnostic improvement.

## Contributor Checklist

- [x] I have read the contribution guide.
- [x] I have the right to contribute the submitted material under the project terms.
- [x] I have updated tests and documentation where appropriate.
- [x] If I used a coding assistant, I remain responsible for the entire contribution and have reviewed it accordingly.