### PR TITLE
Fix Ruby flavor extended-mode comments to always end at a newline

### DIFF
--- a/regex/src/com.oracle.truffle.regex.test/src/com/oracle/truffle/regex/tregex/test/RubyTests.java
+++ b/regex/src/com.oracle.truffle.regex.test/src/com/oracle/truffle/regex/tregex/test/RubyTests.java
@@ -384,6 +384,13 @@ public class RubyTests extends RegexTestBase {
     }
 
     @Test
+    public void github4435() {
+        // In extended mode, a newline always ends a comment, even when preceded by a backslash.
+        test("(a) # c\\\n(b)", "x", "ab", 0, true, 0, 2, 0, 1, 1, 2);
+        test("(x # c\\\n)", "x", "x", 0, true, 0, 1, 0, 1);
+    }
+
+    @Test
     public void beginningAnchor() {
         test("\\Ga", "", "a", 0, true, 0, 1);
         test("\\Ga", "", "ba", 0, false);

--- a/regex/src/com.oracle.truffle.regex/src/com/oracle/truffle/regex/flavor/ruby/RubyRegexParser.java
+++ b/regex/src/com.oracle.truffle.regex/src/com/oracle/truffle/regex/flavor/ruby/RubyRegexParser.java
@@ -1068,14 +1068,13 @@ public final class RubyRegexParser implements RegexValidator, RegexParser {
 
     /**
      * A comment starts with a '#' and ends at the end of the line. The leading '#' is assumed to
-     * have already been parsed.
+     * have already been parsed. A newline always terminates the comment, even when preceded by a
+     * backslash.
      */
     private void comment() {
         while (!atEnd()) {
             int ch = consumeChar();
-            if (ch == '\\' && !atEnd()) {
-                advance();
-            } else if (ch == '\n') {
+            if (ch == '\n') {
                 break;
             }
         }


### PR DESCRIPTION
## Summary

A backslash at the end of a comment line must not escape the newline: Onigmo ends extended-mode comments at a newline unconditionally. The escape handling was inherited from duplicating the Python flavor.

cc @djoooooe 

## Related Issues

Fixes https://github.com/truffleruby/truffleruby/issues/4435

## Testing

Added test.

## Documentation

- Describe any documentation updates included in this pull request.
- If no documentation updates are needed, state that explicitly.

## Contributor Checklist

- [x] I have read the contribution guide.
- [x] I have the right to contribute the submitted material under the project terms.
- [x] I have updated tests and documentation where appropriate.
- [x] If I used a coding assistant, I remain responsible for the entire contribution and have reviewed it accordingly.