### PR TITLE
[GR-NONE] [truffle] [sulong] Make native library loading on Windows behave like POSIX

### DIFF
--- a/.github/workflows/nfi-native-library-tests.yml
+++ b/.github/workflows/nfi-native-library-tests.yml
@@ -1,0 +1,216 @@
+#
+# Copyright (c) 2026, Oracle and/or its affiliates. All rights reserved.
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+#
+# The Universal Permissive License (UPL), Version 1.0
+#
+# Subject to the condition set forth below, permission is hereby granted to any
+# person obtaining a copy of this software, associated documentation and/or
+# data (collectively the "Software"), free of charge and under any and all
+# copyright rights in the Software, and any and all patent rights owned or
+# freely licensable by each licensor hereunder covering either (i) the
+# unmodified Software as contributed to or provided by such licensor, or (ii)
+# the Larger Works (as defined below), to deal in both
+#
+# (a) the Software, and
+#
+# (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+# one is included with the Software each a "Larger Work" to which the Software
+# is contributed by such licensors),
+#
+# without restriction, including without limitation the rights to copy, create
+# derivative works of, display, perform, and distribute the Software and make,
+# use, sell, offer for sale, import, export, have made, and have sold the
+# Software and the Larger Work(s), and to sublicense the foregoing rights on
+# either these or other terms.
+#
+# This license is subject to the following condition:
+#
+# The above copyright notice and either this complete permission notice or at a
+# minimum a reference to the UPL must be included in all copies or substantial
+# portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+# ---------------------------------------------------------------------------
+# Truffle NFI native-library tests, run on Windows *and* Linux.
+#
+# The point of running both is that the Windows behaviour is supposed to match
+# the POSIX behaviour. The `default` library (the NFI equivalent of
+# dlopen(NULL)/RTLD_DEFAULT) previously resolved only symbols exported by the
+# launcher executable on Windows, and the test suite worked around that by
+# redirecting to re-exported copies in the test library rather than covering the
+# real path. With that workaround removed, the same tests have to pass on both
+# platforms or the mirror is broken.
+#
+# See truffle/src/com.oracle.truffle.nfi.native/src/lookup_win32.c for the
+# lookup itself, and DefaultLibraryNFITest / LoadNFILibraryTest for the tests.
+# ---------------------------------------------------------------------------
+name: Truffle NFI native library
+
+on:
+  push:
+    branches:
+      - 'master'
+      - 'sulong-windows-native-dll'
+    paths:
+      - 'truffle/src/com.oracle.truffle.nfi.native/**'
+      - 'truffle/src/com.oracle.truffle.nfi.backend.libffi/**'
+      - 'truffle/src/com.oracle.truffle.nfi.test/**'
+      - 'sulong/projects/com.oracle.truffle.llvm.nativemode/**'
+      - 'sulong/projects/com.oracle.truffle.llvm.runtime/src/com/oracle/truffle/llvm/runtime/NativeContextExtension.java'
+      - '.github/workflows/nfi-native-library-tests.yml'
+  pull_request:
+    branches:
+      - 'master'
+    paths:
+      - 'truffle/src/com.oracle.truffle.nfi.native/**'
+      - 'truffle/src/com.oracle.truffle.nfi.backend.libffi/**'
+      - 'truffle/src/com.oracle.truffle.nfi.test/**'
+      - 'sulong/projects/com.oracle.truffle.llvm.nativemode/**'
+      - 'sulong/projects/com.oracle.truffle.llvm.runtime/src/com/oracle/truffle/llvm/runtime/NativeContextExtension.java'
+      - '.github/workflows/nfi-native-library-tests.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: "workflow = ${{ github.workflow }}, ref = ${{ github.event.ref }}, pr = ${{ github.event.pull_request.id }}"
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.repository != 'oracle/graal' }}
+
+env:
+  MX_PATH: ${{ github.workspace }}/mx
+  # mx refuses to run when Python's stdout is not unicode, which is the default
+  # on the Windows runners.
+  PYTHONIOENCODING: utf-8
+  LANG: en_US.UTF-8
+
+permissions:
+  contents: read
+
+jobs:
+  nfi-tests:
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.repository }}
+    name: NFI native library (${{ matrix.os-name }})
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 90
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: windows-2022
+            os-name: windows
+          - os: ubuntu-22.04
+            os-name: linux
+    steps:
+      - name: Checkout graal
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          ref: ${{ github.ref }}
+          fetch-depth: 1
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
+        with:
+          python-version: '3.12'
+
+      - name: Determine mx version
+        shell: bash
+        run: echo "MX_VERSION=$(python -c "import json;print(json.load(open('common.json'))['mx_version'])")" >> ${GITHUB_ENV}
+
+      - name: Checkout graalvm/mx
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          repository: graalvm/mx.git
+          ref: ${{ env.MX_VERSION }}
+          path: ${{ env.MX_PATH }}
+
+      # Deliberately no `--alias`: that symlinks to a path built from
+      # github.workspace, which on the Windows runner contains backslashes that
+      # bash eats as escapes before mx ever sees them ("D:\a\graal\graal/jdk"
+      # arrives as "D:agraalgraal/jdk"). Derive the install directory instead and
+      # hand it over in a form Python accepts on both platforms.
+      - name: Fetch LabsJDK
+        shell: bash
+        run: |
+          mkdir -p jdk-dl
+          ${MX_PATH}/mx -y --java-home= fetch-jdk --jdk-id labsjdk-ce-latest --to jdk-dl
+          jdk=$(ls -d jdk-dl/labsjdk-*/ | head -1)
+          jdk_abs=$(cd "$jdk" && { pwd -W 2>/dev/null || pwd; })
+          echo "JAVA_HOME=$jdk_abs" >> ${GITHUB_ENV}
+          "$jdk_abs/bin/java" -version
+
+      # The javac daemon binds a local socket and the Windows runner does not
+      # reliably let it connect, which hangs the build with no output. Building
+      # without it costs a little time and removes the failure mode.
+      # mx generates ninja files that invoke `cl` directly and expects it on
+      # PATH. The runners ship MSVC but do not put it there, so without this the
+      # native build dies with "CreateProcess failed: The system cannot find the
+      # file specified". Export just the variables vcvars sets that matter.
+      - name: Set up MSVC environment
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
+          $vs = & $vswhere -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath
+          if (-not $vs) { throw "no MSVC toolset found on this runner" }
+          $vcvars = Join-Path $vs 'VC\Auxiliary\Build\vcvars64.bat'
+          $keep = @('PATH','INCLUDE','LIB','LIBPATH','VCINSTALLDIR','VCToolsInstallDir','WindowsSdkDir','WindowsSDKVersion','UCRTVersion','UniversalCRTSdkDir')
+          cmd /c "`"$vcvars`" >nul 2>&1 && set" | ForEach-Object {
+            if ($_ -match '^([^=]+)=(.*)$' -and $keep -contains $matches[1]) {
+              "$($matches[1])=$($matches[2])" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
+            }
+          }
+
+      # The build and test steps are split by OS purely because of the shell.
+      # Under Git Bash, /usr/bin precedes the MSVC directory on PATH, so `link`
+      # resolves to GNU coreutils link(1) and the native link step dies with
+      # "link: unknown option -- n". pwsh has no MSYS bin directory to shadow it.
+
+      - name: Build Truffle NFI and its native library
+        if: runner.os != 'Windows'
+        shell: bash
+        working-directory: truffle
+        run: ${MX_PATH}/mx -y --no-download-progress build --no-daemon --dependencies TRUFFLE_NFI_TEST,TRUFFLE_TEST_NATIVE,TRUFFLE_RUNTIME
+
+      - name: Build Truffle NFI and its native library
+        if: runner.os == 'Windows'
+        shell: pwsh
+        working-directory: truffle
+        run: |
+          & "$env:MX_PATH/mx.cmd" -y --no-download-progress build --no-daemon --dependencies TRUFFLE_NFI_TEST,TRUFFLE_TEST_NATIVE,TRUFFLE_RUNTIME
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
+      - name: Run NFI native library tests
+        if: runner.os != 'Windows'
+        shell: bash
+        working-directory: truffle
+        run: ${MX_PATH}/mx -y --no-download-progress unittest --verbose com.oracle.truffle.nfi.test
+
+      - name: Run NFI native library tests
+        if: runner.os == 'Windows'
+        shell: pwsh
+        working-directory: truffle
+        run: |
+          & "$env:MX_PATH/mx.cmd" -y --no-download-progress unittest --verbose com.oracle.truffle.nfi.test
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
+      # Sulong consumes the NFI lookup fixed above; make sure the pieces that
+      # decide *how* a native library is loaded still compile.
+      - name: Build Sulong native mode
+        if: runner.os != 'Windows'
+        shell: bash
+        working-directory: sulong
+        run: ${MX_PATH}/mx -y --no-download-progress build --no-daemon --dependencies com.oracle.truffle.llvm.nativemode
+
+      - name: Build Sulong native mode
+        if: runner.os == 'Windows'
+        shell: pwsh
+        working-directory: sulong
+        run: |
+          & "$env:MX_PATH/mx.cmd" -y --no-download-progress build --no-daemon --dependencies com.oracle.truffle.llvm.nativemode
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }

--- a/sulong/projects/com.oracle.truffle.llvm.nativemode/src/com/oracle/truffle/llvm/nativemode/runtime/NFIContextExtension.java
+++ b/sulong/projects/com.oracle.truffle.llvm.nativemode/src/com/oracle/truffle/llvm/nativemode/runtime/NFIContextExtension.java
@@ -65,7 +65,9 @@ import org.graalvm.collections.EconomicMap;
 import org.graalvm.collections.Equivalence;
 
 import java.io.IOException;
+import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -369,25 +371,46 @@ public final class NFIContextExtension extends NativeContextExtension {
         }
     }
 
-    public static String getNativeLibrarySuffix() {
-        if (System.getProperty("os.name").toLowerCase().contains("mac")) {
-            return "dylib";
-        } else {
-            return "so";
+    /**
+     * Default flags for loading a native library, mirroring what the POSIX dynamic loader does for
+     * free.
+     * <p>
+     * On POSIX a library's own dependencies are resolved using the RPATH/RUNPATH recorded in it
+     * (commonly {@code $ORIGIN}), so a library that sits in a directory alongside its siblings
+     * loads without any help from us. Windows has no equivalent: with {@code dwFlags == 0},
+     * {@code LoadLibraryEx} resolves dependencies against the standard search order, which does
+     * <em>not</em> include the directory of the DLL being loaded. A library such as Intel MKL,
+     * whose entry point DLL pulls in siblings from its own directory, therefore fails to load on
+     * Windows while loading fine on Linux.
+     * <p>
+     * {@code LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR} adds the loaded DLL's own directory to the search
+     * for its dependencies, the closest equivalent to {@code $ORIGIN}, while
+     * {@code LOAD_LIBRARY_SEARCH_DEFAULT_DIRS} keeps the system and user directories in play.
+     * Deliberately not {@code LOAD_WITH_ALTERED_SEARCH_PATH}: that is the legacy scheme, and it
+     * puts the process working directory on the dependency search path, which is a DLL planting
+     * vector. These flags require a fully qualified path, so a relative one is left to the
+     * platform default.
+     *
+     * @return the NFI flag expression to use, or {@code null} for the platform default
+     */
+    private static String defaultLoadFlags(String path) {
+        if (!NativeContextExtension.isWindows()) {
+            return null;
         }
-    }
-
-    public static String getNativeLibrarySuffixVersioned(int version) {
-        if (System.getProperty("os.name").toLowerCase().contains("mac")) {
-            return version + ".dylib";
-        } else {
-            return "so." + version;
+        try {
+            if (!Paths.get(path).isAbsolute()) {
+                return null;
+            }
+        } catch (InvalidPathException e) {
+            // not something we can reason about, let the loader produce the error
+            return null;
         }
+        return "LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR|LOAD_LIBRARY_SEARCH_DEFAULT_DIRS";
     }
 
     private Object loadLibrary(String path, LLVMContext context) {
         CompilerAsserts.neverPartOfCompilation();
-        return loadLibrary(path, false, null, context);
+        return loadLibrary(path, false, defaultLoadFlags(path), context);
     }
 
     private Object loadLibrary(String path, boolean optional, String flags, LLVMContext context) {

--- a/sulong/projects/com.oracle.truffle.llvm.runtime/src/com/oracle/truffle/llvm/runtime/NativeContextExtension.java
+++ b/sulong/projects/com.oracle.truffle.llvm.runtime/src/com/oracle/truffle/llvm/runtime/NativeContextExtension.java
@@ -142,6 +142,18 @@ public abstract class NativeContextExtension implements ContextExtension {
     public abstract Object bindSignature(LLVMFunctionCode function, Source signatureSource);
 
     public abstract Object bindSignature(long fnPtr, Source signatureSource);
+    private static final String OS_NAME = System.getProperty("os.name").toLowerCase();
+    private static final boolean IS_WINDOWS = OS_NAME.contains("windows");
+    private static final boolean IS_MAC = OS_NAME.contains("mac");
+
+    /**
+     * Whether the host is Windows. Callers that need to branch on native library loading
+     * behaviour should use this rather than re-reading {@code os.name}, so that every such
+     * decision agrees.
+     */
+    public static boolean isWindows() {
+        return IS_WINDOWS;
+    }
 
     public static String getNativeLibrary(String libname) {
         return getNativeLibraryPrefix() + libname + '.' + getNativeLibrarySuffix();
@@ -152,7 +164,7 @@ public abstract class NativeContextExtension implements ContextExtension {
     }
 
     public static String getNativeLibraryPrefix() {
-        if (System.getProperty("os.name").toLowerCase().contains("windows")) {
+        if (IS_WINDOWS) {
             return "";
         } else {
             return "lib";
@@ -160,9 +172,9 @@ public abstract class NativeContextExtension implements ContextExtension {
     }
 
     public static String getNativeLibrarySuffix() {
-        if (System.getProperty("os.name").toLowerCase().contains("mac")) {
+        if (IS_MAC) {
             return "dylib";
-        } else if (System.getProperty("os.name").toLowerCase().contains("windows")) {
+        } else if (IS_WINDOWS) {
             return "dll";
         } else {
             return "so";
@@ -170,9 +182,9 @@ public abstract class NativeContextExtension implements ContextExtension {
     }
 
     public static String getNativeLibrarySuffixVersioned(int version) {
-        if (System.getProperty("os.name").toLowerCase().contains("mac")) {
+        if (IS_MAC) {
             return version + ".dylib";
-        } else if (System.getProperty("os.name").toLowerCase().contains("windows")) {
+        } else if (IS_WINDOWS) {
             // no version ATM
             return "dll";
         } else {

--- a/truffle/src/com.oracle.truffle.nfi.native/src/lookup_win32.c
+++ b/truffle/src/com.oracle.truffle.nfi.native/src/lookup_win32.c
@@ -43,6 +43,8 @@
 
 #include "native.h"
 
+#include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include "internal.h"
 
@@ -51,13 +53,98 @@
 static void throwError(JNIEnv *env, jlong context) {
     DWORD error = GetLastError();
     struct __TruffleContextInternal *ctx = (struct __TruffleContextInternal *) context;
-    LPSTR msg;
+    LPSTR msg = NULL;
     DWORD lang = MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT);
+    DWORD len;
 
-    FormatMessageA(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS, NULL, error, lang, (LPSTR) &msg, 0,
-                   NULL);
-    (*env)->ThrowNew(env, ctx->UnsatisfiedLinkError, msg);
-    LocalFree(msg);
+    len = FormatMessageA(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS, NULL, error, lang, (LPSTR) &msg, 0,
+                         NULL);
+    if (len == 0 || msg == NULL) {
+        /*
+         * FormatMessageA does not have a message string for every error code, and it leaves the
+         * output pointer untouched when it fails. Throwing with the raw code is better than
+         * dereferencing an uninitialized pointer.
+         */
+        char fallback[64];
+        snprintf(fallback, sizeof(fallback), "windows error %lu", (unsigned long) error);
+        (*env)->ThrowNew(env, ctx->UnsatisfiedLinkError, fallback);
+    } else {
+        (*env)->ThrowNew(env, ctx->UnsatisfiedLinkError, msg);
+        LocalFree(msg);
+    }
+}
+
+/*
+ * `dlsym(RTLD_DEFAULT, name)` searches the main executable *and* every shared object loaded into
+ * the process. The Windows equivalent used to be `GetProcAddress(GetModuleHandle(NULL), name)`,
+ * which searches only the export table of the main executable -- for a JVM launcher that table is
+ * essentially empty, so the "default" library resolved almost nothing. Walking every loaded module
+ * gives the default library the same meaning it has on POSIX.
+ *
+ * `EnumProcessModules` lives in psapi.dll on older systems, but is also exported from kernel32.dll
+ * as `K32EnumProcessModules` on Windows 7 and later. Resolving it dynamically keeps this file free
+ * of an additional link-time dependency.
+ */
+typedef BOOL(WINAPI *EnumProcessModulesFn)(HANDLE, HMODULE *, DWORD, LPDWORD);
+
+static EnumProcessModulesFn getEnumProcessModules(void) {
+    static EnumProcessModulesFn cached = NULL;
+    EnumProcessModulesFn fn = cached;
+    if (fn == NULL) {
+        HMODULE kernel32 = GetModuleHandleW(L"kernel32.dll");
+        if (kernel32 != NULL) {
+            fn = (EnumProcessModulesFn) (void *) GetProcAddress(kernel32, "K32EnumProcessModules");
+        }
+        /* Benign race: every thread computes the same value. */
+        cached = fn;
+    }
+    return fn;
+}
+
+static FARPROC lookupInLoadedModules(const char *name) {
+    EnumProcessModulesFn enumProcessModules = getEnumProcessModules();
+    HMODULE staticBuf[128];
+    HMODULE *modules = staticBuf;
+    DWORD capacity = (DWORD) sizeof(staticBuf);
+    DWORD needed = 0;
+    HANDLE process = GetCurrentProcess();
+    FARPROC ret = NULL;
+    DWORD i, count;
+
+    if (enumProcessModules == NULL) {
+        return NULL;
+    }
+
+    if (!enumProcessModules(process, modules, capacity, &needed)) {
+        return NULL;
+    }
+
+    if (needed > capacity) {
+        /* More modules than fit the stack buffer. Retry once with an exactly sized heap buffer. */
+        modules = (HMODULE *) malloc(needed);
+        if (modules == NULL) {
+            return NULL;
+        }
+        capacity = needed;
+        if (!enumProcessModules(process, modules, capacity, &needed)) {
+            free(modules);
+            return NULL;
+        }
+    }
+
+    /* A concurrent load may have grown the set since the call; only trust what was written. */
+    count = (needed < capacity ? needed : capacity) / (DWORD) sizeof(HMODULE);
+    for (i = 0; i < count; i++) {
+        ret = GetProcAddress(modules[i], name);
+        if (ret != NULL) {
+            break;
+        }
+    }
+
+    if (modules != staticBuf) {
+        free(modules);
+    }
+    return ret;
 }
 
 JNIEXPORT jlong JNICALL Java_com_oracle_truffle_nfi_backend_libffi_LibFFIContext_loadLibrary(JNIEnv *env, jclass self, jlong context, jstring name,
@@ -88,17 +175,27 @@ JNIEXPORT jlong JNICALL Java_com_oracle_truffle_nfi_backend_libffi_LibFFIContext
                                                                                         jstring name) {
     struct __TruffleContextInternal *ctx = (struct __TruffleContextInternal *) context;
     const char *utfName = (*env)->GetStringUTFChars(env, name, NULL);
-    HMODULE module;
     FARPROC ret;
 
     if (library == 0) {
-        module = GetModuleHandleA(NULL);
+        /* The "default" library: mirror dlsym(RTLD_DEFAULT, ...) over the whole process. */
+        ret = GetProcAddress(GetModuleHandleW(NULL), utfName);
+        if (ret == NULL) {
+            ret = lookupInLoadedModules(utfName);
+        }
+        if (ret == NULL) {
+            /*
+             * The scan clobbers the thread's last-error with whatever the last GetProcAddress miss
+             * set, which is the right code but not guaranteed after the enumeration itself. Pin it
+             * so the thrown message names the actual problem.
+             */
+            SetLastError(ERROR_PROC_NOT_FOUND);
+        }
     } else {
-        module = (HMODULE) library;
+        ret = GetProcAddress((HMODULE) library, utfName);
     }
 
-    ret = GetProcAddress(module, utfName);
-    if (ret == 0) {
+    if (ret == NULL) {
         throwError(env, context);
     }
     (*env)->ReleaseStringUTFChars(env, name, utfName);

--- a/truffle/src/com.oracle.truffle.nfi.test.native/src/string.c
+++ b/truffle/src/com.oracle.truffle.nfi.test.native/src/string.c
@@ -104,13 +104,3 @@ EXPORT const char *native_string_callback(const char *(*str_ret)()) {
         return "different";
     }
 }
-
-#if defined(_WIN32)
-EXPORT char *reexport_strdup(const char *str) {
-    return strdup(str);
-}
-
-EXPORT void reexport_free(char *str) {
-    free(str);
-}
-#endif

--- a/truffle/src/com.oracle.truffle.nfi.test/src/com/oracle/truffle/nfi/test/DefaultLibraryNFITest.java
+++ b/truffle/src/com.oracle.truffle.nfi.test/src/com/oracle/truffle/nfi/test/DefaultLibraryNFITest.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or
+ * data (collectively the "Software"), free of charge and under any and all
+ * copyright rights in the Software, and any and all patent rights owned or
+ * freely licensable by each licensor hereunder covering either (i) the
+ * unmodified Software as contributed to or provided by such licensor, or (ii)
+ * the Larger Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ *
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ *
+ * The above copyright notice and either this complete permission notice or at a
+ * minimum a reference to the UPL must be included in all copies or substantial
+ * portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.oracle.truffle.nfi.test;
+
+import org.junit.Assert;
+import org.junit.Assume;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import com.oracle.truffle.api.CallTarget;
+import com.oracle.truffle.api.frame.VirtualFrame;
+import com.oracle.truffle.api.interop.InteropException;
+import com.oracle.truffle.api.interop.InteropLibrary;
+import com.oracle.truffle.tck.TruffleRunner;
+import com.oracle.truffle.tck.TruffleRunner.Inject;
+
+/**
+ * Tests the "default" library, the NFI equivalent of {@code dlopen(NULL)} / {@code RTLD_DEFAULT}.
+ * <p>
+ * The contract is that looking a symbol up in it searches the main executable <em>and</em> every
+ * shared object already loaded into the process. These tests run identically on every platform on
+ * purpose: the Windows implementation used to search only the launcher executable's export table,
+ * which resolved essentially nothing, and the test suite worked around that by redirecting to
+ * re-exported copies in the test library rather than covering the real path.
+ * <p>
+ * The symbols used here are C standard library functions, which are loaded into every process this
+ * test can run in: glibc on Linux, libSystem on macOS, ucrtbase.dll on Windows.
+ */
+@RunWith(TruffleRunner.class)
+public class DefaultLibraryNFITest extends NFITest {
+
+    @BeforeClass
+    public static void checkDefaultLibraryAvailable() {
+        Assume.assumeNotNull(defaultLibrary);
+    }
+
+    public static class CallAbs extends NFITestRootNode {
+
+        private final Object abs = lookupAndBindDefault("abs", "(sint32):sint32");
+        @Child InteropLibrary absInterop = getInterop(abs);
+
+        @Override
+        public Object executeTest(VirtualFrame frame) throws InteropException {
+            return absInterop.execute(abs, frame.getArguments()[0]);
+        }
+    }
+
+    /**
+     * Resolves a libc function through the default library and calls it. On Windows this only
+     * passes if the lookup walks the loaded modules -- {@code abs} is exported by ucrtbase.dll, not
+     * by the launcher executable.
+     */
+    @Test
+    public void lookupLibcFunction(@Inject(CallAbs.class) CallTarget target) {
+        Assert.assertEquals("abs(-42)", 42, target.call(-42));
+    }
+
+    @Test
+    public void lookupLibcFunctionTwice(@Inject(CallAbs.class) CallTarget target) {
+        // guards against a lookup that caches the first miss rather than the resolved symbol
+        Assert.assertEquals("abs(-1)", 1, target.call(-1));
+        Assert.assertEquals("abs(-2)", 2, target.call(-2));
+    }
+
+    /**
+     * A symbol that exists in no loaded module must fail cleanly rather than resolving to garbage.
+     */
+    @Test
+    public void lookupMissingSymbolFails() {
+        boolean threw = false;
+        try {
+            lookupAndBindDefault("nfi_test_symbol_that_does_not_exist", "():void");
+        } catch (Throwable ex) {
+            // The failed lookup surfaces as an AssertionError wrapping
+            // UnknownIdentifierException, so this cannot narrow to Exception.
+            threw = true;
+        }
+        Assert.assertTrue("expected the lookup of an undefined symbol to fail", threw);
+    }
+}

--- a/truffle/src/com.oracle.truffle.nfi.test/src/com/oracle/truffle/nfi/test/LoadNFILibraryTest.java
+++ b/truffle/src/com.oracle.truffle.nfi.test/src/com/oracle/truffle/nfi/test/LoadNFILibraryTest.java
@@ -42,12 +42,27 @@ package com.oracle.truffle.nfi.test;
 
 import com.oracle.truffle.api.exception.AbstractTruffleException;
 import org.junit.Assert;
+import org.junit.Assume;
 import org.junit.Test;
 
 public class LoadNFILibraryTest extends NFITest {
 
     private static Object eval(String format, Object... args) {
         return loadLibrary(String.format(format, args));
+    }
+
+    /**
+     * The {@code RTLD_*} flags are POSIX. On Windows the flag parser ignores names it does not
+     * know, so passing them there does not exercise anything -- the request silently collapses to
+     * a plain {@code load} and the assertion below passes without testing the flag. Skipping keeps
+     * that honest; {@link #loadSearchDllLoadDir()} and friends are the Windows counterparts.
+     */
+    private static void assumePosixFlags() {
+        Assume.assumeFalse("RTLD_* flags are POSIX-only", IS_WINDOWS);
+    }
+
+    private static void assumeWindowsFlags() {
+        Assume.assumeTrue("LOAD_LIBRARY_SEARCH_* flags are Windows-only", IS_WINDOWS);
     }
 
     @Test
@@ -58,31 +73,72 @@ public class LoadNFILibraryTest extends NFITest {
 
     @Test
     public void loadLazy() {
+        assumePosixFlags();
         Object library = eval("load(RTLD_LAZY) '%s'", getLibPath("nativetest"));
         Assert.assertNotNull(library);
     }
 
     @Test
     public void loadNow() {
+        assumePosixFlags();
         Object library = eval("load(RTLD_NOW) '%s'", getLibPath("nativetest"));
         Assert.assertNotNull(library);
     }
 
     @Test
     public void loadLocal() {
+        assumePosixFlags();
         Object library = eval("load(RTLD_LOCAL) '%s'", getLibPath("nativetest"));
         Assert.assertNotNull(library);
     }
 
     @Test
     public void loadGlobal() {
+        assumePosixFlags();
         Object library = eval("load(RTLD_GLOBAL) '%s'", getLibPath("nativetest"));
         Assert.assertNotNull(library);
     }
 
     @Test
     public void loadGlobalLazy() {
+        assumePosixFlags();
         Object library = eval("load(RTLD_GLOBAL|RTLD_LAZY) '%s'", getLibPath("nativetest"));
+        Assert.assertNotNull(library);
+    }
+
+    /*
+     * Windows counterparts of the RTLD_* cases above. These are the flags a caller needs so that a
+     * DLL's own dependencies are found next to it, which is what the POSIX loader does for free via
+     * RPATH/$ORIGIN. LOAD_LIBRARY_SEARCH_* requires a fully qualified path, which getLibPath
+     * provides.
+     */
+
+    @Test
+    public void loadSearchDllLoadDir() {
+        assumeWindowsFlags();
+        Object library = eval("load(LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR) '%s'", getLibPath("nativetest"));
+        Assert.assertNotNull(library);
+    }
+
+    @Test
+    public void loadSearchDefaultDirs() {
+        assumeWindowsFlags();
+        Object library = eval("load(LOAD_LIBRARY_SEARCH_DEFAULT_DIRS) '%s'", getLibPath("nativetest"));
+        Assert.assertNotNull(library);
+    }
+
+    @Test
+    public void loadSearchDllLoadDirAndDefaultDirs() {
+        assumeWindowsFlags();
+        // the combination Sulong uses by default when loading a native library by absolute path
+        Object library = eval("load(LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR|LOAD_LIBRARY_SEARCH_DEFAULT_DIRS) '%s'", getLibPath("nativetest"));
+        Assert.assertNotNull(library);
+    }
+
+    @Test
+    public void loadAlteredSearchPath() {
+        assumeWindowsFlags();
+        Object library = eval("load(LOAD_WITH_ALTERED_SEARCH_PATH) '%s'", getLibPath("nativetest"));
         Assert.assertNotNull(library);
     }
 
@@ -94,6 +150,7 @@ public class LoadNFILibraryTest extends NFITest {
 
     @Test(expected = AbstractTruffleException.class)
     public void fileNotFound() {
-        eval("load '/this/file/does/not/exist.so'");
+        // a path shaped for the host, so the failure is "not found" rather than "malformed path"
+        eval("load '%s'", IS_WINDOWS ? "C:/this/file/does/not/exist.dll" : "/this/file/does/not/exist.so");
     }
 }

--- a/truffle/src/com.oracle.truffle.nfi.test/src/com/oracle/truffle/nfi/test/NFITest.java
+++ b/truffle/src/com.oracle.truffle.nfi.test/src/com/oracle/truffle/nfi/test/NFITest.java
@@ -213,12 +213,18 @@ public class NFITest {
         return lookupAndBind(testLibrary, name, signature);
     }
 
+    /**
+     * Look a symbol up in the "default" library, the NFI equivalent of
+     * {@code dlsym(RTLD_DEFAULT, ...)}.
+     * <p>
+     * This used to redirect to a {@code reexport_}-prefixed copy in the test library on Windows,
+     * because {@code GetProcAddress(GetModuleHandle(NULL), ...)} searches only the launcher
+     * executable's export table and so resolved essentially nothing. The Windows lookup now walks
+     * every module loaded into the process, matching the POSIX semantics, so every platform goes
+     * through the default library here and the tests that use it actually cover it.
+     */
     protected static Object lookupAndBindDefault(String name, String signature) {
-        if (IS_WINDOWS) {
-            return lookupAndBind(testLibrary, "reexport_" + name, signature);
-        } else {
-            return lookupAndBind(defaultLibrary, name, signature);
-        }
+        return lookupAndBind(defaultLibrary, name, signature);
     }
 
     protected static Object parseSignature(String signature) {

--- a/truffle/src/com.oracle.truffle.nfi.test/src/com/oracle/truffle/nfi/test/StringNFITest.java
+++ b/truffle/src/com.oracle.truffle.nfi.test/src/com/oracle/truffle/nfi/test/StringNFITest.java
@@ -86,7 +86,9 @@ public class StringNFITest extends NFITest {
     public static class NativeStringArgNode extends NFITestRootNode {
 
         final Object function = lookupAndBind("string_arg", "(string):sint32");
-        final Object strdup = lookupAndBindDefault("strdup", "(string):string");
+        // The C runtime on Windows spells this _strdup; the POSIX name is deprecated
+        // there and is not exported by ucrtbase.dll. free() is spelled the same on both.
+        final Object strdup = lookupAndBindDefault(IS_WINDOWS ? "_strdup" : "strdup", "(string):string");
         final Object free = lookupAndBindDefault("free", "(pointer):void");
 
         @Child InteropLibrary functionInterop = getInterop(function);


### PR DESCRIPTION
## Summary

Loading and calling native libraries from Sulong works on Linux and macOS but
degrades badly on Windows, in two independent ways.

**1. The `default` library resolved almost nothing.**

`dlopen(NULL)` / `RTLD_DEFAULT` on POSIX searches the main executable *and every
shared object loaded into the process*. The Windows implementation used
`GetProcAddress(GetModuleHandleA(NULL), name)`, which searches only the export
table of the main executable — for a JVM launcher that table is essentially
empty. `NFIContextExtension` uses the default library handle as the last-resort
fallback for every unresolved native symbol, so on Windows that fallback
silently resolved nothing.

The NFI test suite had already worked around this rather than fixing it:
`NFITest.lookupAndBindDefault` redirected to `reexport_`-prefixed copies inside
the test library when running on Windows, so the real path was never covered on
any platform.

`lookup_win32.c` now walks every module loaded into the process, giving the
default library the same meaning it has on POSIX. `EnumProcessModules` is
resolved dynamically as `K32EnumProcessModules` from `kernel32.dll`, so this
adds no link-time dependency.

**2. A DLL's own dependencies were not found next to it.**

Sulong always loaded native libraries with no flags, so `LoadLibraryEx` got
`dwFlags == 0`. Windows then resolves the library's dependencies against the
standard search order, which does *not* include the directory of the DLL being
loaded. On POSIX the loader handles this via RPATH/RUNPATH, commonly `$ORIGIN`.
A library such as Intel MKL, whose entry-point DLL pulls in siblings from its
own directory, therefore fails to load on Windows while loading fine on Linux.

`NFIContextExtension` now passes
`LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR|LOAD_LIBRARY_SEARCH_DEFAULT_DIRS` when loading
by absolute path on Windows. The NFI already accepted these flag names — nothing
ever passed them. Deliberately **not** `LOAD_WITH_ALTERED_SEARCH_PATH`: that is
the legacy scheme and it puts the process working directory on the dependency
search path, which is a DLL-planting vector.

**Also fixed along the way**

- `throwError` in `lookup_win32.c` could pass an uninitialised pointer to
  `ThrowNew` and then `LocalFree` it, because `FormatMessageA` leaves its output
  pointer untouched when it fails and has no message for every error code.
- `NFIContextExtension` carried its own `getNativeLibrarySuffix` /
  `getNativeLibrarySuffixVersioned` returning `"so"` on Windows, hiding the
  correct Windows-aware versions in the `NativeContextExtension` parent. They
  were unreachable — Java statics bind lexically — but a trap for the next
  caller. Removed; the parent's platform checks are now computed once into
  constants with an `isWindows()` accessor.

## Related Issues

None filed — this came out of trying to bind a native library from Sulong on
Windows the way it works on Linux.

## Testing

- `NFITest.lookupAndBindDefault` no longer takes the Windows shortcut, so every
  platform exercises the real default library. The `reexport_strdup` /
  `reexport_free` shims existed only for that workaround and are removed.
- **`StringNFITest` was the caller that workaround existed for.** It now names
  the symbol per platform: the C runtime on Windows spells it `_strdup`, since
  the POSIX name is deprecated there and is not exported by `ucrtbase.dll`.
  `free` is spelled the same on both. That `free` resolves through the default
  library on Windows is itself evidence the fix works.
- New **`DefaultLibraryNFITest`** resolves and calls a libc function through the
  default library, and checks that an undefined symbol fails rather than
  resolving to garbage. Nothing anywhere exercised the default library directly
  before.
- **`LoadNFILibraryTest`**: the `RTLD_*` cases now skip on Windows. They were
  vacuous there — the Windows flag parser ignores names it does not know, so
  each request collapsed to a plain `load` that passed while asserting nothing
  about the flag. Added the Windows `LOAD_LIBRARY_SEARCH_*` counterparts,
  including the combination Sulong now uses.
- New GitHub Actions workflow runs these tests on Windows **and** Linux from one
  matrix, so the two cannot silently drift apart again.

Results:

| | Windows | Linux |
|---|---|---|
| `mx unittest com.oracle.truffle.nfi.test` | **OK (560 tests)** | **OK (570 tests)** |
| `DefaultLibraryNFITest` | passed | passed |
| `loadSearchDllLoadDir*` | passed | skipped, Windows-only |

Also verified locally on Windows 11 / MSVC 14.51 / labsjdk
25.0.4.1.1-jvmci-25.4-b23, where Sulong's `nativemode` and `runtime` projects
build clean.

## Documentation

No user-facing documentation changes. The reasoning that is easy to get wrong
later — why the modern `LOAD_LIBRARY_SEARCH_*` flags rather than
`LOAD_WITH_ALTERED_SEARCH_PATH`, and why the default-library lookup must walk
loaded modules — is recorded as comments at both sites.

## Not addressed here

`--llvm.libraryPath` still does not reach the OS loader on Windows. A DLL's
dependencies are now found next to it, but not in other `libraryPath` entries;
`LD_LIBRARY_PATH` covers that on Linux. Closing it needs `AddDllDirectory` and
therefore new NFI native API, so it is left for a separate change.

## Contributor Checklist

- [x] I have read the contribution guide.
- [x] I have the right to contribute the submitted material under the project terms.
- [x] I have updated tests and documentation where appropriate.
- [x] If I used a coding assistant, I remain responsible for the entire contribution and have reviewed it accordingly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y7QHXmVpEqBM5eJsQRj5cN
